### PR TITLE
Livereload CSS and images without browser refresh

### DIFF
--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -122,3 +122,26 @@ func TestMakePermalink(t *testing.T) {
 		}
 	}
 }
+
+func TestMakePathRelative(t *testing.T) {
+	type test struct {
+		inPath, path1, path2, output string
+	}
+
+	data := []test{
+		{"/abc/bcd/ab.css", "/abc/bcd", "/bbc/bcd", "/ab.css"},
+		{"/abc/bcd/ab.css", "/abcd/bcd", "/abc/bcd", "/ab.css"},
+	}
+
+	for i, d := range data {
+		output, _ := MakePathRelative(d.inPath, d.path1, d.path2)
+		if d.output != output {
+			t.Errorf("Test #%d failed. Expected %q got %q", i, d.output, output)
+		}
+	}
+	_, error := MakePathRelative("a/b/c.ss", "/a/c", "/d/c", "/e/f")
+
+	if error == nil {
+		t.Errorf("Test #%d failed. Expected error")
+	}
+}

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -14,6 +14,7 @@
 package helpers
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -128,6 +129,23 @@ func AbsPathify(inPath string) string {
 	}
 
 	return filepath.Clean(filepath.Join(viper.GetString("WorkingDir"), inPath))
+}
+
+func MakeStaticPathRelative(inPath string) (string, error) {
+	staticDir := AbsPathify(viper.GetString("StaticDir"))
+	themeStaticDir := AbsPathify("themes/"+viper.GetString("theme")) + "/static/"
+
+	return MakePathRelative(inPath, staticDir, themeStaticDir)
+}
+
+func MakePathRelative(inPath string, possibleDirectories ...string) (string, error) {
+
+	for _, currentPath := range possibleDirectories {
+		if strings.HasPrefix(inPath, currentPath) {
+			return strings.TrimPrefix(inPath, currentPath), nil
+		}
+	}
+	return inPath, errors.New("Can't extract relative path, unknown prefix")
 }
 
 func Filename(in string) (name string) {

--- a/livereload/livereload.go
+++ b/livereload/livereload.go
@@ -39,7 +39,12 @@ func Initialize() {
 
 func ForceRefresh() {
 	// Tell livereload a js file changed to force a hard refresh
-	wsHub.broadcast <- []byte(`{"command":"reload","path":"/x.js","originalPath":"","liveCSS":true}`)
+	RefreshPath("/x.js")
+}
+
+func RefreshPath(s string) {
+	// Tell livereload a file has changed - will force a hard refresh if not CSS or an image
+	wsHub.broadcast <- []byte(`{"command":"reload","path":"` + s + "\"" + `,"originalPath":"","liveCSS":true,"liveImg":true}`)
 }
 
 func ServeJS(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Not sure if this is as-designed or not, but it's stated in the documentation that _Hugo may not be the first static site generator to utilize live reload technology, but it’s the first to do it right_ so I create this issue:
- I'm used to LiveReload in Grunt (grunt-contrib-watch), and when I make changes to CSS - it will inject the changes without making a reload of the page.
- In Hugo evey change forces a browser refresh
- I have confirmed that the only change in /public is the CSS file I changed.

If your normal work flow is writing articles, then this isn't a real issue - but for pixel tweeking in CSS there is a big difference.
