### PR TITLE
Update version command to use the right type

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -54,7 +54,7 @@ var version = &cobra.Command{
 
 // setBuildDate checks the ModTime of the Hugo executable and returns it as a
 // formatted string.  This assumes that the executable name is Hugo, if it does
-// not exist, an empty string will be returned.  This is only called if the 
+// not exist, an empty string will be returned.  This is only called if the
 // buildDate wasn't set during compile time.
 //
 // osext is used for cross-platform.
@@ -88,11 +88,10 @@ func getDateFormat() string {
 	if params == nil {
 		return time.RFC3339
 	}
-	parms := params.(map[interface{}]interface{})
+	parms := params.(map[string]interface{})
 	layout := parms["DateFormat"]
 	if layout == nil || layout == "" {
 		return time.RFC3339
 	}
 	return layout.(string)
 }
-


### PR DESCRIPTION
Recently I've been receiving an error when running `hugo version` in the dev branch:

```
panic: interface conversion: interface is map[string]interface {}, not map[interface {}]interface {}
```

Updated type to match expected type and not error.
