### PR TITLE
update summary.md with info on handling of html tags

### DIFF
--- a/docs/content/content/summaries.md
+++ b/docs/content/content/summaries.md
@@ -18,12 +18,14 @@ Content summaries provide links to the original content, usually in the form of 
 
 By default, Hugo automatically splits content after 70 words, with the content prior to the split being used for the content summary. This way you don't have to worry about content summary unless you want to customize it; the summary is automatically created for you, and available to be used by Hugo, without any additional work on your part.
 
+When using automatic summaries, Hugo will strip all HTML tags from the summary.
+
 ## User-defined: manual summary split:
 
 Hugo also provides an easy way to customize where a piece of content will be split with its summary content divider:  <code>&#60;&#33;&#45;&#45;more&#45;&#45;&#62;</code>. The summary content divider is Hugo's version of a "more tag", "summary divider", "excerpt separator", etc. found in other systems. For the summary content divider to be valid, it most be entered as <code>&#60;&#33;&#45;&#45;more&#45;&#45;&#62;</code>; with no additional spaces or other characters between the `<code>` and `</code>` tags.
 
 If the summary content divider exists within a piece of content, Hugo will split the content at that point, instead of its default split point of 70 words. The content prior to the summary content provider will be used as that content's summary and the summary content divider will be replaces with a `Read More` link. When the full content is rendered, the summary content provider, <code>&#60;&#33;&#45;&#45;more&#45;&#45;&#62;</code>, is elided from the output.
 
-A primary benefit of using <code>&#60;&#33;&#45;&#45;more&#45;&#45;&#62;</code> is that a user-defined summary split preserves all of the summary formatting.
+When using user-defined summaries, <code>&#60;&#33;&#45;&#45;more&#45;&#45;&#62;</code>, Hugo will preserve the HTML in the summary.
 
 The summary content divider only applies to the content that it appears in.


### PR DESCRIPTION
This updates the documentation with Hugo's handling for tags when using automatic summaries and user-defined summaries. It also adds @anthonyfok's feedback to the original summary.md
