### PR TITLE
Create directories in publishdir with mode 0777.

### DIFF
--- a/target/file.go
+++ b/target/file.go
@@ -42,7 +42,7 @@ func writeToDisk(translated string, r io.Reader) (err error) {
 	ospath := filepath.FromSlash(path)
 
 	if ospath != "" {
-		err = os.MkdirAll(ospath, 0764) // rwx, rw, r
+		err = os.MkdirAll(ospath, 0777) // rwx, rw, r
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
The previous permissions (0764), were unusable (directories must
be executable) when generating files for use by another uid. The
Right Thing™ is to use mode 0777. The OS will subtract the process
umask (usually 022) to the for the final permissions.

This is related to issue #130
