### PR TITLE
commands: converted path 2 filepath

### DIFF
--- a/commands/convert.go
+++ b/commands/convert.go
@@ -15,7 +15,7 @@ package commands
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cast"
@@ -133,7 +133,7 @@ func convertContents(mark rune) (err error) {
 		page.SetSourceMetaData(metadata, mark)
 
 		if OutputDir != "" {
-			page.SaveSourceAs(path.Join(OutputDir, page.FullFilePath()))
+			page.SaveSourceAs(filepath.Join(OutputDir, page.FullFilePath()))
 		} else {
 			if Unsafe {
 				page.SaveSource()

--- a/commands/new.go
+++ b/commands/new.go
@@ -14,7 +14,6 @@ package commands
 import (
 	"bytes"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -141,7 +140,7 @@ func NewTheme(cmd *cobra.Command, args []string) {
 		jww.FATAL.Fatalln("theme name needs to be provided")
 	}
 
-	createpath := helpers.AbsPathify(path.Join("themes", args[0]))
+	createpath := helpers.AbsPathify(filepath.Join("themes", args[0]))
 	jww.INFO.Println("creating theme at", createpath)
 
 	if x, _ := helpers.Exists(createpath, hugofs.SourceFs); x {
@@ -186,7 +185,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 `)
 
-	err := helpers.WriteToDisk(path.Join(createpath, "LICENSE.md"), bytes.NewReader(by), hugofs.SourceFs)
+	err := helpers.WriteToDisk(filepath.Join(createpath, "LICENSE.md"), bytes.NewReader(by), hugofs.SourceFs)
 	if err != nil {
 		jww.FATAL.Fatalln(err)
 	}
@@ -195,7 +194,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 }
 
 func mkdir(x ...string) {
-	p := path.Join(x...)
+	p := filepath.Join(x...)
 
 	err := os.MkdirAll(p, 0777) // rwx, rw, r
 	if err != nil {
@@ -204,7 +203,7 @@ func mkdir(x ...string) {
 }
 
 func touchFile(x ...string) {
-	inpath := path.Join(x...)
+	inpath := filepath.Join(x...)
 	mkdir(filepath.Dir(inpath))
 	err := helpers.WriteToDisk(inpath, bytes.NewReader([]byte{}), hugofs.SourceFs)
 	if err != nil {
@@ -228,7 +227,7 @@ func createThemeMD(inpath string) (err error) {
 		return err
 	}
 
-	err = helpers.WriteToDisk(path.Join(inpath, "theme.toml"), bytes.NewReader(by), hugofs.SourceFs)
+	err = helpers.WriteToDisk(filepath.Join(inpath, "theme.toml"), bytes.NewReader(by), hugofs.SourceFs)
 	if err != nil {
 		return
 	}
@@ -245,7 +244,7 @@ func createConfig(inpath string, kind string) (err error) {
 		return err
 	}
 
-	err = helpers.WriteToDisk(path.Join(inpath, "config."+kind), bytes.NewReader(by), hugofs.SourceFs)
+	err = helpers.WriteToDisk(filepath.Join(inpath, "config."+kind), bytes.NewReader(by), hugofs.SourceFs)
 	if err != nil {
 		return
 	}

--- a/commands/version.go
+++ b/commands/version.go
@@ -16,7 +16,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -54,7 +53,7 @@ var version = &cobra.Command{
 
 // setBuildDate checks the ModTime of the Hugo executable and returns it as a
 // formatted string.  This assumes that the executable name is Hugo, if it does
-// not exist, an empty string will be returned.  This is only called if the 
+// not exist, an empty string will be returned.  This is only called if the
 // buildDate wasn't set during compile time.
 //
 // osext is used for cross-platform.
@@ -65,7 +64,7 @@ func setBuildDate() {
 		fmt.Println(err)
 		return
 	}
-	fi, err := os.Lstat(path.Join(dir, "hugo"))
+	fi, err := os.Lstat(filepath.Join(dir, "hugo"))
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -95,4 +94,3 @@ func getDateFormat() string {
 	}
 	return layout.(string)
 }
-


### PR DESCRIPTION
convert `commands` usage of `path` to `path/filepath`
