### PR TITLE
Make template comparison functions handle floats

### DIFF
--- a/hugolib/template.go
+++ b/hugolib/template.go
@@ -25,47 +25,51 @@ func Ne(x, y interface{}) bool {
 }
 
 func Ge(a, b interface{}) bool {
-	left, right := compareGetInt(a, b)
+	left, right := compareGetFloat(a, b)
 	return left >= right
 }
 
 func Gt(a, b interface{}) bool {
-	left, right := compareGetInt(a, b)
+	left, right := compareGetFloat(a, b)
 	return left > right
 }
 
 func Le(a, b interface{}) bool {
-	left, right := compareGetInt(a, b)
+	left, right := compareGetFloat(a, b)
 	return left <= right
 }
 
 func Lt(a, b interface{}) bool {
-	left, right := compareGetInt(a, b)
+	left, right := compareGetFloat(a, b)
 	return left < right
 }
 
-func compareGetInt(a interface{}, b interface{}) (int64, int64) {
-	var left, right int64
+func compareGetFloat(a interface{}, b interface{}) (float64, float64) {
+	var left, right float64
 	av := reflect.ValueOf(a)
 
 	switch av.Kind() {
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
-		left = int64(av.Len())
+		left = float64(av.Len())
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		left = av.Int()
+		left = float64(av.Int())
+	case reflect.Float32, reflect.Float64:
+		left = av.Float()
 	case reflect.String:
-		left, _ = strconv.ParseInt(av.String(), 10, 64)
+		left, _ = strconv.ParseFloat(av.String(), 64)
 	}
 
 	bv := reflect.ValueOf(b)
 
 	switch bv.Kind() {
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
-		right = int64(bv.Len())
+		right = float64(bv.Len())
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		right = bv.Int()
+		right = float64(bv.Int())
+	case reflect.Float32, reflect.Float64:
+		right = bv.Float()
 	case reflect.String:
-		right, _ = strconv.ParseInt(bv.String(), 10, 64)
+		right, _ = strconv.ParseFloat(bv.String(), 64)
 	}
 
 	return left, right

--- a/hugolib/template_test.go
+++ b/hugolib/template_test.go
@@ -16,6 +16,8 @@ func TestGt(t *testing.T) {
 		{5, 5, false},
 		{-2, 1, false},
 		{2, -5, true},
+		{0.0, 1.23, false},
+		{1.23, 0.0, true},
 		{"8", "5", true},
 		{"5", "0001", true},
 		{[]int{100, 99}, []int{1, 2, 3, 4}, false},


### PR DESCRIPTION
I modified the template comparison functions to add `float` type handling.

Indeed when dealing with floats, the current functions treat them as `0`, making `ge` and `le` returning `true` no matter `a` and `b` values.
