### PR TITLE
Minor proofreading corrections to Hugo docs

### DIFF
--- a/docs/content/community/mailing-list.md
+++ b/docs/content/community/mailing-list.md
@@ -11,7 +11,7 @@ weight: 10
 
 # Discussion Forum
 
-Hugo has it’s own [discussion forum](http://discuss.gohugo.io) powered by [Discourse](http://www.discourse.org/)
+Hugo has its own [discussion forum](http://discuss.gohugo.io) powered by [Discourse](http://www.discourse.org/).
 
 Please use this for all discussions, questions, etc.
 

--- a/docs/content/extras/comments.md
+++ b/docs/content/extras/comments.md
@@ -14,19 +14,19 @@ As Hugo is a static site generator, the content produced is static and
 doesn’t interact with the users. The most common interaction people ask
 for is comment capability.
 
-Hugo ships with support for [disqus](http://disqus.com), a third party
+Hugo ships with support for [Disqus](http://disqus.com), a third-party
 service that provides comment and community capabilities to website via
-javascript.
+JavaScript.
 
-Your theme may already support disqus, but even it if doesn’t it is easy
+Your theme may already support Disqus, but even it if doesn’t, it is easy
 to add.
 
 # Disqus Support
 
 ## Adding Disqus to a template
 
-Hugo comes with all the code you would need to include load disqus.
-Simply include the following line where you want your comments to appear
+Hugo comes with all the code you would need to include load Disqus.
+Simply include the following line where you want your comments to appear:
 
     {{ template "_internal/disqus.html" . }}
 
@@ -37,8 +37,8 @@ That template requires you to set a single value in your site config file, e.g. 
 
     disqusShortname = "XYW"
 
-Additionally you can optionally set the following in the front matter
-for a given piece of content
+Additionally, you can optionally set the following in the front matter
+for a given piece of content:
 
  * **disqus_identifier**
  * **disqus_title**
@@ -47,16 +47,16 @@ for a given piece of content
 
 ## Conditional Loading of Disqus Comments
 
-Users have noticed that enabling disqus comments when running the hugo web server on localhost causes the creation of unwanted discussions on the associated disqus account. In order to prevent this, a slightly tweaked partial template is required. So, rather than using the built-in `"_internal/disqus.html"` template referenced above, create a template in your `partials` folder that looks like this:
+Users have noticed that enabling Disqus comments when running the Hugo web server on localhost causes the creation of unwanted discussions on the associated Disqus account. In order to prevent this, a slightly tweaked partial template is required. So, rather than using the built-in `"_internal/disqus.html"` template referenced above, create a template in your `partials` folder that looks like this:
 
 ```javascript
 <div id="disqus_thread"></div>
 <script type="text/javascript">
 
 (function() {
-    // Don't ever inject disqus on localhost--it creates unwanted 
-    // discussions from 'localhost:1313' on your disqus account...
-    if (window.location.hostname == "localhost") 
+    // Don't ever inject Disqus on localhost--it creates unwanted
+    // discussions from 'localhost:1313' on your Disqus account...
+    if (window.location.hostname == "localhost")
         return;
 
     var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
@@ -69,31 +69,32 @@ Users have noticed that enabling disqus comments when running the hugo web serve
 <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 ```
 
-Notice that there is a simple if statement that detects when you are running on localhost and skips the initialization of the disqus comment injection.
+Notice that there is a simple `if` statement that detects when you are running on localhost and skips the initialization of the Disqus comment injection.
 
-Now reference the partial template from your page template:
+Now, reference the partial template from your page template:
 
     {{ partial "disqus.html" . }}
 
 
 # Alternatives
 
-A few alternatives exist to Disqus.
+A few alternatives exist to [Disqus](http://disqus.com):
 
 * [Intense Debate](http://intensedebate.com/)
 * [LiveFyre](http://livefyre.com/)
 * [Moot](http://muut.com)
+* [多说](http://duoshuo.com/) ([Duoshuo](http://duoshuo.com/), popular in China)
 * [Kaiju](http://github.com/spf13/kaiju)
 
 
-[Kaiju](http://github.com/spf13/kaiju) is a open source project started
+[Kaiju](http://github.com/spf13/kaiju) is an open-source project started
 by [spf13](http://spf13.com) (Hugo’s author) to bring easy and fast real
 time discussions to the web.
 
-Written using Go, Socket.io and MongoDB it is very fast and easy to
+Written using Go, Socket.io and MongoDB, it is very fast and easy to
 deploy.
 
-It is in early development but shows promise.. If you have interest
+It is in early development but shows promise. If you have interest,
 please help by contributing whether via a pull request, an issue or even
 just a tweet. Everything helps.
 

--- a/docs/content/extras/menus.md
+++ b/docs/content/extras/menus.md
@@ -21,7 +21,7 @@ Some of the features of Hugo Menus:
 
 ## What is a menu?
 
-A menus is a named array of menu entries accessible on the site under
+A menu is a named array of menu entries accessible on the site under
 `.Site.Menus` by name. For example, if I have a menu called `main`, I would
 access it via `.Site.Menus.main`.
 
@@ -87,7 +87,7 @@ available.
 ## Adding (non-content) entries to a menu
 
 You can also add entries to menus that aren’t attached to a piece of
-content. This takes place in the site wide [config file](http://gohugo.io/overview/configuration).
+content. This takes place in the sitewide [config file](/overview/configuration).
 
 Here’s an example (in TOML):
 

--- a/docs/content/extras/shortcodes.md
+++ b/docs/content/extras/shortcodes.md
@@ -11,39 +11,39 @@ title: Shortcodes
 weight: 40
 ---
 
-Hugo uses markdown for its simple content format, however there's a lot
-of things that markdown doesn't support well.
+Hugo uses Markdown for its simple content format. However, there’s a lot
+of things that Markdown doesn’t support well.
 
 We are unwilling to accept being constrained by our simple format. Also
-unacceptable is writing raw html in our markdown every time we want to include
+unacceptable is writing raw HTML in our Markdown every time we want to include
 unsupported content such as a video. To do so is in complete opposition to the
 intent of using a bare bones format for our content and utilizing templates to
 apply styling for display.
 
-To avoid both of these limitations Hugo created shortcodes.
+To avoid both of these limitations, Hugo created shortcodes.
 
 A shortcode is a simple snippet inside a content file that Hugo will render
-using a predefined template. Note that shortcodes will not work in template 
-files - if you need a functionality like that in a template, you most likely
+using a predefined template. Note that shortcodes will not work in template
+files---if you need a functionality like that in a template, you most likely
 want a [partial template](/templates/partial) instead.
 
 ## Using a shortcode
 
-In your content files a shortcode can be called by using '{{&#37; name parameters
-%}}' respectively. Shortcodes are space delimited (parameters with spaces
+In your content files, a shortcode can be called by using '`{{% name parameters
+%}}`' respectively. Shortcodes are space delimited (parameters with spaces
 can be quoted).
 
 The first word is always the name of the shortcode. Parameters follow the name.
-The format for named parameters models that of html with the format
-name="value". The current implementation only supports this exact format. Extra
-spaces or different quote marks will not parse properly.
+The format for named parameters models that of HTML with the format
+`name="value"`. The current implementation only supports this exact format. Extra
+spaces or different quotation marks will not parse properly.
 
 Some shortcodes use or require closing shortcodes. Like HTML, the opening and closing
 shortcodes match (name only), the closing being prepended with a slash.
 
 Example of a paired shortcode:
 
-    {{ % highlight go %}} A bunch of code here {{ % /highlight %}} 
+    {{ % highlight go %}} A bunch of code here {{ % /highlight %}}
 
 
 ## Hugo Shortcodes
@@ -53,14 +53,14 @@ Hugo ships with a set of predefined shortcodes.
 ### highlight
 
 This shortcode will convert the source code provided into syntax highlighted
-html. Read more on [highlighting](/extras/highlighting).
+HTML. Read more on [highlighting](/extras/highlighting).
 
 #### Usage
-Highlight takes exactly one required parameter of language and requires a
+`highlight` takes exactly one required parameter of _language_ and requires a
 closing shortcode.
 
 #### Example
-The example has an extra space between the “{{” and “%” characters to prevent rendering here.
+The example has an extra space between the “`{{`” and “`%`” characters to prevent rendering here.
 
     {{ % highlight html %}}
     <section id="main">
@@ -86,12 +86,12 @@ The example has an extra space between the “{{” and “%” characters to pr
     <span style="color: #f92672">&lt;/section&gt;</span>
 
 ### figure
-Figure is simply an extension of the image capabilities present with Markdown.
-figure provides the ability to add captions, css classes, alt text, links etc.
+`figure` is simply an extension of the image capabilities present with Markdown.
+`figure` provides the ability to add captions, CSS classes, alt text, links etc.
 
 #### Usage
 
-figure can use the following parameters
+`figure` can use the following parameters:
 
  * src
  * link
@@ -102,7 +102,7 @@ figure can use the following parameters
  * alt
 
 #### Example
-*Example has an extra space so Hugo doesn't actually render it*.
+*Example has an extra space so Hugo doesn’t actually render it*.
 
     {{ % figure src="/media/spf13.jpg" title="Steve Francia" %}}
 
@@ -120,30 +120,29 @@ figure can use the following parameters
 To create a shortcode, place a template in the layouts/shortcodes directory. The
 template name will be the name of the shortcode.
 
-In creating a shortcode you can choose if the short code will use positional
-parameters or named parameters (but not both). A good rule of thumb is that if a
-short code has a single required value in the case of the youtube example below
+In creating a shortcode, you can choose if the shortcode will use _positional
+parameters_ or _named parameters_ (but not both). A good rule of thumb is that if a
+shortcode has a single required value in the case of the `youtube` example below,
 then positional works very well. For more complex layouts with optional
-parameters named parameters work best.
+parameters, named parameters work best.
 
 **Inside the template**
 
-To access a parameter by position the `.Get` method can be used.
+To access a parameter by position, the `.Get` method can be used:
 
     {{ .Get 0 }}
 
-To access a parameter by name the `.Get` method should be utilized
+To access a parameter by name, the `.Get` method should be utilized:
 
     {{ .Get "class" }}
 
-
-With is great when the output depends on a parameter being set
+`with` is great when the output depends on a parameter being set:
 
     {{ with .Get "class"}} class="{{.}}"{{ end }}
 
-Get can also be used to check if a parameter has been provided. This is
+`.Get` can also be used to check if a parameter has been provided. This is
 most helpful when the condition depends on either one value or another...
-or both. 
+or both:
 
     {{ or .Get "title" | .Get "alt" | if }} alt="{{ with .Get "alt"}}{{.}}{{else}}{{.Get "title"}}{{end}}"{{ end }}
 
@@ -167,18 +166,18 @@ Would load the template /layouts/shortcodes/youtube.html
     </iframe>
     </div>
 
-This would be rendered as 
+This would be rendered as:
 
     <div class="embed video-player">
     <iframe class="youtube-player" type="text/html"
-        width="640" height="385" 
+        width="640" height="385"
         src="http://www.youtube.com/embed/09jf3ow9jfw"
         allowfullscreen frameborder="0">
     </iframe>
     </div>
 
 ## Single Named Example: image with caption
-*Example has an extra space so Hugo doesn't actually render it*
+*Example has an extra space so Hugo doesn’t actually render it*
 
     {{ % img src="/media/spf13.jpg" title="Steve Francia" %}}
 
@@ -213,15 +212,16 @@ Would be rendered as:
     </figure>
 
 ## Paired Example: Highlight
-*Hugo already ships with the highlight shortcode*
+*Hugo already ships with the `highlight` shortcode*
 
-*Example has an extra space so Hugo doesn't actually render it*.
+*Example has an extra space so Hugo doesn’t actually render it*.
 
     <html>
         <body> This HTML </body>
     </html>
 
-The template for this utilizes the following code (already include in hugo)
+The template for this utilizes the following code (already include in Hugo)
+
     {{ .Get 0 | highlight .Inner  }}
 
 And will be rendered as:
@@ -231,7 +231,7 @@ And will be rendered as:
     <span style="color: #f92672">&lt;/html&gt;</span>
     </pre></div>
 
-Please notice that this template makes use of a hugo specific template function
-called highlight which uses pygments to add the highlighting code.
+Please notice that this template makes use of a Hugo-specific template function
+called `highlight` which uses Pygments to add the highlighting code.
 
-More shortcode examples can be found at [spf13.com](https://github.com/spf13/spf13.com/tree/master/layouts/shortcodes)
+More shortcode examples can be found at [spf13.com](https://github.com/spf13/spf13.com/tree/master/layouts/shortcodes).

--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -65,6 +65,6 @@ Here is a yaml configuration file which sets a few more options
 
 ## Notes
 
-Config changes do not reflect with [Live Reload](http://gohugo.io/extras/livereload)
+Config changes do not reflect with [Live Reload](/extras/livereload).
 
 Please restart `hugo server --watch` whenever you make a config change.

--- a/docs/content/overview/introduction.md
+++ b/docs/content/overview/introduction.md
@@ -66,7 +66,7 @@ Hugo boasts the following features:
   * Completely [customizable homepage](/layout/homepage)
   * Support for multiple [content types](/content/types)
   * Automatic and user defined [summaries](/content/summaries)
-  * [shortcodes](/extras/shortcodes) to enable rich content inside of Markdown
+  * [Shortcodes](/extras/shortcodes) to enable rich content inside of Markdown
   * ["Minutes to Read"](/layout/variables) functionality
   * ["Wordcount"](/layout/variables) functionality
 

--- a/docs/content/overview/quickstart.md
+++ b/docs/content/overview/quickstart.md
@@ -77,7 +77,7 @@ We still lack any templates to tell us how to display the content.
 
 ## Step 4. Install some themes
 
-Hugo has rich theme support and a growing set of themes to choose from.
+Hugo has rich theme support and a growing set of themes to choose from:
 
     git clone --recursive https://github.com/spf13/hugoThemes themes
 

--- a/docs/content/overview/usage.md
+++ b/docs/content/overview/usage.md
@@ -27,12 +27,12 @@ Make sure either hugo is in your path or provide a path to it.
       hugo [command]
 
     Available Commands:
-      server                    :: Hugo runs its own a webserver to render the files
-      version                   :: Print the version number of Hugo
-      check                     :: Check content in the source directory
-      benchmark                 :: Benchmark hugo by building a site a number of times
-      new [path]                :: Create new content for your site
-      help [command]            :: Help about any command
+      server                    Hugo runs its own webserver to render the files
+      version                   Print the version number of Hugo
+      check                     Check content in the source directory
+      benchmark                 Benchmark hugo by building a site a number of times
+      new [path]                Create new content for your site
+      help [command]            Help about any command
 
      Available Flags:
       -b, --baseUrl="": hostname (and path) to the root eg. http://spf13.com/

--- a/docs/content/showcase/ucsb.md
+++ b/docs/content/showcase/ucsb.md
@@ -6,7 +6,7 @@ licenseLink: ""
 sitelink: http://www.philosophy.ucsb.edu/
 sourceLink: https://github.com/grumble/philweb
 tags:
-- educatation
+- education
 thumbnail: /img/ucsb-tn.jpg
 title: ucsb
 ---

--- a/docs/content/taxonomies/displaying.md
+++ b/docs/content/taxonomies/displaying.md
@@ -14,23 +14,23 @@ weight: 20
 
 There are four common ways you can display the data in your
 taxonomies in addition to the automatic taxonomy pages created by hugo
-using the [list templates](/templates/list).
+using the [list templates](/templates/list):
 
-1. For a given piece of content you can list the terms attached 
-2. For a given piece of content you can list other content with the same
+1. For a given piece of content, you can list the terms attached
+2. For a given piece of content, you can list other content with the same
    term
 3. You can list all terms for a taxonomy
 4. You can list all taxonomies (with their terms)
 
 ## 1. Displaying taxonomy terms assigned to this content
 
-Within your content templates you may wish to display 
+Within your content templates, you may wish to display
 the taxonomies that that piece of content is assigned to.
 
-Because we are leveraging the front matter system to 
-define taxonomies for content, the taxonomies assigned to 
-each content piece are located in the usual place 
-(.Params.`plural`)
+Because we are leveraging the front matter system to
+define taxonomies for content, the taxonomies assigned to
+each content piece are located in the usual place
+(.Params.`plural`).
 
 ### Example
 
@@ -42,7 +42,7 @@ each content piece are located in the usual place
 
 ## 2. Listing content with the same taxonomy term
 
-First you may be asking why you would use this. If you are using a
+First, you may be asking why you would use this. If you are using a
 taxonomy for something like a series of posts, this is exactly how you
 would do it. It’s also an quick and dirty way to show some related
 content.
@@ -80,7 +80,7 @@ different terms to the content.
 
 ## 4. Rendering a Site's Taxonomies
 
-If you wish to display the list of all keys for an taxonomy you can find retrieve
+If you wish to display the list of all keys for an taxonomy, you can find retrieve
 them from the `.Site` variable which is available on every page.
 
 This may take the form of a tag cloud, a menu or simply a list.
@@ -91,7 +91,7 @@ The following example displays all tag keys:
 
     <ul id="all-tags">
       {{ range $name, $taxonomy := .Site.Taxonomies.tags }}
-        <li><a href="/tags/{{ $name | urlize }}">{{ $name }}</a></li>  
+        <li><a href="/tags/{{ $name | urlize }}">{{ $name }}</a></li>
       {{ end }}
     </ul>
 
@@ -101,7 +101,7 @@ This example will list all taxonomies, each of their keys and all the content as
     <section>
       <ul>
         {{ range $taxonomyname, $taxonomy := .Site.Taxonomies }}
-          <li><a href="/{{ $taxonomyname | urlize }}">{{ $taxonomyname }}</a> 
+          <li><a href="/{{ $taxonomyname | urlize }}">{{ $taxonomyname }}</a>
             <ul>
               {{ range $key, $value := $taxonomy }}
               <li> {{ $key }} </li>
@@ -112,7 +112,7 @@ This example will list all taxonomies, each of their keys and all the content as
                     </ul>
               {{ end }}
             </ul>
-          </li> 
+          </li>
         {{ end }}
       </ul>
     </section>

--- a/docs/content/taxonomies/overview.md
+++ b/docs/content/taxonomies/overview.md
@@ -27,7 +27,7 @@ good use for taxonomies is to group a set of posts into a series. Other
 common uses would include categories, tags, groups, series and many
 more.
 
-When taxonomies are used (and templates are provided) Hugo will
+When taxonomies are used (and templates are provided), Hugo will
 automatically create pages listing all of the taxonomies, their terms
 and all of the content attached to those terms.
 
@@ -41,7 +41,7 @@ and all of the content attached to those terms.
 
 ## Example
 
-For example if I was writing about movies I may want the following
+For example, if I was writing about movies, I may want the following
 taxonomies:
 
 * Actors
@@ -51,7 +51,7 @@ taxonomies:
 * Year
 * Awards
 
-I would then specify in each movies front-matter the specific terms for
+I would then specify in each movie’s front-matter the specific terms for
 each of those taxonomies. Hugo would then automatically create pages for
 each Actor, Director, Studio, Genre, Year and Award listing all of the
 Movies that matched that specific Actor, Director, etc.
@@ -60,7 +60,7 @@ Movies that matched that specific Actor, Director, etc.
 ### Taxonomy Organization
 
 Let’s use an example to demonstrate the different labels in action.
-From the perspective of the taxonomy it could be visualized as:
+From the perspective of the taxonomy, it could be visualized as:
 
     Actor                    <- Taxonomy
         Bruce Willis         <- Term
@@ -72,7 +72,7 @@ From the perspective of the taxonomy it could be visualized as:
             The Avengers     <- Content
             xXx              <- Content
 
-From the perspective of the content if would appear differently, though
+From the perspective of the content, it would appear differently, though
 the data and labels used are the same:
 
     Unbreakable                 <- Content

--- a/docs/content/taxonomies/usage.md
+++ b/docs/content/taxonomies/usage.md
@@ -12,7 +12,7 @@ weight: 15
 
 ## Defining taxonomies for a site
 
-Taxonomies must be defined in the site configuration, before they can be
+Taxonomies must be defined in the site configuration before they can be
 used throughout the site. You need to provide both the plural and
 singular labels for each taxonomy.
 
@@ -39,6 +39,17 @@ Simply create a variable with the *plural* name of the taxonomy
 and assign all terms you want to apply to this content.
 
 **taxonomy values are case insensitive**
+
+### Front Matter Example (in TOML)
+
+    +++
+    title = "Hugo: A fast and flexible static site generator"
+    tags = [ "Development", "Go", "fast", "Blogging" ]
+    categories = [ "Development" ]
+    series = [ "Go Web Dev" ]
+    slug = "hugo"
+    project_url = "http://github.com/spf13/hugo"
+    +++
 
 ### Front Matter Example (in JSON)
 

--- a/docs/content/templates/go-templates.md
+++ b/docs/content/templates/go-templates.md
@@ -211,7 +211,7 @@ is the same as
 
     {{ eq 1 1 | if }} Same {{ end }}
 
-It does look odd to place the if at the end, but it does provide a good
+It does look odd to place the `if` at the end, but it does provide a good
 illustration of how to use the pipes.
 
 **Example 2:**

--- a/docs/content/tutorials/github_pages_blog.md
+++ b/docs/content/tutorials/github_pages_blog.md
@@ -175,7 +175,7 @@ To build all draft posts *(If you only have drafts, no site will be generated)*
 
     #!/bin/bash
 
-    echo -e "\033[0;32mDeploying updates to Github...\033[0m"
+    echo -e "\033[0;32mDeploying updates to GitHub...\033[0m"
 
     # Build the project. 
     hugo

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -31,7 +31,7 @@
         <a href="/overview/introduction" class="btn btn-primary btn-lg">Docs <i class="icon-idea"></i></a>
         <a href="#action" class="btn btn-success btn-lg">Install <i class="icon-arrow-down"></i></a>
         <a href="http://discuss.gohugo.io" class="btn btn-info btn-lg">Community <i class="icon-talking"></i></a>
-        <a href="https://github.com/spf13/hugo" class="btn btn-dark btn-lg">Github <i class="icon-circlestar"></i></a>
+        <a href="https://github.com/spf13/hugo" class="btn btn-dark btn-lg">GitHub <i class="icon-circlestar"></i></a>
         </div>
       </div>
     </div>
@@ -49,7 +49,7 @@
                     Introducing Hugo, a new idea around making website creation simple again.
                     Hugo flexibly works with many formats and is ideal for
                     blogs, docs, portfolios and much more.
-                    Hugo&#39;s speed fosters
+                    Hugo’s speed fosters
                     creativity and makes building a website fun again.
                 </p>
               </div>
@@ -68,9 +68,9 @@
                   <i class="point-icon icon-windows8"></i>
                 <h2>Run Anywhere</h2>
                 <p class="lead">
-                Hugo is quite possibly the easiest to install software you&#39;ve ever used,
-                simply download and run. <b>Hugo doesn&#39;t depend on administrative privileges, databases, runtimes, interpreters
-                    or external libraries</b>. Sites built with Hugo can be deployed on S3, Github Pages, Dropbox or any web host.
+                Hugo is quite possibly the easiest to install software you’ve ever used,
+                simply download and run. <b>Hugo doesn’t depend on administrative privileges, databases, runtimes, interpreters
+                    or external libraries</b>. Sites built with Hugo can be deployed on S3, GitHub Pages, Dropbox or any web host.
                 </p>
               </div>
             </div>
@@ -89,7 +89,7 @@
 
                 Hugo is written for speed and performance. Great care has been
                 taken to ensure that Hugo build time is as short as possible.
-                We're talking milliseconds to build your entire site for most setups.
+                We’re talking milliseconds to build your entire site for most setups.
 
                 </p>
               </div>
@@ -147,7 +147,7 @@
                       <div class="item"> <blockquote><p>I love Hugo! My site is generated with it now http://rjrbt.io </p>&mdash; Nathan Toups (@rojoroboto) <a href="https://twitter.com/rojoroboto/status/423439915620106242">January 15, 2014</a></blockquote> </div>
                       <div class="item"> <blockquote><p>this is AWESOME. a single little executable and so fast.</p>&mdash; Luke Holder (@lukeholder) <a href="https://twitter.com/lukeholder/status/430352287936946176">February 3, 2014</a></blockquote> </div>
                       <div class="item"> <blockquote><p>OK, so in today's speed battle of static site generators, @spf13's hugo is kicking everyone's ass, by miles.</p>&mdash; Kieran Healy (@kjhealy) <a href="https://twitter.com/kjhealy/status/437349384809115648">February 22, 2014</a></blockquote> </div>
-                      <div class="item"> <blockquote><p>I think I'm going to level up and try @spf13 's Hugo for my next project.</p>Dave Cheney (@davecheney ) <a href="https://twitter.com/davecheney/status/448036906740097024">March 24, 2014</a></blockquote> </div>
+                      <div class="item"> <blockquote><p>I think I'm going to level up and try @spf13&nbsp;'s Hugo for my next project.</p>Dave Cheney (@davecheney ) <a href="https://twitter.com/davecheney/status/448036906740097024">March 24, 2014</a></blockquote> </div>
                       <div class="item"> <blockquote><p>I just fell in love with #hugo, a static site/blog engine written by @spf13 in #golang  + stellar docs</p>&mdash; Dave Cottlehuber (@dch__) <a href="https://twitter.com/dch__/status/460158115498176512">April 26, 2014</a></blockquote> </div>
                       <div class="item"> <blockquote><p>Another site generated with Hugo here! I'm getting in love with it. </p>&mdash; Javier Segura (@jsegura) <a href="https://twitter.com/jsegura/status/465978434154659841">May 12, 2014</a></blockquote> </div>
                       <div class="item"> <blockquote><p>One more satisfied #Hugo blogger. Thanks @spf13 and friends!</p>&mdash; Michael Whatcott (@mdwhatcott) <a href="https://twitter.com/mdwhatcott/status/469980686531571712">May 23, 2014</a></blockquote> </div>

--- a/docs/layouts/section/showcase.html
+++ b/docs/layouts/section/showcase.html
@@ -7,6 +7,6 @@
         {{ end }}
         </div>
   <br><br>
-  If you want to be added to this page please send a <a href="https://github.com/spf13/hugo/pulls">pull request</a>.
+  If you want to be added to this page, please send a <a href="https://github.com/spf13/hugo/pulls">pull request</a>.
 
 {{ partial "footer.html" . }}


### PR DESCRIPTION
- Add backticks and commas where necessary
- Remove some trailing whitespace
- Add front matter example in TOML
- Fix typo in one of the tags in Showcase
- Add 多说 (Duoshuo) as an alternative to Disqus
- Use internal links (i.e. without gohugo.io) where possible
- Use a colon to set off an example
- Change "it's" to "its" where appropriate
- Use typographical (i.e. curly) apostrophe on the front page
  where appropriate
- Capitalize "Github" as "GitHub"
