### PR TITLE
Set Content-Type for livereload.js

### DIFF
--- a/livereload/livereload.go
+++ b/livereload/livereload.go
@@ -48,6 +48,7 @@ func RefreshPath(s string) {
 }
 
 func ServeJS(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/javascript")
 	w.Write(livereloadJS)
 }
 


### PR DESCRIPTION
The Content-Type was not set for livereload.js and was interpreteted by the
browser as text/plain.

This commit sets it to application/javascript.
