### PR TITLE
fix tags not being in lowercase, #491

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -431,7 +431,7 @@ func (page *Page) GetParam(key string) interface{} {
 	case bool:
 		return cast.ToBool(v)
 	case string:
-		return cast.ToString(v)
+		return strings.ToLower(cast.ToString(v))
 	case int64, int32, int16, int8, int:
 		return cast.ToInt(v)
 	case float64, float32:
@@ -439,7 +439,7 @@ func (page *Page) GetParam(key string) interface{} {
 	case time.Time:
 		return cast.ToTime(v)
 	case []string:
-		return v
+		return sliceToLower(v.([]string))
 	}
 	return nil
 }
@@ -794,4 +794,18 @@ func (p *Page) TargetPath() (outfile string) {
 	}
 
 	return path.Join(p.Dir, strings.TrimSpace(outfile))
+}
+
+// sliceToLower goes through the source slice and lowers all values.
+func sliceToLower(s []string) []string {
+	if s == nil {
+		return nil
+	}
+
+	l  := make([]string, len(s))
+	for i, v := range s {
+		l[i] = strings.ToLower(v)
+	}
+
+	return l
 }

--- a/hugolib/page_taxonomy_test.go
+++ b/hugolib/page_taxonomy_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 var PAGE_YAML_WITH_TAXONOMIES_A = `---
-tags: ['a', 'b', 'c']
+tags: ['a', 'B', 'c']
 categories: 'd'
 ---
 YAML frontmatter with tags and categories taxonomy.`
@@ -14,20 +14,20 @@ YAML frontmatter with tags and categories taxonomy.`
 var PAGE_YAML_WITH_TAXONOMIES_B = `---
 tags:
  - "a"
- - "b"
+ - "B"
  - "c"
 categories: 'd'
 ---
 YAML frontmatter with tags and categories taxonomy.`
 
 var PAGE_YAML_WITH_TAXONOMIES_C = `---
-tags: 'e'
+tags: 'E'
 categories: 'd'
 ---
 YAML frontmatter with tags and categories taxonomy.`
 
 var PAGE_JSON_WITH_TAXONOMIES = `{
-  "categories": "d",
+  "categories": "D",
   "tags": [
     "a",
     "b",
@@ -37,7 +37,7 @@ var PAGE_JSON_WITH_TAXONOMIES = `{
 JSON Front Matter with tags and categories`
 
 var PAGE_TOML_WITH_TAXONOMIES = `+++
-tags = [ "a", "b", "c" ]
+tags = [ "a", "B", "c" ]
 categories = "d"
 +++
 TOML Front Matter with tags and categories`

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -40,7 +40,7 @@ Leading
 {
 "title": "spf13-vim 3.0 release and new website",
 "description": "spf13-vim is a cross platform distribution of vim plugins and resources for Vim.",
-"tags": [ ".vimrc", "plugins", "spf13-vim", "vim" ],
+"tags": [ ".vimrc", "plugins", "spf13-vim", "VIm" ],
 "date": "2012-04-06",
 "categories": [
     "Development",
@@ -55,7 +55,7 @@ Content of the file goes Here
 {
 "title": "spf13-vim 3.0 release and new website"
 "description": "spf13-vim is a cross platform distribution of vim plugins and resources for Vim."
-"tags": [ ".vimrc", "plugins", "spf13-vim", "vim" ]
+"tags": [ ".vimrc", "plugins", "spf13-vim", "VIm" ]
 "date": "2012-04-06"
 "categories": [
     "Development"
@@ -561,6 +561,26 @@ func TestLayoutOverride(t *testing.T) {
 		}
 		if !listEqual(p.Layout(), test.expectedLayout) {
 			t.Errorf("Layout mismatch. Expected: %s, got: %s", test.expectedLayout, p.Layout())
+		}
+	}
+}
+
+func TestSliceToLower(t *testing.T) {
+	tests := []struct{
+		value []string
+		expected []string
+	}{
+		{[]string{"a","b","c"}, []string{"a", "b", "c"}},
+                {[]string{"a","B","c"}, []string{"a", "b", "c"}},
+                {[]string{"A","B","C"}, []string{"a", "b", "c"}},
+	}
+
+	for _, test := range tests {
+		res := sliceToLower(test.value)
+		for i, val := range res {
+			if val != test.expected[i] {
+				t.Errorf("Case mismatch. Expected %s, got %s", test.expected[i], res[i])
+			}
 		}
 	}
 }


### PR DESCRIPTION
This should fix issue  #491. Tags that are of type `string` and `[]string` are converted to lowercase.

A new function was added to process `[]string` tags. 

Tests were added and modified, as appropriate.
