### PR TITLE
Added a safeHtml template function

### DIFF
--- a/template/bundle/template.go
+++ b/template/bundle/template.go
@@ -78,6 +78,10 @@ func ReturnWhenSet(a interface{}, index int) interface{} {
 	return ""
 }
 
+func SafeHtml(text string) template.HTML {
+	return template.HTML(text)
+}
+
 type Template interface {
 	ExecuteTemplate(wr io.Writer, name string, data interface{}) error
 	Lookup(name string) *template.Template
@@ -108,6 +112,7 @@ func NewTemplate() Template {
 		"gt":        Gt,
 		"isset":     IsSet,
 		"echoParam": ReturnWhenSet,
+		"safeHtml":  SafeHtml,
 	}
 
 	templates.Funcs(funcMap)


### PR DESCRIPTION
The purpose of this function is to allow custom safe html code in layouts. Since these are Go templates some of the code might be stripped, like comments which can be helpful for other chained build tools (like usemin which use comments to mark blocks of JS scripts and CSS links to be concat and minimized). 
