### PR TITLE
fixed trailing dir slash when using slug

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -265,7 +265,7 @@ func (p *Page) permalink() (*url.URL, error) {
 			if p.Site.Config != nil && p.Site.Config.UglyUrls {
 				permalink = path.Join(dir, p.Slug, p.Extension)
 			} else {
-				permalink = dir + "/" + p.Slug + "/"
+				permalink = path.Join(dir, p.Slug) + "/"
 			}
 		} else if len(pUrl) > 2 {
 			permalink = pUrl

--- a/hugolib/page_permalink_test.go
+++ b/hugolib/page_permalink_test.go
@@ -7,12 +7,18 @@ import (
 
 func TestPermalink(t *testing.T) {
 	tests := []struct {
+		file        string
+		dir         string
 		base        template.URL
+		slug        string
 		expectedAbs string
 		expectedRel string
 	}{
-		{"", "/x/y/z/boofar", "/x/y/z/boofar"},
-		{"http://barnew/", "http://barnew/x/y/z/boofar", "/x/y/z/boofar"},
+		{"x/y/z/boofar.md", "x/y/z", "", "", "/x/y/z/boofar", "/x/y/z/boofar"},
+		{"x/y/z/boofar.md", "x/y/z/", "", "", "/x/y/z/boofar", "/x/y/z/boofar"},
+		{"x/y/z/boofar.md", "x/y/z/", "", "boofar", "/x/y/z/boofar/", "/x/y/z/boofar/"},
+		{"x/y/z/boofar.md", "x/y/z", "http://barnew/", "", "http://barnew/x/y/z/boofar", "/x/y/z/boofar"},
+		{"x/y/z/boofar.md", "x/y/z/", "http://barnew/", "boofar", "http://barnew/x/y/z/boofar/", "/x/y/z/boofar/"},
 	}
 
 	for _, test := range tests {
@@ -21,7 +27,13 @@ func TestPermalink(t *testing.T) {
 				UrlPath: UrlPath{Section: "z"},
 				Site:    SiteInfo{BaseUrl: test.base},
 			},
-			File: File{FileName: "x/y/z/boofar.md", Dir: "x/y/z"},
+			File: File{FileName: test.file, Dir: test.dir},
+		}
+
+		if test.slug != "" {
+			p.update(map[string]interface{}{
+				"slug": test.slug,
+			})
 		}
 
 		u, err := p.Permalink()


### PR DESCRIPTION
See testcase, dir + slug contained double slash when dir had a trailing
slash.
