### PR TITLE
Fix #363 - Docs: make the fixed menu on the left scrollable

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -354,10 +354,11 @@ table tr th { color: #007AFF;}
 /*sidebar navigation*/
 
 #sidebar {
-    width: 180px;
+    width: 190px;
     height: 100%;
     position: fixed;
     background: #ffffff;
+    overflow-y: auto;
 }
 
 .nav-collapse.collapse {


### PR DESCRIPTION
Hi guys,

First of all, I love this generator, great work!

This PR fixes #363 making the menu on the left of the docs page scrollable on small screens, also increments the size of the menu by 10px in order to give some space for the scrollbar.

Tested locally on Chrome, Firefox and Opera.
