### PR TITLE
Don't process dotfiles

### DIFF
--- a/source/content_directory_test.go
+++ b/source/content_directory_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 )
 
-func TestIgnoreDotFiles(t *testing.T) {
+func TestIgnoreDotFilesAndDirectories(t *testing.T) {
 	tests := []struct {
 		path   string
 		ignore bool
 	}{
+		{".foobar/", true },
+		{"foobar/.barfoo/", true },
 		{"barfoo.md", false},
 		{"foobar/barfoo.md", false},
 		{"foobar/.barfoo.md", true},
@@ -22,7 +24,7 @@ func TestIgnoreDotFiles(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if ignored := ignoreDotFile(test.path); test.ignore != ignored {
+		if ignored := isNonProcessablePath(test.path); test.ignore != ignored {
 			t.Errorf("File not ignored.  Expected: %t, got: %t", test.ignore, ignored)
 		}
 	}

--- a/source/filesystem.go
+++ b/source/filesystem.go
@@ -87,12 +87,12 @@ func (f *Filesystem) captureFiles() {
 		}
 
 		if fi.IsDir() {
-			if f.avoid(filePath) {
+			if f.avoid(filePath) || isNonProcessablePath(filePath) {
 				return filepath.SkipDir
 			}
 			return nil
 		} else {
-			if ignoreDotFile(filePath) {
+			if isNonProcessablePath(filePath) {
 				return nil
 			}
 			data, err := ioutil.ReadFile(filePath)
@@ -116,7 +116,7 @@ func (f *Filesystem) avoid(filePath string) bool {
 	return false
 }
 
-func ignoreDotFile(filePath string) bool {
+func isNonProcessablePath(filePath string) bool {
 	base := filepath.Base(filePath)
 	if base[0] == '.' {
 		return true


### PR DESCRIPTION
This commit makes it so that not only files
but also folders which start with a dot
are ignored.

Fixes #239

I basically just renamed `ignoreDotFile` to `isNonProcessablePath` to be more generic and allow broader use. Then I extended the path check that was already in place.
