### PR TITLE
fix version command so that it will work with all supported config

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -87,7 +87,19 @@ func getDateFormat() string {
 	if params == nil {
 		return time.RFC3339
 	}
-	parms := params.(map[string]interface{})
+
+	//	var typMapIfaceIface = reflect.TypeOf(map[interface{}{}]interface{}{})
+	//	var typMapStringIface = reflect.TypeOf(map[string]interface{}{})
+	parms := map[string]interface{}{}
+	switch params.(type) {
+	case map[interface{}]interface{}:
+		for k, v := range params.(map[interface{}]interface{}) {
+			parms[k.(string)] = v
+		}
+	case map[string]interface{}:
+		parms = params.(map[string]interface{})
+	}
+
 	layout := parms["DateFormat"]
 	if layout == nil || layout == "" {
 		return time.RFC3339

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// config json
+var JSONConfig = []byte(`{
+	"params": {
+		"DateFormat": "Jan 2 2006"
+	}		
+}`)
+
+// config toml
+var TOMLConfig = []byte(`
+[params]
+DateFormat =  "Jan 2 2006"
+`)
+
+// config yaml
+var YAMLConfig = []byte(`
+params:
+  DateFormat: "Jan 2 2006"
+`)
+
+var config map[string]interface{} = make(map[string]interface{})
+
+func TestGetDateFormatJSON(t *testing.T) {
+	jsonFile, _ := ioutil.TempFile("", "config.json")
+	fname := jsonFile.Name()
+	jsonFile.Write(JSONConfig)
+	jsonFile.Close()
+	viper.SetConfigFile(fname)
+	viper.SetConfigType("json")
+	viper.ReadInConfig()
+
+	dateFmt := getDateFormat()
+	assert.Equal(t, "Jan 2 2006", dateFmt)
+}
+
+func TestGetDateFormatTOML(t *testing.T) {
+	viper.Reset()
+	tomlFile, _ := ioutil.TempFile("", "config.toml")
+	fname := tomlFile.Name()
+	tomlFile.Write(TOMLConfig)
+	tomlFile.Close()
+	viper.SetConfigFile(fname)
+	viper.SetConfigType("toml")
+	viper.ReadInConfig()
+
+	dateFmt := getDateFormat()
+	assert.Equal(t, "Jan 2 2006", dateFmt)
+}
+
+func TestGetDateFormatYAML(t *testing.T) {
+	viper.Reset()
+	yamlFile, _ := ioutil.TempFile("", "config.yaml")
+	fname := yamlFile.Name()
+	yamlFile.Write(YAMLConfig)
+	yamlFile.Close()
+	viper.SetConfigFile(fname)
+	viper.SetConfigType("yaml")
+	viper.ReadInConfig()
+
+	dateFmt := getDateFormat()
+	assert.Equal(t, "Jan 2 2006", dateFmt)
+}


### PR DESCRIPTION
formats and added tests.

This resolves #609,  #634, and #657.

The issues ping-pong between map[string]interface{} and map[interface{}interface{}. This is due to the differences between the way TOML and YAML `param` settings are stored. JSON is also affected, but I am not sure which way panics JSON as I did not test JSON configs before implementing fix/tests.

`getDateFormat()` now checks the interface type and converts `map[interface{}]interface{})` to `map[string]interface{}`.

Tests were added, which I should have done in the first place; mea culpa
