### PR TITLE
Display an error if RenderHomePage fails

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -120,7 +120,9 @@ func (site *Site) Render() (err error) {
 		return
 	}
 	site.timerStep("render pages")
-	site.RenderHomePage()
+	if err = site.RenderHomePage(); err != nil {
+		return
+        }
 	site.timerStep("render and write homepage")
 	return
 }


### PR DESCRIPTION
The RenderHomePage function was failing silently.

I'm not sure if you want this in RenderHomePage or in the top level Render
function.  I think that there are likely other silent failures from the other
rendering functions called in Render.
