### PR TITLE
Also ignore Emacs lock & recovery files.

### DIFF
--- a/source/filesystem.go
+++ b/source/filesystem.go
@@ -122,6 +122,10 @@ func ignoreDotFile(filePath string) bool {
 		return true
 	}
 
+	if base[0] == '#' {
+		return true
+	}
+
 	if base[len(base)-1] == '~' {
 		return true
 	}


### PR DESCRIPTION
I was excited to see the recent commit to ignore *~ files.  Having just started using Hugo & being an Emacs user, that was really bothering me.  It would also be useful to ignore Emacs' #* files, which this trivial addition does.

Thx
