### PR TITLE
Make taxonomy documentation match the example.

### DIFF
--- a/docs/content/taxonomies/usage.md
+++ b/docs/content/taxonomies/usage.md
@@ -16,7 +16,8 @@ Taxonomies must be defined in the site configuration, before they can be
 used throughout the site. You need to provide both the plural and
 singular labels for each taxonomy.
 
-Here is an example configuration in YAML that specifies two taxonomies.
+Here is an example configuration in YAML that specifies three taxonomies
+(the default two, plus `series`).
 
 Notice the format is **singular key** : *plural value*. 
 ### config.yaml


### PR DESCRIPTION
diff --git a/docs/content/taxonomies/usage.md b/docs/content/taxonomies/usage.md
index 4db3736..cd462ec 100644
--- a/docs/content/taxonomies/usage.md
+++ b/docs/content/taxonomies/usage.md
@@ -16,7 +16,8 @@ Taxonomies must be defined in the site configuration, before they can be
 used throughout the site. You need to provide both the plural and
 singular labels for each taxonomy.

-Here is an example configuration in YAML that specifies two taxonomies.
+Here is an example configuration in YAML that specifies three taxonomies
+(the default two, plus `series`).

 Notice the format is **singular key** : _plural value_. 
 ### config.yaml
