### PR TITLE
Fix example in docs that wouldn't work in practice

### DIFF
--- a/docs/content/doc/usage.md
+++ b/docs/content/doc/usage.md
@@ -37,7 +37,7 @@ immediately, tell Hugo to watch for changes. **It will
 recreate the site faster than you can tab over to
 your browser to view the changes.**
 
-    $ hugo --source ~/mysite --watch
+    $ hugo -s ~/mysite --watch
        Watching for changes. Press ctrl+c to stop
        15 pages created
        0 tags created


### PR DESCRIPTION
The pflag package used in hugo has to use the "=" sign
for double dash options such as --source. Thus the original
example `--source ~/mysite` is already incorrect. Adding
the = sign though woul not fix things in this case, since
`--source=~/mysite` does not get resolved to /home/username/mysite,
but looks for the ./~/mysite directory within the current directory.

To resolve this, either the directory name has to be changed in
the docs not to use the "~" sign, or have to change to use the
single dash version of the command line flag. The latter seems
to be more in line with the rest of the example.

Leaving `--watch` as a double dash option to minimize the change,
though it could be either way, since the follow up example uses
the single dash version of both.
