### PR TITLE
fix link to template primer

### DIFF
--- a/docs/content/themes/creation.md
+++ b/docs/content/themes/creation.md
@@ -16,7 +16,7 @@ using the `hugo new` command.
 
 This command will initialize all of the files and directories a basic theme
 would need. Hugo themes are written in the go template language. If you are new
-to Go, the [go template primer](/templates/primer/) will help you get started.
+to Go, the [go template primer](/layout/go-templates/) will help you get started.
 
 ## Theme Components
 


### PR DESCRIPTION
Tried this out in a browser and it worked.

It seems like it would be useful to add a test for broken links in the docs, but I don't know where to start, so just this for now.
