### PR TITLE
report errors

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,16 +8,24 @@ import (
 
 func CheckErr(err error, s ...string) {
 	if err != nil {
-		for _, message := range s {
-			jww.ERROR.Println(message)
+		if len(s) == 0 {
+			jww.CRITICAL.Println(err)
+		} else {
+			for _, message := range s {
+				jww.ERROR.Println(message)
+			}
 		}
 	}
 }
 
 func StopOnErr(err error, s ...string) {
 	if err != nil {
-		for _, message := range s {
-			jww.CRITICAL.Println(message)
+		if len(s) == 0 {
+			jww.CRITICAL.Println(err)
+		} else {
+			for _, message := range s {
+				jww.CRITICAL.Println(message)
+			}
 		}
 		os.Exit(-1)
 	}


### PR DESCRIPTION
Modify CheckErr and StopOnErrErr to report the error if there aren't any
other messages.

When `hugo` is run on a site with no content, no errors are reported. `hugo server` also doesn't report any errors, but it returns immediately if there is no content. More generically, errors that occurred during the site generation were being swallowed. This change ensures that the errors that occurred in those situations are reported.
