### PR TITLE
indexes rss.xml has wrong permalinks with ugly urls off

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -470,11 +470,11 @@ func (s *Site) RenderLists() error {
 
 		if a := s.Tmpl.Lookup("rss.xml"); a != nil {
 			// XML Feed
-            if s.Config.UglyUrls {
-                    n.Url = Urlize(section + ".xml")
-            } else {
-                    n.Url = Urlize(section + "/" + "index.xml")
-            }
+			if s.Config.UglyUrls {
+			        n.Url = Urlize(section + ".xml")
+			} else {
+			        n.Url = Urlize(section + "/" + "index.xml")
+			}
 			n.Permalink = template.HTML(string(n.Site.BaseUrl) + n.Url)
 			y := s.NewXMLBuffer()
 			s.Tmpl.ExecuteTemplate(y, "rss.xml", n)


### PR DESCRIPTION
Non-ugly urls are not being taken into account for renderlist rss temlates (results in wrong permalink).

This fixes it for me.

```
diff --git a/hugolib/site.go b/hugolib/site.go
index 1edca19..a85d61b 100644
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -467,7 +467,11 @@ func (s *Site) RenderLists() error {

                if a := s.Tmpl.Lookup("rss.xml"); a != nil {
                        // XML Feed
-                       n.Url = Urlize(section + ".xml")
+                       if s.Config.UglyUrls {
+                               n.Url = Urlize(section + ".xml")
+                       } else {
+                               n.Url = Urlize(section + "/" + "index.xml")
+                       }
                        n.Permalink = template.HTML(string(n.Site.BaseUrl) + n.U
                        y := s.NewXMLBuffer()
                        s.Tmpl.ExecuteTemplate(y, "rss.xml", n)
```
