### PR TITLE
Add HBS template helper so handlebars partials are not evaluated as a Hugo Template

### DIFF
--- a/hugolib/template.go
+++ b/hugolib/template.go
@@ -537,6 +537,7 @@ func NewTemplate() Template {
 		"upper":       func(a string) string { return strings.ToUpper(a) },
 		"title":       func(a string) string { return strings.Title(a) },
 		"partial":     Partial,
+		"hbs":         Hbs,
 	}
 
 	templates.Funcs(funcMap)
@@ -583,6 +584,14 @@ func ExecuteTemplate(context interface{}, layouts ...string) *bytes.Buffer {
 func ExecuteTemplateToHTML(context interface{}, layouts ...string) template.HTML {
 	b := ExecuteTemplate(context, layouts...)
 	return template.HTML(string(b.Bytes()))
+}
+
+func Hbs(name string) template.HTML {
+	file, err := ioutil.ReadFile("./layouts/partials/" + name)
+	if err == nil {
+		return template.HTML(html.UnescapeString((string(file))))
+	}
+	return ""
 }
 
 func (t *GoHtmlTemplate) LoadEmbedded() {


### PR DESCRIPTION
I have multiple projects that leverage handlebars partials being rendered in in layouts as templates:

```
        <template id="footer">
          {{ hbs "globals/footer.hbs" }}
        </template>
```

This template helper will allow partials to be rendered as handlebars without trying to evaluate and interpolate the variables in the template language.

A pull would be great, I'm also open to changing this to `rawPartial` or adding `rawPartial` as an alias for the helper.
