### PR TITLE
Added makefile that builds with git information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+
+# Adds build information from git repo
+#
+# as suggested by tatsushid in
+# https://github.com/spf13/hugo/issues/540
+
+COMMIT_HASH=`git rev-parse --short HEAD 2>/dev/null`
+BUILD_DATE=`date +%FT%T%z`
+LDFLAGS=-ldflags "-X github.com/spf13/hugo/commands.commitHash ${COMMIT_HASH} -X github.com/spf13/hugo/commands.buildDate ${BUILD_DATE}"
+
+all: gitinfo
+
+help:
+	echo ${COMMIT_HASH}
+	echo ${BUILD_DATE}
+
+gitinfo:
+	go build ${LDFLAGS} -o hugo main.go
+
+no-git-info:
+	go build -o hugo main.go
+


### PR DESCRIPTION
I have put the extra linker flags in a makefile to avoid having to remember the long command to get the commitHash in the version command.

See comment by tatsushid here:
#540

NB: only tested on Mac OS x 10.10.1 since that is what I have access to
