### PR TITLE
Add support for embedding script tags in markdown pages.

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -652,7 +652,6 @@ func (page *Page) Convert() error {
 
 func markdownRender(content []byte) []byte {
 	htmlFlags := 0
-	htmlFlags |= blackfriday.HTML_SKIP_SCRIPT
 	htmlFlags |= blackfriday.HTML_USE_XHTML
 	htmlFlags |= blackfriday.HTML_USE_SMARTYPANTS
 	htmlFlags |= blackfriday.HTML_SMARTYPANTS_FRACTIONS
@@ -672,7 +671,6 @@ func markdownRender(content []byte) []byte {
 
 func markdownRenderWithTOC(content []byte) []byte {
 	htmlFlags := 0
-	htmlFlags |= blackfriday.HTML_SKIP_SCRIPT
 	htmlFlags |= blackfriday.HTML_TOC
 	htmlFlags |= blackfriday.HTML_USE_XHTML
 	htmlFlags |= blackfriday.HTML_USE_SMARTYPANTS

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -120,6 +120,12 @@ More text here.
 Some more text
 `
 
+	SIMPLE_PAGE_WITH_EMBEDDED_SCRIPT = `---
+title: Simple
+---
+<script type='text/javascript'>alert('the script tags are still there, right?');</script>
+`
+
 	SIMPLE_PAGE_WITH_SUMMARY_DELIMITER_SAME_LINE = `---
 title: Simple
 ---
@@ -338,6 +344,16 @@ func TestPageWithShortCodeInSummary(t *testing.T) {
 	checkPageSummary(t, p, "Summary Next Line. . More text here. Some more text")
 	checkPageType(t, p, "page")
 	checkPageLayout(t, p, "page/single.html", "single.html")
+}
+
+func TestPageWithEmbeddedScriptTag(t *testing.T) {
+	p, _ := NewPage("simple.md")
+	err := p.ReadFrom(strings.NewReader(SIMPLE_PAGE_WITH_EMBEDDED_SCRIPT))
+	p.Convert()
+	if err != nil {
+		t.Fatalf("Unable to create a page with frontmatter and body content: %s", err)
+	}
+	checkPageContent(t, p, "<script type='text/javascript'>alert('the script tags are still there, right?');</script>\n")
 }
 
 func TestTableOfContents(t *testing.T) {


### PR DESCRIPTION
Disabled by default, but can be enabled on a per-page basis using the 'allowscripts' frontmatter.
