### PR TITLE
Fix #405: Feeds the title-ized taxonomy key through string replace to replace...

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -815,7 +815,7 @@ func taxonomyRenderer(s *Site, taxes <-chan taxRenderInfo, results chan<- error,
 	for t := range taxes {
 		base := t.plural + "/" + t.key
 		n := s.NewNode()
-		n.Title = strings.Title(t.key)
+		n.Title = strings.Replace(strings.Title(t.key), "-", " ", -1)
 		s.setUrls(n, base)
 		n.Date = t.pages[0].Page.Date
 		n.Data[t.singular] = t.pages


### PR DESCRIPTION
...the '-' with ' ' for proper display of the taxonomy title. 

`categories/basic-citizen-income/` listing page's title is now **Basic Citizen Income** instead of **Basic-Citizen-Income**.

I did not see a setting to configure the character used for space replacement so I hard-coded "-". If this is configurable, or should be, please let me know where I should be obtaining this value from for the string.Replace().
