### PR TITLE
Enable header id blackfriday extension

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -684,6 +684,7 @@ func markdownRender(content []byte) []byte {
 	extensions |= blackfriday.EXTENSION_STRIKETHROUGH
 	extensions |= blackfriday.EXTENSION_SPACE_HEADERS
 	extensions |= blackfriday.EXTENSION_FOOTNOTES
+	extensions |= blackfriday.EXTENSION_HEADER_IDS
 
 	return blackfriday.Markdown(content, renderer, extensions)
 }
@@ -706,6 +707,7 @@ func markdownRenderWithTOC(content []byte) []byte {
 	extensions |= blackfriday.EXTENSION_STRIKETHROUGH
 	extensions |= blackfriday.EXTENSION_SPACE_HEADERS
 	extensions |= blackfriday.EXTENSION_FOOTNOTES
+	extensions |= blackfriday.EXTENSION_HEADER_IDS
 
 	return blackfriday.Markdown(content, renderer, extensions)
 }


### PR DESCRIPTION
This patch enables the header ID extension in blackfriday, which allows headers to optionally emit ID attributes such that they can be linked to via URL fragments.
