### PR TITLE
fix zero date

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -154,7 +154,6 @@ func newPage(filename string) *Page {
 		Params: make(map[string]interface{})}
 
 	jww.DEBUG.Println("Reading from", page.File.FileName)
-	page.Date, _ = time.Parse("20060102", "20080101")
 	page.guessSection()
 	return &page
 }

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -533,8 +533,8 @@ func TestGroupedPages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to make PageGroup array: %s", err)
 	}
-	if bydate[0].Key != "2008-01" {
-		t.Errorf("PageGroup array in unexpected order. First group key should be '%s', got '%s'", "2008-01", bydate[0].Key)
+	if bydate[0].Key != "0001-01" {
+		t.Errorf("PageGroup array in unexpected order. First group key should be '%s', got '%s'", "0001-01", bydate[0].Key)
 	}
 	if bydate[1].Key != "2012-01" {
 		t.Errorf("PageGroup array in unexpected order. Second group key should be '%s', got '%s'", "2012-01", bydate[1].Key)


### PR DESCRIPTION
I'm not exactly sure why we were defaulting the date on pages to 2008, but it breaks pages that intentionally don't set a date.  Fixed to just not do that.  With this change you can do this and it'll do the expected thing:

{{ if not .Date.IsZero }} {{.Date.Format "something" }} {{end}}
