### PR TITLE
preserve alias case while lowercasing taxonomy

### DIFF
--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -40,11 +40,34 @@ func TestMakePath(t *testing.T) {
 		input    string
 		expected string
 	}{
+		{"  Foo bar  ", "Foo-bar"},
+		{"Foo.Bar/foo_Bar-Foo", "Foo.Bar/foo_Bar-Foo"},
+		{"fOO,bar:foo%bAR", "fOObarfoobAR"},
+		{"FOo/BaR.html", "FOo/BaR.html"},
+		{"трям/трям", "трям/трям"},
+		{"은행","은행"},
+		{"Банковский кассир","Банковский-кассир"},
+	}
+
+	for _, test := range tests {
+		output := MakePath(test.input)
+		if output != test.expected {
+			t.Errorf("Expected %#v, got %#v\n", test.expected, output)
+		}
+	}
+}
+
+func TestMakeToLower(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
 		{"  foo bar  ", "foo-bar"},
 		{"foo.bar/foo_bar-foo", "foo.bar/foo_bar-foo"},
 		{"foo,bar:foo%bar", "foobarfoobar"},
 		{"foo/bar.html", "foo/bar.html"},
 		{"трям/трям", "трям/трям"},
+		{"은행","은행"},
 	}
 
 	for _, test := range tests {

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -29,9 +29,18 @@ import (
 var sanitizeRegexp = regexp.MustCompile("[^a-zA-Z0-9./_-]")
 
 // Take a string with any characters and replace it so the string could be used in a path.
-// E.g. Social Media -> social-media
+// MakePath creates a Unicode sanitized string, with the spaces replaced, whilst
+// preserving the original casing of the string.
+// E.g. Social Media -> Social-Media
 func MakePath(s string) string {
-	return UnicodeSanitize(strings.ToLower(strings.Replace(strings.TrimSpace(s), " ", "-", -1)))
+	return UnicodeSanitize(strings.Replace(strings.TrimSpace(s), " ", "-", -1))
+}
+
+// MakePathToLowerr creates a Unicode santized string, with the spaces replaced,
+// and transformed to lower case.
+// E.g. Social Media -> social-media
+func MakePathToLower(s string) string {
+        return UnicodeSanitize(strings.ToLower(strings.Replace(strings.TrimSpace(s), " ", "-", -1)))
 }
 
 func MakeTitle(inpath string) string {

--- a/hugolib/taxonomy.go
+++ b/hugolib/taxonomy.go
@@ -60,7 +60,7 @@ type OrderedTaxonomyEntry struct {
 
 // KeyPrep... Taxonomies should be case insensitive. Can make it easily conditional later.
 func kp(in string) string {
-	return helpers.MakePath(in)
+	return helpers.MakePathToLower(in)
 }
 
 func (i Taxonomy) Get(key string) WeightedPages { return i[kp(key)] }


### PR DESCRIPTION
- Changed MakePath so that it preserves original case. 
- Added a MakePathToLower that lowercases the generated path. 
- Modified kp in taxonomy.go to call the new MakePathToLower instead of the original MakePath.
- Added and modified tests for MakePath and MakePathToLower.

Additional calls to MakePath that were not changed:
- helpers/url.go line 36 
- target/htmlredirect.go line 43 

The affect on tags is unknown.

Affects: https://github.com/spf13/hugo/issues/329
