### PR TITLE
Use / for template names regardless of platform.

### DIFF
--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -148,7 +148,7 @@ func FindPath() (string, error) {
 }
 
 func (c *Config) GetAbsPath(name string) string {
-	if path.IsAbs(name) {
+	if filepath.IsAbs(name) {
 		return name
 	}
 

--- a/hugolib/path_seperators_test.go
+++ b/hugolib/path_seperators_test.go
@@ -23,25 +23,29 @@ func TestDegenerateMissingFolderInPageFilename(t *testing.T) {
 }
 
 func TestNewPageWithFilePath(t *testing.T) {
-	toCheck := []map[string]string{
-		{"input": filepath.Join("sub", "foobar.html"), "expect": "sub"},
-		{"input": filepath.Join("content", "sub", "foobar.html"), "expect": "sub"},
-		{"input": filepath.Join("content", "dub", "sub", "foobar.html"), "expect": "sub"},
+	toCheck := []struct{
+		input string
+		section string
+		layout string
+	}{
+		{filepath.Join("sub", "foobar.html"), "sub", "sub/single.html"},
+		{filepath.Join("content", "sub", "foobar.html"), "sub", "sub/single.html"},
+		{filepath.Join("content", "dub", "sub", "foobar.html"), "sub", "sub/single.html"},
 	}
 
 	for _, el := range toCheck {
-		p, err := ReadFrom(strings.NewReader(SIMPLE_PAGE_YAML), el["input"])
+		p, err := ReadFrom(strings.NewReader(SIMPLE_PAGE_YAML), el.input)
 		if err != nil {
 			t.Fatalf("Reading from SIMPLE_PAGE_YAML resulted in an error: %s", err)
 		}
-		if p.Section != el["expect"] {
-			t.Fatalf("Section not set to %s for page %s. Got: %s", el["expect"], el["input"], p.Section)
+		if p.Section != el.section {
+			t.Fatalf("Section not set to %s for page %s. Got: %s", el.section, el.input, p.Section)
+		}
+
+		if p.Layout() != el.layout {
+			t.Fatalf("Layout incorrect. Expected: '%s', Got: '%s'", el.layout, p.Layout())
 		}
 	}
 }
 
-func TestSettingOutFileOnPageContainsCorrectSlashes(t *testing.T) {
-	s := &Site{Config: Config{}}
-	p := NewPage(filepath.Join("sub", "foobar"))
-	s.setOutFile(p)
-}
+

--- a/hugolib/path_seperators_windows_test.go
+++ b/hugolib/path_seperators_windows_test.go
@@ -1,0 +1,16 @@
+package hugolib
+
+import (
+	"testing"
+)
+
+func TestTemplatePathSeperator(t *testing.T) {
+	config := Config{
+		LayoutDir: "c:\\a\\windows\\path\\layout",
+		Path: "c:\\a\\windows\\path",
+	}
+	s := &Site{Config: config}
+	if name := s.generateTemplateNameFrom("c:\\a\\windows\\path\\layout\\sub1\\index.html"); name != "sub1/index.html" {
+		t.Fatalf("Template name incorrect.  Expected: %s, Got: %s", "sub1/index.html", name)
+	}
+}

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -163,14 +163,18 @@ func (s *Site) loadTemplates() {
 				return err
 			}
 			text := string(filetext)
-			name := path[len(s.Config.GetAbsPath(s.Config.LayoutDir))+1:]
-			t := s.Tmpl.New(name)
+			t := s.Tmpl.New(s.generateTemplateNameFrom(path))
 			template.Must(t.Parse(text))
 		}
 		return nil
 	}
 
-	filepath.Walk(s.Config.GetAbsPath(s.Config.LayoutDir), walker)
+	filepath.Walk(s.absLayoutDir(), walker)
+}
+
+func (s *Site) generateTemplateNameFrom(path string) (name string) {
+	name = filepath.ToSlash(path[len(s.absLayoutDir())+1:])
+	return
 }
 
 func (s *Site) primeTemplates() {


### PR DESCRIPTION
The path seperator was causing templates to not be loaded on windows.
Now all template names use / internally.
