### PR TITLE
fix error on InitializeConfig() for hugo version - preserve support for dateformat

### DIFF
--- a/commands/benchmark.go
+++ b/commands/benchmark.go
@@ -14,9 +14,10 @@
 package commands
 
 import (
-	"github.com/spf13/cobra"
 	"os"
 	"runtime/pprof"
+
+	"github.com/spf13/cobra"
 )
 
 var cpuProfilefile string
@@ -28,7 +29,7 @@ var benchmark = &cobra.Command{
 	Long: `Hugo can build a site many times over and anlyze the
     running process creating a `,
 	Run: func(cmd *cobra.Command, args []string) {
-		InitializeConfig()
+		InitializeConfig(cmdBenchmark)
 		bench(cmd, args)
 	},
 }

--- a/commands/check.go
+++ b/commands/check.go
@@ -24,7 +24,7 @@ var check = &cobra.Command{
 	Long: `Hugo will perform some basic analysis on the
     content provided and will give feedback.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		InitializeConfig()
+		InitializeConfig(cmdCheck)
 		site := hugolib.Site{}
 		site.Analyze()
 	},

--- a/commands/convert.go
+++ b/commands/convert.go
@@ -85,7 +85,7 @@ func init() {
 }
 
 func convertContents(mark rune) (err error) {
-	InitializeConfig()
+	InitializeConfig(cmdConvert)
 	site := &hugolib.Site{}
 
 	if err := site.Initialise(); err != nil {

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -36,6 +36,42 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	cmdUnknown cmdType = iota
+	cmdBenchmark
+	cmdCheck
+	cmdConvert
+	cmdHugo
+	cmdList
+	cmdNew
+	cmdServer
+	cmdVersion
+)
+
+type cmdType int
+
+func (c cmdType) String() string {
+	switch c {
+	case cmdBenchmark:
+		return "benchmark"
+	case cmdCheck:
+		return "check"
+	case cmdConvert:
+		return "convert"
+	case cmdHugo:
+		return "hugo"
+	case cmdList:
+		return "list"
+	case cmdNew:
+		return "new"
+	case cmdServer:
+		return "server"
+	case cmdVersion:
+		return "version"
+	}
+	return "unknown"
+}
+
 //var Config *hugolib.Config
 var HugoCmd = &cobra.Command{
 	Use:   "hugo",
@@ -45,7 +81,7 @@ love by spf13 and friends in Go.
 
 Complete documentation is available at http://gohugo.io`,
 	Run: func(cmd *cobra.Command, args []string) {
-		InitializeConfig()
+		InitializeConfig(cmdHugo)
 		build()
 	},
 }
@@ -92,12 +128,14 @@ func init() {
 	hugoCmdV = HugoCmd
 }
 
-func InitializeConfig() {
+func InitializeConfig(cmd cmdType) {
 	viper.SetConfigFile(CfgFile)
 	viper.AddConfigPath(Source)
 	err := viper.ReadInConfig()
-	if err != nil {
-		jww.ERROR.Println("Unable to locate Config file. Perhaps you need to create a new site. Run `hugo help new` for details")
+	if cmd != cmdVersion {
+		if err != nil {
+			jww.ERROR.Println("Unable to locate Config file. Perhaps you need to create a new site. Run `hugo help new` for details")
+		}
 	}
 
 	viper.RegisterAlias("taxonomies", "indexes")

--- a/commands/list.go
+++ b/commands/list.go
@@ -40,7 +40,7 @@ var listDraftsCmd = &cobra.Command{
 	Long:  `List all of the drafts in your content directory`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		InitializeConfig()
+		InitializeConfig(cmdList)
 		viper.Set("BuildDrafts", true)
 
 		site := &hugolib.Site{}
@@ -65,7 +65,7 @@ var listFutureCmd = &cobra.Command{
 	Long:  `List all of the posts in your content directory who will be posted in the future`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		InitializeConfig()
+		InitializeConfig(cmdList)
 		viper.Set("BuildFuture", true)
 
 		site := &hugolib.Site{}

--- a/commands/new.go
+++ b/commands/new.go
@@ -73,7 +73,7 @@ as you see fit.
 }
 
 func NewContent(cmd *cobra.Command, args []string) {
-	InitializeConfig()
+	InitializeConfig(cmdNew)
 
 	if cmd.Flags().Lookup("format").Changed {
 		viper.Set("MetaDataFormat", configFormat)
@@ -133,7 +133,7 @@ func NewSite(cmd *cobra.Command, args []string) {
 }
 
 func NewTheme(cmd *cobra.Command, args []string) {
-	InitializeConfig()
+	InitializeConfig(cmdNew)
 
 	if len(args) < 1 {
 		cmd.Usage()

--- a/commands/server.go
+++ b/commands/server.go
@@ -59,7 +59,7 @@ func init() {
 }
 
 func server(cmd *cobra.Command, args []string) {
-	InitializeConfig()
+	InitializeConfig(cmdServer)
 
 	if cmd.Flags().Lookup("disableLiveReload").Changed {
 		viper.Set("DisableLiveReload", disableLiveReload)

--- a/commands/version.go
+++ b/commands/version.go
@@ -37,7 +37,7 @@ var version = &cobra.Command{
 	Short: "Print the version number of Hugo",
 	Long:  `All software has versions. This is Hugo's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		InitializeConfig()
+		InitializeConfig(cmdVersion)
 		if buildDate == "" {
 			setBuildDate() // set the build date from executable's mdate
 		} else {


### PR DESCRIPTION
...for error on initialization of version.

This resolves #695 with the suggested fix. When `hugo version` is run, the error message from Viper will be suppressed. This results in the reported issue being resolved while maintaining the ability to customize the way the compile date is displayed.

This adds the `cmdType` type along with constants and the `String()` func to fulfill the stringer interface. All Hugo command calls to `InitializeConfig()` have been updated to `InitializeConfig(cmdType)` so that Hugo will correctly handle errors from Viper. 

These changes do not change the behavior of the updated command, with the exception of `version`.

There is another pull request related to #695: https://github.com/spf13/hugo/pull/696. Either that pull request or this one should be accepted, and not both.
