### PR TITLE
Update broken localhost link in migrate-from-jekyll tut

### DIFF
--- a/docs/content/tutorials/migrate-from-jekyll.md
+++ b/docs/content/tutorials/migrate-from-jekyll.md
@@ -45,7 +45,7 @@ git submodule add -b gh-pages git@github.com:your-username/your-repo.git public
 {{% /highlight %}}
 
 ## Convert Jekyll templates to Hugo templates
-That's the bulk of the work right here. The documentation is your friend. You should refer to [Jekyll's template documentation](http://jekyllrb.com/docs/templates/) if you need to refresh your memory on how you built your blog and [Hugo's template](http://localhost:1313/layout/templates/) to learn Hugo's way. 
+That's the bulk of the work right here. The documentation is your friend. You should refer to [Jekyll's template documentation](http://jekyllrb.com/docs/templates/) if you need to refresh your memory on how you built your blog and [Hugo's template](/layout/templates/) to learn Hugo's way. 
 
 As a single reference data point, converting my templates for [heyitsalex.net](http://heyitsalex.net) took me no more than a few hours. 
 


### PR DESCRIPTION
Looks like this one slipped through
