### PR TITLE
do not use angle brackets in hyperlink labels

### DIFF
--- a/docs/content/templates/go-templates.md
+++ b/docs/content/templates/go-templates.md
@@ -335,5 +335,5 @@ so, such as in this example:
 ```
 
 
-[go]: <http://golang.org/>
-[gohtmltemplate]: <http://golang.org/pkg/html/template/>
+[go]: http://golang.org/
+[gohtmltemplate]: http://golang.org/pkg/html/template/


### PR DESCRIPTION
Hello,

I'm very happy with Hugo which made me into learning Go, but being a noob can't contribute code. :-(

However, I noticed in the docs that markdown implementation in Go has problems rendering hyperlabels which use angle brackets around URLs- check: http://hugo.spf13.com/templates/go-templates

So, here is small patch which fixes those hyperlinks.

Sincerely,
Gour
