### PR TITLE
Issue 373: support for futre/draft summary info output 

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -296,6 +296,17 @@ func (page *Page) ShouldBuild() bool {
 	return false
 }
 
+func (page *Page) IsDraft() bool {
+	return page.Draft
+}
+
+func (page *Page) IsFuture() bool {
+	if page.PublishDate.Before(time.Now()) {
+		return false
+	}
+	return true
+}
+
 func (p *Page) Permalink() (string, error) {
 	link, err := p.permalink()
 	if err != nil {


### PR DESCRIPTION
https://github.com/spf13/hugo/issues/373

Added support for draft and future content info in the site summary print per discussion.

One additional change to output: the draft and future info are now the first lines printed. This change keeps the 'created' information together. It also is more coherent, in terms of information presentation, imo.
