### PR TITLE
Restore main XML feed to index.xml

### DIFF
--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -56,10 +56,10 @@ func TestRSSOutput(t *testing.T) {
 		t.Fatalf("Unable to RenderHomePage: %s", err)
 	}
 
-	file, err := hugofs.DestinationFS.Open("rss.xml")
+	file, err := hugofs.DestinationFS.Open("index.xml")
 
 	if err != nil {
-		t.Fatalf("Unable to locate: %s", "rss.xml")
+		t.Fatalf("Unable to locate: %s", "index.xml")
 	}
 
 	rss := helpers.ReaderToBytes(file)

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -983,15 +983,13 @@ func (s *Site) RenderHomePage() error {
 			n.Date = s.Pages[0].Date
 		}
 
-		if !viper.GetBool("DisableRSS") {
-			rssLayouts := []string{"rss.xml", "_default/rss.xml", "_internal/_default/rss.xml"}
-			b, err := s.renderXML("homepage rss", n, s.appendThemeTemplates(rssLayouts)...)
-			if err != nil {
-				return err
-			}
-			if err := s.WriteDestFile("rss.xml", b); err != nil {
-				return err
-			}
+		rssLayouts := []string{"rss.xml", "_default/rss.xml", "_internal/_default/rss.xml"}
+		b, err := s.renderXML("homepage rss", n, s.appendThemeTemplates(rssLayouts)...)
+		if err != nil {
+			return err
+		}
+		if err := s.WriteDestFile("index.xml", b); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Recent refactoring changed the filename of main XML feed from index.xml to rss.xml. This PR restores the behavior.

EDIT: 2nd commit can go together as they are in same function, squashed them.
