### PR TITLE
The <!--more--> (summary divider) now works even if it is on the same li...

### DIFF
--- a/hugolib/helpers.go
+++ b/hugolib/helpers.go
@@ -270,6 +270,10 @@ func WordCount(s string) map[string]int {
 	return m
 }
 
+func RemoveSummaryDivider(content []byte) []byte {
+	return bytes.Replace(content, summaryDivider, []byte(""), -1)
+}
+
 func StripHTML(s string) string {
 	output := ""
 

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -481,7 +481,7 @@ func (page *Page) convertMarkdown(lines io.Reader) {
 	b := new(bytes.Buffer)
 	b.ReadFrom(lines)
 	content := b.Bytes()
-	page.Content = template.HTML(string(blackfriday.MarkdownCommon(content)))
+	page.Content = template.HTML(string(blackfriday.MarkdownCommon(RemoveSummaryDivider(content))))
 	summary, plain := getSummaryString(content)
 	if plain {
 		page.Summary = template.HTML(string(summary))

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -100,6 +100,14 @@ Simple Page
 Some more text
 `
 
+var SIMPLE_PAGE_WITH_SUMMARY_DELIMITER_SAME_LINE = `---
+title: Simple
+---
+Simple Page<!--more-->
+
+Some more text
+`
+
 func checkError(t *testing.T, err error, expected string) {
 	if err == nil {
 		t.Fatalf("err is nil")
@@ -175,7 +183,20 @@ func TestPageWithDelimiter(t *testing.T) {
 		t.Fatalf("Unable to create a page with frontmatter and body content: %s", err)
 	}
 	checkPageTitle(t, p, "Simple")
-	checkPageContent(t, p, "<p>Simple Page</p>\n\n<!--more-->\n\n<p>Some more text</p>\n")
+	checkPageContent(t, p, "<p>Simple Page</p>\n\n<p>Some more text</p>\n")
+	checkPageSummary(t, p, "<p>Simple Page</p>\n")
+	checkPageType(t, p, "page")
+	checkPageLayout(t, p, "page/single.html")
+
+}
+
+func TestPageWithMoreTag(t *testing.T) {
+	p, err := ReadFrom(strings.NewReader(SIMPLE_PAGE_WITH_SUMMARY_DELIMITER_SAME_LINE), "simple")
+	if err != nil {
+		t.Fatalf("Unable to create a page with frontmatter and body content: %s", err)
+	}
+	checkPageTitle(t, p, "Simple")
+	checkPageContent(t, p, "<p>Simple Page</p>\n\n<p>Some more text</p>\n")
 	checkPageSummary(t, p, "<p>Simple Page</p>\n")
 	checkPageType(t, p, "page")
 	checkPageLayout(t, p, "page/single.html")

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -31,16 +31,16 @@ import (
 var DefaultTimer = nitro.Initalize()
 
 type Site struct {
-	Config      Config
-	Pages       Pages
-	Tmpl        *template.Template
-	Indexes     IndexList
-	Files       []string
-	Sections    Index
-	Info        SiteInfo
-	Shortcodes  map[string]ShortcodeFunc
-	timer       *nitro.B
-	Target      target.Publisher
+	Config     Config
+	Pages      Pages
+	Tmpl       *template.Template
+	Indexes    IndexList
+	Files      []string
+	Sections   Index
+	Info       SiteInfo
+	Shortcodes map[string]ShortcodeFunc
+	timer      *nitro.B
+	Target     target.Publisher
 }
 
 type SiteInfo struct {


### PR DESCRIPTION
The <!--more--> summary divider would automatically get html escaped by the blackfriday parser unless it was on its own line.  I found it was best to just remove it entirely before parsing.  This allows the <!--more--> tag to be used in a more flexible way.  It would also mean that in a future one might be able to specify their own summaryDivider and it would work regardless of what the parser does with it.

The only downside I see is that <!--more--> will not be in the html output.

Thoughts?
