### PR TITLE
Added append-port flag

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -23,10 +23,12 @@ import (
 
 var serverPort int
 var serverWatch bool
+var serverAppend bool
 
 func init() {
 	serverCmd.Flags().IntVarP(&serverPort, "port", "p", 1313, "port to run the server on")
 	serverCmd.Flags().BoolVarP(&serverWatch, "watch", "w", false, "watch filesystem for changes and recreate as needed")
+	serverCmd.Flags().BoolVarP(&serverAppend, "append-port", "", true, "append port to baseurl")
 }
 
 var serverCmd = &cobra.Command{
@@ -49,7 +51,11 @@ func server(cmd *cobra.Command, args []string) {
 		BaseUrl = "http://" + BaseUrl
 	}
 
-	Config.BaseUrl = strings.TrimSuffix(BaseUrl, "/") + ":" + strconv.Itoa(serverPort)
+    if serverAppend {
+        Config.BaseUrl = strings.TrimSuffix(BaseUrl, "/") + ":" + strconv.Itoa(serverPort)
+    } else {
+        Config.BaseUrl = strings.TrimSuffix(BaseUrl, "/")
+    }
 
 	build(serverWatch)
 


### PR DESCRIPTION
Hy spf13!

I've installed hugo on my production system behind nginx (reverse proxy), because I have many servers on the same box.
The automatic URL expanding in the content directory included the port number in the href attributes.
This wasn't good for me because I wanted to serve it normally (:80) on a subdomain, not exposing the "real" port number.

This pull request contains a new flag that doesn't append the port number, when given.
