### PR TITLE
switch back to master blackfriday; enable footnotes

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/hugo/parser"
 	jww "github.com/spf13/jwalterweatherman"
 	"github.com/spf13/viper"
-	"github.com/theplant/blackfriday"
+	"github.com/russross/blackfriday"
 )
 
 type Page struct {
@@ -652,11 +652,12 @@ func (page *Page) Convert() error {
 
 func markdownRender(content []byte) []byte {
 	htmlFlags := 0
-	htmlFlags |= blackfriday.HTML_SKIP_SCRIPT
+	//htmlFlags |= blackfriday.HTML_SKIP_SCRIPT // not present in blackfriday
 	htmlFlags |= blackfriday.HTML_USE_XHTML
 	htmlFlags |= blackfriday.HTML_USE_SMARTYPANTS
 	htmlFlags |= blackfriday.HTML_SMARTYPANTS_FRACTIONS
 	htmlFlags |= blackfriday.HTML_SMARTYPANTS_LATEX_DASHES
+	htmlFlags |= blackfriday.HTML_FOOTNOTE_RETURN_LINKS
 	renderer := blackfriday.HtmlRenderer(htmlFlags, "", "")
 
 	extensions := 0
@@ -666,18 +667,20 @@ func markdownRender(content []byte) []byte {
 	extensions |= blackfriday.EXTENSION_AUTOLINK
 	extensions |= blackfriday.EXTENSION_STRIKETHROUGH
 	extensions |= blackfriday.EXTENSION_SPACE_HEADERS
+	extensions |= blackfriday.EXTENSION_FOOTNOTES
 
 	return blackfriday.Markdown(content, renderer, extensions)
 }
 
 func markdownRenderWithTOC(content []byte) []byte {
 	htmlFlags := 0
-	htmlFlags |= blackfriday.HTML_SKIP_SCRIPT
+	//htmlFlags |= blackfriday.HTML_SKIP_SCRIPT
 	htmlFlags |= blackfriday.HTML_TOC
 	htmlFlags |= blackfriday.HTML_USE_XHTML
 	htmlFlags |= blackfriday.HTML_USE_SMARTYPANTS
 	htmlFlags |= blackfriday.HTML_SMARTYPANTS_FRACTIONS
 	htmlFlags |= blackfriday.HTML_SMARTYPANTS_LATEX_DASHES
+	htmlFlags |= blackfriday.HTML_FOOTNOTE_RETURN_LINKS
 	renderer := blackfriday.HtmlRenderer(htmlFlags, "", "")
 
 	extensions := 0
@@ -687,6 +690,7 @@ func markdownRenderWithTOC(content []byte) []byte {
 	extensions |= blackfriday.EXTENSION_AUTOLINK
 	extensions |= blackfriday.EXTENSION_STRIKETHROUGH
 	extensions |= blackfriday.EXTENSION_SPACE_HEADERS
+	extensions |= blackfriday.EXTENSION_FOOTNOTES
 
 	return blackfriday.Markdown(content, renderer, extensions)
 }


### PR DESCRIPTION
As discussed on the mailing list.

Note that the master blackfriday does not have support for `HTML_SKIP_SCRIPT`. There seems to be [a discussion](https://github.com/russross/blackfriday/issues/11) about adding this feature, but it's not there yet.

However, I'm not sure it's really required, as we are not accepting user input for content. If an author does want to embed some script in his content then I don't see why hugo would need to strip it out.
