### PR TITLE
Support subdir in baseurl

### DIFF
--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestFixUrl(t *testing.T) {
+	type data struct {
+		TestName   string
+		CliBaseUrl string
+		CfgBaseUrl string
+		AppendPort bool
+		Port       int
+		Result     string
+	}
+	tests := []data{
+		{"Basic localhost", "", "http://foo.com", true, 1313, "http://localhost:1313"},
+		{"Basic subdir", "", "http://foo.com/bar", true, 1313, "http://localhost:1313/bar"},
+		{"Basic production", "http://foo.com", "http://foo.com", false, 80, "http://foo.com"},
+		{"Production subdir", "http://foo.com/bar", "http://foo.com/bar", false, 80, "http://foo.com/bar"},
+		{"No http", "", "foo.com", true, 1313, "http://localhost:1313"},
+		{"Override configured port", "", "foo.com:2020", true, 1313, "http://localhost:1313"},
+		{"No http production", "foo.com", "foo.com", false, 80, "http://foo.com"},
+		{"No http production with port", "foo.com", "foo.com", true, 2020, "http://foo.com:2020"},
+	}
+
+	for i, test := range tests {
+		BaseUrl = test.CliBaseUrl
+		viper.Set("BaseUrl", test.CfgBaseUrl)
+		serverAppend = test.AppendPort
+		serverPort = test.Port
+		result, err := fixUrl(BaseUrl)
+		if err != nil {
+			t.Errorf("Test #%d %s: unexpected error %s", err)
+		}
+		if result != test.Result {
+			t.Errorf("Test #%d %s: expected %q, got %q", i, test.TestName, test.Result, result)
+		}
+	}
+}

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -74,3 +74,25 @@ func TestUrlize(t *testing.T) {
 		}
 	}
 }
+
+func TestMakePermalink(t *testing.T) {
+	type test struct {
+		host, link, output string
+	}
+
+	data := []test{
+		{"http://abc.com/foo", "post/bar", "http://abc.com/foo/post/bar"},
+		{"http://abc.com/foo/", "post/bar", "http://abc.com/foo/post/bar"},
+		{"http://abc.com", "post/bar", "http://abc.com/post/bar"},
+		{"http://abc.com", "bar", "http://abc.com/bar"},
+		{"http://abc.com/foo/bar", "post/bar", "http://abc.com/foo/bar/post/bar"},
+		{"http://abc.com/foo/bar", "post/bar/", "http://abc.com/foo/bar/post/bar/"},
+	}
+
+	for i, d := range data {
+		output := MakePermalink(d.host, d.link).String()
+		if d.output != output {
+			t.Errorf("Test #%d failed. Expected %q got %q", i, d.output, output)
+		}
+	}
+}

--- a/helpers/url.go
+++ b/helpers/url.go
@@ -14,8 +14,10 @@
 package helpers
 
 import (
+	"fmt"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/PuerkitoBio/purell"
 )
@@ -57,11 +59,23 @@ func MakePermalink(host, plink string) *url.URL {
 		panic(err)
 	}
 
-	path, err := url.Parse(plink)
+	p, err := url.Parse(plink)
 	if err != nil {
 		panic(err)
 	}
-	return base.ResolveReference(path)
+
+	if p.Host != "" {
+		panic(fmt.Errorf("Can't make permalink from absolute link %q", plink))
+	}
+
+	base.Path = path.Join(base.Path, p.Path)
+
+	// path.Join will strip off the last /, so put it back if it was there.
+	if strings.HasSuffix(p.Path, "/") && !strings.HasSuffix(base.Path, "/") {
+		base.Path = base.Path + "/"
+	}
+
+	return base
 }
 
 func UrlPrep(ugly bool, in string) string {

--- a/hugolib/page_permalink_test.go
+++ b/hugolib/page_permalink_test.go
@@ -33,7 +33,7 @@ func TestPermalink(t *testing.T) {
 		{"x/y/z/boofar.md", "x/y/z", "", "", "/z/y/q/", false, "/z/y/q/", "/z/y/q/"},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
 		viper.Set("uglyurls", test.uglyurls)
 		p := &Page{
 			Node: Node{
@@ -56,22 +56,22 @@ func TestPermalink(t *testing.T) {
 
 		u, err := p.Permalink()
 		if err != nil {
-			t.Errorf("Unable to process permalink: %s", err)
+			t.Errorf("Test %d: Unable to process permalink: %s", i, err)
 		}
 
 		expected := test.expectedAbs
 		if u != expected {
-			t.Errorf("Expected abs url: %s, got: %s", expected, u)
+			t.Errorf("Test %d: Expected abs url: %s, got: %s", i, expected, u)
 		}
 
 		u, err = p.RelPermalink()
 		if err != nil {
-			t.Errorf("Unable to process permalink: %s", err)
+			t.Errorf("Test %d: Unable to process permalink: %s", i, err)
 		}
 
 		expected = test.expectedRel
 		if u != expected {
-			t.Errorf("Expected abs url: %s, got: %s", expected, u)
+			t.Errorf("Test %d: Expected abs url: %s, got: %s", i, expected, u)
 		}
 	}
 }


### PR DESCRIPTION
This fixes #334, #325, #230.

Mainly this was a change to helpers.MakePermalink, but to get the local server to run with the subdirectory, we needed to redirect the path of the request from /foo to /.  In addition, I added tests for the server's code for fixing up the base url with different config file & CLI options, and tests for MakePermalink (which were somewhat already covered by the page tests, but I like tests a little closer to the meat of the code, so I know where the failures are).
