### PR TITLE
Correct alias

### DIFF
--- a/docs/content/templates/content.md
+++ b/docs/content/templates/content.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /layout/functions/
+- /layout/content/
 date: 2013-07-01
 linktitle: Single Content
 menu:


### PR DESCRIPTION
This was wrongly overriding the functions doc alias. Found after following a wrong link in template primer doc page.
