### PR TITLE
sanitizeRegex chopping dots

### DIFF
--- a/hugolib/helpers.go
+++ b/hugolib/helpers.go
@@ -27,7 +27,7 @@ import (
 	"time"
 )
 
-var sanitizeRegexp = regexp.MustCompile("[^a-zA-Z0-9/_-.]")
+var sanitizeRegexp = regexp.MustCompile("[^a-zA-Z0-9./_-]")
 
 // TODO: Make these wrappers private
 // Wrapper around Fprintf taking verbose flag in account.


### PR DESCRIPTION
``` go
var sanitizeRegexp = regexp.MustCompile("[^a-zA-Z0-9/_-]")
```

The above, as part of RenderIndexes with rss.xml template, results in Permalink being set to ".../indexxml" instead of ".../index.xml".

If I change it to 

``` go
var sanitizeRegexp = regexp.MustCompile("[^.a-zA-Z0-9/_-]")
```

It works ok.
