### PR TITLE
Add redirect to page parameters and redirects example

### DIFF
--- a/docs/content/doc/front-matter.md
+++ b/docs/content/doc/front-matter.md
@@ -4,8 +4,8 @@ date = "2013-07-01"
 +++
 
 The front matter is one of the features that gives Hugo it's strength. It enables
-you to include the meta data of the content right with it. Hugo supports a few 
-different formats each with their own identifying tokens. 
+you to include the meta data of the content right with it. Hugo supports a few
+different formats each with their own identifying tokens.
 
 Supported formats: <br>
   **YAML**, identified by '\-\-\-'. <br>
@@ -24,7 +24,7 @@ Supported formats: <br>
       - "VIM"
     slug: "spf13-vim-3-0-release-and-new-website"
     ---
-    Content of the file goes Here 
+    Content of the file goes Here
 
 ### TOML Example
 
@@ -39,7 +39,7 @@ Supported formats: <br>
     ]
     slug = "spf13-vim-3-0-release-and-new-website"
     +++
-    Content of the file goes Here 
+    Content of the file goes Here
 
 ### JSON Example
 
@@ -54,7 +54,7 @@ Supported formats: <br>
     ],
     "slug": "spf13-vim-3-0-release-and-new-website",
     }
-    Content of the file goes Here 
+    Content of the file goes Here
 
 ### Variables
 
@@ -71,6 +71,7 @@ any variable they want to. These will be placed into the `.Params` variable avai
 
 #### Optional
 
+**redirect** Mark the post as a redirect post<br>
 **draft** If true the content will not be rendered unless `hugo` is called with -d<br>
 **type** The type of the content (will be derived from the directory automatically if unset).<br>
 **markup** (Experimental) Specify "rst" for reStructuredText (requires

--- a/docs/content/doc/redirects.md
+++ b/docs/content/doc/redirects.md
@@ -1,0 +1,37 @@
+---
+title: "Redirects"
+Pubdate: "2013-07-09"
+---
+
+For people migrating existing published content to Hugo theres a good chance
+you need a mechanism to handle redirecting old urls.
+
+Luckily, this can be handled easily in a couple of easy steps.
+
+1. Create a special post for the redirect and mark the file as a `redirect`
+    file in the front matter.  Here is an example
+    `content/redirects/my-awesome-blog-post.md` :
+
+    ```markdown
+    ---
+    redirect: true
+    slug: /my-awesome-blog-post/
+    url: /docs/redirects/
+    ---
+```
+
+2. Set the redirect template `layouts/redirects/single.html`:
+
+    ```html
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <link rel="canonical" href="{{ .Url }}"/>
+      <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+      <meta http-equiv="refresh" content="0;url={{ .Url }}" />
+    </head>
+    </html>
+    ```
+
+Now when you go to `/my-awesome-blog-post/` it will do a meta redirect to
+`/docs/redirects/`.

--- a/docs/content/redirects/my-awesome-blog-post.md
+++ b/docs/content/redirects/my-awesome-blog-post.md
@@ -1,0 +1,5 @@
+---
+redirect: true
+slug: /my-awesome-blog-post/
+url: /docs/redirects1/
+---

--- a/docs/layouts/chrome/menu.html
+++ b/docs/layouts/chrome/menu.html
@@ -19,6 +19,7 @@
             <li class="nav-header">Extras</li>
             <li> <a href="/doc/shortcodes">ShortCodes</a></li>
             <li> <a href="/doc/indexes">Indexes</a></li>
+            <li> <a href="/doc/redirects">Redirects</a></li>
             <li class="divider"></li>
             <li class="nav-header">Meta</li>
             <li> <a href="/doc/release-notes">Release Notes</a></li>

--- a/docs/layouts/redirects/single.html
+++ b/docs/layouts/redirects/single.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="canonical" href="{{ .Url }}"/>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <meta http-equiv="refresh" content="0;url={{ .Url }}" />
+</head>
+</html>


### PR DESCRIPTION
Adding a new page parameter so that if `redirect: true` then it doesn't nest the post in the directory it comes from - making the slug canonical (rather than section + slug).
