### PR TITLE
Shortcode rewrite

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -54,7 +54,7 @@ var version = &cobra.Command{
 
 // setBuildDate checks the ModTime of the Hugo executable and returns it as a
 // formatted string.  This assumes that the executable name is Hugo, if it does
-// not exist, an empty string will be returned.  This is only called if the 
+// not exist, an empty string will be returned.  This is only called if the
 // buildDate wasn't set during compile time.
 //
 // osext is used for cross-platform.
@@ -88,11 +88,10 @@ func getDateFormat() string {
 	if params == nil {
 		return time.RFC3339
 	}
-	parms := params.(map[interface{}]interface{})
+	parms := params.(map[string]interface{})
 	layout := parms["DateFormat"]
 	if layout == nil || layout == "" {
 		return time.RFC3339
 	}
 	return layout.(string)
 }
-

--- a/helpers/pygments.go
+++ b/helpers/pygments.go
@@ -1,4 +1,4 @@
-// Copyright © 2013 Steve Francia <spf@spf13.com>.
+// Copyright © 2013-14 Steve Francia <spf@spf13.com>.
 //
 // Licensed under the Simple Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,11 +23,18 @@ import (
 	"github.com/spf13/viper"
 )
 
-func Highlight(code string, lexer string) string {
-	var pygmentsBin = "pygmentize"
+const pygmentsBin = "pygmentize"
 
+func HasPygments() bool {
 	if _, err := exec.LookPath(pygmentsBin); err != nil {
+		return false
+	}
+	return true
+}
 
+func Highlight(code string, lexer string) string {
+
+	if !HasPygments() {
 		jww.WARN.Println("Highlighting requires Pygments to be installed and in the path")
 		return code
 	}

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -116,7 +116,7 @@ Some more text
 	SIMPLE_PAGE_WITH_SHORTCODE_IN_SUMMARY = `---
 title: Simple
 ---
-Summary Next Line. {{% img src="/not/real" %}}.
+Summary Next Line. {{<figure src="/not/real" >}}.
 More text here.
 
 Some more text
@@ -335,14 +335,18 @@ func TestPageWithDelimiter(t *testing.T) {
 }
 
 func TestPageWithShortCodeInSummary(t *testing.T) {
+	s := new(Site)
+	s.prepTemplates()
 	p, _ := NewPage("simple.md")
 	err := p.ReadFrom(strings.NewReader(SIMPLE_PAGE_WITH_SHORTCODE_IN_SUMMARY))
-	p.Convert()
 	if err != nil {
 		t.Fatalf("Unable to create a page with frontmatter and body content: %s", err)
 	}
+	p.ProcessShortcodes(s.Tmpl)
+	p.Convert()
+
 	checkPageTitle(t, p, "Simple")
-	checkPageContent(t, p, "<p>Summary Next Line. {{% img src=&ldquo;/not/real&rdquo; %}}.\nMore text here.</p>\n\n<p>Some more text</p>\n")
+	checkPageContent(t, p, "<p>Summary Next Line. \n<figure >\n    \n        <img src=\"/not/real\"  />\n    \n    \n</figure>\n.\nMore text here.</p>\n\n<p>Some more text</p>\n")
 	checkPageSummary(t, p, "Summary Next Line. . More text here. Some more text")
 	checkPageType(t, p, "page")
 	checkPageLayout(t, p, "page/single.html", "_default/single.html", "theme/page/single.html", "theme/_default/single.html")

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -1,4 +1,4 @@
-// Copyright © 2013 Steve Francia <spf@spf13.com>.
+// Copyright © 2013-14 Steve Francia <spf@spf13.com>.
 //
 // Licensed under the Simple Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@ package hugolib
 
 import (
 	"bytes"
-	"html/template"
-	"reflect"
-	"strings"
-	"unicode"
-
+	"fmt"
 	"github.com/spf13/hugo/helpers"
 	jww "github.com/spf13/jwalterweatherman"
+	"html/template"
+	"reflect"
+	"strconv"
+	"strings"
 )
 
 type ShortcodeFunc func([]string) string
@@ -76,75 +76,243 @@ func (scp *ShortcodeWithPage) Get(key interface{}) interface{} {
 
 }
 
-type Shortcodes map[string]ShortcodeFunc
+// Note - this value must not contain any markup syntax
+const shortcodePlaceholderPrefix = "HUGOSHORTCODE"
 
-func ShortcodesHandle(stringToParse string, p *Page, t Template) string {
-	leadStart := strings.Index(stringToParse, `{{%`)
-	if leadStart >= 0 {
-		leadEnd := strings.Index(stringToParse[leadStart:], `%}}`) + leadStart
-		if leadEnd > leadStart {
-			name, par := SplitParams(stringToParse[leadStart+3 : leadEnd])
-			tmpl := GetTemplate(name, t)
-			if tmpl == nil {
-				return stringToParse
-			}
-			params := Tokenize(par)
-			// Always look for closing tag.
-			endStart, endEnd := FindEnd(stringToParse[leadEnd:], name)
-			var data = &ShortcodeWithPage{Params: params, Page: p}
-			if endStart > 0 {
-				s := stringToParse[leadEnd+3 : leadEnd+endStart]
-				data.Inner = template.HTML(helpers.RenderBytes([]byte(CleanP(ShortcodesHandle(s, p, t))), p.guessMarkupType(), p.UniqueId()))
-				remainder := CleanP(stringToParse[leadEnd+endEnd:])
-
-				return CleanP(stringToParse[:leadStart]) +
-					ShortcodeRender(tmpl, data) +
-					CleanP(ShortcodesHandle(remainder, p, t))
-			}
-			return CleanP(stringToParse[:leadStart]) +
-				ShortcodeRender(tmpl, data) +
-				CleanP(ShortcodesHandle(stringToParse[leadEnd+3:], p,
-					t))
-		}
-	}
-	return stringToParse
+type shortCode struct {
+	name     string
+	inner    string
+	params   interface{} // map or array
+	doMarkup bool
 }
 
-// Clean up odd behavior when closing tag is on first line
-// or opening tag is on the last line due to extra line in markdown file
-func CleanP(str string) string {
-	if strings.HasSuffix(strings.TrimSpace(str), "<p>") {
-		idx := strings.LastIndex(str, "<p>")
-		str = str[:idx]
-	}
-
-	if strings.HasPrefix(strings.TrimSpace(str), "</p>") {
-		str = str[strings.Index(str, "</p>")+5:]
-	}
-
-	return str
+func (sc shortCode) String() string {
+	// for testing (mostly), so any change here will break tests!
+	return fmt.Sprintf("%s(%q, %t){%s}", sc.name, sc.params, sc.doMarkup, sc.inner)
 }
 
-func FindEnd(str string, name string) (int, int) {
-	var endPos int
-	var startPos int
-	var try []string
+// all in  one go: extract, render and replace
+// only used for testing
+func ShortcodesHandle(stringToParse string, page *Page, t Template) string {
 
-	try = append(try, "{{% /"+name+" %}}")
-	try = append(try, "{{% /"+name+"%}}")
-	try = append(try, "{{%/"+name+"%}}")
-	try = append(try, "{{%/"+name+" %}}")
+	tmpContent, tmpShortcodes := extractAndRenderShortcodes(stringToParse, page, t)
 
-	lowest := len(str)
-	for _, x := range try {
-		start := strings.Index(str, x)
-		if start < lowest && start > 0 {
-			startPos = start
-			endPos = startPos + len(x)
+	if len(tmpShortcodes) > 0 {
+		tmpContentWithTokensReplaced, err := replaceShortcodeTokens([]byte(tmpContent), shortcodePlaceholderPrefix, -1, true, tmpShortcodes)
+
+		if err != nil {
+			jww.ERROR.Printf("Fail to replace short code tokens in %s:\n%s", page.BaseFileName(), err.Error())
+		} else {
+			return string(tmpContentWithTokensReplaced)
 		}
 	}
 
-	return startPos, endPos
+	return string(tmpContent)
+}
+
+func extractAndRenderShortcodes(stringToParse string, p *Page, t Template) (string, map[string]string) {
+
+	content, shortcodes, err := extractShortcodes(stringToParse, p)
+	renderedShortcodes := make(map[string]string)
+
+	if err != nil {
+		//  try to render what we have whilst logging the error
+		jww.ERROR.Println(err.Error())
+	}
+
+	for key, sc := range shortcodes {
+		var data = &ShortcodeWithPage{Params: sc.params, Page: p}
+		if sc.inner != "" {
+			if sc.doMarkup {
+				data.Inner = template.HTML(helpers.RenderBytes([]byte(sc.inner), p.guessMarkupType(), p.UniqueId()))
+			} else {
+				data.Inner = template.HTML(sc.inner)
+			}
+
+		}
+
+		tmpl := GetTemplate(sc.name, t)
+
+		if tmpl == nil {
+			jww.ERROR.Printf("Unable to locate template for shortcode '%s' in page %s", sc.name, p.BaseFileName())
+			continue
+		}
+		renderedShortcode := ShortcodeRender(tmpl, data)
+		renderedShortcodes[key] = renderedShortcode
+	}
+
+	return content, renderedShortcodes
+
+}
+
+func extractShortcodes(stringToParse string, p *Page) (string, map[string]shortCode, error) {
+
+	shortCodes := make(map[string]shortCode)
+
+	startIdx := strings.Index(stringToParse, "{{")
+
+	// short cut for docs with no shortcodes
+	if startIdx < 0 {
+		return stringToParse, shortCodes, nil
+	}
+
+	// the parser takes a string;
+	// since this is an internal API, it could make sense to use the mutable []byte all the way, but
+	// it seems that the time isn't really spent in the byte copy operations, and the impl. gets a lot cleaner
+	t := pageTokens{lexer: newShortcodeLexer("parse-page", stringToParse, pos(startIdx))}
+
+	id := 1 // incremented id, will be appended onto temp. shortcode placeholders
+	var result bytes.Buffer
+
+	// the parser is guaranteed to return items in proper order or fail, so …
+	// … it's safe to keep some "global" state
+	var currItem item
+	var currShortcode shortCode
+
+Loop:
+	for {
+		currItem = t.next()
+
+		switch currItem.typ {
+		case tText:
+			result.WriteString(currItem.val)
+		case tLeftDelimScWithMarkup, tLeftDelimScNoMarkup:
+			currShortcode = shortCode{}
+			currShortcode.doMarkup = currItem.typ == tLeftDelimScWithMarkup
+		case tRightDelimScWithMarkup, tRightDelimScNoMarkup:
+			// need 3-token look-ahead here in the worst case looking for
+			// some shortcode inner content
+			if t.peek().typ == tText {
+				textToken := t.next()
+				if t.isLeftShortcodeDelim(t.peek()) {
+					delim := t.next()
+					if t.peek().typ == tScClose {
+						currShortcode.inner = textToken.val
+						// consume the shortcode close
+						t.consume(3)
+					} else {
+						// shortcode is open
+						t.backup3(textToken, delim)
+					}
+				} else {
+					// let the text item be handled elsewhere
+					t.backup2(textToken)
+				}
+			} else if t.isLeftShortcodeDelim(t.peek()) {
+				// check for empty inner content
+				delim := t.next()
+				if t.peek().typ == tScClose {
+					t.consume(3)
+				} else {
+					// new shortcode
+					t.backup2(delim)
+				}
+
+			}
+
+			if currShortcode.params == nil {
+				currShortcode.params = make([]string, 0)
+			}
+
+			// wrap it in a block level element to let it be left alone by the markup engine
+			placeHolder := fmt.Sprintf("<div>%s-%d</div>", shortcodePlaceholderPrefix, id)
+			result.WriteString(placeHolder)
+			shortCodes[placeHolder] = currShortcode
+			id++
+		case tScName:
+			currShortcode.name = currItem.val
+		case tScParam:
+			if !t.isValueNext() {
+				continue
+			} else if t.peek().typ == tScParamVal {
+				// named params
+				if currShortcode.params == nil {
+					params := make(map[string]string)
+					params[currItem.val] = t.next().val
+					currShortcode.params = params
+				} else {
+					params := currShortcode.params.(map[string]string)
+					params[currItem.val] = t.next().val
+				}
+			} else {
+				// positional params
+				if currShortcode.params == nil {
+					var params []string
+					params = append(params, currItem.val)
+					currShortcode.params = params
+				} else {
+					params := currShortcode.params.([]string)
+					params = append(params, currItem.val)
+					currShortcode.params = params
+				}
+			}
+
+		case tEOF:
+			break Loop
+		case tError:
+			return result.String(), shortCodes, fmt.Errorf("%s:%d: %s",
+				p.BaseFileName(), (p.lineNumRawContentStart() + t.lexer.lineNum() - 1), currItem)
+		}
+	}
+
+	return result.String(), shortCodes, nil
+
+}
+
+// Replace prefixed shortcode tokens (HUGOSHORTCODE-1, HUGOSHORTCODE-2) with the real content.
+// This assumes that all tokens exist in the input string and that they are in order.
+// numReplacements = -1 will do len(replacements), and it will always start from the beginning (1)
+// wrappendInDiv = true means that the token is wrapped in a <div></div>
+func replaceShortcodeTokens(source []byte, prefix string, numReplacements int, wrappedInDiv bool, replacements map[string]string) ([]byte, error) {
+
+	if numReplacements < 0 {
+		numReplacements = len(replacements)
+	}
+
+	if numReplacements == 0 {
+		return source, nil
+	}
+
+	newLen := len(source)
+
+	for i := 1; i <= numReplacements; i++ {
+		key := prefix + "-" + strconv.Itoa(i)
+
+		if wrappedInDiv {
+			key = "<div>" + key + "</div>"
+		}
+		val := []byte(replacements[key])
+
+		newLen += (len(val) - len(key))
+	}
+
+	buff := make([]byte, newLen)
+
+	width := 0
+	start := 0
+
+	for i := 0; i < numReplacements; i++ {
+		tokenNum := i + 1
+		oldVal := prefix + "-" + strconv.Itoa(tokenNum)
+		if wrappedInDiv {
+			oldVal = "<div>" + oldVal + "</div>"
+		}
+		newVal := []byte(replacements[oldVal])
+		j := start
+
+		k := bytes.Index(source[start:], []byte(oldVal))
+		if k < 0 {
+			// this should never happen, but let the caller decide to panic or not
+			return nil, fmt.Errorf("illegal state in content; shortcode token #%d is missing or out of order", tokenNum)
+		}
+		j += k
+
+		width += copy(buff[width:], source[start:j])
+		width += copy(buff[width:], newVal)
+		start = j + len(oldVal)
+	}
+	width += copy(buff[width:], source[start:])
+	return buff[0:width], nil
 }
 
 func GetTemplate(name string, t Template) *template.Template {
@@ -155,143 +323,6 @@ func GetTemplate(name string, t Template) *template.Template {
 		return x
 	}
 	return t.Lookup("_internal/shortcodes/" + name + ".html")
-}
-
-func StripShortcodes(stringToParse string) string {
-	posStart := strings.Index(stringToParse, "{{%")
-	if posStart > 0 {
-		posEnd := strings.Index(stringToParse[posStart:], "%}}") + posStart
-		if posEnd > posStart {
-			newString := stringToParse[:posStart] + StripShortcodes(stringToParse[posEnd+3:])
-			return newString
-		}
-	}
-	return stringToParse
-}
-
-func CleanupSpacesAroundEquals(rawfirst []string) []string {
-	var first = make([]string, 0)
-
-	for i := 0; i < len(rawfirst); i++ {
-		v := rawfirst[i]
-		index := strings.Index(v, "=")
-
-		if index == len(v)-1 {
-			// Trailing '='
-			if len(rawfirst) > i {
-				if v == "=" {
-					first[len(first)-1] = first[len(first)-1] + v + rawfirst[i+1] // concat prior with this and next
-					i++                                                           // Skip next
-				} else {
-					// Trailing ' = '
-					first = append(first, v+rawfirst[i+1]) // append this token and the next
-					i++                                    // Skip next
-				}
-			} else {
-				break
-			}
-		} else if index == 0 {
-			// Leading '='
-			first[len(first)-1] = first[len(first)-1] + v // concat this token to the prior one
-			continue
-		} else {
-			first = append(first, v)
-		}
-	}
-
-	return first
-}
-
-func Tokenize(in string) interface{} {
-	var final = make([]string, 0)
-
-	// if there isn't a space or an equal sign, no need to parse
-	if strings.Index(in, " ") < 0 && strings.Index(in, "=") < 0 {
-		return append(final, in)
-	}
-
-	var keys = make([]string, 0)
-	inQuote := false
-	start := 0
-
-	first := CleanupSpacesAroundEquals(strings.Fields(in))
-
-	for i, v := range first {
-		index := strings.Index(v, "=")
-		if !inQuote {
-			if index > 1 {
-				keys = append(keys, v[:index])
-				v = v[index+1:]
-			}
-		}
-
-		// Adjusted to handle htmlencoded and non htmlencoded input
-		if !strings.HasPrefix(v, "&ldquo;") && !strings.HasPrefix(v, "\"") && !inQuote {
-			final = append(final, v)
-		} else if inQuote && (strings.HasSuffix(v, "&rdquo;") ||
-			strings.HasSuffix(v, "\"")) && !strings.HasSuffix(v, "\\\"") {
-			if strings.HasSuffix(v, "\"") {
-				first[i] = v[:len(v)-1]
-			} else {
-				first[i] = v[:len(v)-7]
-			}
-			final = append(final, strings.Join(first[start:i+1], " "))
-			inQuote = false
-		} else if (strings.HasPrefix(v, "&ldquo;") ||
-			strings.HasPrefix(v, "\"")) && !inQuote {
-			if strings.HasSuffix(v, "&rdquo;") || strings.HasSuffix(v,
-				"\"") {
-				if strings.HasSuffix(v, "\"") {
-					if len(v) > 1 {
-						final = append(final, v[1:len(v)-1])
-					} else {
-						final = append(final, "")
-					}
-				} else {
-					final = append(final, v[7:len(v)-7])
-				}
-			} else {
-				start = i
-				if strings.HasPrefix(v, "\"") {
-					first[i] = v[1:]
-				} else {
-					first[i] = v[7:]
-				}
-				inQuote = true
-			}
-		}
-
-		// No closing "... just make remainder the final token
-		if inQuote && i == len(first) {
-			final = append(final, first[start:]...)
-		}
-	}
-
-	if len(keys) > 0 && (len(keys) != len(final)) {
-		// This will happen if the quotes aren't balanced
-		return final
-	}
-
-	if len(keys) > 0 {
-		var m = make(map[string]string)
-		for i, k := range keys {
-			m[k] = final[i]
-		}
-
-		return m
-	}
-
-	return final
-}
-
-func SplitParams(in string) (name string, par2 string) {
-	newIn := strings.TrimSpace(in)
-	i := strings.IndexFunc(newIn, unicode.IsSpace)
-	if i < 1 {
-		return strings.TrimSpace(in), ""
-	}
-
-	return strings.TrimSpace(newIn[:i+1]), strings.TrimSpace(newIn[i+1:])
 }
 
 func ShortcodeRender(tmpl *template.Template, data *ShortcodeWithPage) string {

--- a/hugolib/shortcodeparser.go
+++ b/hugolib/shortcodeparser.go
@@ -1,0 +1,573 @@
+// Copyright © 2013-14 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Simple Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://opensource.org/licenses/Simple-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hugolib
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// The lexical scanning below is highly inspired by the great talk given by
+// Rob Pike called "Lexical Scanning in Go" (it's on YouTube, Google it!).
+// See slides here: http://cuddle.googlecode.com/hg/talk/lex.html
+
+// parsing
+
+type pageTokens struct {
+	lexer     *pagelexer
+	token     [3]item // 3-item look-ahead is what we currently need
+	peekCount int
+}
+
+func (t *pageTokens) next() item {
+	if t.peekCount > 0 {
+		t.peekCount--
+	} else {
+		t.token[0] = t.lexer.nextItem()
+	}
+	return t.token[t.peekCount]
+}
+
+// backs up one token.
+func (t *pageTokens) backup() {
+	t.peekCount++
+}
+
+// backs up two tokens.
+func (t *pageTokens) backup2(t1 item) {
+	t.token[1] = t1
+	t.peekCount = 2
+}
+
+// backs up three tokens.
+func (t *pageTokens) backup3(t2, t1 item) {
+	t.token[1] = t1
+	t.token[2] = t2
+	t.peekCount = 3
+}
+
+// check for non-error and non-EOF types coming next
+func (t *pageTokens) isValueNext() bool {
+	i := t.peek()
+	return i.typ != tError && i.typ != tEOF
+}
+
+// look at, but do not consume, the next item
+// repeated, sequential calls will return the same item
+func (t *pageTokens) peek() item {
+	if t.peekCount > 0 {
+		return t.token[t.peekCount-1]
+	}
+	t.peekCount = 1
+	t.token[0] = t.lexer.nextItem()
+	return t.token[0]
+}
+
+// convencience method to consume the next n tokens, but back off Errors and EOF
+func (t *pageTokens) consume(cnt int) {
+	for i := 0; i < cnt; i++ {
+		token := t.next()
+		if token.typ == tError || token.typ == tEOF {
+			t.backup()
+			break
+		}
+	}
+}
+
+func (t *pageTokens) isLeftShortcodeDelim(i item) bool {
+	return i.typ == tLeftDelimScNoMarkup || i.typ == tLeftDelimScWithMarkup
+}
+
+func (t *pageTokens) isRightShortcodeDelim(i item) bool {
+	return i.typ == tRightDelimScNoMarkup || i.typ == tRightDelimScWithMarkup
+}
+
+// lexical scanning
+
+// position (in bytes)
+type pos int
+
+type item struct {
+	typ itemType
+	pos pos
+	val string
+}
+
+func (i item) String() string {
+	switch {
+	case i.typ == tEOF:
+		return "EOF"
+	case i.typ == tError:
+		return i.val
+	case i.typ > tKeywordMarker:
+		return fmt.Sprintf("<%s>", i.val)
+	case len(i.val) > 20:
+		return fmt.Sprintf("%.20q...", i.val)
+	}
+	return fmt.Sprintf("[%s]", i.val)
+}
+
+type itemType int
+
+// named params in shortcodes
+type namedParam struct {
+	name  string
+	value string
+}
+
+// for testing
+func (np namedParam) String() string {
+	return fmt.Sprintf("%s=%s", np.name, np.value)
+}
+
+const (
+	tError itemType = iota
+	tEOF
+
+	// shortcode items
+	tLeftDelimScNoMarkup
+	tRightDelimScNoMarkup
+	tLeftDelimScWithMarkup
+	tRightDelimScWithMarkup
+	tScClose
+	tScName
+	tScParam
+	tScParamVal
+
+	//itemIdentifier
+	tText // plain text, used for everything outside the shortcodes
+
+	// preserved for later - keywords come after this
+	tKeywordMarker
+)
+
+const eof = -1
+
+// returns the next state in scanner.
+type stateFunc func(*pagelexer) stateFunc
+
+type pagelexer struct {
+	name    string
+	input   string
+	state   stateFunc
+	pos     pos // input position
+	start   pos // item start position
+	width   pos // width of last element
+	lastPos pos // position of the last item returned by nextItem
+
+	// shortcode state
+	currLeftDelimItem  itemType
+	currRightDelimItem itemType
+	currShortcodeName  string // is only set when a shortcode is in opened state
+	closedShortcodes   int    // number of closed shortcodes; max 1 for now
+	elementStepNum     int    // step number in element
+	paramElements      int    // number of elements (name + value = 2) found first
+
+	// items delivered to client
+	items chan item
+}
+
+// note: the input position here is normally 0 (start), but
+// can be set if position of first shortcode is known
+func newShortcodeLexer(name, input string, inputPosition pos) *pagelexer {
+	lexer := &pagelexer{
+		name:               name,
+		input:              input,
+		currLeftDelimItem:  tLeftDelimScNoMarkup,
+		currRightDelimItem: tRightDelimScNoMarkup,
+		pos:                inputPosition,
+		items:              make(chan item),
+	}
+	go lexer.runShortcodeLexer()
+	return lexer
+}
+
+// main loop
+// this looks kind of funky, but it works
+func (l *pagelexer) runShortcodeLexer() {
+	for l.state = lexTextOutsideShortcodes; l.state != nil; {
+		l.state = l.state(l)
+	}
+
+	close(l.items)
+
+}
+
+// state functions
+
+const (
+	leftDelimScNoMarkup    = "{{<"
+	rightDelimScNoMarkup   = ">}}"
+	leftDelimScWithMarkup  = "{{%"
+	rightDelimScWithMarkup = "%}}"
+)
+
+func (l *pagelexer) next() rune {
+	if int(l.pos) >= len(l.input) {
+		l.width = 0
+		return eof
+	}
+
+	// looks expensive, but should produce the same iteration sequence as the string range loop
+	// see: http://blog.golang.org/strings
+	runeValue, runeWidth := utf8.DecodeRuneInString(l.input[l.pos:])
+	l.width = pos(runeWidth)
+	l.pos += l.width
+	return runeValue
+}
+
+// peek, but no consume
+func (l *pagelexer) peek() rune {
+	r := l.next()
+	l.backup()
+	return r
+}
+
+// steps back one
+func (l *pagelexer) backup() {
+	l.pos -= l.width
+}
+
+// sends an item back to the client.
+func (l *pagelexer) emit(t itemType) {
+	l.items <- item{t, l.start, l.input[l.start:l.pos]}
+	l.start = l.pos
+}
+
+// special case, do not send '\\' back to client
+func (l *pagelexer) ignoreEscapesAndEmit(t itemType) {
+	val := strings.Map(func(r rune) rune {
+		if r == '\\' {
+			return -1
+		}
+		return r
+	}, l.input[l.start:l.pos])
+	l.items <- item{t, l.start, val}
+	l.start = l.pos
+}
+
+// gets the current value (for debugging and error handling)
+func (l *pagelexer) current() string {
+	return l.input[l.start:l.pos]
+}
+
+// ignore current element
+func (l *pagelexer) ignore() {
+	l.start = l.pos
+}
+
+// nice to have in error logs
+func (l *pagelexer) lineNum() int {
+	return strings.Count(l.input[:l.lastPos], "\n") + 1
+}
+
+// nil terminates the parser
+func (l *pagelexer) errorf(format string, args ...interface{}) stateFunc {
+	l.items <- item{tError, l.start, fmt.Sprintf(format, args...)}
+	return nil
+}
+
+// consumes and returns the next item
+func (l *pagelexer) nextItem() item {
+	item := <-l.items
+	l.lastPos = item.pos
+	return item
+}
+
+// scans until an opening shortcode opening bracket.
+// if no shortcodes, it will keep on scanning until EOF
+func lexTextOutsideShortcodes(l *pagelexer) stateFunc {
+	for {
+		if strings.HasPrefix(l.input[l.pos:], leftDelimScWithMarkup) || strings.HasPrefix(l.input[l.pos:], leftDelimScNoMarkup) {
+			if l.pos > l.start {
+				l.emit(tText)
+			}
+			if strings.HasPrefix(l.input[l.pos:], leftDelimScWithMarkup) {
+				l.currLeftDelimItem = tLeftDelimScWithMarkup
+				l.currRightDelimItem = tRightDelimScWithMarkup
+			} else {
+				l.currLeftDelimItem = tLeftDelimScNoMarkup
+				l.currRightDelimItem = tRightDelimScNoMarkup
+			}
+			return lexShortcodeLeftDelim
+
+		}
+		if l.next() == eof {
+			break
+		}
+	}
+	// Done!
+	if l.pos > l.start {
+		l.emit(tText)
+	}
+	l.emit(tEOF)
+	return nil
+}
+
+func lexShortcodeLeftDelim(l *pagelexer) stateFunc {
+	l.pos += pos(len(l.currentLeftShortcodeDelim()))
+	l.emit(l.currentLeftShortcodeDelimItem())
+	l.elementStepNum = 0
+	l.paramElements = 0
+	return lexInsideShortcode
+}
+
+func lexShortcodeRightDelim(l *pagelexer) stateFunc {
+	l.pos += pos(len(l.currentRightShortcodeDelim()))
+	l.emit(l.currentRightShortcodeDelimItem())
+	return lexTextOutsideShortcodes
+}
+
+// either:
+// 1. param
+// 2. "param" or "param\"
+// 3. param="123" or param="123\"
+// 4. param="Some \"escaped\" text"
+func lexShortcodeParam(l *pagelexer, escapedQuoteStart bool) stateFunc {
+
+	first := true
+	nextEq := false
+
+	var r rune
+
+	for {
+		r = l.next()
+		if first {
+			if r == '"' {
+				// a positional param with quotes
+				l.paramElements = 1
+				l.backup()
+				return lexShortcodeQuotedParamVal(l, !escapedQuoteStart, tScParam)
+			}
+			first = false
+		} else if r == '=' {
+			// a named param
+			l.backup()
+			nextEq = true
+			break
+		}
+
+		if !isValidParamRune(r) {
+			l.backup()
+			break
+		}
+	}
+
+	if l.paramElements == 0 {
+		l.paramElements++
+
+		if nextEq {
+			l.paramElements++
+		}
+	} else {
+		if nextEq && l.paramElements == 1 {
+			return l.errorf("got named parameter '%s'. Cannot mix named and positional parameters", l.current())
+		} else if !nextEq && l.paramElements == 2 {
+			return l.errorf("got positional parameter '%s'. Cannot mix named and positional parameters", l.current())
+		}
+	}
+
+	l.emit(tScParam)
+	return lexInsideShortcode
+
+}
+
+func lexShortcodeQuotedParamVal(l *pagelexer, escapedQuotedValuesAllowed bool, typ itemType) stateFunc {
+	openQuoteFound := false
+	escapedInnerQuoteFound := false
+	escapedQuoteState := 0
+
+Loop:
+	for {
+		switch r := l.next(); {
+		case r == '\\':
+			if l.peek() == '"' {
+				if openQuoteFound && !escapedQuotedValuesAllowed {
+					l.backup()
+					break Loop
+				} else if openQuoteFound {
+					// the coming quoute is inside
+					escapedInnerQuoteFound = true
+					escapedQuoteState = 1
+				}
+			}
+		case r == eof, r == '\n':
+			return l.errorf("unterminated quoted string in shortcode parameter-argument: '%s'", l.current())
+		case r == '"':
+			if escapedQuoteState == 0 {
+				if openQuoteFound {
+					l.backup()
+					break Loop
+
+				} else {
+					openQuoteFound = true
+					l.ignore()
+				}
+			} else {
+				escapedQuoteState = 0
+			}
+
+		}
+	}
+
+	if escapedInnerQuoteFound {
+		l.ignoreEscapesAndEmit(typ)
+	} else {
+		l.emit(typ)
+	}
+
+	r := l.next()
+
+	if r == '\\' {
+		if l.peek() == '"' {
+			// ignore the escaped closing quote
+			l.ignore()
+			l.next()
+			l.ignore()
+		}
+	} else if r == '"' {
+		// ignore closing quote
+		l.ignore()
+	} else {
+		// handled by next state
+		l.backup()
+	}
+
+	return lexInsideShortcode
+}
+
+// scans an alphanumeric inside shortcode
+func lexIdentifierInShortcode(l *pagelexer) stateFunc {
+	lookForEnd := false
+Loop:
+	for {
+		switch r := l.next(); {
+		case isAlphaNumeric(r):
+		default:
+			l.backup()
+			word := l.input[l.start:l.pos]
+			if l.closedShortcodes > 0 && l.currShortcodeName != word {
+				return l.errorf("closing tag for shortcode '%s' does not match start tag", word)
+			} else if l.closedShortcodes > 0 {
+				lookForEnd = true
+			}
+			l.closedShortcodes = 0
+			l.currShortcodeName = word
+			l.elementStepNum++
+			l.emit(tScName)
+			break Loop
+		}
+	}
+
+	if lookForEnd {
+		return lexEndOfShortcode
+	}
+	return lexInsideShortcode
+}
+
+func lexEndOfShortcode(l *pagelexer) stateFunc {
+	if strings.HasPrefix(l.input[l.pos:], l.currentRightShortcodeDelim()) {
+		return lexShortcodeRightDelim
+	}
+	switch r := l.next(); {
+	case isSpace(r):
+		l.ignore()
+	default:
+		return l.errorf("unclosed shortcode")
+	}
+	return lexEndOfShortcode
+}
+
+// scans the elements inside shortcode tags
+func lexInsideShortcode(l *pagelexer) stateFunc {
+	if strings.HasPrefix(l.input[l.pos:], l.currentRightShortcodeDelim()) {
+		return lexShortcodeRightDelim
+	}
+	switch r := l.next(); {
+	case r == eof:
+		// eol is allowed inside shortcodes; this may go to end of document before it fails
+		return l.errorf("unclosed shortcode action")
+	case isSpace(r), isEndOfLine(r):
+		l.ignore()
+	case r == '=':
+		l.ignore()
+		return lexShortcodeQuotedParamVal(l, l.peek() != '\\', tScParamVal)
+	case r == '/':
+		if l.currShortcodeName == "" {
+			return l.errorf("got closing shortcode, but none is open")
+		}
+		l.closedShortcodes++
+		l.emit(tScClose)
+	case r == '\\':
+		l.ignore()
+		if l.peek() == '"' {
+			return lexShortcodeParam(l, true)
+		}
+	case l.elementStepNum > 0 && (isValidParamRune(r) || r == '"'): // positional params can have quotes
+		l.backup()
+		return lexShortcodeParam(l, false)
+	case isAlphaNumeric(r):
+		l.backup()
+		return lexIdentifierInShortcode
+	default:
+		return l.errorf("unrecognized character in shortcode action: %#U. Note: Parameters with non-alphanumeric args must be quoted", r)
+	}
+	return lexInsideShortcode
+}
+
+// state helpers
+
+func (l *pagelexer) currentLeftShortcodeDelimItem() itemType {
+	return l.currLeftDelimItem
+}
+
+func (l *pagelexer) currentRightShortcodeDelimItem() itemType {
+	return l.currRightDelimItem
+}
+
+func (l *pagelexer) currentLeftShortcodeDelim() string {
+	if l.currLeftDelimItem == tLeftDelimScWithMarkup {
+		return leftDelimScWithMarkup
+	}
+	return leftDelimScNoMarkup
+
+}
+
+func (l *pagelexer) currentRightShortcodeDelim() string {
+	if l.currRightDelimItem == tRightDelimScWithMarkup {
+		return rightDelimScWithMarkup
+	}
+	return rightDelimScNoMarkup
+}
+
+// helper functions
+
+func isSpace(r rune) bool {
+	return r == ' ' || r == '\t'
+}
+
+func isValidParamRune(r rune) bool {
+	// let unquoted YouTube ids as positional params slip through (they contain hyphens)
+	return isAlphaNumeric(r) || r == '-'
+}
+
+func isEndOfLine(r rune) bool {
+	return r == '\r' || r == '\n'
+}
+
+func isAlphaNumeric(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}

--- a/hugolib/shortcodeparser_test.go
+++ b/hugolib/shortcodeparser_test.go
@@ -1,0 +1,127 @@
+package hugolib
+
+import (
+	"testing"
+)
+
+type shortCodeLexerTest struct {
+	name  string
+	input string
+	items []item
+}
+
+var (
+	tstEOF       = item{tEOF, 0, ""}
+	tstLeftNoMD  = item{tLeftDelimScNoMarkup, 0, "{{<"}
+	tstRightNoMD = item{tRightDelimScNoMarkup, 0, ">}}"}
+	tstLeftMD    = item{tLeftDelimScWithMarkup, 0, "{{%"}
+	tstRightMD   = item{tRightDelimScWithMarkup, 0, "%}}"}
+	tstSCClose   = item{tScClose, 0, "/"}
+	tstSC1       = item{tScName, 0, "simple"}
+	tstSC2       = item{tScName, 0, "shortcode2"}
+	tstParam1    = item{tScParam, 0, "param1"}
+	tstParam2    = item{tScParam, 0, "param2"}
+	tstVal       = item{tScParamVal, 0, "Hello World"}
+)
+
+var shortCodeLexerTests = []shortCodeLexerTest{
+	{"empty", "", []item{tstEOF}},
+	{"spaces", " \t\n", []item{{tText, 0, " \t\n"}, tstEOF}},
+	{"text", `to be or not`, []item{{tText, 0, "to be or not"}, tstEOF}},
+	{"no markup", `{{< simple >}}`, []item{tstLeftNoMD, tstSC1, tstRightNoMD, tstEOF}},
+	{"with EOL", "{{< simple \n >}}", []item{tstLeftNoMD, tstSC1, tstRightNoMD, tstEOF}},
+
+	{"simple with markup", `{{% simple %}}`, []item{tstLeftMD, tstSC1, tstRightMD, tstEOF}},
+	{"with spaces", `{{<     simple     >}}`, []item{tstLeftNoMD, tstSC1, tstRightNoMD, tstEOF}},
+	{"mismatched rightDelim", `{{< simple %}}`, []item{tstLeftNoMD, tstSC1,
+		{tError, 0, "unrecognized character in shortcode action: U+0025 '%'. Note: Parameters with non-alphanumeric args must be quoted"}}},
+	{"inner, markup", `{{% simple %}} inner {{% /simple %}}`, []item{
+		tstLeftMD,
+		tstSC1,
+		tstRightMD,
+		{tText, 0, " inner "},
+		tstLeftMD,
+		tstSCClose,
+		tstSC1,
+		tstRightMD,
+		tstEOF,
+	}},
+	{"close, but no open", `{{< /simple >}}`, []item{
+		tstLeftNoMD, {tError, 0, "got closing shortcode, but none is open"}}},
+	{"close wrong", `{{< simple >}}{{< /another >}}`, []item{
+		tstLeftNoMD, tstSC1, tstRightNoMD, tstLeftNoMD, tstSCClose,
+		{tError, 0, "closing tag for shortcode 'another' does not match start tag"}}},
+	{"close, but no open, more", `{{< simple >}}{{< /simple >}}{{< /another >}}`, []item{
+		tstLeftNoMD, tstSC1, tstRightNoMD, tstLeftNoMD, tstSCClose, tstSC1, tstRightNoMD, tstLeftNoMD, tstSCClose,
+		{tError, 0, "closing tag for shortcode 'another' does not match start tag"}}},
+	{"close with extra keyword", `{{< simple >}}{{< /simple keyword>}}`, []item{
+		tstLeftNoMD, tstSC1, tstRightNoMD, tstLeftNoMD, tstSCClose, tstSC1,
+		{tError, 0, "unclosed shortcode"}}},
+	{"Youtube id", `{{< simple -ziL-Q_456igdO-4 >}}`, []item{
+		tstLeftNoMD, tstSC1, item{tScParam, 0, "-ziL-Q_456igdO-4"}, tstRightNoMD, tstEOF}},
+	{"non-alphanumerics param quoted", `{{< simple "-ziL-.%QigdO-4" >}}`, []item{
+		tstLeftNoMD, tstSC1, item{tScParam, 0, "-ziL-.%QigdO-4"}, tstRightNoMD, tstEOF}},
+	{"two params", `{{< simple param1   param2 >}}`, []item{
+		tstLeftNoMD, tstSC1, tstParam1, tstParam2, tstRightNoMD, tstEOF}},
+	{"two quoted params", `{{< simple "param nr. 1" "param nr. 2" >}}`, []item{
+		tstLeftNoMD, tstSC1, item{tScParam, 0, "param nr. 1"}, item{tScParam, 0, "param nr. 2"}, tstRightNoMD, tstEOF}},
+	{"two named params", `{{< simple param1="Hello World" param2="p2Val">}}`, []item{
+		tstLeftNoMD, tstSC1, tstParam1, tstVal, tstParam2, {tScParamVal, 0, "p2Val"}, tstRightNoMD, tstEOF}},
+	{"escaped quotes", `{{< simple param1=\"Hello World\"  >}}`, []item{
+		tstLeftNoMD, tstSC1, tstParam1, tstVal, tstRightNoMD, tstEOF}},
+	{"escaped quotes inside escaped quotes", `{{< simple param1=\"Hello \"escaped\" World\"  >}}`, []item{
+		tstLeftNoMD, tstSC1, tstParam1,
+		item{tScParamVal, 0, `Hello `}, {tError, 0, `got positional parameter 'escaped'. Cannot mix named and positional parameters`}}},
+	{"escaped quotes inside nonescaped quotes",
+		`{{< simple param1="Hello \"escaped\" World"  >}}`, []item{
+			tstLeftNoMD, tstSC1, tstParam1, item{tScParamVal, 0, `Hello "escaped" World`}, tstRightNoMD, tstEOF}},
+	{"escaped quotes inside nonescaped quotes in positional param",
+		`{{< simple "Hello \"escaped\" World"  >}}`, []item{
+			tstLeftNoMD, tstSC1, item{tScParam, 0, `Hello "escaped" World`}, tstRightNoMD, tstEOF}},
+	{"unterminated quote", `{{< simple param2="Hello World>}}`, []item{
+		tstLeftNoMD, tstSC1, tstParam2, {tError, 0, "unterminated quoted string in shortcode parameter-argument: 'Hello World>}}'"}}},
+	{"one named param, one not", `{{< simple param1="Hello World" p2 >}}`, []item{
+		tstLeftNoMD, tstSC1, tstParam1, tstVal,
+		{tError, 0, "got positional parameter 'p2'. Cannot mix named and positional parameters"}}},
+	{"ono positional param, one not", `{{< simple param1 param2="Hello World">}}`, []item{
+		tstLeftNoMD, tstSC1, tstParam1,
+		{tError, 0, "got named parameter 'param2'. Cannot mix named and positional parameters"}}},
+}
+
+func TestPagelexer(t *testing.T) {
+	for _, test := range shortCodeLexerTests {
+
+		items := collect(&test)
+		if !equal(items, test.items) {
+			t.Errorf("%s: got\n\t%v\nexpected\n\t%v", test.name, items, test.items)
+		}
+	}
+}
+
+func collect(t *shortCodeLexerTest) (items []item) {
+	l := newShortcodeLexer(t.name, t.input, 0)
+	for {
+		item := l.nextItem()
+		items = append(items, item)
+		if item.typ == tEOF || item.typ == tError {
+			break
+		}
+	}
+	return
+}
+
+// no positional checking, for now ...
+func equal(i1, i2 []item) bool {
+	if len(i1) != len(i2) {
+		return false
+	}
+	for k := range i1 {
+		if i1[k].typ != i2[k].typ {
+			return false
+		}
+		if i1[k].val != i2[k].val {
+			return false
+		}
+	}
+	return true
+}

--- a/hugolib/template.go
+++ b/hugolib/template.go
@@ -314,12 +314,6 @@ func Highlight(in interface{}, lang string) template.HTML {
 		str = av.String()
 	}
 
-	if strings.HasPrefix(strings.TrimSpace(str), "<pre><code>") {
-		str = str[strings.Index(str, "<pre><code>")+11:]
-	}
-	if strings.HasSuffix(strings.TrimSpace(str), "</code></pre>") {
-		str = str[:strings.LastIndex(str, "</code></pre>")]
-	}
 	return template.HTML(helpers.Highlight(html.UnescapeString(str), lang))
 }
 


### PR DESCRIPTION
This commit contains a restructuring and partial rewrite of the shortcode
handling.

Prior to this commit rendering of the page content was mingled with handling
of the shortcodes. This led to several oddities.

The new flow is:
1. Shortcodes are extracted from page and replaced with placeholders. 
2. Shortcodes are processed and rendered 
3. Page is processed 
4. The placeholders are replaced with the rendered shortcodes

The handling of summaries is also made simpler by this.

This also introduces the distinction between shortcodes that need further
processing and those who do not:
- `{{< >}}`: Typically raw HTML. Will not be processed.
- `{{% %}}`: Will be processed by the page's markup engine (Markdown or
  (infuture) Asciidoctor)

The above also involves a new shortcode-parser, with lexical scanning inspired
by Rob Pike's talk called "Lexical Scanning in Go", which should be easier to
understand, give better error messages and perform better.

Fixes #565
Fixes #480
Fixes #461
