### PR TITLE
Fix various Windows-issues

### DIFF
--- a/helpers/general.go
+++ b/helpers/general.go
@@ -20,8 +20,11 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"path/filepath"
 	"strings"
 )
+
+const FilePathSeparator = string(filepath.Separator)
 
 func FindAvailablePort() (*net.TCPAddr, error) {
 	l, err := net.Listen("tcp", ":0")

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -119,7 +119,7 @@ func TestReplaceExtension(t *testing.T) {
 	}
 
 	for i, d := range data {
-		output := ReplaceExtension(d.input, d.newext)
+		output := ReplaceExtension(filepath.FromSlash(d.input), d.newext)
 		if d.expected != output {
 			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
 		}
@@ -139,8 +139,8 @@ func TestDirExists(t *testing.T) {
 		{"../", true},
 		{"./..", true},
 		{"./../", true},
-		{"/tmp", true},
-		{"/tmp/", true},
+		{os.TempDir(), true},
+		{os.TempDir() + FilePathSeparator, true},
 		{"/", true},
 		{"/some-really-random-directory-name", false},
 		{"/some/really/random/directory/name", false},
@@ -149,7 +149,7 @@ func TestDirExists(t *testing.T) {
 	}
 
 	for i, d := range data {
-		exists, _ := DirExists(d.input, new(afero.OsFs))
+		exists, _ := DirExists(filepath.FromSlash(d.input), new(afero.OsFs))
 		if d.expected != exists {
 			t.Errorf("Test %d failed. Expected %t got %t", i, d.expected, exists)
 		}
@@ -366,8 +366,8 @@ func TestAbsPathify(t *testing.T) {
 		input, expected string
 	}
 	data := []test{
-		{os.TempDir(), path.Clean(os.TempDir())}, // TempDir has trailing slash
-		{"/banana/../dir/", "/dir"},
+		{os.TempDir(), filepath.Clean(os.TempDir())}, // TempDir has trailing slash
+		{filepath.FromSlash("/banana/../dir/"), filepath.FromSlash("/dir")},
 	}
 
 	for i, d := range data {
@@ -400,7 +400,7 @@ func TestFilename(t *testing.T) {
 	}
 
 	for i, d := range data {
-		output := Filename(d.input)
+		output := Filename(filepath.FromSlash(d.input))
 		if d.expected != output {
 			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
 		}
@@ -429,7 +429,7 @@ func TestFileAndExt(t *testing.T) {
 	}
 
 	for i, d := range data {
-		file, ext := FileAndExt(d.input)
+		file, ext := FileAndExt(filepath.FromSlash(d.input))
 		if d.expectedFile != file {
 			t.Errorf("Test %d failed. Expected filename %q got %q.", i, d.expectedFile, file)
 		}
@@ -467,7 +467,7 @@ func TestGuessSection(t *testing.T) {
 	}
 
 	for i, d := range data {
-		expected := GuessSection(d.input)
+		expected := GuessSection(filepath.FromSlash(d.input))
 		if d.expected != expected {
 			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, expected)
 		}

--- a/helpers/url_test.go
+++ b/helpers/url_test.go
@@ -69,14 +69,14 @@ func TestUrlPrep(t *testing.T) {
 }
 
 func TestPretty(t *testing.T) {
-	assert.Equal(t, PrettifyPath("/section/name.html"), "/section/name/index.html")
-	assert.Equal(t, PrettifyPath("/section/sub/name.html"), "/section/sub/name/index.html")
-	assert.Equal(t, PrettifyPath("/section/name/"), "/section/name/index.html")
-	assert.Equal(t, PrettifyPath("/section/name/index.html"), "/section/name/index.html")
-	assert.Equal(t, PrettifyPath("/index.html"), "/index.html")
-	assert.Equal(t, PrettifyPath("/name.xml"), "/name/index.xml")
-	assert.Equal(t, PrettifyPath("/"), "/")
-	assert.Equal(t, PrettifyPath(""), "/")
+	assert.Equal(t, PrettifyUrlPath("/section/name.html"), "/section/name/index.html")
+	assert.Equal(t, PrettifyUrlPath("/section/sub/name.html"), "/section/sub/name/index.html")
+	assert.Equal(t, PrettifyUrlPath("/section/name/"), "/section/name/index.html")
+	assert.Equal(t, PrettifyUrlPath("/section/name/index.html"), "/section/name/index.html")
+	assert.Equal(t, PrettifyUrlPath("/index.html"), "/index.html")
+	assert.Equal(t, PrettifyUrlPath("/name.xml"), "/name/index.xml")
+	assert.Equal(t, PrettifyUrlPath("/"), "/")
+	assert.Equal(t, PrettifyUrlPath(""), "/")
 	assert.Equal(t, PrettifyUrl("/section/name.html"), "/section/name")
 	assert.Equal(t, PrettifyUrl("/section/sub/name.html"), "/section/sub/name")
 	assert.Equal(t, PrettifyUrl("/section/name/"), "/section/name")

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -17,13 +17,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"html/template"
-	"io"
-	"net/url"
-	"path/filepath"
-	"strings"
-	"time"
-
 	"github.com/spf13/cast"
 	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/hugo/hugofs"
@@ -32,6 +25,13 @@ import (
 	"github.com/spf13/hugo/tpl"
 	jww "github.com/spf13/jwalterweatherman"
 	"github.com/spf13/viper"
+	"html/template"
+	"io"
+	"net/url"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
 )
 
 type Page struct {
@@ -197,7 +197,7 @@ func layouts(types string, layout string) (layouts []string) {
 	// Add type/layout.html
 	for i := range t {
 		search := t[:len(t)-i]
-		layouts = append(layouts, fmt.Sprintf("%s/%s.html", strings.ToLower(filepath.Join(search...)), layout))
+		layouts = append(layouts, fmt.Sprintf("%s/%s.html", strings.ToLower(path.Join(search...)), layout))
 	}
 
 	// Add _default/layout.html
@@ -250,7 +250,7 @@ func (p *Page) analyzePage() {
 
 func (p *Page) permalink() (*url.URL, error) {
 	baseUrl := string(p.Site.BaseUrl)
-	dir := strings.TrimSpace(p.Source.Dir())
+	dir := strings.TrimSpace(filepath.ToSlash(p.Source.Dir()))
 	pSlug := strings.TrimSpace(p.Slug)
 	pUrl := strings.TrimSpace(p.Url)
 	var permalink string
@@ -269,10 +269,10 @@ func (p *Page) permalink() (*url.URL, error) {
 		// fmt.Printf("have a section override for %q in section %s → %s\n", p.Title, p.Section, permalink)
 	} else {
 		if len(pSlug) > 0 {
-			permalink = helpers.UrlPrep(viper.GetBool("UglyUrls"), filepath.Join(dir, p.Slug+"."+p.Extension()))
+			permalink = helpers.UrlPrep(viper.GetBool("UglyUrls"), path.Join(dir, p.Slug+"."+p.Extension()))
 		} else {
 			_, t := filepath.Split(p.Source.LogicalName())
-			permalink = helpers.UrlPrep(viper.GetBool("UglyUrls"), filepath.Join(dir, helpers.ReplaceExtension(strings.TrimSpace(t), p.Extension())))
+			permalink = helpers.UrlPrep(viper.GetBool("UglyUrls"), path.Join(dir, helpers.ReplaceExtension(strings.TrimSpace(t), p.Extension())))
 		}
 	}
 
@@ -674,6 +674,7 @@ func (p *Page) TargetPath() (outfile string) {
 		if strings.HasSuffix(outfile, "/") {
 			outfile = outfile + "index.html"
 		}
+		outfile = filepath.FromSlash(outfile)
 		return
 	}
 
@@ -685,6 +686,7 @@ func (p *Page) TargetPath() (outfile string) {
 			if strings.HasSuffix(outfile, "/") {
 				outfile += "index.html"
 			}
+			outfile = filepath.FromSlash(outfile)
 			return
 		}
 	}

--- a/hugolib/pageGroup_test.go
+++ b/hugolib/pageGroup_test.go
@@ -2,6 +2,7 @@ package hugolib
 
 import (
 	"errors"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -26,7 +27,7 @@ var pageGroupTestSources = []pageGroupTestObject{
 func preparePageGroupTestPages(t *testing.T) Pages {
 	var pages Pages
 	for _, s := range pageGroupTestSources {
-		p, err := NewPage(s.path)
+		p, err := NewPage(filepath.FromSlash(s.path))
 		if err != nil {
 			t.Fatalf("failed to prepare test page %s", s.path)
 		}

--- a/hugolib/page_permalink_test.go
+++ b/hugolib/page_permalink_test.go
@@ -2,6 +2,7 @@ package hugolib
 
 import (
 	"html/template"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/hugo/source"
@@ -48,7 +49,7 @@ func TestPermalink(t *testing.T) {
 					BaseUrl: test.base,
 				},
 			},
-			Source: Source{File: *source.NewFile(test.file)},
+			Source: Source{File: *source.NewFile(filepath.FromSlash(test.file))},
 		}
 
 		if test.slug != "" {

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -510,10 +510,10 @@ func TestDegenerateInvalidFrontMatterLeadingWhitespace(t *testing.T) {
 }
 
 func TestSectionEvaluation(t *testing.T) {
-	page, _ := NewPage("blue/file1.md")
+	page, _ := NewPage(filepath.FromSlash("blue/file1.md"))
 	page.ReadFrom(strings.NewReader(SIMPLE_PAGE))
 	if page.Section() != "blue" {
-		t.Errorf("Section should be %s, got: %s", "blue", page.Section)
+		t.Errorf("Section should be %s, got: %s", "blue", page.Section())
 	}
 }
 

--- a/hugolib/path_seperators_windows_test.go
+++ b/hugolib/path_seperators_windows_test.go
@@ -1,6 +1,7 @@
 package hugolib
 
 import (
+	"github.com/spf13/hugo/tpl"
 	"testing"
 )
 
@@ -10,8 +11,8 @@ const (
 )
 
 func TestTemplatePathSeperator(t *testing.T) {
-	tmpl := new(GoHtmlTemplate)
-	if name := tmpl.generateTemplateNameFrom(win_base, win_path); name != "sub1/index.html" {
+	tmpl := new(tpl.GoHtmlTemplate)
+	if name := tmpl.GenerateTemplateNameFrom(win_base, win_path); name != "sub1/index.html" {
 		t.Fatalf("Template name incorrect.  Expected: %s, Got: %s", "sub1/index.html", name)
 	}
 }

--- a/hugolib/site_show_plan_test.go
+++ b/hugolib/site_show_plan_test.go
@@ -2,26 +2,27 @@ package hugolib
 
 import (
 	"bytes"
-	"strings"
-	"testing"
-
+	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/hugo/source"
 	"github.com/spf13/hugo/target"
+	"path/filepath"
+	"strings"
+	"testing"
 )
 
 const ALIAS_DOC_1 = "---\ntitle: alias doc\naliases:\n  - \"alias1/\"\n  - \"alias-2/\"\n---\naliases\n"
 
 var fakeSource = []source.ByteSource{
 	{
-		Name:    "foo/bar/file.md",
+		Name:    filepath.FromSlash("foo/bar/file.md"),
 		Content: []byte(SIMPLE_PAGE),
 	},
 	{
-		Name:    "alias/test/file1.md",
+		Name:    filepath.FromSlash("alias/test/file1.md"),
 		Content: []byte(ALIAS_DOC_1),
 	},
 	{
-		Name:    "section/somecontent.html",
+		Name:    filepath.FromSlash("section/somecontent.html"),
 		Content: []byte(RENDER_NO_FRONT_MATTER),
 	},
 }
@@ -36,25 +37,24 @@ func stringInSlice(a string, list []string) bool {
 }
 
 func checkShowPlanExpected(t *testing.T, s *Site, expected string) {
+
 	out := new(bytes.Buffer)
 	if err := s.ShowPlan(out); err != nil {
 		t.Fatalf("ShowPlan unexpectedly returned an error: %s", err)
 	}
 	got := out.String()
 
+	expected = filepath.FromSlash(expected)
+	// hackety hack: alias is an Url
+	expected = strings.Replace(expected, (helpers.FilePathSeparator + " =>"), "/ =>", -1)
+	expected = strings.Replace(expected, "n"+(helpers.FilePathSeparator+"a"), "n/a", -1)
 	gotList := strings.Split(got, "\n")
 	expectedList := strings.Split(expected, "\n")
 
-	for _, x := range gotList {
-		if !stringInSlice(x, expectedList) {
-			t.Errorf("%v %v %v %v", "\nShowPlan expected:\n", expected, "\ngot:\n", got)
-		}
-	}
+	diff := DiffStringSlices(gotList, expectedList)
 
-	for _, x := range expectedList {
-		if !stringInSlice(x, gotList) {
-			t.Errorf("%v %v %v %v", "\nShowPlan expected:\n", expected, "\ngot:\n", got)
-		}
+	if len(diff) > 0 {
+		t.Errorf("Got diff in show plan: %s", diff)
 	}
 }
 
@@ -125,4 +125,27 @@ func TestFileTargetPublishDir(t *testing.T) {
 		" alias-2/ => ../public/alias-2/index.html\n\n" +
 		"section/somecontent.html (renderer: n/a)\n canonical => ../public/section/somecontent/index.html\n\n"
 	checkShowPlanExpected(t, s, expected)
+}
+
+// DiffStringSlices returns the difference between two string slices.
+// See:
+// http://stackoverflow.com/questions/19374219/how-to-find-the-difference-between-two-slices-of-strings-in-golang
+func DiffStringSlices(slice1 []string, slice2 []string) []string {
+	diffStr := []string{}
+	m := map[string]int{}
+
+	for _, s1Val := range slice1 {
+		m[s1Val] = 1
+	}
+	for _, s2Val := range slice2 {
+		m[s2Val] = m[s2Val] + 1
+	}
+
+	for mKey, mVal := range m {
+		if mVal == 1 {
+			diffStr = append(diffStr, mKey)
+		}
+	}
+
+	return diffStr
 }

--- a/hugolib/site_url_test.go
+++ b/hugolib/site_url_test.go
@@ -2,6 +2,7 @@ package hugolib
 
 import (
 	"html/template"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -47,8 +48,8 @@ func (t *InMemoryAliasTarget) Publish(label string, permalink template.HTML) (er
 }
 
 var urlFakeSource = []source.ByteSource{
-	{"content/blue/doc1.md", []byte(SLUG_DOC_1)},
-	{"content/blue/doc2.md", []byte(SLUG_DOC_2)},
+	{filepath.FromSlash("content/blue/doc1.md"), []byte(SLUG_DOC_1)},
+	{filepath.FromSlash("content/blue/doc2.md"), []byte(SLUG_DOC_2)},
 }
 
 func TestPageCount(t *testing.T) {
@@ -93,7 +94,7 @@ func TestPageCount(t *testing.T) {
 		"sd3/index.html",
 		"sd4.html",
 	} {
-		if _, err := hugofs.DestinationFS.Open(s); err != nil {
+		if _, err := hugofs.DestinationFS.Open(filepath.FromSlash(s)); err != nil {
 			t.Errorf("No alias rendered: %s", s)
 		}
 	}

--- a/source/file.go
+++ b/source/file.go
@@ -14,12 +14,10 @@
 package source
 
 import (
+	"github.com/spf13/hugo/helpers"
 	"io"
-	"path"
 	"path/filepath"
 	"strings"
-
-	"github.com/spf13/hugo/helpers"
 )
 
 type File struct {
@@ -65,7 +63,7 @@ func (f *File) LogicalName() string {
 	if f.logicalName != "" {
 		return f.logicalName
 	} else {
-		_, f.logicalName = path.Split(f.relpath)
+		_, f.logicalName = filepath.Split(f.relpath)
 		return f.logicalName
 	}
 }
@@ -78,7 +76,7 @@ func (f *File) Dir() string {
 	if f.dir != "" {
 		return f.dir
 	} else {
-		f.dir, _ = path.Split(f.relpath)
+		f.dir, _ = filepath.Split(f.relpath)
 		return f.dir
 	}
 }

--- a/source/filesystem_windows_test.go
+++ b/source/filesystem_windows_test.go
@@ -8,8 +8,8 @@ package source
 var platformBase = "C:\\foo\\"
 var platformPaths = []TestPath{
 	{"foobar", "foobar", "aaa", "", ""},
-	{"b\\1file", "1file", "aaa", "b", "b/"},
-	{"c\\d\\2file", "2file", "aaa", "c", "c/d/"},
-	{"C:\\foo\\e\\f\\3file", "3file", "aaa", "e", "e/f/"}, // note volume case is equal to platformBase
-	{"section\\foo.rss", "foo.rss", "aaa", "section", "section/"},
+	{"b\\1file", "1file", "aaa", "b", "b\\"},
+	{"c\\d\\2file", "2file", "aaa", "c", "c\\d\\"},
+	{"C:\\foo\\e\\f\\3file", "3file", "aaa", "e", "e\\f\\"}, // note volume case is equal to platformBase
+	{"section\\foo.rss", "foo.rss", "aaa", "section", "section\\"},
 }

--- a/target/alias_test.go
+++ b/target/alias_test.go
@@ -1,6 +1,7 @@
 package target
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -13,14 +14,14 @@ func TestHTMLRedirectAlias(t *testing.T) {
 		expected string
 	}{
 		{"", ""},
-		{"s", "s/index.html"},
-		{"/", "/index.html"},
-		{"alias 1", "alias-1/index.html"},
-		{"alias 2/", "alias-2/index.html"},
+		{"s", filepath.FromSlash("s/index.html")},
+		{"/", filepath.FromSlash("/index.html")},
+		{"alias 1", filepath.FromSlash("alias-1/index.html")},
+		{"alias 2/", filepath.FromSlash("alias-2/index.html")},
 		{"alias 3.html", "alias-3.html"},
 		{"alias4.html", "alias4.html"},
-		{"/alias 5.html", "/alias-5.html"},
-		{"/трям.html", "/трям.html"},
+		{"/alias 5.html", filepath.FromSlash("/alias-5.html")},
+		{"/трям.html", filepath.FromSlash("/трям.html")},
 	}
 
 	for _, test := range tests {

--- a/target/page.go
+++ b/target/page.go
@@ -32,7 +32,7 @@ func (pp *PagePub) Publish(path string, r io.Reader) (err error) {
 }
 
 func (pp *PagePub) Translate(src string) (dest string, err error) {
-	if src == "/" {
+	if src == helpers.FilePathSeparator {
 		if pp.PublishDir != "" {
 			return filepath.Join(pp.PublishDir, "index.html"), nil
 		}

--- a/target/page_test.go
+++ b/target/page_test.go
@@ -1,6 +1,7 @@
 package target
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -24,13 +25,14 @@ func TestPageTranslator(t *testing.T) {
 
 	for _, test := range tests {
 		f := new(PagePub)
-		dest, err := f.Translate(test.content)
+		dest, err := f.Translate(filepath.FromSlash(test.content))
+		expected := filepath.FromSlash(test.expected)
 		if err != nil {
 			t.Fatalf("Translate returned and unexpected err: %s", err)
 		}
 
-		if dest != test.expected {
-			t.Errorf("Tranlate expected return: %s, got: %s", test.expected, dest)
+		if dest != expected {
+			t.Errorf("Translate expected return: %s, got: %s", expected, dest)
 		}
 	}
 }
@@ -53,7 +55,7 @@ func TestPageTranslatorBase(t *testing.T) {
 				t.Fatalf("Translated returned and err: %s", err)
 			}
 
-			if dest != test.expected {
+			if dest != filepath.FromSlash(test.expected) {
 				t.Errorf("Translate expected: %s, got: %s", test.expected, dest)
 			}
 		}
@@ -73,7 +75,7 @@ func TestTranslateUglyUrls(t *testing.T) {
 
 	for _, test := range tests {
 		f := &PagePub{UglyUrls: true}
-		dest, err := f.Translate(test.content)
+		dest, err := f.Translate(filepath.FromSlash(test.content))
 		if err != nil {
 			t.Fatalf("Translate returned an unexpected err: %s", err)
 		}
@@ -87,7 +89,7 @@ func TestTranslateUglyUrls(t *testing.T) {
 func TestTranslateDefaultExtension(t *testing.T) {
 	f := &PagePub{DefaultExtension: ".foobar"}
 	dest, _ := f.Translate("baz")
-	if dest != "baz/index.foobar" {
+	if dest != filepath.FromSlash("baz/index.foobar") {
 		t.Errorf("Translate expected return: %s, got %s", "baz/index.foobar", dest)
 	}
 }

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -603,6 +603,7 @@ func ExecuteTemplate(context interface{}, layouts ...string) *bytes.Buffer {
 	buffer := new(bytes.Buffer)
 	worked := false
 	for _, layout := range layouts {
+
 		name := layout
 
 		if localTemplates.Lookup(name) == nil {
@@ -701,7 +702,7 @@ func (t *GoHtmlTemplate) AddTemplateFile(name, path string) error {
 
 }
 
-func (t *GoHtmlTemplate) generateTemplateNameFrom(base, path string) string {
+func (t *GoHtmlTemplate) GenerateTemplateNameFrom(base, path string) string {
 	return filepath.ToSlash(path[len(base)+1:])
 }
 
@@ -720,7 +721,7 @@ func (t *GoHtmlTemplate) loadTemplates(absPath string, prefix string) {
 				return nil
 			}
 
-			tplName := t.generateTemplateNameFrom(absPath, path)
+			tplName := t.GenerateTemplateNameFrom(absPath, path)
 
 			if prefix != "" {
 				tplName = strings.Trim(prefix, "/") + "/" + tplName


### PR DESCRIPTION
File handling was broken on Windows. This commit contains a revision of the path handling with separation of file paths and urls where needed.

There may be remaining issues and there may be better ways to do this, but it is easier to start that refactoring job with a set of passing tests.

Fixes #687
Fixes #660
