### PR TITLE
Add a blank line after the front matter when writing back a page

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -570,6 +570,7 @@ func (page *Page) SetSourceMetaData(in interface{}, mark rune) (err error) {
 	if err != nil {
 		return err
 	}
+	by = append(by, '\n')
 
 	page.sourceFrontmatter = by
 


### PR DESCRIPTION
Could also be done in parser.InterfaceToFrontMatter(), but logically the
extra blank line belongs to the page, not the front matter itself.
