### PR TITLE
make type-or-section more obvious

### DIFF
--- a/docs/content/templates/content.md
+++ b/docs/content/templates/content.md
@@ -32,11 +32,11 @@ it will be used instead of `section`.
 
 ### Single
 
-* /layouts/`TYPE` or `SECTION`/`LAYOUT`.html
-* /layouts/`TYPE` or `SECTION`/single.html
+* /layouts/`TYPE`-or-`SECTION`/`LAYOUT`.html
+* /layouts/`TYPE`-or-`SECTION`/single.html
 * /layouts/\_default/single.html
-* /themes/`THEME`/layouts/`TYPE` or `SECTION`/`LAYOUT`.html
-* /themes/`THEME`/layouts/`TYPE` or `SECTION`/single.html
+* /themes/`THEME`/layouts/`TYPE`-or-`SECTION`/`LAYOUT`.html
+* /themes/`THEME`/layouts/`TYPE`-or-`SECTION`/single.html
 * /themes/`THEME`/layouts/\_default/single.html
 
 ## Example Single Template File


### PR DESCRIPTION
It took me a long time to realize that /layouts/TYPE or SECTION/LAYOUT.html  was supposed to be a single URL and not two urls (/layouts/TYPE) or (SECTION/LAYOUT.html) ... putting in the hyphens I think makes it much more clear it's all one URL, and only the middle part is an either-or.
