### PR TITLE
Various fixes in RSS feed generation

### DIFF
--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -56,10 +56,10 @@ func TestRSSOutput(t *testing.T) {
 		t.Fatalf("Unable to RenderHomePage: %s", err)
 	}
 
-	file, err := hugofs.DestinationFS.Open("rss.xml")
+	file, err := hugofs.DestinationFS.Open("index.xml")
 
 	if err != nil {
-		t.Fatalf("Unable to locate: %s", "rss.xml")
+		t.Fatalf("Unable to locate: %s", "index.xml")
 	}
 
 	rss := helpers.ReaderToBytes(file)

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -867,14 +867,15 @@ func taxonomyRenderer(s *Site, taxes <-chan taxRenderInfo, results chan<- error,
 
 		if !viper.GetBool("DisableRSS") {
 			// XML Feed
-			s.setUrls(n, base+".xml")
+			n.Url = s.permalinkStr(base + "/index.xml")
+			n.Permalink = s.permalink(base)
 			rssLayouts := []string{"taxonomy/" + t.singular + ".rss.xml", "_default/rss.xml", "rss.xml", "_internal/_default/rss.xml"}
 			b, err := s.renderXML("taxonomy "+t.singular+" rss", n, s.appendThemeTemplates(rssLayouts)...)
 			if err != nil {
 				results <- err
 				continue
 			} else {
-				err := s.WriteDestFile(base+".xml", b)
+				err := s.WriteDestFile(base+"/index.xml", b)
 				if err != nil {
 					results <- err
 				}
@@ -934,15 +935,16 @@ func (s *Site) RenderSectionLists() error {
 			return err
 		}
 
-		if !viper.GetBool("DisableRSS") {
+		if !viper.GetBool("DisableRSS") && section != "" {
 			// XML Feed
+			n.Url = s.permalinkStr(section + "/index.xml")
+			n.Permalink = s.permalink(section)
 			rssLayouts := []string{"section/" + section + ".rss.xml", "_default/rss.xml", "rss.xml", "_internal/_default/rss.xml"}
-			s.setUrls(n, section+".xml")
 			b, err = s.renderXML("section "+section+" rss", n, s.appendThemeTemplates(rssLayouts)...)
 			if err != nil {
 				return err
 			}
-			if err := s.WriteDestFile(section+".xml", b); err != nil {
+			if err := s.WriteDestFile(section+"/index.xml", b); err != nil {
 				return err
 			}
 		}
@@ -971,9 +973,8 @@ func (s *Site) RenderHomePage() error {
 
 	if !viper.GetBool("DisableRSS") {
 		// XML Feed
-		n.Url = helpers.Urlize("index.xml")
-		n.Title = "Recent Content"
-		n.Permalink = s.permalink("index.xml")
+		n.Url = s.permalinkStr("index.xml")
+		n.Title = ""
 		high := 50
 		if len(s.Pages) < high {
 			high = len(s.Pages)
@@ -983,15 +984,13 @@ func (s *Site) RenderHomePage() error {
 			n.Date = s.Pages[0].Date
 		}
 
-		if !viper.GetBool("DisableRSS") {
-			rssLayouts := []string{"rss.xml", "_default/rss.xml", "_internal/_default/rss.xml"}
-			b, err := s.renderXML("homepage rss", n, s.appendThemeTemplates(rssLayouts)...)
-			if err != nil {
-				return err
-			}
-			if err := s.WriteDestFile("rss.xml", b); err != nil {
-				return err
-			}
+		rssLayouts := []string{"rss.xml", "_default/rss.xml", "_internal/_default/rss.xml"}
+		b, err := s.renderXML("homepage rss", n, s.appendThemeTemplates(rssLayouts)...)
+		if err != nil {
+			return err
+		}
+		if err := s.WriteDestFile("index.xml", b); err != nil {
+			return err
 		}
 	}
 

--- a/hugolib/template_embedded.go
+++ b/hugolib/template_embedded.go
@@ -45,13 +45,15 @@ func (t *GoHtmlTemplate) EmbedTemplates() {
 
 	t.AddInternalTemplate("_default", "rss.xml", `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-      <title>{{ .Title }} on {{ .Site.Title }} </title>
-      <generator uri="https://gohugo.io">Hugo</generator>
+    <title>{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}</title>
     <link>{{ .Permalink }}</link>
+    <description>Recent content {{ with .Title }}in {{.}} {{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>
     {{ with .Site.LanguageCode }}<language>{{.}}</language>{{end}}
     {{ with .Site.Author.name }}<author>{{.}}</author>{{end}}
     {{ with .Site.Copyright }}<copyright>{{.}}</copyright>{{end}}
-    <updated>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</updated>
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</lastBuildDate>
+    <atom:link href="{{.Url}}" rel="self" type="application/rss+xml" />
     {{ range first 15 .Data.Pages }}
     <item>
       <title>{{ .Title }}</title>


### PR DESCRIPTION
- Prevent `.xml` generation for root section
- Remove redundant check for DisableRSS
- Fix permalinks for rel="alternate"
- Rename generated xml file to `<type>/index.xml`
- Add required description element in default template
- Make default RSS template validate on w3c (timezone format is still an issue)
