### PR TITLE
Make sure hugo --version prints the version and does *nothing* else.

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,11 @@ func main() {
 		usage()
 	}
 
+	if *version {
+		fmt.Println("Hugo Static Site Generator v0.8")
+		return
+	}
+
 	config := hugolib.SetupConfig(cfgfile, source)
 	config.BuildDrafts = *draft
 	config.UglyUrls = *uglyUrls
@@ -73,10 +78,6 @@ func main() {
 
 	if *destination != "" {
 		config.PublishDir = *destination
-	}
-
-	if *version {
-		fmt.Println("Hugo Static Site Generator v0.8")
 	}
 
 	if *cpuprofile != 0 {


### PR DESCRIPTION
Any program, when asks to print their version, only prints that, and then
stops.
hugo checks the config (and prints a warning message if not found), and
proceeds to generate the site!
Yet, the user just wanted to check the version.

This patch makes sure hugo stops after printing the version.
