### PR TITLE
Added better error message for poorly formed frontmatters in archtypes

### DIFF
--- a/create/content.go
+++ b/create/content.go
@@ -56,6 +56,7 @@ func NewContent(kind, name string) (err error) {
 	}
 	newmetadata, err := cast.ToStringMapE(metadata)
 	if err != nil {
+		jww.ERROR.Println("Error processing archetype file:", location)
 		return err
 	}
 


### PR DESCRIPTION
Ran into an issue where the theme I was using (purehugo) had an empty archetype `themes/purehugo/archetypes/default.md`. The produced error message was a bit cryptic:

```
ERROR: 2014/11/02 Unable to Cast <nil> to map[string]interface{}
```

This makes it a bit more explicit:

```
ERROR: 2014/11/02 Error processing archetype file: /path/to/project/themes/purehugo/archetypes/default.md
```
