### PR TITLE
Fix panic with HTTP serve initialization problems.

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -83,5 +84,10 @@ func serve(port int) {
 	}
 
 	fmt.Println("Press ctrl+c to stop")
-	panic(http.ListenAndServe(":"+strconv.Itoa(port), http.FileServer(http.Dir(Config.GetAbsPath(Config.PublishDir)))))
+
+	err := http.ListenAndServe(":"+strconv.Itoa(port), http.FileServer(http.Dir(Config.GetAbsPath(Config.PublishDir))))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Hi,

I just made a little patch to try handling errors when HTTP serve starts. It prevents panic when address and port are already use by example.

Let me know if it suits to you.

Regards,

Vincent
