### PR TITLE
Fix loading of Lato font in style.css for docs

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1,3 +1,5 @@
+/* Import fonts */
+@import url(http://fonts.googleapis.com/css?family=Lato:300,400,700,900,300italic,400italic,700italic,900italic);
 
 /* ******************************
  For the github btn
@@ -90,12 +92,8 @@ h1, h2, h3 {
 
 pre code {
     font-size: 18px !important;
-    font-family: "courier new", monospace;
+    font-family: 'Courier New', monospace;
 }
-
-/* Import fonts */
-@import url(http://fonts.googleapis.com/css?family=Lato:400,300,300italic,400italic,600,600italic,700,700italic,800,800italic);
-@import url(line-icons.css);
 
 body {
     color: #353b44;


### PR DESCRIPTION
Hello Steve,

The "@import url()" statement for loading Lato from Google Fonts
was ignored because "@import are not allowed after any valid statement
other than @charset and @import" according to the W3C CSS Validator,
so I moved the @import statement to the very top.

Also, the latest Lato font on Google seems to have some of its font weights
adjusted, so the @import line has been updated accordingly.

There also used to be `@import url(line-icons.css)`, but the file isn't found
in the git repository.  I presume that line-icons.css has been replaced
with the use of FontAwesome?  :-)

Thank you for creating Hugo.  It has been fun learning it.
