### PR TITLE
avoid possible redirects with non-ugly slug urls

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -192,7 +192,7 @@ func (p *Page) Permalink() template.HTML {
 		if p.Site.Config.UglyUrls {
 			return template.HTML(MakePermalink(string(p.Site.BaseUrl), strings.TrimSpace(p.Section)+"/"+p.Slug+"."+p.Extension))
 		} else {
-			return template.HTML(MakePermalink(string(p.Site.BaseUrl), strings.TrimSpace(p.Section)+"/"+p.Slug))
+			return template.HTML(MakePermalink(string(p.Site.BaseUrl), strings.TrimSpace(p.Section)+"/"+p.Slug+"/"))
 		}
 	} else if len(strings.TrimSpace(p.Url)) > 2 {
 		return template.HTML(MakePermalink(string(p.Site.BaseUrl), strings.TrimSpace(p.Url)))


### PR DESCRIPTION
slug urls currently do not end with a slash (in Permalink link outputs such as
indexes and rss feeds). This may cause an unnecessary redirect for the client.

Adding a slash to the end of slug urls should resolve this.
