### PR TITLE
Include Section Taxonomy into SiteInfo

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -565,6 +565,9 @@ func (s *Site) RenderPages() (err error) {
 				layouts = append(layouts, p.Layout()...)
 				layouts = append(layouts, "_default/single.html")
 			}
+			// Page is a node, which has Site info passed as value
+			// hence we need to refresh it before rendering
+			p.Site = s.Info
 
 			return s.render(p, p.TargetPath(), s.appendThemeTemplates(layouts)...)
 		}(page)


### PR DESCRIPTION
This allows to build more complex pages, like :
http://martinfowler.com/tags/
