### PR TITLE
hugolib: converted path 2 filepath

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -20,7 +20,7 @@ import (
 	"html/template"
 	"io"
 	"net/url"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -175,7 +175,7 @@ func layouts(types string, layout string) (layouts []string) {
 	// Add type/layout.html
 	for i := range t {
 		search := t[:len(t)-i]
-		layouts = append(layouts, fmt.Sprintf("%s/%s.html", strings.ToLower(path.Join(search...)), layout))
+		layouts = append(layouts, fmt.Sprintf("%s/%s.html", strings.ToLower(filepath.Join(search...)), layout))
 	}
 
 	// Add _default/layout.html
@@ -250,10 +250,10 @@ func (p *Page) permalink() (*url.URL, error) {
 		// fmt.Printf("have a section override for %q in section %s → %s\n", p.Title, p.Section, permalink)
 	} else {
 		if len(pSlug) > 0 {
-			permalink = helpers.UrlPrep(viper.GetBool("UglyUrls"), path.Join(dir, p.Slug+"."+p.Extension()))
+			permalink = helpers.UrlPrep(viper.GetBool("UglyUrls"), filepath.Join(dir, p.Slug+"."+p.Extension()))
 		} else {
-			_, t := path.Split(p.Source.LogicalName())
-			permalink = helpers.UrlPrep(viper.GetBool("UglyUrls"), path.Join(dir, helpers.ReplaceExtension(strings.TrimSpace(t), p.Extension())))
+			_, t := filepath.Split(p.Source.LogicalName())
+			permalink = helpers.UrlPrep(viper.GetBool("UglyUrls"), filepath.Join(dir, helpers.ReplaceExtension(strings.TrimSpace(t), p.Extension())))
 		}
 	}
 
@@ -592,7 +592,7 @@ func (page *Page) saveSourceAs(path string, safe bool) error {
 }
 
 func (page *Page) saveSource(by []byte, inpath string, safe bool) (err error) {
-	if !path.IsAbs(inpath) {
+	if !filepath.IsAbs(inpath) {
 		inpath = helpers.AbsPathify(inpath)
 	}
 	jww.INFO.Println("creating", inpath)
@@ -633,7 +633,7 @@ func (page *Page) Convert() error {
 }
 
 func (p *Page) FullFilePath() string {
-	return path.Join(p.Source.Dir(), p.Source.Path())
+	return filepath.Join(p.Source.Dir(), p.Source.Path())
 }
 
 func (p *Page) TargetPath() (outfile string) {
@@ -667,5 +667,5 @@ func (p *Page) TargetPath() (outfile string) {
 		outfile = helpers.ReplaceExtension(p.Source.LogicalName(), p.Extension())
 	}
 
-	return path.Join(p.Source.Dir(), strings.TrimSpace(outfile))
+	return filepath.Join(p.Source.Dir(), strings.TrimSpace(outfile))
 }

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -2,7 +2,7 @@ package hugolib
 
 import (
 	"html/template"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -520,11 +520,11 @@ func L(s ...string) []string {
 
 func TestLayoutOverride(t *testing.T) {
 	var (
-		path_content_two_dir = path.Join("content", "dub", "sub", "file1.md")
-		path_content_one_dir = path.Join("content", "gub", "file1.md")
-		path_content_no_dir  = path.Join("content", "file1")
-		path_one_directory   = path.Join("fub", "file1.md")
-		path_no_directory    = path.Join("file1.md")
+		path_content_two_dir = filepath.Join("content", "dub", "sub", "file1.md")
+		path_content_one_dir = filepath.Join("content", "gub", "file1.md")
+		path_content_no_dir  = filepath.Join("content", "file1")
+		path_one_directory   = filepath.Join("fub", "file1.md")
+		path_no_directory    = filepath.Join("file1.md")
 	)
 	tests := []struct {
 		content        string

--- a/hugolib/path_seperators_test.go
+++ b/hugolib/path_seperators_test.go
@@ -1,7 +1,7 @@
 package hugolib
 
 import (
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -13,7 +13,7 @@ Sample Text
 `
 
 func TestDegenerateMissingFolderInPageFilename(t *testing.T) {
-	p, err := NewPageFrom(strings.NewReader(SIMPLE_PAGE_YAML), path.Join("foobar"))
+	p, err := NewPageFrom(strings.NewReader(SIMPLE_PAGE_YAML), filepath.Join("foobar"))
 	if err != nil {
 		t.Fatalf("Error in NewPageFrom")
 	}
@@ -28,10 +28,10 @@ func TestNewPageWithFilePath(t *testing.T) {
 		section string
 		layout  []string
 	}{
-		{path.Join("sub", "foobar.html"), "sub", L("sub/single.html", "_default/single.html")},
-		{path.Join("content", "foobar.html"), "", L("page/single.html", "_default/single.html")},
-		{path.Join("content", "sub", "foobar.html"), "sub", L("sub/single.html", "_default/single.html")},
-		{path.Join("content", "dub", "sub", "foobar.html"), "dub", L("dub/single.html", "_default/single.html")},
+		{filepath.Join("sub", "foobar.html"), "sub", L("sub/single.html", "_default/single.html")},
+		{filepath.Join("content", "foobar.html"), "", L("page/single.html", "_default/single.html")},
+		{filepath.Join("content", "sub", "foobar.html"), "sub", L("sub/single.html", "_default/single.html")},
+		{filepath.Join("content", "dub", "sub", "foobar.html"), "dub", L("dub/single.html", "_default/single.html")},
 	}
 
 	for _, el := range toCheck {


### PR DESCRIPTION
convert `hugolib`'s `path` usage to `path/filepath` 
