### PR TITLE
add Name to File, which is the filename minus the extension

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/url"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -61,7 +62,7 @@ type Page struct {
 }
 
 type File struct {
-	FileName, Extension, Dir string
+	Name, FileName, Extension, Dir string
 }
 
 type PageMeta struct {
@@ -148,8 +149,12 @@ func renderBytes(content []byte, pagefmt string) []byte {
 }
 
 func newPage(filename string) *Page {
+	name := filepath.Base(filename)
+	// strip off the extension
+	name = name[:len(name)-len(filepath.Ext(name))]
+
 	page := Page{contentType: "",
-		File:   File{FileName: filename, Extension: "html"},
+		File:   File{Name: name, FileName: filename, Extension: "html"},
 		Node:   Node{Keywords: []string{}, Sitemap: Sitemap{Priority: -1}},
 		Params: make(map[string]interface{})}
 


### PR DESCRIPTION
This is useful as a shorthand reference to the piece of content, kind of like referencing it by slug, except it works even if you're not setting slugs.  

This is useful for wiki-style links in shortcodes.  This lets you use a shortcode like this:

{{% link boston %}}

and then in link.html:

```
{{$name := .Get 0}}

{{range .Page.Site.Recent }}
    {{if eq .File.Name $name }}
        <a href="{{.Permalink}}">{{.LinkTitle}}</a>     
    {{ end }}
{{end}}
```

If you have a piece of content that is boston.md, it'll create a link for it in the output with the rght oermalink url and correct title, and even if the link to the content changes or the title changes, this will stay up to date.

You can do this currently by just using .File.Filename, and passing it boston.md, but that's pretty ugly.
