### PR TITLE
More error messages at syncing static contents

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -229,7 +229,7 @@ func copyStatic() error {
 
 		// Copy Static to Destination
 		jww.INFO.Println("syncing from", themeDir, "to", publishDir)
-		fsync.Sync(publishDir, themeDir)
+		utils.CheckErr(fsync.Sync(publishDir, themeDir), fmt.Sprintf("Error copying static files of theme to %s", publishDir))
 	}
 
 	// Copy Static to Destination

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,6 +15,7 @@ func CheckErr(err error, s ...string) {
 			for _, message := range s {
 				jww.ERROR.Println(message)
 			}
+			jww.ERROR.Println(err)
 		}
 	}
 }


### PR DESCRIPTION
At issue #482, we found out an original error message output was helpful to determine what's wrong in static dir but the message was hidden, overwritten so to display it, we had to rewrite a code.

This is a small fix for it. it displays both a specified message and an original error message.
