### PR TITLE
make the value of the BuildDrafts flag available to templates.

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -92,6 +92,7 @@ type SiteInfo struct {
 	ConfigGet       func(key string) interface{}
 	Permalinks      PermalinkOverrides
 	Params          map[string]interface{}
+	BuildDrafts     bool
 }
 
 func (s *SiteInfo) GetParam(key string) interface{} {
@@ -279,6 +280,7 @@ func (s *Site) initializeSiteInfo() {
 		LanguageCode:    viper.GetString("languagecode"),
 		Copyright:       viper.GetString("copyright"),
 		DisqusShortname: viper.GetString("DisqusShortname"),
+		BuildDrafts:     viper.GetBool("BuildDrafts"),
 		Pages:           &s.Pages,
 		Recent:          &s.Pages,
 		Menus:           &s.Menus,


### PR DESCRIPTION
This can be very useful for templates that want to show data only when run locally on your machine.   I use it as a way to keep some data hidden from the published website, that is displayed only to me when I run locally showing drafts.  This can also be useful to partition off drafts in a list that only shows up when you know you're building drafts.
