### PR TITLE
Fix Viperized .Site.Params

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -260,9 +260,17 @@ func (s *Site) initialize() (err error) {
 }
 
 func (s *Site) initializeSiteInfo() {
-	params, ok := viper.Get("Params").(map[string]interface{})
+	paramsV, ok := viper.Get("Params").(map[interface{}]interface{})
+	// Warning: viper.Get(map_item) returns map[interface{}]interface{}
+	// even if .SetDefault called with a map[string]interface{}
 	if !ok {
-		params = make(map[string]interface{})
+		paramsV = make(map[interface{}]interface{})
+	}
+	params := make(map[string]interface{}, len(paramsV))
+	for k, v := range paramsV {
+		if s, ok := k.(string); ok {
+			params[s] = v
+		}
 	}
 
 	permalinks := make(PermalinkOverrides)


### PR DESCRIPTION
git bisect identified 62dd1d4 as the breaking commit; when
github.com/spf13/viper was introduced, the Params field was always
empty.

Given a map in YAML in Viper, the return type is
`map[interface{}]interface{}`, _not_ `map[string]interface{}`, even if
`.SetDefault()` has been called with an item of
`map[string]interface{}{}` so the cast assertion on the `.Get("Params")`
always failed.
