### PR TITLE
Print error if index value in a page is wrong type

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -362,8 +362,13 @@ func (s *Site) BuildSiteMeta() (err error) {
 			vals := p.GetParam(plural)
 
 			if vals != nil {
-				for _, idx := range vals.([]string) {
-					s.Indexes[plural].Add(idx, s.Pages[i])
+				v, ok := vals.([]string)
+				if ok {
+					for _, idx := range v {
+						s.Indexes[plural].Add(idx, s.Pages[i])
+					}
+				} else {
+					PrintErr("Invalid " + plural + " in " + p.File.FileName)
 				}
 			}
 		}


### PR DESCRIPTION
This was causing a panic with no information displayed about the page causing
the error.

I treated this as some sort of warning, rather than return an error and stop
processing.
