### PR TITLE
Add document about page grouping functions

### DIFF
--- a/docs/content/templates/list.md
+++ b/docs/content/templates/list.md
@@ -215,3 +215,39 @@ Can be applied to any of the above. Using Date for an example.
     <div class="meta">{{ .Date.Format "Mon, Jan 2, 2006" }}</div>
     </li>
     {{ end }}
+
+## Grouping Content
+
+Hugo provides some grouping functions for list pages. You can use them to
+group pages by Section, Date etc.
+
+Here are a variety of different ways you can group the content items in
+your list templates:
+
+### Grouping by Page field
+
+    {{ range .Data.Pages.GroupBy "Section" "asc" }}
+    <h3>{{ .Key }}</h3>
+    <ul>
+        {{ range .Data }}
+        <li>
+        <a href="{{ .Permalink }}">{{ .Title }}</a>
+        <div class="meta">{{ .Date.Format "Mon, Jan 2, 2006" }}</div>
+        </li>
+        {{ end }}
+    </ul>
+    {{ end }}
+
+### Grouping by Page date
+
+    {{ range .Data.Pages.GroupByDate "2006-01" "desc" }}
+    <h3>{{ .Key }}</h3>
+    <ul>
+        {{ range .Data }}
+        <li>
+        <a href="{{ .Permalink }}">{{ .Title }}</a>
+        <div class="meta">{{ .Date.Format "Mon, Jan 2, 2006" }}</div>
+        </li>
+        {{ end }}
+    </ul>
+    {{ end }}


### PR DESCRIPTION
I wrote some documents about grouping functions added at #425. I added them to end of the template/list document, near the order functions descriptions.

While I was writing them, I came up with some improvements of the functions
- Changing Data property name of PageGroup to Pages is more user friendly
- It is more consistent using Reverse function to get reverse ordered PageGroup array as Pages does instead of using order argument ("asc" and "desc") at those function calls
- I couldn't think any use cases except using with .Section, .Type, .Date, .PublishDate (Someone may also need .Keywords and .Indexes). So, the current GroupBy implement may be too much flexible. It may be better to rewrite it some functions like GroupByType, GroupBySection etc.

Maybe it should be discussed as other issue. If so, I'll create an issue.
