### PR TITLE
Sort by title if dates are the same

### DIFF
--- a/hugolib/taxonomy.go
+++ b/hugolib/taxonomy.go
@@ -166,10 +166,12 @@ func (p WeightedPages) Sort()         { sort.Stable(p) }
 func (p WeightedPages) Count() int    { return len(p) }
 func (p WeightedPages) Less(i, j int) bool {
 	if p[i].Weight == p[j].Weight {
-		return p[i].Page.Date.Unix() > p[j].Page.Date.Unix()
-	} else {
-		return p[i].Weight < p[j].Weight
+		if p[i].Page.Date.Equal(p[j].Page.Date) {
+			return p[i].Page.Title < p[j].Page.Title
+		}
+		return p[i].Page.Date.After(p[i].Page.Date)
 	}
+	return p[i].Weight < p[j].Weight
 }
 
 // TODO mimic PagesSorter for WeightedPages


### PR DESCRIPTION
This change makes it so that if you have a list of content, they'll get sorted into some sort of reasonable order even if they don't have dates. This is actually a follow up from the other sorting change where I used sort.stable, but I realized that change alone was not enough to get the code to produce consistent output.   Sorting by title when all else is equal, is, though.
