### PR TITLE
Fix a couple of bad commandline args in the quickstart

### DIFF
--- a/docs/content/overview/quickstart.md
+++ b/docs/content/overview/quickstart.md
@@ -31,7 +31,7 @@ Corresponding pseudo commands:
 
     git clone https://github.com/spf13/hugo
     cd hugo
-    /path/to/hugo/from/step/1/hugo server --source ./docs
+    /path/to/hugo/from/step/1/hugo server --source=./docs
     > 29 pages created
     > 0 tags index created
     > in 27 ms
@@ -46,7 +46,7 @@ Stop the Hugo process by hitting ctrl+c.
 
 Now we are going to run hugo again, but this time with hugo in watch mode.
 
-    /path/to/hugo/from/step/1/hugo server --source ./docs --watch
+    /path/to/hugo/from/step/1/hugo server --source=./docs --watch
     > 29 pages created
     > 0 tags index created
     > in 27 ms


### PR DESCRIPTION
Pflag accepts `-f arg` and `--flag=arg`, but not `-f=arg` or `--flag arg` forms (the latter was shown erroneously in the quickstart guide).
