### PR TITLE
Clarify uglyurls flag.

### DIFF
--- a/docs/content/doc/usage.md
+++ b/docs/content/doc/usage.md
@@ -15,7 +15,7 @@ Make sure either hugo is in your path or provide a path to it.
           --port="1313": port to run web server on, default :1313
       -S, --server=false: run a (very) simple web server
       -s, --source="": filesystem path to read files relative from
-          --uglyurls=false: use /filename.html instead of /filename/
+          --uglyurls=false: if true, use /filename.html instead of /filename/
       -v, --verbose=false: verbose output
           --version=false: which version of hugo
       -w, --watch=false: watch filesystem for changes and recreate as needed

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ var (
 	watchMode   = flag.BoolP("watch", "w", false, "watch filesystem for changes and recreate as needed")
 	server      = flag.BoolP("server", "S", false, "run a (very) simple web server")
 	port        = flag.String("port", "1313", "port to run web server on, default :1313")
-	uglyUrls    = flag.Bool("uglyurls", false, "use /filename.html instead of /filename/ ")
+	uglyUrls    = flag.Bool("uglyurls", false, "if true, use /filename.html instead of /filename/")
 )
 
 func usage() {


### PR DESCRIPTION
Mention more clearly that, for generating `/filename.html`, you need to
set the `uglyurls` flag to `true`.

From the initial documentation, I got the false impression that  
`--uglyurls=false` would "use `/filename.html` instead of `/filename/`".

But that is incorrect: the `=false` is the default value, and, **if true**, then the description applies.
