### PR TITLE
Add `canonifyurls` config option.

### DIFF
--- a/docs/content/extras/urls.md
+++ b/docs/content/extras/urls.md
@@ -1,0 +1,21 @@
+---
+title: "URLs"
+date: "2014-01-03"
+aliases:
+  - "/doc/urls/"
+groups: ["extras"]
+groups_weight: 40
+---
+By default, all relative URLs encountered in the input will be canonicalized
+using `baseurl`, so that a link `/css/foo.css` becomes
+`http://yoursite.example.com/css/foo.css`.
+
+Setting `canonifyurls` to `false` will prevent this canonicalization.
+
+Benefits of canonicalization include fixing all URLs to be absolute, which may
+aid with some parsing tasks.  Note though that all real browsers handle this
+client-side without issues.
+
+Benefits of non-canonicalization include being able to have resource inclusion
+be scheme-relative, so that http vs https can be decided based on how this
+page was retrieved.

--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -30,6 +30,7 @@ The following is an example of a yaml config file with the default values:
        category: "categories"
        tag: "tags"
     baseurl: "http://yoursite.example.com/"
+    canonifyurls: true
     ...
 
 
@@ -44,7 +45,8 @@ The following is an example of a json config file with the default values:
            "category": "categories",
            "tag": "tags"
         },
-        "baseurl": "http://yoursite.example.com/"
+        "baseurl": "http://yoursite.example.com/",
+        "canonifyurls": true
     }
 
 
@@ -55,6 +57,7 @@ The following is an example of a toml config file with the default values:
     publishdir = "public"
     builddrafts = false
     baseurl = "http://yoursite.example.com/"
+    canonifyurls = true
     [indexes]
        category = "categories"
        tag = "tags"

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Params                                     map[string]interface{}
 	Permalinks                                 PermalinkOverrides
 	BuildDrafts, UglyUrls, Verbose             bool
+	CanonifyUrls							   bool
 }
 
 var c Config
@@ -61,6 +62,7 @@ func SetupConfig(cfgfile *string, path *string) *Config {
 	c.BuildDrafts = false
 	c.UglyUrls = false
 	c.Verbose = false
+	c.CanonifyUrls = true
 
 	c.readInConfig()
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -573,11 +573,17 @@ func (s *Site) render(d interface{}, out string, layouts ...string) (err error) 
 		return
 	}
 
-	absURL, err := transform.AbsURL(s.Config.BaseUrl)
-	if err != nil {
-		return
+	transformLinks := transform.NewEmptyTransforms()
+
+	if s.Config.CanonifyUrls {
+		absURL, err := transform.AbsURL(s.Config.BaseUrl)
+		if err != nil {
+			return err
+		}
+		transformLinks = append(transformLinks, absURL...)
 	}
-	transformer := transform.NewChain(absURL...)
+
+	transformer := transform.NewChain(transformLinks...)
 
 	var renderBuffer *bytes.Buffer
 

--- a/transform/chain.go
+++ b/transform/chain.go
@@ -15,6 +15,10 @@ func NewChain(trs ...link) chain {
 	return trs
 }
 
+func NewEmptyTransforms() []link {
+	return make([]link, 0, 20)
+}
+
 func (c *chain) Apply(w io.Writer, r io.Reader) (err error) {
 
 	buffer := new(bytes.Buffer)


### PR DESCRIPTION
Be able to inhibit AbsURL canonicalization of content, on a site
configuration basis.  Advantages of being able to inhibit this include
making it easier to rendering on other hostnames, and being able to
include resources on http or https depending on how this page was
retrieved, avoiding mixed-mode client complaints without adding latency
for plain http.
