### PR TITLE
Prevent `.xml` generation for root section

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -934,7 +934,7 @@ func (s *Site) RenderSectionLists() error {
 			return err
 		}
 
-		if !viper.GetBool("DisableRSS") {
+		if !viper.GetBool("DisableRSS") && section != "" {
 			// XML Feed
 			rssLayouts := []string{"section/" + section + ".rss.xml", "_default/rss.xml", "rss.xml", "_internal/_default/rss.xml"}
 			s.setUrls(n, section+".xml")


### PR DESCRIPTION
I have an about.md file in my content directory, and after the recent refactoring I started seeing a `.xml` file in my public root for the empty section, which is unintentional. This PR takes care of that.
