### PR TITLE
Configure footnote rendering.

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -121,6 +121,8 @@ func InitializeConfig() {
 	viper.SetDefault("PygmentsUseClasses", false)
 	viper.SetDefault("DisableLiveReload", false)
 	viper.SetDefault("PluralizeListTitles", true)
+	viper.SetDefault("FootnoteAnchorPrefix", "")
+	viper.SetDefault("FootnoteReturnLinkContents", "")
 
 	if hugoCmdV.PersistentFlags().Lookup("buildDrafts").Changed {
 		viper.Set("BuildDrafts", Draft)

--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -40,6 +40,7 @@ The following is an example of a toml config file with some of the default value
     builddrafts = false
     baseurl = "http://yoursite.example.com/"
     canonifyurls = true
+
     [indexes]
        category = "categories"
        tag = "tags"
@@ -49,6 +50,7 @@ Here is a yaml configuration file which sets a few more options
     ---
     baseurl: "http://yoursite.example.com/"
     title: "Yoyodyne Widget Blogging"
+    footnotereturnlinkcontents: "↩"
     permalinks:
       post: /:year/:month/:title/
     params:


### PR DESCRIPTION
- The config file can provide `FootnoteAnchorPrefix`, which will be used by blackfriday when rendering to HTML. A value of `q:` has the effect of making the anchor for a footnote `[^footie]` be `fn:q:footie`. The default is `""`.
- The config file can provide `FootnoteReturnLinkContents`, which will be used by blackfriday when rendering to HTML. A value of `^` has the effect of making the return link be `^` instead of `[return]`.
