### PR TITLE
Fix date issue with home page in Sitemap

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -759,6 +759,7 @@ func (s *Site) RenderSitemap() error {
 	pages := make(Pages, 0)
 
 	page := &Page{}
+	page.Date = s.Info.LastChange
 	page.Site = s.Info
 	page.Url = "/"
 


### PR DESCRIPTION
An issue is present with Sitemap support, not handling the home page date when generating the `sitemap.xml` file.

The issue was discussed in #275 and this little change corrects this.

NB: thanks to @LK4D4 for pointing this out.
