### PR TITLE
Populated page Site metadata.  Enables accessing Indexes from Page template.

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -271,6 +271,12 @@ func (s *Site) BuildSiteMeta() (err error) {
 		return errors.New(fmt.Sprintf("Unable to build site metadata, no pages found in directory %s", s.c.ContentDir))
 	}
 	s.Info.LastChange = s.Pages[0].Date
+
+	// populate pages with site metadata
+	for _, p := range s.Pages {
+		p.Site = s.Info
+	}
+
 	return
 }
 


### PR DESCRIPTION
In site.Process(), site.CreatePages() is called, which sets page.Site prior to site.BuildSiteMeta(). This change re-populates page.Site with site metadata once it is created. This allows access to the indexes when the pages are being rendered (via {{ .Site.Indexes }} ).
