### PR TITLE
Fixing issues go vet reports.

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -213,12 +213,12 @@ func NewWatcher(port int) error {
 				}
 
 				if static_changed {
-					fmt.Println("Static file changed, syncing\n")
+					fmt.Print("Static file changed, syncing\n\n")
 					utils.CheckErr(copyStatic(), fmt.Sprintf("Error copying static files to %s", Config.GetAbsPath(Config.PublishDir)))
 				}
 
 				if dynamic_changed {
-					fmt.Println("Change detected, rebuilding site\n")
+					fmt.Print("Change detected, rebuilding site\n\n")
 					utils.StopOnErr(buildSite(true))
 				}
 			case err := <-watcher.Error:

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -116,5 +116,4 @@ func PrettifyPath(in string) string {
 			return path.Join(path.Dir(in), name, "index"+ext)
 		}
 	}
-	return in
 }

--- a/helpers/url.go
+++ b/helpers/url.go
@@ -105,6 +105,4 @@ func Uglify(in string) string {
 			return path.Clean(in)
 		}
 	}
-
-	return in
 }

--- a/hugolib/benchmark_test.go
+++ b/hugolib/benchmark_test.go
@@ -12,7 +12,6 @@ func BenchmarkParsePage(b *testing.B) {
 	sample.ReadFrom(f)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		p, _ := ReadFrom(bytes.NewReader(sample.Bytes()), "bench")
-		p = p
+		ReadFrom(bytes.NewReader(sample.Bytes()), "bench")
 	}
 }

--- a/hugolib/metadata.go
+++ b/hugolib/metadata.go
@@ -17,9 +17,9 @@ func interfaceToTime(i interface{}) time.Time {
 		if e == nil {
 			return d
 		}
-		errorf("Could not parse Date/Time format:", e)
+		errorln("Could not parse Date/Time format:", e)
 	default:
-		errorf("Only Time is supported for this key")
+		errorln("Only Time is supported for this key")
 	}
 
 	return *new(time.Time)
@@ -54,7 +54,7 @@ func stringToDate(s string) (time.Time, error) {
 }
 
 // TODO remove this and return a proper error.
-func errorf(str string, a ...interface{}) {
+func errorln(str string, a ...interface{}) {
 	fmt.Fprintln(os.Stderr, str, a)
 }
 
@@ -77,7 +77,7 @@ func interfaceToBool(i interface{}) bool {
 		}
 		return false
 	default:
-		errorf("Only Boolean values are supported for this YAML key")
+		errorln("Only Boolean values are supported for this YAML key")
 	}
 
 	return false
@@ -109,11 +109,11 @@ func interfaceToFloat64(i interface{}) float64 {
 		if err == nil {
 			return float64(v)
 		} else {
-			errorf("Only Floats are supported for this key\nErr:", err)
+			errorln("Only Floats are supported for this key\nErr:", err)
 		}
 
 	default:
-		errorf("Only Floats are supported for this key")
+		errorln("Only Floats are supported for this key")
 	}
 
 	return 0.0
@@ -136,10 +136,10 @@ func interfaceToInt(i interface{}) int {
 		if err == nil {
 			return int(v)
 		} else {
-			errorf("Only Ints are supported for this key\nErr:", err)
+			errorln("Only Ints are supported for this key\nErr:", err)
 		}
 	default:
-		errorf("Only Ints are supported for this key")
+		errorln("Only Ints are supported for this key")
 	}
 
 	return 0
@@ -154,7 +154,7 @@ func interfaceToString(i interface{}) string {
 	case int:
 		return strconv.FormatInt(int64(i.(int)), 10)
 	default:
-		errorf(fmt.Sprintf("Only Strings are supported for this key (got type '%T'): %s", s, s))
+		errorln(fmt.Sprintf("Only Strings are supported for this key (got type '%T'): %s", s, s))
 	}
 
 	return ""

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -457,10 +457,10 @@ func TestDifferentFrontMatterVarTypes(t *testing.T) {
 		t.Errorf("frontmatter not handling ints correctly should be %s, got: %s", "1", page.GetParam("an_integer"))
 	}
 	if page.GetParam("a_float") != 1.3 {
-		t.Errorf("frontmatter not handling floats correctly should be %s, got: %s", 1.3, page.GetParam("a_float"))
+		t.Errorf("frontmatter not handling floats correctly should be %f, got: %s", 1.3, page.GetParam("a_float"))
 	}
 	if page.GetParam("a_bool") != false {
-		t.Errorf("frontmatter not handling bools correctly should be %s, got: %s", false, page.GetParam("a_bool"))
+		t.Errorf("frontmatter not handling bools correctly should be %t, got: %s", false, page.GetParam("a_bool"))
 	}
 	if page.GetParam("a_date") != dateval {
 		t.Errorf("frontmatter not handling dates correctly should be %s, got: %s", dateval, page.GetParam("a_date"))

--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -34,7 +34,7 @@ func TestRSSOutput(t *testing.T) {
 	s := &Site{
 		Target: target,
 		Config: Config{BaseUrl: "http://auth/bub/"},
-		Source: &source.InMemorySource{WEIGHTED_SOURCES},
+		Source: &source.InMemorySource{ByteSource: WEIGHTED_SOURCES},
 	}
 	s.initializeSiteInfo()
 	s.prepTemplates()

--- a/hugolib/site_show_plan_test.go
+++ b/hugolib/site_show_plan_test.go
@@ -41,7 +41,7 @@ func TestDegenerateNoFiles(t *testing.T) {
 
 func TestDegenerateNoTarget(t *testing.T) {
 	s := &Site{
-		Source: &source.InMemorySource{fakeSource},
+		Source: &source.InMemorySource{ByteSource: fakeSource},
 	}
 	must(s.CreatePages())
 	expected := "foo/bar/file.md (renderer: markdown)\n canonical => !no target specified!\n\n" +
@@ -52,7 +52,7 @@ func TestDegenerateNoTarget(t *testing.T) {
 
 func TestFileTarget(t *testing.T) {
 	s := &Site{
-		Source: &source.InMemorySource{fakeSource},
+		Source: &source.InMemorySource{ByteSource: fakeSource},
 		Target: new(target.Filesystem),
 		Alias:  new(target.HTMLRedirectAlias),
 	}
@@ -70,7 +70,7 @@ func TestFileTarget(t *testing.T) {
 func TestFileTargetUgly(t *testing.T) {
 	s := &Site{
 		Target: &target.Filesystem{UglyUrls: true},
-		Source: &source.InMemorySource{fakeSource},
+		Source: &source.InMemorySource{ByteSource: fakeSource},
 		Alias:  new(target.HTMLRedirectAlias),
 	}
 	s.CreatePages()
@@ -86,7 +86,7 @@ func TestFileTargetUgly(t *testing.T) {
 func TestFileTargetPublishDir(t *testing.T) {
 	s := &Site{
 		Target: &target.Filesystem{PublishDir: "../public"},
-		Source: &source.InMemorySource{fakeSource},
+		Source: &source.InMemorySource{ByteSource: fakeSource},
 		Alias:  &target.HTMLRedirectAlias{PublishDir: "../public"},
 	}
 

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -239,7 +239,7 @@ func TestSkipRender(t *testing.T) {
 			BaseUrl:      "http://auth/bub",
 			CanonifyUrls: true,
 		},
-		Source: &source.InMemorySource{sources},
+		Source: &source.InMemorySource{ByteSource: sources},
 	}
 
 	s.initializeSiteInfo()
@@ -301,7 +301,7 @@ func TestAbsUrlify(t *testing.T) {
 				BaseUrl:      "http://auth/bub",
 				CanonifyUrls: canonify,
 			},
-			Source: &source.InMemorySource{sources},
+			Source: &source.InMemorySource{ByteSource: sources},
 		}
 		t.Logf("Rendering with BaseUrl %q and CanonifyUrls set %v", s.Config.BaseUrl, canonify)
 		s.initializeSiteInfo()
@@ -383,7 +383,7 @@ func TestOrderedPages(t *testing.T) {
 	s := &Site{
 		Target: target,
 		Config: Config{BaseUrl: "http://auth/bub/"},
-		Source: &source.InMemorySource{WEIGHTED_SOURCES},
+		Source: &source.InMemorySource{ByteSource: WEIGHTED_SOURCES},
 	}
 	s.initializeSiteInfo()
 
@@ -396,7 +396,7 @@ func TestOrderedPages(t *testing.T) {
 	}
 
 	if s.Sections["sect"][0].Weight != 2 || s.Sections["sect"][3].Weight != 6 {
-		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", 2, s.Sections["sect"][0].Weight)
+		t.Errorf("Pages in unexpected order. First should be '%d', got '%d'", 2, s.Sections["sect"][0].Weight)
 	}
 
 	if s.Sections["sect"][1].Page.Title != "Three" || s.Sections["sect"][2].Page.Title != "Four" {
@@ -469,7 +469,7 @@ func TestWeightedIndexes(t *testing.T) {
 	s := &Site{
 		Target: target,
 		Config: Config{BaseUrl: "http://auth/bub/", Indexes: indexes},
-		Source: &source.InMemorySource{sources},
+		Source: &source.InMemorySource{ByteSource: sources},
 	}
 	s.initializeSiteInfo()
 

--- a/hugolib/site_url_test.go
+++ b/hugolib/site_url_test.go
@@ -55,7 +55,7 @@ func TestPageCount(t *testing.T) {
 		Target: target,
 		Alias:  alias,
 		Config: Config{UglyUrls: false},
-		Source: &source.InMemorySource{urlFakeSource},
+		Source: &source.InMemorySource{ByteSource: urlFakeSource},
 	}
 	s.initializeSiteInfo()
 	s.prepTemplates()

--- a/parser/page.go
+++ b/parser/page.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"unicode"
@@ -106,7 +105,6 @@ func chompWhitespace(r io.RuneScanner) (err error) {
 			return nil
 		}
 	}
-	return
 }
 
 func peekLine(r *bufio.Reader) (line []byte, err error) {
@@ -165,7 +163,6 @@ func determineDelims(firstLine []byte) (left, right []byte) {
 	default:
 		panic(fmt.Sprintf("Unable to determine delims from %q", firstLine))
 	}
-	return
 }
 
 func extractFrontMatterDelims(r *bufio.Reader, left, right []byte) (fm FrontMatter, err error) {
@@ -243,7 +240,6 @@ func extractFrontMatterDelims(r *bufio.Reader, left, right []byte) (fm FrontMatt
 			return wr.Bytes(), nil
 		}
 	}
-	return nil, errors.New("Could not find front matter.")
 }
 
 func matches_quick(buf, expected []byte) (ok bool, err error) {


### PR DESCRIPTION
Running go vet uncovered a few style issues.

1) Several unreachable returns (no longer necessary because hugo requires go >= 1.1)
2) Several creations of source.InMemorySource not using the field's name when creating an instance (really only in tests).
3) A few incorrect types in formatting directives for printf
4) Renaming errorf -> errorln to no longer imply it takes a formatting argument (which confused go vet and anyone using the function).
