### PR TITLE
added functionality to check the error message returned from Cobra, if a...

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"strings"
 
 	jww "github.com/spf13/jwalterweatherman"
 )
@@ -21,12 +22,35 @@ func CheckErr(err error, s ...string) {
 func StopOnErr(err error, s ...string) {
 	if err != nil {
 		if len(s) == 0 {
-			jww.CRITICAL.Println(err)
+			newMessage := cutUsageMessage(err.Error())
+
+			// Printing an empty string results in a error with
+			// no message, no bueno.
+			if newMessage != "" {
+				jww.CRITICAL.Println(newMessage)
+			}
 		} else {
 			for _, message := range s {
-				jww.CRITICAL.Println(message)
+				message := cutUsageMessage(message)
+
+				if message != "" {
+					jww.CRITICAL.Println(message)
+				}
 			}
 		}
 		os.Exit(-1)
 	}
+}
+
+// cutUsageMessage splits the incoming string on the beginning of the usage
+// message text. Anything in the first element of the returned slice, trimmed
+// of its Unicode defined spaces, should be returned. The 2nd element of the 
+// slice will have the usage message  that we wish to elide.
+//
+// This is done because Cobra already prints Hugo's usage message; not eliding
+// would result in the usage output being printed twice, which leads to bug 
+// reports, more specifically: https://github.com/spf13/hugo/issues/374
+func cutUsageMessage(s string) string {
+	pieces :=  strings.Split(s, "Usage of") 
+	return strings.TrimSpace(pieces[0])
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"testing"
+	)
+
+
+
+func TestCutUsageMessage(t *testing.T) {
+	tests := []struct{
+		message string
+		cutMessage string
+	}{
+		{"", ""},
+                {" Usage of hugo: \n  -b, --baseUrl=...", ""},
+                {"Some error Usage of hugo: \n", "Some error"},
+                {"Usage of hugo: \n -b --baseU", ""},
+                {"CRITICAL error for usage of hugo ", "CRITICAL error for usage of hugo"},
+                {"Invalid short flag a in -abcde", "Invalid short flag a in -abcde"},
+	}
+
+	for _, test := range tests {
+		message := cutUsageMessage(test.message)
+		if message != test.cutMessage {
+			t.Errorf("Expected %#v, got %#v", test.cutMessage, message)
+		}
+	}
+}


### PR DESCRIPTION
...ny. for uage message text. If its present, the usage message gets truncated and the resulting message is returned to be used for the rest of the error message. If the resulting error is blank, no error message is printed

This resolves issue 374, though it may not handle it in the best manner.
## Issue Summary

Duplicate usage message were being printed out when invalid flags were being passed to Hugo. Cobra would print out the command usage message for Hugo and return an error, with the usage message embedded in the error.

Because Hugo handles this as a CRITICAL error, it gets surfaced to std out, which results in the usage message being printed the second time.
## Solution:

If Cobra returns an error, the error message text is checked for the 'Usage for' string, which is the beginning of the usage text. If it exists in the error message, a split is done on that point and the 2nd element of the slice, which contains the usage message is discarded. The first slice element is trimmed of its Unicode spaces and returned.

If the returned string is not empty, not "", Hugo handles the resulting error message by issueing a CRITICAL log message. If the returned string is empty, no error message is logged as a log message of 'CRITICAL' with no additional message is not useful.

Tests were added to test the various split scenarios.
