### PR TITLE
#462 fix, remove leading and trailing dashes from urlized slug. includes...

### DIFF
--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -46,7 +46,7 @@ Leading
     "Development",
     "VIM"
 ],
-"slug": "spf13-vim-3-0-release-and-new-website"
+"slug": "-spf13-vim-3-0-release-and-new-website-"
 }
 
 Content of the file goes Here
@@ -566,13 +566,13 @@ func TestLayoutOverride(t *testing.T) {
 }
 
 func TestSliceToLower(t *testing.T) {
-	tests := []struct{
-		value []string
+	tests := []struct {
+		value    []string
 		expected []string
 	}{
-		{[]string{"a","b","c"}, []string{"a", "b", "c"}},
-                {[]string{"a","B","c"}, []string{"a", "b", "c"}},
-                {[]string{"A","B","C"}, []string{"a", "b", "c"}},
+		{[]string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{[]string{"a", "B", "c"}, []string{"a", "b", "c"}},
+		{[]string{"A", "B", "C"}, []string{"a", "b", "c"}},
 	}
 
 	for _, test := range tests {

--- a/hugolib/permalinks.go
+++ b/hugolib/permalinks.go
@@ -128,6 +128,14 @@ func pageToPermalinkFilename(p *Page, _ string) (string, error) {
 // if the page has a slug, return the slug, else return the title
 func pageToPermalinkSlugElseTitle(p *Page, a string) (string, error) {
 	if p.Slug != "" {
+		// Don't start or end with a -
+		if strings.HasPrefix(p.Slug, "-") {
+			p.Slug = p.Slug[1:len(p.Slug)]
+		}
+
+		if strings.HasSuffix(p.Slug, "-") {
+			p.Slug = p.Slug[0 : len(p.Slug)-1]
+		}
 		return p.Slug, nil
 	}
 	return pageToPermalinkTitle(p, a)


### PR DESCRIPTION
... test changes

This fixes #462. Leading and trailing dashes `-` are removed from a urlized slug so that it results in a url slug like `url-slug` instead of `-url-slug-`  as referenced in the issue.
