### PR TITLE
Fix a bug with taxonomy rendering.

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -843,6 +843,8 @@ func (s *Site) newTaxonomyNode(t taxRenderInfo) (*Node, string) {
 		n.Date = t.pages[0].Page.Date
 	}
 	n.Data[t.singular] = t.pages
+	n.Data["Singular"] = t.singular
+	n.Data["Plural"] = t.plural
 	n.Data["Pages"] = t.pages.Pages()
 	return n, base
 }


### PR DESCRIPTION
- In `layouts/_default/taxonomy.html`, the `.Data` result does not provide the same information that `layouts/_default/terms.html` does for being able to identify the plural value of the term.
- This change adds `.Data.Singular` and `.Data.Plural` to provide similar capabilities.
- This _may_ be incompatible with templates that check for `{{ if ne $taxonomy "Pages" }}` if the `page.Params` has either the singular or plural values as keys.

Note: alternatively, this could implemented by changing line 821:

``` diff
- n.Data[t.singular] = t.pages
+ n.Data[t.plural] = t.pages
```

I think that the approach I’ve taken is more appropriate and similar to the results in `RenderListsOfTaxonomyTerms`.
