### PR TITLE
added evaluation for toml for metadataformat date handling

### DIFF
--- a/commands/convert.go
+++ b/commands/convert.go
@@ -117,7 +117,7 @@ func convertContents(mark rune) (err error) {
 		}
 
 		// better handling of dates in formats that don't have support for them
-		if mark == parser.FormatToLeadRune("json") || mark == parser.FormatToLeadRune("yaml") {
+		if mark == parser.FormatToLeadRune("json") || mark == parser.FormatToLeadRune("yaml") || mark == parser.FormatToLeadRune("toml") {
 			newmetadata := cast.ToStringMap(metadata)
 			for k, v := range newmetadata {
 				switch vv := v.(type) {

--- a/create/content.go
+++ b/create/content.go
@@ -90,7 +90,7 @@ func NewContent(kind, name string) (err error) {
 		return err
 	}
 
-	if x := viper.GetString("MetaDataFormat"); x == "json" || x == "yaml" {
+	if x := viper.GetString("MetaDataFormat"); x == "json" || x == "yaml" || x == "toml" {
 		newmetadata["date"] = time.Now().Format(time.RFC3339)
 	}
 


### PR DESCRIPTION
When Hugo creates new content with front matter in TOML, the MetadataFormat for date is malformed, resulting in errors during page creation. The solution is to add `toml` to the relevant evaluations, which already support `json` and `yaml`.

Steps to replicate issue:
Compile from source.

`hugo new site sitename`
`cd sitename`
`hugo new hello.md`
`vi content/hello.md`

Results in:

```
+++
draft = true
title = "hello"date = 2015-08-17T22:12:40.262090604-5:00
+++
```

This results in an error when creating the site:

```
hugo server --buildDrafts
ERROR: 2014/08/17 Error parsing page meta data for hello.md
ERROR: 2014/08/17 Near line 3, key '': Near line 3: Expected a top-level item to end with a new line, comment or EOF, but got 'd' instead.
ERROR: 2014/08/17 Near line 3, key '': Near line 3: Expected a top-level item to end with a new line, comment or EOF, but got 'd' instead.
0 pages created...
```

The resolution is to add `toml` to the evaluations in `commands/convert.go` and `create/content.go`, which already evaluate for `json` and `yaml`.

This results in:

```
hugo new hello.md
vi content/hello.md

+++
date = "2014-08-17T22:24:22-05:00"
draft = true
title = "hello"
+++

hugo serve --buildDrafts
1 pages created
```
