### PR TITLE
No markdown for Pygments

### DIFF
--- a/helpers/pygments.go
+++ b/helpers/pygments.go
@@ -23,10 +23,18 @@ import (
 	"github.com/spf13/viper"
 )
 
-func Highlight(code string, lexer string) string {
-	var pygmentsBin = "pygmentize"
+const PYGMENTS_BIN = "pygmentize"
 
-	if _, err := exec.LookPath(pygmentsBin); err != nil {
+func HasPygments() bool {
+	if _, err := exec.LookPath(PYGMENTS_BIN); err != nil {
+		return false
+	}
+	return true
+}
+
+func Highlight(code string, lexer string) string {
+
+	if !HasPygments() {
 
 		jww.WARN.Println("Highlighting requires Pygments to be installed and in the path")
 		return code
@@ -41,7 +49,7 @@ func Highlight(code string, lexer string) string {
 		noclasses = "false"
 	}
 
-	cmd := exec.Command(pygmentsBin, "-l"+lexer, "-fhtml", "-O",
+	cmd := exec.Command(PYGMENTS_BIN, "-l"+lexer, "-fhtml", "-O",
 		fmt.Sprintf("style=%s,noclasses=%s,encoding=utf8", style, noclasses))
 	cmd.Stdin = strings.NewReader(code)
 	cmd.Stdout = &out

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -36,6 +36,11 @@ type ShortcodeWithPage struct {
 	Page   *Page
 }
 
+// a set of internal short codes that should not be treated as markdown
+var noMarkupShortCodes = map[string]bool{
+	"highlight": true,
+}
+
 func (scp *ShortcodeWithPage) Get(key interface{}) interface{} {
 	if reflect.ValueOf(scp.Params).Len() == 0 {
 		return nil
@@ -93,7 +98,13 @@ func ShortcodesHandle(stringToParse string, p *Page, t Template) string {
 			var data = &ShortcodeWithPage{Params: params, Page: p}
 			if endStart > 0 {
 				s := stringToParse[leadEnd+3 : leadEnd+endStart]
-				data.Inner = template.HTML(renderBytes([]byte(CleanP(ShortcodesHandle(s, p, t))), p.guessMarkupType(), p.UniqueId()))
+
+				if noMarkupShortCodes[name] {
+					data.Inner = template.HTML(ShortcodesHandle(s, p, t))
+				} else {
+					data.Inner = template.HTML(renderBytes([]byte(CleanP(ShortcodesHandle(s, p, t))), p.guessMarkupType(), p.UniqueId()))
+				}
+
 				remainder := CleanP(stringToParse[leadEnd+endEnd:])
 
 				return CleanP(stringToParse[:leadStart]) +

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -1,6 +1,8 @@
 package hugolib
 
 import (
+	"github.com/spf13/hugo/helpers"
+	"github.com/spf13/viper"
 	"strings"
 	"testing"
 )
@@ -85,4 +87,20 @@ func TestUnbalancedQuotes(t *testing.T) {
 	tem := NewTemplate()
 
 	CheckShortCodeMatch(t, `{{% figure src="/uploads/2011/12/spf13-mongosv-speaking-copy-1024x749.jpg "Steve Francia speaking at OSCON 2012" alt="MongoSV 2011" %}}`, "\n<figure >\n    \n        <img src=\"/uploads/2011/12/spf13-mongosv-speaking-copy-1024x749.jpg%20%22Steve%20Francia%20speaking%20at%20OSCON%202012\" alt=\"MongoSV 2011\" />\n    \n    \n</figure>\n", tem)
+}
+
+func TestHighlight(t *testing.T) {
+	if !helpers.HasPygments() {
+		t.Skip("Skip test as Pygments is not installed")
+	}
+	defer viper.Set("PygmentsStyle", viper.Get("PygmentsStyle"))
+	viper.Set("PygmentsStyle", "bw")
+
+	tem := NewTemplate()
+
+	code := `
+{{% highlight java %}}
+void do();
+{{% /highlight %}}`
+	CheckShortCodeMatch(t, code, "\n<div class=\"highlight\" style=\"background: #ffffff\"><pre style=\"line-height: 125%\"><span style=\"font-weight: bold\">void</span> do();\n</pre></div>\n", tem)
 }

--- a/hugolib/template.go
+++ b/hugolib/template.go
@@ -314,12 +314,6 @@ func Highlight(in interface{}, lang string) template.HTML {
 		str = av.String()
 	}
 
-	if strings.HasPrefix(strings.TrimSpace(str), "<pre><code>") {
-		str = str[strings.Index(str, "<pre><code>")+11:]
-	}
-	if strings.HasSuffix(strings.TrimSpace(str), "</code></pre>") {
-		str = str[:strings.LastIndex(str, "</code></pre>")]
-	}
 	return template.HTML(helpers.Highlight(html.UnescapeString(str), lang))
 }
 


### PR DESCRIPTION
Treating the content of the highlight-shortcode as Markdown has created some
issues; one had to indent the source code with 4 spaces to make it look OK.

There is an ongoing debate in the issues below about changing the shortcode API
to mark shortcodes that does not want/need Markdown processing.

This commit skips that whole discussion by fixing just the code higlighter
shortcode, by adding a new internal Set for shortcodes that should not be
processed as Markdown.

Relates to #560 and #565
