### PR TITLE
Add new TableOfContents Page variable (Markdown only)

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -34,22 +34,23 @@ import (
 )
 
 type Page struct {
-	Status      string
-	Images      []string
-	RawContent  []byte
-	Content     template.HTML
-	Summary     template.HTML
-	Truncated   bool
-	plain       string // TODO should be []byte
-	Params      map[string]interface{}
-	contentType string
-	Draft       bool
-	Aliases     []string
-	Tmpl        bundle.Template
-	Markup      string
-	renderable  bool
-	layout      string
-	linkTitle   string
+	Status          string
+	Images          []string
+	RawContent      []byte
+	Content         template.HTML
+	Summary         template.HTML
+	TableOfContents template.HTML
+	Truncated       bool
+	plain           string // TODO should be []byte
+	Params          map[string]interface{}
+	contentType     string
+	Draft           bool
+	Aliases         []string
+	Tmpl            bundle.Template
+	Markup          string
+	renderable      bool
+	layout          string
+	linkTitle       string
 	PageMeta
 	File
 	Position
@@ -624,6 +625,16 @@ func (page *Page) Convert() error {
 	return nil
 }
 
+func getTableOfContents(content []byte) template.HTML {
+	htmlFlags := 0
+	htmlFlags |= blackfriday.HTML_SKIP_SCRIPT
+	htmlFlags |= blackfriday.HTML_TOC
+	htmlFlags |= blackfriday.HTML_OMIT_CONTENTS
+	renderer := blackfriday.HtmlRenderer(htmlFlags, "", "")
+
+	return template.HTML(string(blackfriday.Markdown(content, renderer, 0)))
+}
+
 func (page *Page) convertMarkdown(lines io.Reader) {
 	b := new(bytes.Buffer)
 	b.ReadFrom(lines)
@@ -631,6 +642,7 @@ func (page *Page) convertMarkdown(lines io.Reader) {
 	page.Content = template.HTML(string(blackfriday.MarkdownCommon(RemoveSummaryDivider(content))))
 	summary, truncated := getSummaryString(content, "markdown")
 	page.Summary = template.HTML(string(summary))
+	page.TableOfContents = getTableOfContents(RemoveSummaryDivider(content))
 	page.Truncated = truncated
 }
 

--- a/hugolib/page_toc_test.go
+++ b/hugolib/page_toc_test.go
@@ -1,0 +1,51 @@
+package hugolib
+
+import (
+	"testing"
+)
+
+func TestTableOfContents(t *testing.T) {
+	text := `
+Blah blah blah blah blah.
+
+## AA
+
+Blah blah blah blah blah.
+
+### AAA
+
+Blah blah blah blah blah.
+
+## BB
+
+Blah blah blah blah blah.
+
+### BBB
+
+Blah blah blah blah blah.
+`
+
+	markdown := RemoveSummaryDivider([]byte(text))
+	toc := string(getTableOfContents(markdown))
+
+	expected := `<nav>
+<ul>
+<li>
+<ul>
+<li><a href="#toc_0">AA</a>
+<ul>
+<li><a href="#toc_1">AAA</a></li>
+</ul></li>
+<li><a href="#toc_2">BB</a>
+<ul>
+<li><a href="#toc_3">BBB</a></li>
+</ul></li>
+</ul></li>
+</ul>
+</nav>
+`
+
+	if toc != expected {
+		t.Errorf("Expected table of contents: %s, got: %s", expected, toc)
+	}
+}


### PR DESCRIPTION
Added TableOfContents field to hugolib.Page struct.  New function
getTableOfContents is used in convertMarkdown to set the TableOfContents
field.

Added new test file hugolib/page_toc_test.go with a simple test of the
new functionality.

Pull request for issue #153.
