### PR TITLE
Fix missing space before 'width'

### DIFF
--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -72,13 +72,13 @@ func TestInnerSCWithMarkdown(t *testing.T) {
 func TestEmbeddedSC(t *testing.T) {
 	tem := NewTemplate()
 	CheckShortCodeMatch(t, "{{% test %}}", "This is a simple Test", tem)
-	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" %}}`, "\n<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\"  />\n    \n    \n</figure>\n", tem)
+	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" %}}`, "\n<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" />\n    \n    \n</figure>\n", tem)
 	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" caption="This is a caption" %}}`, "\n<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" alt=\"This is a caption\" />\n    \n    \n    <figcaption>\n        <p>\n        This is a caption\n        \n            \n        \n        </p> \n    </figcaption>\n    \n</figure>\n", tem)
 }
 
 func TestFigureImgWidth(t *testing.T) {
 	tem := NewTemplate()
-	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" width="100px" %}}`, "\n<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" width=\"100px\" />\n    \n    \n</figure>\n", tem)
+	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" alt="apple" width="100px" %}}`, "\n<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" alt=\"apple\" width=\"100px\" />\n    \n    \n</figure>\n", tem)
 }
 
 func TestUnbalancedQuotes(t *testing.T) {

--- a/hugolib/template_embedded.go
+++ b/hugolib/template_embedded.go
@@ -24,7 +24,7 @@ func (t *GoHtmlTemplate) EmbedShortcodes() {
 	t.AddInternalShortcode("figure.html", `<!-- image -->
 <figure {{ with .Get "class" }}class="{{.}}"{{ end }}>
     {{ with .Get "link"}}<a href="{{.}}">{{ end }}
-        <img src="{{ .Get "src" }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }}{{ with .Get "width" }}width="{{.}}"{{ end }} />
+        <img src="{{ .Get "src" }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}" {{ end }}{{ with .Get "width" }}width="{{.}}" {{ end }}/>
     {{ if .Get "link"}}</a>{{ end }}
     {{ if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
     <figcaption>{{ if isset .Params "title" }}


### PR DESCRIPTION
The newly introduced width-param on figure did not work in combo with alt or
caption due to space-issues.

This fixes that.
