### PR TITLE
Correctly print server URL when base-url is specified in the command line

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -79,11 +79,7 @@ func server(cmd *cobra.Command, args []string) {
 func serve(port int) {
 	jww.FEEDBACK.Println("Serving pages from " + helpers.AbsPathify(viper.GetString("PublishDir")))
 
-	if BaseUrl == "" {
-		jww.FEEDBACK.Printf("Web Server is available at %s\n", viper.GetString("BaseUrl"))
-	} else {
-		jww.FEEDBACK.Printf("Web Server is available at http://localhost:%v\n", port)
-	}
+	jww.FEEDBACK.Printf("Web Server is available at %s\n", viper.GetString("BaseUrl"))
 
 	fmt.Println("Press ctrl+c to stop")
 


### PR DESCRIPTION
When running hugo server like:

```
$ hugo server -s docs -b myhostname
```

the printed output now directs to http://myhostname:1313 instead of
(invariably) http://localhost:1313.

As per server(), BaseUrl is never empty, and the required value is always
found in Viper.
