### PR TITLE
Truncated page var; .Site.Params; First function in templates

### DIFF
--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Title                                      string
 	Indexes                                    map[string]string // singular, plural
 	ProcessFilters                             map[string][]string
+	Params                                     map[string]interface{}
 	BuildDrafts, UglyUrls, Verbose             bool
 }
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -212,6 +212,19 @@ func checkPageDate(t *testing.T, page *Page, time time.Time) {
 	}
 }
 
+func checkTruncation(t *testing.T, page *Page, shouldBe bool, msg string) {
+	if page.Summary == "" {
+		t.Fatal("page has no summary, can not check truncation")
+	}
+	if page.Truncated != shouldBe {
+		if shouldBe {
+			t.Fatalf("page wasn't truncated: %s", msg)
+		} else {
+			t.Fatalf("page was truncated: %s", msg)
+		}
+	}
+}
+
 func TestCreateNewPage(t *testing.T) {
 	p, err := ReadFrom(strings.NewReader(SIMPLE_PAGE), "simple.md")
 	if err != nil {
@@ -222,6 +235,7 @@ func TestCreateNewPage(t *testing.T) {
 	checkPageSummary(t, p, "Simple Page")
 	checkPageType(t, p, "page")
 	checkPageLayout(t, p, "page/single.html", "single.html")
+	checkTruncation(t, p, false, "simple short page")
 }
 
 func TestPageWithDelimiter(t *testing.T) {
@@ -234,6 +248,7 @@ func TestPageWithDelimiter(t *testing.T) {
 	checkPageSummary(t, p, "<p>Summary Next Line</p>\n")
 	checkPageType(t, p, "page")
 	checkPageLayout(t, p, "page/single.html", "single.html")
+	checkTruncation(t, p, true, "page with summary delimiter")
 }
 
 func TestPageWithShortCodeInSummary(t *testing.T) {
@@ -273,7 +288,7 @@ func TestPageWithDate(t *testing.T) {
 }
 
 func TestWordCount(t *testing.T) {
-	p, err := ReadFrom(strings.NewReader(SIMPLE_PAGE_WITH_LONG_CONTENT), "simple")
+	p, err := ReadFrom(strings.NewReader(SIMPLE_PAGE_WITH_LONG_CONTENT), "simple.md")
 	if err != nil {
 		t.Fatalf("Unable to create a page with frontmatter and body content: %s", err)
 	}
@@ -289,6 +304,8 @@ func TestWordCount(t *testing.T) {
 	if p.MinRead != 3 {
 		t.Fatalf("incorrect min read. expected %v, got %v", 3, p.MinRead)
 	}
+
+	checkTruncation(t, p, true, "long page")
 }
 
 func TestCreatePage(t *testing.T) {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -70,6 +70,7 @@ type Site struct {
 	Alias      target.AliasPublisher
 	Completed  chan bool
 	RunMode    runmode
+	params     map[string]interface{}
 }
 
 type SiteInfo struct {
@@ -79,6 +80,7 @@ type SiteInfo struct {
 	LastChange time.Time
 	Title      string
 	Config     *Config
+	Params     map[string]interface{}
 }
 
 type runmode struct {
@@ -222,6 +224,7 @@ func (s *Site) initializeSiteInfo() {
 		Title:   s.Config.Title,
 		Recent:  &s.Pages,
 		Config:  &s.Config,
+		Params:  s.Config.Params,
 	}
 }
 

--- a/hugolib/siteinfo_test.go
+++ b/hugolib/siteinfo_test.go
@@ -1,0 +1,32 @@
+package hugolib
+
+import (
+	"testing"
+	"bytes"
+)
+
+const SITE_INFO_PARAM_TEMPLATE = `{{ .Site.Params.MyGlobalParam }}`
+
+
+func TestSiteInfoParams(t *testing.T) {
+	s := &Site{
+		Config: Config{Params: map[string]interface{}{"MyGlobalParam": "FOOBAR_PARAM"}},
+	}
+
+	s.initialize()
+	if s.Info.Params["MyGlobalParam"] != "FOOBAR_PARAM" {
+		t.Errorf("Unable to set site.Info.Param")
+	}
+	s.prepTemplates()
+	s.addTemplate("template", SITE_INFO_PARAM_TEMPLATE)
+	buf := new(bytes.Buffer)
+
+	err := s.renderThing(s.NewNode(), "template", buf)
+	if err != nil {
+		t.Errorf("Unable to render template: %s", err)
+	}
+
+	if buf.String() != "FOOBAR_PARAM" {
+		t.Errorf("Expected FOOBAR_PARAM: got %s", buf.String())
+	}
+}

--- a/template/bundle/template_test.go
+++ b/template/bundle/template_test.go
@@ -1,0 +1,55 @@
+package bundle
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGt(t *testing.T) {
+	for i, this := range []struct{
+		left interface{}
+		right interface{}
+		leftShouldWin bool
+	}{
+		{ 5, 8, false },
+		{ 8, 5, true },
+		{ 5, 5, false },
+		{ -2, 1, false },
+		{ 2, -5, true },
+		{ "8", "5", true },
+		{ "5", "0001", true },
+		{ []int{100,99}, []int{1,2,3,4}, false },
+	} {
+		leftIsBigger := Gt(this.left, this.right)
+		if leftIsBigger != this.leftShouldWin {
+			var which string
+			if leftIsBigger {
+				which = "expected right to be bigger, but left was"
+			} else {
+				which = "expected left to be bigger, but right was"
+			}
+			t.Errorf("[%d] %v compared to %v: %s", i, this.left, this.right, which)
+		}
+	}
+}
+
+func TestFirst(t *testing.T) {
+	for i, this := range []struct{
+		count int
+		sequence interface{}
+		expect interface{}
+	} {
+		{ 2, []string{"a", "b", "c"}, []string{"a", "b"} },
+		{ 3, []string{"a", "b"}, []string{"a", "b"} },
+		{ 2, []int{100, 200, 300}, []int{100, 200} },
+	} {
+		results, err := First(this.count, this.sequence)
+		if err != nil {
+			t.Errorf("[%d] failed: %s", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(results, this.expect) {
+			t.Errorf("[%d] First %d items, got %v but expected %v", i, this.count, results, this.expect)
+		}
+	}
+}


### PR DESCRIPTION
Three changes I've made to hugo while exploring migrating my site to it:
1. Add a `.Truncated` var to each page, indicating that `.Summary` is truncated from the full text, so that a "more" link can be conditional instead of having "click here for more ... oh, that was it"
2. Provide for a `.Site.Params` equivalent to page `.Params`; I'm not fixed on the name in the config file (`siteparamsbag`) but I definitely want this functionality, so that I can pull various mutating bits out to the top-level and write my layouts to reference these site variables
3. Rather than create custom slice copies of lists for new constrained lists, add a `First` function to the template parser, which can return the first "up to N" items from a list, letting me use `{{range First 5 .Site.Recent}}` in a sidebar.
