### PR TITLE
Be more specific about .Params field names defined in front matter.

### DIFF
--- a/docs/content/content/front-matter.md
+++ b/docs/content/content/front-matter.md
@@ -68,7 +68,7 @@ Supported formats: <br>
 
 There are a few predefined variables that Hugo is aware of and utilizes. The user can also create
 any variable they want to. These will be placed into the `.Params` variable available to the templates.
-Field names are always normalized to lowercase (eg `camelCase: true` is available as `.Params.camelcase`.
+Field names are always normalized to lowercase (eg. `camelCase: true` is available as `.Params.camelcase`).
 
 ### Required
 


### PR DESCRIPTION
I'm not 100% sure whether this is _always_ the case, but it definitely has been the case for me.
