### PR TITLE
Fix permalinks to subdomains

### DIFF
--- a/hugolib/permalinks.go
+++ b/hugolib/permalinks.go
@@ -26,9 +26,6 @@ var knownPermalinkAttributes map[string]PageToPermaAttribute
 
 // validate determines if a PathPattern is well-formed
 func (pp PathPattern) validate() bool {
-	if pp[0] != '/' {
-		return false
-	}
 	fragments := strings.Split(string(pp[1:]), "/")
 	var bail = false
 	for i := range fragments {

--- a/hugolib/permalinks_test.go
+++ b/hugolib/permalinks_test.go
@@ -14,9 +14,8 @@ var testdataPermalinks = []struct {
 }{
 	{"/:year/:month/:title/", true, "/2012/04/spf13-vim-3.0-release-and-new-website/"},
 	{"/:title", true, "/spf13-vim-3.0-release-and-new-website"},
-	{":title", false, ""},
+	{":title", true, "spf13-vim-3.0-release-and-new-website"},
 	{"/blog/:year/:yearday/:title", true, "/blog/2012/97/spf13-vim-3.0-release-and-new-website"},
-	{":fred", false, ""},
 	{"/blog/:fred", false, ""},
 	{"/:year//:title", false, ""},
 	{


### PR DESCRIPTION
Alright, so I know I opened issue #230 a while ago, decided to just bite the bullet and PR a fix.

To review, the issue was that, if a site is hosted at a subdomain, eg `tummychow.github.io/myproject`, you can't use custom permalinks, because the permalinks have to begin with a slash. The slash indicates a URL starting from the root domain, so Go's URL resolution library sees the slash and discards any subdomains. Therefore, if you have a baseurl of `yoursite.com/yoursubdomain`, and your permalinks are `/:title`, then permalinks will be resolved to `yoursite.com/:title` instead of `yoursite.com/yoursubdomain/:title`.

The fix for this is pretty simple, I just took out the check in permalinks.go that requires the leading slash. If you specify permalinks without a leading slash, then they'll be relative to the baseurl including subdomains, which resolves the issue. I also corrected any tests that were broken by the change. Let me know what you think.
