### PR TITLE
Add Ace template engine support

### DIFF
--- a/tpl/template.go
+++ b/tpl/template.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/hugo/helpers"
 	jww "github.com/spf13/jwalterweatherman"
+	"github.com/yosssi/ace"
 )
 
 var localTemplates *template.Template
@@ -669,6 +670,24 @@ func (t *GoHtmlTemplate) AddTemplateFile(name, path string) error {
 		if _, err := compiler.CompileWithTemplate(t.New(name)); err != nil {
 			return err
 		}
+	case ".ace":
+		b, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		name = name[:len(name)-len(ext)] + ".html"
+		base := ace.NewFile(path, b)
+		inner := ace.NewFile("", []byte{})
+		rslt, err := ace.ParseSource(ace.NewSource(base, inner, []*ace.File{}), nil)
+		if err != nil {
+			t.errors = append(t.errors, &templateErr{name: name, err: err})
+			return err
+		}
+		_, err = ace.CompileResultWithTemplate(t.New(name), rslt, nil)
+		if err != nil {
+			t.errors = append(t.errors, &templateErr{name: name, err: err})
+		}
+		return err
 	default:
 		b, err := ioutil.ReadFile(path)
 		if err != nil {


### PR DESCRIPTION
This feature is discussed at forum topic "[Amber templates not working… documentation?](http://discuss.gohugo.io/t/amber-templates-not-working-documentation/129/15)". The needed upstream (Ace) modification was merged so it's time to send this.

This detects `.ace` suffix of a template file and treat it as a template written in Ace. It has a small trick

```
name = name[:len(name)-len(ext)] + ".html"
```

to avoid a layout call error (like "Unable to locate layout") at rendering pages because `.html` suffix is hard coded in many caller functions. It also has unexpected feature using multi template engine at the same time.

It only affects an internal template name, not a real file name but I think it's better to use a template engine independent name in caller functions or allow to specify a suffix it in future version.
