### PR TITLE
Add 404.html support for gh-pages

### DIFF
--- a/docs/content/layout/404.html
+++ b/docs/content/layout/404.html
@@ -1,0 +1,31 @@
+---
+title: "404.html Templates"
+date: "2013-08-21"
+---
+
+When using Hugo with [github pages](http://pages.github.com/) you can provide
+your own 404 template by creating a 404.html file in the root.
+
+404 pages are of the type "node" and have all the [node
+variables](/layout/variables/) available to use in the templates.
+
+In addition to the standard node variables, the homepage has access to
+all site content accessible from .Data.Pages
+
+    ▾ layouts/
+        404.html
+
+## 404.html
+This is a basic example of a 404.html template:
+
+    {{ template "chrome/header.html" . }}
+    {{ template "chrome/subheader.html" . }}
+
+    <section id="main">
+      <div>
+       <h1 id="title">{{ .Title }}</h1>
+      </div>
+    </section>
+
+    {{ template "chrome/footer.html" }}
+

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -596,6 +596,18 @@ func (s *Site) RenderHomePage() error {
 		s.Tmpl.ExecuteTemplate(y, "rss.xml", n)
 		s.WritePublic("index.xml", y.Bytes())
 	}
+
+	if a := s.Tmpl.Lookup("404.html"); a != nil {
+		n.Url = Urlize("404.html")
+		n.Title = "404 Page not found"
+		n.Permalink = template.HTML(string(n.Site.BaseUrl) + "404.html")
+		x, err := s.RenderThing(n, "404.html")
+		if err != nil {
+			return err
+		}
+		s.WritePublic("404.html", x.Bytes())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Similar in style to rss.xml, but means you can reuse templates rather than creating a 404.html in the static directory.
