### PR TITLE
Add support for both non-rendered and rendered shortcodes

### DIFF
--- a/helpers/pygments.go
+++ b/helpers/pygments.go
@@ -1,4 +1,4 @@
-// Copyright © 2013 Steve Francia <spf@spf13.com>.
+// Copyright © 2013-14 Steve Francia <spf@spf13.com>.
 //
 // Licensed under the Simple Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,11 +23,18 @@ import (
 	"github.com/spf13/viper"
 )
 
+const PYGMENTS_BIN = "pygmentize"
+
+func HasPygments() bool {
+	if _, err := exec.LookPath(PYGMENTS_BIN); err != nil {
+		return false
+	}
+	return true
+}
+
 func Highlight(code string, lexer string) string {
-	var pygmentsBin = "pygmentize"
 
-	if _, err := exec.LookPath(pygmentsBin); err != nil {
-
+	if !HasPygments() {
 		jww.WARN.Println("Highlighting requires Pygments to be installed and in the path")
 		return code
 	}
@@ -41,7 +48,7 @@ func Highlight(code string, lexer string) string {
 		noclasses = "false"
 	}
 
-	cmd := exec.Command(pygmentsBin, "-l"+lexer, "-fhtml", "-O",
+	cmd := exec.Command(PYGMENTS_BIN, "-l"+lexer, "-fhtml", "-O",
 		fmt.Sprintf("style=%s,noclasses=%s,encoding=utf8", style, noclasses))
 	cmd.Stdin = strings.NewReader(code)
 	cmd.Stdout = &out

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -1,6 +1,8 @@
 package hugolib
 
 import (
+	"github.com/spf13/hugo/helpers"
+	"github.com/spf13/viper"
 	"strings"
 	"testing"
 )
@@ -22,39 +24,39 @@ func CheckShortCodeMatch(t *testing.T, input, expected string, template Template
 func TestNonSC(t *testing.T) {
 	tem := NewTemplate()
 
-	CheckShortCodeMatch(t, "{{% movie 47238zzb %}}", "{{% movie 47238zzb %}}", tem)
+	CheckShortCodeMatch(t, "{{< movie 47238zzb >}}", "{{< movie 47238zzb >}}", tem)
 }
 
 func TestPositionalParamSC(t *testing.T) {
 	tem := NewTemplate()
 	tem.AddInternalShortcode("video.html", `Playing Video {{ .Get 0 }}`)
 
-	CheckShortCodeMatch(t, "{{% video 47238zzb %}}", "Playing Video 47238zzb", tem)
-	CheckShortCodeMatch(t, "{{% video 47238zzb 132 %}}", "Playing Video 47238zzb", tem)
-	CheckShortCodeMatch(t, "{{%video 47238zzb%}}", "Playing Video 47238zzb", tem)
-	CheckShortCodeMatch(t, "{{%video 47238zzb    %}}", "Playing Video 47238zzb", tem)
-	CheckShortCodeMatch(t, "{{%   video   47238zzb    %}}", "Playing Video 47238zzb", tem)
+	CheckShortCodeMatch(t, "{{< video 47238zzb >}}", "Playing Video 47238zzb", tem)
+	CheckShortCodeMatch(t, "{{< video 47238zzb 132 >}}", "Playing Video 47238zzb", tem)
+	CheckShortCodeMatch(t, "{{<video 47238zzb>}}", "Playing Video 47238zzb", tem)
+	CheckShortCodeMatch(t, "{{<video 47238zzb    >}}", "Playing Video 47238zzb", tem)
+	CheckShortCodeMatch(t, "{{<   video   47238zzb    >}}", "Playing Video 47238zzb", tem)
 }
 
 func TestNamedParamSC(t *testing.T) {
 	tem := NewTemplate()
 	tem.AddInternalShortcode("img.html", `<img{{ with .Get "src" }} src="{{.}}"{{end}}{{with .Get "class"}} class="{{.}}"{{end}}>`)
 
-	CheckShortCodeMatch(t, `{{% img src="one" %}}`, `<img src="one">`, tem)
-	CheckShortCodeMatch(t, `{{% img class="aspen" %}}`, `<img class="aspen">`, tem)
-	CheckShortCodeMatch(t, `{{% img src= "one" %}}`, `<img src="one">`, tem)
-	CheckShortCodeMatch(t, `{{% img src ="one" %}}`, `<img src="one">`, tem)
-	CheckShortCodeMatch(t, `{{% img src = "one" %}}`, `<img src="one">`, tem)
-	CheckShortCodeMatch(t, `{{% img src = "one" class = "aspen grove" %}}`, `<img src="one" class="aspen grove">`, tem)
+	CheckShortCodeMatch(t, `{{< img src="one" >}}`, `<img src="one">`, tem)
+	CheckShortCodeMatch(t, `{{< img class="aspen" >}}`, `<img class="aspen">`, tem)
+	CheckShortCodeMatch(t, `{{< img src= "one" >}}`, `<img src="one">`, tem)
+	CheckShortCodeMatch(t, `{{< img src ="one" >}}`, `<img src="one">`, tem)
+	CheckShortCodeMatch(t, `{{< img src = "one" >}}`, `<img src="one">`, tem)
+	CheckShortCodeMatch(t, `{{< img src = "one" class = "aspen grove" >}}`, `<img src="one" class="aspen grove">`, tem)
 }
 
 func TestInnerSC(t *testing.T) {
 	tem := NewTemplate()
 	tem.AddInternalShortcode("inside.html", `<div{{with .Get "class"}} class="{{.}}"{{end}}>{{ .Inner }}</div>`)
 
-	CheckShortCodeMatch(t, `{{% inside class="aspen" %}}`, `<div class="aspen"></div>`, tem)
-	CheckShortCodeMatch(t, `{{% inside class="aspen" %}}More Here{{% /inside %}}`, "<div class=\"aspen\"><p>More Here</p>\n</div>", tem)
-	CheckShortCodeMatch(t, `{{% inside %}}More Here{{% /inside %}}`, "<div><p>More Here</p>\n</div>", tem)
+	CheckShortCodeMatch(t, `{{< inside class="aspen" >}}`, `<div class="aspen"></div>`, tem)
+	CheckShortCodeMatch(t, `{{< inside class="aspen" >}}More Here{{< /inside >}}`, "<div class=\"aspen\">More Here</div>", tem)
+	CheckShortCodeMatch(t, `{{< inside >}}More Here{{< /inside >}}`, "<div>More Here</div>", tem)
 }
 
 func TestInnerSCWithMarkdown(t *testing.T) {
@@ -67,6 +69,28 @@ func TestInnerSCWithMarkdown(t *testing.T) {
 [link](http://spf13.com) and text
 
 {{% /inside %}}`, "<div><h1>More Here</h1>\n\n<p><a href=\"http://spf13.com\">link</a> and text</p>\n</div>", tem)
+}
+
+func TestInnerSCWithAndWithoutMarkdown(t *testing.T) {
+	tem := NewTemplate()
+	tem.AddInternalShortcode("inside.html", `<div{{with .Get "class"}} class="{{.}}"{{end}}>{{ .Inner }}</div>`)
+
+	CheckShortCodeMatch(t, `{{% inside %}}
+# More Here
+
+[link](http://spf13.com) and text
+
+{{% /inside %}}
+
+And then:
+
+{{< inside >}}
+# More Here
+
+This is **plain** text.
+
+{{< /inside >}}
+`, "<div><h1>More Here</h1>\n\n<p><a href=\"http://spf13.com\">link</a> and text</p>\n</div>\n\nAnd then:\n\n<div>\n# More Here\n\nThis is **plain** text.\n\n</div>\n", tem)
 }
 
 func TestEmbeddedSC(t *testing.T) {
@@ -85,4 +109,20 @@ func TestUnbalancedQuotes(t *testing.T) {
 	tem := NewTemplate()
 
 	CheckShortCodeMatch(t, `{{% figure src="/uploads/2011/12/spf13-mongosv-speaking-copy-1024x749.jpg "Steve Francia speaking at OSCON 2012" alt="MongoSV 2011" %}}`, "\n<figure >\n    \n        <img src=\"/uploads/2011/12/spf13-mongosv-speaking-copy-1024x749.jpg%20%22Steve%20Francia%20speaking%20at%20OSCON%202012\" alt=\"MongoSV 2011\" />\n    \n    \n</figure>\n", tem)
+}
+
+func TestHighlight(t *testing.T) {
+	if !helpers.HasPygments() {
+		t.Skip("Skip test as Pygments is not installed")
+	}
+	defer viper.Set("PygmentsStyle", viper.Get("PygmentsStyle"))
+	viper.Set("PygmentsStyle", "bw")
+
+	tem := NewTemplate()
+
+	code := `
+{{< highlight java >}}
+void do();
+{{< /highlight >}}`
+	CheckShortCodeMatch(t, code, "\n<div class=\"highlight\" style=\"background: #ffffff\"><pre style=\"line-height: 125%\"><span style=\"font-weight: bold\">void</span> do();\n</pre></div>\n", tem)
 }

--- a/hugolib/template.go
+++ b/hugolib/template.go
@@ -314,12 +314,6 @@ func Highlight(in interface{}, lang string) template.HTML {
 		str = av.String()
 	}
 
-	if strings.HasPrefix(strings.TrimSpace(str), "<pre><code>") {
-		str = str[strings.Index(str, "<pre><code>")+11:]
-	}
-	if strings.HasSuffix(strings.TrimSpace(str), "</code></pre>") {
-		str = str[:strings.LastIndex(str, "</code></pre>")]
-	}
 	return template.HTML(helpers.Highlight(html.UnescapeString(str), lang))
 }
 


### PR DESCRIPTION
There were some issues with how all shortcodes were pushed through the
markdown processord.

This commit introduces new syntax:
- `{{< >}}`: Typically raw HTML. Will not be processed.
- `{{% %}}`: Will be processed by the page's markup engine (Markdown or (in
  future) Asciidoctor)

Fixes #480
