### PR TITLE
Fix redirect-loop in Hugo server

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -120,7 +120,7 @@ func serve(port int) {
 	if u.Path == "" || u.Path == "/" {
 		http.Handle("/", fileserver)
 	} else {
-		http.Handle(u.Path+"/", http.StripPrefix(u.Path+"/", fileserver))
+		http.Handle(u.Path, http.StripPrefix(u.Path, fileserver))
 	}
 
 	err = http.ListenAndServe(":"+strconv.Itoa(port), nil)


### PR DESCRIPTION
An extra slash was added to the path if baseUrl had a sub-directory, causing
infinite redirect loop in Go's HTTP server.

Fixes #510
