### PR TITLE
change golang to go

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and [friends](http://github.com/spf13/hugo/graphs/contributors) in Go.
 
 ## Overview
 
-Hugo is a static site generator written in GoLang. It is optimized for
+Hugo is a static site generator written in Go. It is optimized for
 speed, easy use and configurability. Hugo takes a directory with content and
 templates and renders them into a full html website.
 
@@ -26,7 +26,7 @@ kind of website including blogs, tumbles and docs.
 
 ## Installing Hugo
 
-Hugo is written in GoLang with support for Windows, Linux, FreeBSD and OSX.
+Hugo is written in Go with support for Windows, Linux, FreeBSD and OSX.
 
 The latest release can be found at [hugo releases](https://github.com/spf13/hugo/releases).
 We currently build for Windows, Linux, FreeBSD and OS X for x64

--- a/docs/content/community/contributors.md
+++ b/docs/content/community/contributors.md
@@ -7,7 +7,7 @@ groups_weight: 40
 notoc: true
 ---
 
-Hugo was built with love and golang by:
+Hugo was built with love and Go by:
 
 * Steve Francia - [spf13](https://github.com/spf13)
 * Noah Campbell - [noahcampbell](https://github.com/noahcampbell)

--- a/docs/content/content/example.md
+++ b/docs/content/content/example.md
@@ -14,22 +14,22 @@ Somethings are better shown than explained. The following is a very basic exampl
 
 {{% highlight yaml %}}
 ---
-Title:       "Nitro : A quick and simple profiler for golang"
+Title:       "Nitro : A quick and simple profiler for Go"
 Description: "Nitro is a simple profiler for you go lang applications"
-Tags:        [ "Development", "golang", "profiling" ]
+Tags:        [ "Development", "Go", "profiling" ]
 date:        "2013-06-19"
-Topics:      [ "Development", "GoLang" ]
+Topics:      [ "Development", "Go" ]
 Slug:        "nitro"
 project_url: "http://github.com/spf13/nitro"
 ---
 
 # Nitro
 
-Quick and easy performance analyzer library for golang.
+Quick and easy performance analyzer library for Go.
 
 ## Overview
 
-Nitro is a quick and easy performance analyzer library for golang.
+Nitro is a quick and easy performance analyzer library for Go.
 It is useful for comparing A/B against different drafts of functions
 or different functions.
 

--- a/docs/content/indexes/category.md
+++ b/docs/content/indexes/category.md
@@ -55,7 +55,7 @@ Make sure that the index is set in the front matter:
     "title": "Hugo: A fast and flexible static site generator",
     "categories": [
         "Development",
-        "golang",
+        "Go",
         "Blogging"
     ],
     "slug": "hugo"

--- a/docs/content/indexes/overview.md
+++ b/docs/content/indexes/overview.md
@@ -18,8 +18,8 @@ It's important to understand what Indexes do. At it's most basic form an index
 is simply a map of a key to a list of content values.
 
 In the hugo internals this is stored as `Site.Indexes[Plural][key][]pages`.
-For example all the content tagged with GoLang would be found at 
-`Site.Indexes["tags"]["golang"]`.
+For example all the content tagged with Go would be found at 
+`Site.Indexes["tags"]["Go"]`.
 
 For a
 more complete example see the source of [this docs site](http://github.com/spf13/hugo/docs/).
@@ -65,7 +65,7 @@ and assign all keys you want this content to match against.
     "title": "Hugo: A fast and flexible static site generator",
     "tags": [
         "Development",
-        "golang",
+        "Go",
         "fast",
         "Blogging"
     ],

--- a/docs/content/layout/functions.md
+++ b/docs/content/layout/functions.md
@@ -6,7 +6,7 @@ groups: ["layout"]
 groups_weight: 70
 ---
 
-Hugo uses the excellent golang html/template library for its template engine.
+Hugo uses the excellent go html/template library for its template engine.
 It is an extremely lightweight engine that provides a very small amount of
 logic. In our experience that it is just the right amount of logic to be able
 to create a good static website.
@@ -14,7 +14,7 @@ to create a good static website.
 Go templates are lightweight but extensible. Hugo has added the following
 functions to the basic template logic.
 
-Golang documentation for the built-in functions can be found [here](http://golang.org/pkg/text/template/)
+Go documentation for the built-in functions can be found [here](http://golang.org/pkg/text/template/)
 
 ## General
 

--- a/docs/content/layout/go-templates.md
+++ b/docs/content/layout/go-templates.md
@@ -5,14 +5,14 @@ groups: ["layout"]
 groups_weight: 15
 ---
 
-Hugo uses the excellent [golang][] [html/template][gohtmltemplate] library for
+Hugo uses the excellent [go][] [html/template][gohtmltemplate] library for
 its template engine. It is an extremely lightweight engine that provides a very
 small amount of logic. In our experience that it is just the right amount of
 logic to be able to create a good static website. If you have used other
 template systems from different languages or frameworks you will find a lot of
 similarities in go templates.
 
-This document is a brief primer on using go templates. The [golang docs][gohtmltemplate]
+This document is a brief primer on using go templates. The [go docs][gohtmltemplate]
 provide more details.
 
 ## Introduction to Go Templates
@@ -23,7 +23,7 @@ One consequence of this simplicity is that go templates parse very quickly.
 
 A unique characteristic of go templates is they are content aware. Variables and
 content will be sanitized depending on the context of where they are used. More
-details can be found in the [golang docs][gohtmltemplate].
+details can be found in the [go docs][gohtmltemplate].
 
 ## Basic Syntax
 
@@ -217,7 +217,7 @@ Could be rewritten as
 
 ## Context (aka. the dot)
 
-The most easily overlooked concept to understand about golang templates is that {{ . }}
+The most easily overlooked concept to understand about go templates is that {{ . }}
 always refers to the current context. In the top level of your template this
 will be the data set made available to it. Inside of a iteration it will have
 the value of the current item. When inside of a loop the context has changed. .
@@ -329,5 +329,5 @@ so, such as in this example:
 ```
 
 
-[golang]: <http://golang.org/>
+[go]: <http://golang.org/>
 [gohtmltemplate]: <http://golang.org/pkg/html/template/>

--- a/docs/content/layout/templates.md
+++ b/docs/content/layout/templates.md
@@ -7,7 +7,7 @@ groups: ["layout"]
 groups_weight: 10
 ---
 
-Hugo uses the excellent golang html/template library for its template engine.
+Hugo uses the excellent go html/template library for its template engine.
 It is an extremely lightweight engine that provides a very small amount of
 logic. In our experience that it is just the right amount of logic to be able
 to create a good static website

--- a/docs/content/overview/installing.md
+++ b/docs/content/overview/installing.md
@@ -6,7 +6,7 @@ groups: ['gettingStarted']
 groups_weight: 20
 ---
 
-Hugo is written in GoLang with support for Windows, Linux, FreeBSD and OSX.
+Hugo is written in Go with support for Windows, Linux, FreeBSD and OSX.
 
 The latest release can be found at [hugo releases](https://github.com/spf13/hugo/releases).
 We currently build for Windows, Linux, FreeBSD and OS X for x64

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -152,7 +152,7 @@
                       <div class="item"> <blockquote><p>Finally someone builds me my own static site generator </p>&mdash; Hugo Rodger-Brown (@hugorodgerbrown) <a href="https://twitter.com/hugorodgerbrown/statuses/364417910153818112">August 5, 2013</a></blockquote> </div>
                       <div class="item"> <blockquote><p>I&#39;m loving the static site generator renaissance we are currently enjoying. Hugo is new, looks great, written in Go</p>&mdash; Jim Biancolo (@jimbiancolo) <a href="https://twitter.com/jimbiancolo/statuses/408678420348813314">December 5, 2013</a></blockquote> </div>
                       <div class="item"> <blockquote><p>Good work on Hugo, I&#39;m impressed with the speed!</p>&mdash; Ludovic Chabant (@ludovicchabant) <a href="https://twitter.com/ludovicchabant/statuses/408806199602053120">December 6, 2013</a></blockquote> </div>
-                      <div class="item"> <blockquote><p>Checking out Hugo; Loving it so far. Like Jekyll but not so blog-oriented and written in golang</p>&mdash; Jose Gonzalvo (@jgonzalvo) <a href="https://twitter.com/jgonzalvo/statuses/408177855819173888">December 4, 2013</a></blockquote> </div>
+                      <div class="item"> <blockquote><p>Checking out Hugo; Loving it so far. Like Jekyll but not so blog-oriented and written in go</p>&mdash; Jose Gonzalvo (@jgonzalvo) <a href="https://twitter.com/jgonzalvo/statuses/408177855819173888">December 4, 2013</a></blockquote> </div>
                   </div>
 
                 </div>

--- a/hugolib/index.go
+++ b/hugolib/index.go
@@ -28,7 +28,7 @@ type IndexList map[string]Index
  *  An index is a map of keywords to a list of pages.
  *  For example
  *    TagIndex['technology'] = WeightedPages
- *    TagIndex['golang']  =  WeightedPages2
+ *    TagIndex['go']  =  WeightedPages2
  */
 type Index map[string]WeightedPages
 


### PR DESCRIPTION
Golang is generally regarded as acceptable as a hashtag, or a tag on a post, but is discouraged as a conversational word.
