### PR TITLE
Use current working dir as WorkingDir instead of hugo executable's dir

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -177,7 +177,7 @@ func InitializeConfig() {
 	if Source != "" {
 		viper.Set("WorkingDir", Source)
 	} else {
-		dir, _ := helpers.FindCWD()
+		dir, _ := os.Getwd()
 		viper.Set("WorkingDir", dir)
 	}
 


### PR DESCRIPTION
I found the problem when I ran the latest hugo. The problem is

```
$ ~/Devel/golang/src/github.com/spf13/hugo/hugo -v
INFO: 2014/11/21 Using config file: /Users/demachitatsushi/Devel/hugosite/config.yaml
ERROR: 2014/11/21 Unable to find Static Directory: /Users/demachitatsushi/Devel/golang/src/github.com/spf13/hugo/static/
CRITICAL: 2014/11/21 No source directory found, expecting to find it at /Users/demachitatsushi/Devel/golang/src/github.com/spf13/hugo/content
```

The command was run at my site's top directory but I lazily specified the hugo binary in the package repository directly.

It seems to be solved by replacing `FindCWD()` to `Getwd()`
