### PR TITLE
Fix broken convert

### DIFF
--- a/commands/convert.go
+++ b/commands/convert.go
@@ -15,14 +15,15 @@ package commands
 
 import (
 	"fmt"
-	"path/filepath"
-	"time"
-
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
+	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/hugo/hugolib"
 	"github.com/spf13/hugo/parser"
 	jww "github.com/spf13/jwalterweatherman"
+	"github.com/spf13/viper"
+	"path/filepath"
+	"time"
 )
 
 var OutputDir string
@@ -128,7 +129,7 @@ func convertContents(mark rune) (err error) {
 			metadata = newmetadata
 		}
 
-		//page.Dir = file.Dir
+		page.SetDir(filepath.Join(helpers.AbsPathify(viper.GetString("ContentDir")), file.Dir()))
 		page.SetSourceContent(psr.Content())
 		page.SetSourceMetaData(metadata, mark)
 

--- a/source/file.go
+++ b/source/file.go
@@ -70,9 +70,9 @@ func (f *File) LogicalName() string {
 	}
 }
 
-//func (f *File) SetDir(dir string) {
-//f.dir = dir
-//}
+func (f *File) SetDir(dir string) {
+	f.dir = dir
+}
 
 func (f *File) Dir() string {
 	if f.dir != "" {


### PR DESCRIPTION
The front matter convert-feature didn't work. It placed converted content in
the wrong directory.

This commit fixes this by doing the smallest and safest change possible; the
path logic here should maybe be revisited and generalized.

Fixes #643
