### PR TITLE
Add configurable support for angled quotes

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -136,6 +136,7 @@ func InitializeConfig() {
 	viper.SetDefault("FootnoteAnchorPrefix", "")
 	viper.SetDefault("FootnoteReturnLinkContents", "")
 	viper.SetDefault("NewContentEditor", "")
+	viper.SetDefault("Blackfriday", map[string]bool{"angledQuotes": false})
 
 	if hugoCmdV.PersistentFlags().Lookup("buildDrafts").Changed {
 		viper.Set("BuildDrafts", Draft)

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -212,7 +212,9 @@ func renderShortcode(sc shortcode, tokenizedShortcodes map[string](string), cnt 
 		}
 
 		if sc.doMarkup {
-			newInner := helpers.RenderBytes([]byte(inner), p.guessMarkupType(), p.UniqueId())
+			newInner := helpers.RenderBytes(helpers.RenderingContext{
+				Content: []byte(inner), PageFmt: p.guessMarkupType(),
+				DocumentId: p.UniqueId(), ConfigFlags: p.getRenderingConfigFlags()})
 
 			// If the type is “unknown” or “markdown”, we assume the markdown
 			// generation has been performed. Given the input: `a line`, markdown

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -618,7 +618,7 @@ func Highlight(in interface{}, lang string) template.HTML {
 }
 
 func Markdownify(text string) template.HTML {
-	return template.HTML(helpers.RenderBytes([]byte(text), "markdown", ""))
+	return template.HTML(helpers.RenderBytes(helpers.RenderingContext{Content: []byte(text), PageFmt: "markdown"}))
 }
 
 func refPage(page interface{}, ref, methodName string) template.HTML {


### PR DESCRIPTION
The flag `HTML_SMARTYPANTS_ANGLED_QUOTES` was added to Blackfriday on Black
Friday. This configures rendering of double quotes as angled left and right
quotes (&laquo; &raquo;).

Typical use cases would be either or, or combined, but never in the same 
document. As an example would be a person from Norway; he has a blog in both 
English and Norwegian (his native tongue); he would then configure Blackfriday 
to use angled quotes for the Norwegian section, but keep them as reqular 
double quotes for the English.

This commit adds configuration support for this new flag, configuration that
can be set in the site configuration, but overridden in page front matter.

Fixes #605
