### PR TITLE
Fix permalinks

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -265,9 +265,9 @@ func (s *Site) initializeSiteInfo() {
 		params = make(map[string]interface{})
 	}
 
-	permalinks, ok := viper.Get("Permalinks").(PermalinkOverrides)
-	if !ok {
-		permalinks = make(PermalinkOverrides)
+	permalinks := make(PermalinkOverrides)
+	for k, v := range viper.GetStringMapString("Permalinks") {
+		permalinks[k] = PathPattern(v)
 	}
 
 	s.Info = SiteInfo{

--- a/hugolib/siteinfo_test.go
+++ b/hugolib/siteinfo_test.go
@@ -30,3 +30,15 @@ func TestSiteInfoParams(t *testing.T) {
 		t.Errorf("Expected FOOBAR_PARAM: got %s", buf.String())
 	}
 }
+
+func TestSiteInfoPermalinks (t *testing.T) {
+	viper.Set("Permalinks", map[string]interface{}{"section": "/:title"})
+	s := &Site{}
+
+	s.initialize()
+	permalink := s.Info.Permalinks["section"]
+
+	if permalink != "/:title" {
+		t.Errorf("Could not set permalink (%#v)", permalink)
+	}
+}


### PR DESCRIPTION
SiteInfo.Permalinks wasn’t being initialized correctly after 62dd1d45c12193ac5ad95a4f491dfcdbcad7be7a.
