### PR TITLE
Document manual breakpoint of .Summary

### DIFF
--- a/docs/content/templates/variables.md
+++ b/docs/content/templates/variables.md
@@ -24,7 +24,7 @@ matter, content or derived from file location.
 
 **.Title**  The title for the content.<br>
 **.Content** The content itself, defined below the front matter.<br>
-**.Summary** A generated summary of the content for easily showing a snippet in a summary view.<br>
+**.Summary** A generated summary of the content for easily showing a snippet in a summary view. Note that the breakpoint can be set manually by inserting *&#x3C;!--more--&#x3E;* at the appropriate place in the content page.<br>
 **.Description** The description for the content.<br>
 **.Keywords** The meta keywords for this content.<br>
 **.Date** The date the content is associated with.<br>


### PR DESCRIPTION
The use of <!--more--> to set the breakpoint for the generated page summary is
mentioned in a release note, but not in the doc itself.

Very useful - and it leaves the formatting in place.
