### PR TITLE
Correct URL of the favicon in the documentation

### DIFF
--- a/docs/layouts/partials/header.html
+++ b/docs/layouts/partials/header.html
@@ -6,7 +6,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <meta name="keyword" content="">
-    <link rel="shortcut icon" href="img/favicon.png">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
 
     <title>{{.Title}}</title>
 


### PR DESCRIPTION
I noticed that the Chromium browser was displaying a generic "blank paper icon" for Hugo documentation pages, and later realized that the href `img/favicon.png` does not exist anywhere in the Hugo Git repository, so I thought it is easiest to point to `/favicon.ico` like `docs/layouts/index.html` does.  :-)
