### PR TITLE
Remove extra quotes from meta data

### DIFF
--- a/docs/content/content/example.md
+++ b/docs/content/content/example.md
@@ -9,14 +9,14 @@ Somethings are better shown than explained. The following is a very basic exampl
 **mysite/project/nitro.md  <- http://mysite.com/project/nitro.html**
 
     ---
-    Title: "Nitro : A quick and simple profiler for golang"
-    Description": ""
-    Keywords": [ "Development", "golang", "profiling" ]
-    Tags": [ "Development", "golang", "profiling" ]
-    date": "2013-06-19"
-    Topics": [ "Development", "GoLang" ]
-    Slug": "nitro"
-    project_url": "http://github.com/spf13/nitro"
+    Title:       "Nitro : A quick and simple profiler for golang"
+    Description: ""
+    Keywords:    [ "Development", "golang", "profiling" ]
+    Tags:        [ "Development", "golang", "profiling" ]
+    date:        "2013-06-19"
+    Topics:      [ "Development", "GoLang" ]
+    Slug:        "nitro"
+    project_url: "http://github.com/spf13/nitro"
     ---
 
     # Nitro


### PR DESCRIPTION
While using the example post to test tag pages generation, I've noticed a couple of extra quotes, for example `Tags"`, I removed those and aligned the meta values.
