### PR TITLE
fixed server reporting Web Server is available at https://localhost:1313...

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -108,8 +108,6 @@ func server(cmd *cobra.Command, args []string) {
 
 func serve(port int) {
 	jww.FEEDBACK.Println("Serving pages from " + helpers.AbsPathify(viper.GetString("PublishDir")))
-	jww.FEEDBACK.Printf("Web Server is available at %s\n", viper.GetString("BaseUrl"))
-	fmt.Println("Press ctrl+c to stop")
 
 	fileserver := http.FileServer(http.Dir(helpers.AbsPathify(viper.GetString("PublishDir"))))
 
@@ -122,6 +120,10 @@ func serve(port int) {
 	} else {
 		http.Handle(u.Path+"/", http.StripPrefix(u.Path+"/", fileserver))
 	}
+
+	u.Scheme = "http"
+	jww.FEEDBACK.Printf("Web Server is available at %s\n", u.String())
+	fmt.Println("Press ctrl+c to stop")
 
 	err = http.ListenAndServe(":"+strconv.Itoa(port), nil)
 	if err != nil {


### PR DESCRIPTION
Hi!
This is a trivial fix, we are using hugo to build our site and as we are planning to run it over https we discovered that setting baseurl = "https://..." in config.toml makes "hugo server" output 
"Web Server is available at https://localhost:1313"
Which is not right
This change only modifies the http.scheme for printing.
Regards.
Marcelo
