### PR TITLE
use _default layouts for pages when rendering lists

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -220,6 +220,7 @@ func layouts(types string, layout string) (layouts []string) {
 		layouts = append(layouts, fmt.Sprintf("%s/%s.html", strings.ToLower(path.Join(search...)), layout))
 	}
 	layouts = append(layouts, fmt.Sprintf("%s.html", layout))
+	layouts = append(layouts, fmt.Sprintf("_default/%s.html", layout))
 	return
 }
 


### PR DESCRIPTION
Previously layouts in _default were used when a page was directly
rendered (ie Site.RenderPages), but not when rendered from another
template (ie Site.RenderLists).

Fixes #110, but probably isn't a good long-term solution. Reusing the 
logic in Site.RenderPages seems tricky, though.
