### PR TITLE
Change all uses of sort.Sort to sort.Stable.

### DIFF
--- a/hugolib/menu.go
+++ b/hugolib/menu.go
@@ -129,7 +129,7 @@ func (by MenuEntryBy) Sort(menu Menu) {
 		menu: menu,
 		by:   by, // The Sort method's receiver is the function (closure) that defines the sort order.
 	}
-	sort.Sort(ms)
+	sort.Stable(ms)
 }
 
 var DefaultMenuEntrySort = func(m1, m2 *MenuEntry) bool {

--- a/hugolib/pageSort.go
+++ b/hugolib/pageSort.go
@@ -35,7 +35,7 @@ func (by PageBy) Sort(pages Pages) {
 		pages: pages,
 		by:    by, // The Sort method's receiver is the function (closure) that defines the sort order.
 	}
-	sort.Sort(ps)
+	sort.Stable(ps)
 }
 
 var DefaultPageSort = func(p1, p2 *Page) bool {

--- a/hugolib/taxonomy.go
+++ b/hugolib/taxonomy.go
@@ -134,7 +134,7 @@ func (by OIby) Sort(taxonomy OrderedTaxonomy) {
 		taxonomy: taxonomy,
 		by:       by, // The Sort method's receiver is the function (closure) that defines the sort order.
 	}
-	sort.Sort(ps)
+	sort.Stable(ps)
 }
 
 // Len is part of sort.Interface.
@@ -162,7 +162,7 @@ func (wp WeightedPages) Pages() Pages {
 
 func (p WeightedPages) Len() int      { return len(p) }
 func (p WeightedPages) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
-func (p WeightedPages) Sort()         { sort.Sort(p) }
+func (p WeightedPages) Sort()         { sort.Stable(p) }
 func (p WeightedPages) Count() int    { return len(p) }
 func (p WeightedPages) Less(i, j int) bool {
 	if p[i].Weight == p[j].Weight {


### PR DESCRIPTION
Using sort.Stable ensures that even if the sort keys are the same, the order of the sort will not randomly change.  Using the old sort.Sort, if you had pages with no date, the lists of those pages would randomly reorder every time you regenerate the list, causing spurious changes to the output.  Now they'll always get ordered in the same way.  This does require Go 1.2.1, but I think we already require at least that.
