### PR TITLE
Feature: getJson and getCsv in short codes and other layout files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ kind of website including blogs, tumbles and docs.
 
 Hugo is written in Go with support for Windows, Linux, FreeBSD and OS X.
 
-The latest release can be found at [hugo releases](https://github.com/spf13/hugo/releases).
+The latest release can be found at [Hugo Releases](https://github.com/spf13/hugo/releases).
 We currently build for Windows, Linux, FreeBSD and OS X for x64
 and i386 architectures.
 
@@ -51,7 +51,7 @@ is the most probable location.
 #### Dependencies
 
 * Git
-* Go 1.1+
+* Go 1.1+ (Go 1.4+ on Windows, see Go [Issue #8090](https://code.google.com/p/go/issues/detail?id=8090))
 * Mercurial
 * Bazaar
 
@@ -61,7 +61,7 @@ is the most probable location.
     cd hugo
     go get
 
-Because Go expects all of your libraries to be found in either $GOROOT or $GOPATH,
+Because Go expects all of your libraries to be found in either `$GOROOT` or `$GOPATH`,
 it's helpful to symlink the project to one of the following paths:
 
  * `ln -s /path/to/your/hugo $GOPATH/src/github.com/spf13/hugo`
@@ -81,18 +81,21 @@ If you only want to build from source, it's even easier.
 
 ##### Adding compile information to Hugo
 
-When Hugo is built using the above steps, the `version` sub-command will include the `mdate` of the Hugo executable.  Instead, it is possible to have the `version` sub-command return information about the git commit used and time of compilation using `build` flags.
+When Hugo is built using the above steps, the `version` sub-command will include the `mdate` of the Hugo executable, similar to the following:
+
+    Hugo Static Site Generator v0.13-DEV buildDate: 2014-12-24T04:46:03-07:00
+
+Instead, it is possible to have the `version` sub-command return information about the git commit used and time of compilation using `build` flags.
 
 To do this, replace the `go build` command with the following *(replace `/path/to/hugo` with the actual path)*:
 
-    go build -ldflags "-X /path/to/hugo/commands.commitHash `git rev-parse --short HEAD 2>/dev/null` -X github.com/spf13/hugo/commands.buildDate `date +%FT%T`"  
+    go build -ldflags "-X /path/to/hugo/commands.commitHash `git rev-parse --short HEAD 2>/dev/null` -X github.com/spf13/hugo/commands.buildDate `date +%FT%T%z`"
 
-This will result in hugo version output that looks similar to:
+This will result in `hugo version` output that looks similar to:
 
-    Hugo Static Site Generator v0.13-DEV buildDate: 2014-10-16T09:59:55Z
-    Hugo Static Site Generator v0.13-DEV-24BBFE7 buildDate: 2014-10-16T10:00:55Z
+    Hugo Static Site Generator v0.13-DEV-8042E77 buildDate: 2014-12-25T03:25:57-07:00
 
-The format of the date is configurable via the `Params.DateFormat` setting.  `DateFormat` is a string value representing the Go time layout that should be used to format the date output. If `Params.DateFormat` is not set, `time.RFC3339` will be used as the default format.See [time documentation](http://golang.org/pkg/time/#pkg-constants) for more information.
+The format of the date is configurable via the `Params.DateFormat` setting.  `DateFormat` is a string value representing the Go time layout that should be used to format the date output. If `Params.DateFormat` is not set, `time.RFC3339` will be used as the default format. See Go's ["time" package documentation](http://golang.org/pkg/time/#pkg-constants) for more information.
 
 Configuration setting using config.yaml as example:
 
@@ -119,7 +122,7 @@ We welcome your contributions.  To make the process as seamless as possible, we 
      * Have test cases for the new code.  If you have questions about how to do it, please ask in your pull request.
      * Run `go fmt`
      * Squash your commits into a single commit.  `git rebase -i`.  It's okay to force update your pull request.  
-     * Make sure `go test ./...` passes, and go build completes.  Our Travis CI loop will catch most things that are missing.  The exception: Windows.  We run on Windows from time to time, but if you have access, please check on a Windows machine too.
+     * Make sure `go test ./...` passes, and `go build` completes.  Our Travis CI loop will catch most things that are missing.  The exception: Windows.  We run on Windows from time to time, but if you have access, please check on a Windows machine too.
 
 **Complete documentation is available at [Hugo Documentation](http://gohugo.io).**
 

--- a/commands/benchmark.go
+++ b/commands/benchmark.go
@@ -25,8 +25,8 @@ var benchmarkTimes int
 var benchmark = &cobra.Command{
 	Use:   "benchmark",
 	Short: "Benchmark hugo by building a site a number of times",
-	Long: `Hugo can build a site many times over and anlyze the
-    running process creating a `,
+	Long: `Hugo can build a site many times over and analyze the
+running process creating a benchmark.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		InitializeConfig()
 		bench(cmd, args)

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -56,7 +56,7 @@ var hugoCmdV *cobra.Command
 
 //Flags that are to be added to commands.
 var BuildWatch, Draft, Future, UglyUrls, Verbose, Logging, VerboseLog, DisableRSS, DisableSitemap, PluralizeListTitles, NoTimes bool
-var Source, Destination, Theme, BaseUrl, CfgFile, LogFile, Editor string
+var Source, CacheDir, Destination, Theme, BaseUrl, CfgFile, LogFile, Editor string
 
 //Execute adds all child commands to the root command HugoCmd and sets flags appropriately.
 func Execute() {
@@ -82,6 +82,7 @@ func init() {
 	HugoCmd.PersistentFlags().BoolVar(&DisableRSS, "disableRSS", false, "Do not build RSS files")
 	HugoCmd.PersistentFlags().BoolVar(&DisableSitemap, "disableSitemap", false, "Do not build Sitemap file")
 	HugoCmd.PersistentFlags().StringVarP(&Source, "source", "s", "", "filesystem path to read files relative from")
+	HugoCmd.PersistentFlags().StringVarP(&CacheDir, "cacheDir", "", "$TMPDIR/hugo_cache/", "filesystem path to cache directory")
 	HugoCmd.PersistentFlags().StringVarP(&Destination, "destination", "d", "", "filesystem path to write files to")
 	HugoCmd.PersistentFlags().StringVarP(&Theme, "theme", "t", "", "theme to use (located in /themes/THEMENAME/)")
 	HugoCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
@@ -136,6 +137,7 @@ func InitializeConfig() {
 	viper.SetDefault("FootnoteAnchorPrefix", "")
 	viper.SetDefault("FootnoteReturnLinkContents", "")
 	viper.SetDefault("NewContentEditor", "")
+	viper.SetDefault("Blackfriday", map[string]bool{"angledQuotes": false})
 
 	if hugoCmdV.PersistentFlags().Lookup("buildDrafts").Changed {
 		viper.Set("BuildDrafts", Draft)
@@ -192,6 +194,15 @@ func InitializeConfig() {
 	} else {
 		dir, _ := os.Getwd()
 		viper.Set("WorkingDir", dir)
+	}
+
+	if CacheDir != "" {
+		if helpers.FilePathSeparator != CacheDir[len(CacheDir)-1:] {
+			CacheDir = CacheDir + helpers.FilePathSeparator
+		}
+		viper.Set("CacheDir", CacheDir)
+	} else {
+		viper.Set("CacheDir", helpers.GetTempDir("hugo_cache", hugofs.SourceFs))
 	}
 
 	if VerboseLog || Logging || (viper.IsSet("LogFile") && viper.GetString("LogFile") != "") {

--- a/commands/server.go
+++ b/commands/server.go
@@ -44,7 +44,7 @@ var serverCmd = &cobra.Command{
 	Short: "Hugo runs its own webserver to render the files",
 	Long: `Hugo is able to run its own high performance web server.
 Hugo will render all the files defined in the source directory and
-Serve them up.`,
+serve them up.`,
 	//Run: server,
 }
 

--- a/docs/content/content/front-matter.md
+++ b/docs/content/content/front-matter.md
@@ -93,3 +93,9 @@ Field names are always normalized to lowercase (e.g. `camelCase: true` is availa
 
 *If neither `slug` or `url` is present, the filename will be used.*
 
+## Configure Blackfriday rendering
+
+It's possible to set some options for Markdown rendering in the page's front matter, as an override to the site wide configuration.
+
+See [Configuration]({{< ref "overview/configuration.md#configure-blackfriday-rendering" >}}) for more.
+

--- a/docs/content/content/types.md
+++ b/docs/content/content/types.md
@@ -25,7 +25,7 @@ and each section will use the corresponding type. If you are taking advantage of
 this, then each new piece of content you place into a section will automatically
 inherit the type.
 
-Alternatively you can set the type in the meta data under the key "type".
+Alternatively, you can set the type in the meta data under the key "`type`".
 
 
 ## Creating new content of a specific type
@@ -53,24 +53,24 @@ whenever a specific file is not present.
 *Remember, all of the following are optional:*
 
 ### Create Type Directory
-Create a directory with the name of the type in layouts. Type is always singular.  *Eg /layouts/post*.
+Create a directory with the name of the type in `layouts`. Type is always singular.  *E.g. `/layouts/post`*.
 
 ### Create single template
-Create a file called single.html inside your directory. *Eg /layouts/post/single.html*.
+Create a file called `single.html` inside your directory. *E.g. `/layouts/post/single.html`*.
 
 ### Create list template
-Create a file called list.html inside your directory. *Eg /layouts/post/list.html*.
+Create a file called `list.html` inside your directory. *E.g. `/layouts/post/list.html`*.
 
 ### Create views
-Many sites support rendering content in a few different ways, for
-instance a single page view and a summary view to be used when displaying a list
+Many sites support rendering content in a few different ways, for instance,
+a single page view and a summary view to be used when displaying a list
 of contents on a single page. Hugo makes no assumptions here about how you want
 to display your content, and will support as many different views of a content
 type as your site requires. All that is required for these additional views is
-that a template exists in each layout/type directory with the same name.
+that a template exists in each layouts/`TYPE` directory with the same name.
 
 ### Create a corresponding archetype
 
-Create a file called `type`.md in the /archetypes directory *Eg /archetypes/post.md*.
+Create a file called <code><em>type</em>.md</code> in the `/archetypes` directory. *E.g. `/archetypes/post.md`*.
 
-More details about archetypes can be found at the [archetypes docs](/content/archetypes)
+More details about archetypes can be found at the [archetypes docs](/content/archetypes).

--- a/docs/content/extras/comments.md
+++ b/docs/content/extras/comments.md
@@ -80,9 +80,9 @@ Now, reference the partial template from your page template:
 
 A few alternatives exist to [Disqus](http://disqus.com):
 
-* [Intense Debate](http://intensedebate.com/)
-* [LiveFyre](http://livefyre.com/)
-* [Moot](http://muut.com)
+* [IntenseDebate](http://intensedebate.com/)
+* [Livefyre](http://livefyre.com/)
+* [Muut](http://muut.com)
 * [多说](http://duoshuo.com/) ([Duoshuo](http://duoshuo.com/), popular in China)
 * [Kaiju](http://github.com/spf13/kaiju)
 

--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -63,6 +63,24 @@ Here is a yaml configuration file which sets a few more options
       SidebarRecentLimit: 5
     ...
 
+## Configure Blackfriday rendering
+
+[Blackfriday](https://github.com/russross/blackfriday) is the [Markdown](http://daringfireball.net/projects/markdown/) rendering engine used in Hugo. The Blackfriday configuration in Hugo is mostly a set of sane defaults that should fit most use cases.
+
+But Hugo does expose some options -- in the table below matched with the corresponding flag in the  [Blackfriday source](https://github.com/russross/blackfriday/blob/master/html.go):
+
+
+Flag | Default | Blackfriday flag | Purpose
+--- | --- | --- | ---
+angledQuotes | false | HTML_SMARTYPANTS_ANGLED_QUOTES |  Enable angled double quotes (`« »`)
+
+**Note** that these flags must be grouped under the `blackfriday` key and can be set on **both site and page level**. If set on page, it will override the site setting.
+
+```
+blackfriday:
+  angledQuotes = true
+```
+
 ## Notes
 
 Config changes do not reflect with [Live Reload](/extras/livereload).

--- a/docs/content/overview/installing.md
+++ b/docs/content/overview/installing.md
@@ -49,7 +49,7 @@ placed in your path.
 ### Dependencies
 
 * Git
-* Go 1.1+
+* Go 1.1+ (Go 1.4+ on Windows, see Go [Issue #8090](https://code.google.com/p/go/issues/detail?id=8090))
 * Mercurial
 * Bazaar
 

--- a/docs/content/templates/views.md
+++ b/docs/content/templates/views.md
@@ -23,10 +23,10 @@ different type of content to the content itself.
 
 ## Creating a content view
 
-To create a new view simple create a template in each of your different
-content type directories with the view name. In the following example we
+To create a new view, simply create a template in each of your different
+content type directories with the view name. In the following example, we
 have created a "li" view and a "summary" view for our two content types
-of post and project. As you can see these sit next to the [single
+of post and project. As you can see, these sit next to the [single
 content view](/templates/content) template "single.html". You can even
 provide a specific view for a given type and continue to use the
 \_default/single.html for the primary view.
@@ -86,10 +86,10 @@ templates](/templates/list)).
     </div>
     </section>
 
-In the above example you will notice that we have called .Render and passed in
-which view to render the content with. Render is a special function available on
+In the above example, you will notice that we have called `.Render` and passed in
+which view to render the content with. `.Render` is a special function available on
 a content which tells the content to render itself with the provided view template.
-In this example we are not using the li view. To use this we would
+In this example, we are not using the li view. To use this we would
 change the render line to `{{ .Render "li" }}`.
 
 

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -11,8 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//Package helpers implements general utility functions that work with and on content. The helper functions defined here
-//lay down the foundation of how Hugo works with files, filepaths and does string operations on content.
+// Package helpers implements general utility functions that work with
+// and on content.  The helper functions defined here lay down the
+// foundation of how Hugo works with files and filepaths, and perform
+// string operations on content.
 package helpers
 
 import (
@@ -34,7 +36,7 @@ var SummaryLength = 70
 // Custom divider <!--more--> let's user define where summarization ends.
 var SummaryDivider = []byte("<!--more-->")
 
-//StripHTML accepts a string, strips out all HTML tags and returns it.
+// StripHTML accepts a string, strips out all HTML tags and returns it.
 func StripHTML(s string) string {
 	output := ""
 
@@ -72,20 +74,20 @@ func StripEmptyNav(in []byte) []byte {
 	return bytes.Replace(in, []byte("<nav>\n</nav>\n\n"), []byte(``), -1)
 }
 
-//BytesToHTML converts bytes to type template.HTML.
+// BytesToHTML converts bytes to type template.HTML.
 func BytesToHTML(b []byte) template.HTML {
 	return template.HTML(string(b))
 }
 
-func GetHtmlRenderer(defaultFlags int, documentId string) blackfriday.Renderer {
+func GetHtmlRenderer(defaultFlags int, ctx RenderingContext) blackfriday.Renderer {
 	renderParameters := blackfriday.HtmlRendererParameters{
 		FootnoteAnchorPrefix:       viper.GetString("FootnoteAnchorPrefix"),
 		FootnoteReturnLinkContents: viper.GetString("FootnoteReturnLinkContents"),
 	}
 
-	if len(documentId) != 0 {
-		renderParameters.FootnoteAnchorPrefix = documentId + ":" + renderParameters.FootnoteAnchorPrefix
-		renderParameters.HeaderIDSuffix = ":" + documentId
+	if len(ctx.DocumentId) != 0 {
+		renderParameters.FootnoteAnchorPrefix = ctx.DocumentId + ":" + renderParameters.FootnoteAnchorPrefix
+		renderParameters.HeaderIDSuffix = ":" + ctx.DocumentId
 	}
 
 	htmlFlags := defaultFlags
@@ -94,6 +96,16 @@ func GetHtmlRenderer(defaultFlags int, documentId string) blackfriday.Renderer {
 	htmlFlags |= blackfriday.HTML_SMARTYPANTS_FRACTIONS
 	htmlFlags |= blackfriday.HTML_SMARTYPANTS_LATEX_DASHES
 	htmlFlags |= blackfriday.HTML_FOOTNOTE_RETURN_LINKS
+
+	var angledQuotes bool
+
+	if m, ok := ctx.ConfigFlags["angledQuotes"]; ok {
+		angledQuotes = m
+	}
+
+	if angledQuotes {
+		htmlFlags |= blackfriday.HTML_SMARTYPANTS_ANGLED_QUOTES
+	}
 
 	return blackfriday.HtmlRendererWithParameters(htmlFlags, "", "", renderParameters)
 }
@@ -106,18 +118,18 @@ func GetMarkdownExtensions() int {
 		blackfriday.EXTENSION_HEADER_IDS | blackfriday.EXTENSION_AUTO_HEADER_IDS
 }
 
-func MarkdownRender(content []byte, documentId string) []byte {
-	return blackfriday.Markdown(content, GetHtmlRenderer(0, documentId),
+func MarkdownRender(ctx RenderingContext) []byte {
+	return blackfriday.Markdown(ctx.Content, GetHtmlRenderer(0, ctx),
 		GetMarkdownExtensions())
 }
 
-func MarkdownRenderWithTOC(content []byte, documentId string) []byte {
-	return blackfriday.Markdown(content,
-		GetHtmlRenderer(blackfriday.HTML_TOC, documentId),
+func MarkdownRenderWithTOC(ctx RenderingContext) []byte {
+	return blackfriday.Markdown(ctx.Content,
+		GetHtmlRenderer(blackfriday.HTML_TOC, ctx),
 		GetMarkdownExtensions())
 }
 
-//ExtractTOC extracts Table of Contents from content.
+// ExtractTOC extracts Table of Contents from content.
 func ExtractTOC(content []byte) (newcontent []byte, toc []byte) {
 	origContent := make([]byte, len(content))
 	copy(origContent, content)
@@ -153,25 +165,32 @@ func ExtractTOC(content []byte) (newcontent []byte, toc []byte) {
 	return
 }
 
-func RenderBytesWithTOC(content []byte, pagefmt string, documentId string) []byte {
-	switch pagefmt {
+type RenderingContext struct {
+	Content     []byte
+	PageFmt     string
+	DocumentId  string
+	ConfigFlags map[string]bool
+}
+
+func RenderBytesWithTOC(ctx RenderingContext) []byte {
+	switch ctx.PageFmt {
 	default:
-		return MarkdownRenderWithTOC(content, documentId)
+		return MarkdownRenderWithTOC(ctx)
 	case "markdown":
-		return MarkdownRenderWithTOC(content, documentId)
+		return MarkdownRenderWithTOC(ctx)
 	case "rst":
-		return []byte(GetRstContent(content))
+		return []byte(GetRstContent(ctx.Content))
 	}
 }
 
-func RenderBytes(content []byte, pagefmt string, documentId string) []byte {
-	switch pagefmt {
+func RenderBytes(ctx RenderingContext) []byte {
+	switch ctx.PageFmt {
 	default:
-		return MarkdownRender(content, documentId)
+		return MarkdownRender(ctx)
 	case "markdown":
-		return MarkdownRender(content, documentId)
+		return MarkdownRender(ctx)
 	case "rst":
-		return []byte(GetRstContent(content))
+		return []byte(GetRstContent(ctx.Content))
 	}
 }
 
@@ -180,7 +199,7 @@ func TotalWords(s string) int {
 	return len(strings.Fields(s))
 }
 
-//WordCount takes content and returns a map of words and count of each word.
+// WordCount takes content and returns a map of words and count of each word.
 func WordCount(s string) map[string]int {
 	m := make(map[string]int)
 	for _, f := range strings.Fields(s) {
@@ -190,12 +209,13 @@ func WordCount(s string) map[string]int {
 	return m
 }
 
-//RemoveSummaryDivider removes summary-divider <!--more--> from content.
+// RemoveSummaryDivider removes summary-divider <!--more--> from content.
 func RemoveSummaryDivider(content []byte) []byte {
 	return bytes.Replace(content, SummaryDivider, []byte(""), -1)
 }
 
-//TruncateWords takes content and na int and shortens down the number of words in the content down to the number of int.
+// TruncateWords takes content and an int and shortens down the number
+// of words in the content down to the number of int.
 func TruncateWords(s string, max int) string {
 	words := strings.Fields(s)
 	if max > len(words) {
@@ -205,7 +225,8 @@ func TruncateWords(s string, max int) string {
 	return strings.Join(words[:max], " ")
 }
 
-//TruncateWordsToWholeSentence takes content and an int and returns entire sentences from content, delimited by the int.
+// TruncateWordsToWholeSentence takes content and an int
+// and returns entire sentences from content, delimited by the int.
 func TruncateWordsToWholeSentence(s string, max int) string {
 	words := strings.Fields(s)
 	if max > len(words) {
@@ -224,6 +245,8 @@ func TruncateWordsToWholeSentence(s string, max int) string {
 	return strings.Join(words[:max], " ")
 }
 
+// GetRstContent calls the Python script rst2html as an external helper
+// to convert reStructuredText content to HTML.
 func GetRstContent(content []byte) string {
 	cleanContent := bytes.Replace(content, SummaryDivider, []byte(""), 1)
 

--- a/helpers/general.go
+++ b/helpers/general.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 )
 
-//Filepath separator defined by os.Separator.
+// Filepath separator defined by os.Separator.
 const FilePathSeparator = string(filepath.Separator)
 
 func FindAvailablePort() (*net.TCPAddr, error) {
@@ -40,7 +40,8 @@ func FindAvailablePort() (*net.TCPAddr, error) {
 	return nil, err
 }
 
-// InStringArray checks if a string is an element of a slice of strings and returns a boolean value.
+// InStringArray checks if a string is an element of a slice of strings
+// and returns a boolean value.
 func InStringArray(arr []string, el string) bool {
 	for _, v := range arr {
 		if v == el {
@@ -64,31 +65,32 @@ func GuessType(in string) string {
 	return "unknown"
 }
 
-//ReaderToBytes takes an io.Reader argument, reads from it and returns bytes.
+// ReaderToBytes takes an io.Reader argument, reads from it
+// and returns bytes.
 func ReaderToBytes(lines io.Reader) []byte {
 	b := new(bytes.Buffer)
 	b.ReadFrom(lines)
 	return b.Bytes()
 }
 
-//ReaderToString is the same as ReaderToBytes, but returns a string.
+// ReaderToString is the same as ReaderToBytes, but returns a string.
 func ReaderToString(lines io.Reader) string {
 	b := new(bytes.Buffer)
 	b.ReadFrom(lines)
 	return b.String()
 }
 
-//StringToReader does the opposite of ReaderToString.
+// StringToReader does the opposite of ReaderToString.
 func StringToReader(in string) io.Reader {
 	return strings.NewReader(in)
 }
 
-//BytesToReader does the opposite of ReaderToBytes.
+// BytesToReader does the opposite of ReaderToBytes.
 func BytesToReader(in []byte) io.Reader {
 	return bytes.NewReader(in)
 }
 
-// sliceToLower goes through the source slice and lowers all values.
+// SliceToLower goes through the source slice and lowers all values.
 func SliceToLower(s []string) []string {
 	if s == nil {
 		return nil
@@ -102,7 +104,7 @@ func SliceToLower(s []string) []string {
 	return l
 }
 
-//Md5String takes a string and returns a MD5 Hash of it.
+// Md5String takes a string and returns its MD5 hash.
 func Md5String(f string) string {
 	h := md5.New()
 	h.Write([]byte(f))

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -28,15 +28,16 @@ import (
 
 var sanitizeRegexp = regexp.MustCompile("[^a-zA-Z0-9./_-]")
 
-// Take a string with any characters and replace it so the string could be used in a path.
-// MakePath creates a Unicode sanitized string, with the spaces replaced, whilst
-// preserving the original casing of the string.
+// MakePath takes a string with any characters and replace it
+// so the string could be used in a path.
+// It does so by creating a Unicode-sanitized string, with the spaces replaced,
+// whilst preserving the original casing of the string.
 // E.g. Social Media -> Social-Media
 func MakePath(s string) string {
 	return UnicodeSanitize(strings.Replace(strings.TrimSpace(s), " ", "-", -1))
 }
 
-// MakePathToLower creates a Unicode santized string, with the spaces replaced,
+// MakePathToLower creates a Unicode-sanitized string, with the spaces replaced,
 // and transformed to lower case.
 // E.g. Social Media -> social-media
 func MakePathToLower(s string) string {
@@ -65,7 +66,8 @@ func UnicodeSanitize(s string) string {
 	return string(target)
 }
 
-//ReplaceExtension takes a path and an extension, strips the old extension and returns the path with the new extension.
+// ReplaceExtension takes a path and an extension, strips the old extension
+// and returns the path with the new extension.
 func ReplaceExtension(path string, newExt string) string {
 	f, _ := FileAndExt(path)
 	return f + "." + newExt
@@ -83,7 +85,7 @@ func DirExists(path string, fs afero.Fs) (bool, error) {
 	return false, err
 }
 
-//IsDir check if a given path is a directory.
+// IsDir checks if a given path is a directory.
 func IsDir(path string, fs afero.Fs) (bool, error) {
 	fi, err := fs.Stat(path)
 	if err != nil {
@@ -92,7 +94,7 @@ func IsDir(path string, fs afero.Fs) (bool, error) {
 	return fi.IsDir(), nil
 }
 
-//IsEmpty checks if a given path is empty.
+// IsEmpty checks if a given path is empty.
 func IsEmpty(path string, fs afero.Fs) (bool, error) {
 	if b, _ := Exists(path, fs); !b {
 		return false, fmt.Errorf("%q path does not exist", path)
@@ -154,7 +156,8 @@ func MakePathRelative(inPath string, possibleDirectories ...string) (string, err
 	return inPath, errors.New("Can't extract relative path, unknown prefix")
 }
 
-//Filename takes a path, strips out the extension and returns the name of the file.
+// Filename takes a path, strips out the extension,
+// and returns the name of the file.
 func Filename(in string) (name string) {
 	name, _ = FileAndExt(in)
 	return
@@ -162,14 +165,18 @@ func Filename(in string) (name string) {
 
 // FileAndExt returns the filename and any extension of a file path as
 // two separate strings.
-// If path, in, contains a directory name ending in a slash then
-// both name and ext will be empty strings.
+//
+// If the path, in, contains a directory name ending in a slash,
+// then both name and ext will be empty strings.
+//
 // If the path, in, is either the current directory, the parent
-// directory or the root directory, or an empty string, then both
-// name and ext will be empty strings.
-// If the path, in, represents the path of a file without an extension
+// directory or the root directory, or an empty string,
+// then both name and ext will be empty strings.
+//
+// If the path, in, represents the path of a file without an extension,
 // then name will be the name of the file and ext will be an empty string.
-// If the path, in, represents a filename with an extension then
+//
+// If the path, in, represents a filename with an extension,
 // then name will be the filename minus any extension - including the dot
 // and ext will contain the extension - minus the dot.
 func FileAndExt(in string) (name string, ext string) {
@@ -201,7 +208,7 @@ func FileAndExtSep(in, ext, base, pathSeparator string) (name string) {
 
 }
 
-//GetRelativePath returns the relative path of a given path.
+// GetRelativePath returns the relative path of a given path.
 func GetRelativePath(path, base string) (final string, err error) {
 	if filepath.IsAbs(path) && base == "" {
 		return "", errors.New("source: missing base directory")
@@ -216,8 +223,9 @@ func GetRelativePath(path, base string) (final string, err error) {
 	return name, nil
 }
 
-// Given a source path, determine the section
-// A section is the part between the root slash and the second slash or before the first slash
+// Given a source path, determine the section.
+// A section is the part between the root slash and the second slash
+// or before the first slash.
 func GuessSection(in string) string {
 	parts := strings.Split(in, FilePathSeparator)
 	// This will include an empty entry before and after paths with leading and trailing slashes
@@ -258,10 +266,10 @@ func PathPrep(ugly bool, in string) string {
 	}
 }
 
-// Same as PrettifyUrlPath() but for paths.
-// 	/section/name.html becomes /section/name/index.html
-// 	/section/name/  becomes /section/name/index.html
-// 	/section/name/index.html becomes /section/name/index.html
+// Same as PrettifyUrlPath() but for file paths.
+//     /section/name.html       becomes /section/name/index.html
+//     /section/name/           becomes /section/name/index.html
+//     /section/name/index.html becomes /section/name/index.html
 func PrettifyPath(in string) string {
 	if filepath.Ext(in) == "" {
 		// /section/name/  -> /section/name/index.html
@@ -281,7 +289,8 @@ func PrettifyPath(in string) string {
 	}
 }
 
-//FindCWD returns the current working directory from where the Hugo executable is run.
+// FindCWD returns the current working directory from where the Hugo
+// executable is run.
 func FindCWD() (string, error) {
 	serverFile, err := filepath.Abs(os.Args[0])
 
@@ -305,7 +314,7 @@ func FindCWD() (string, error) {
 	return path, nil
 }
 
-//Same as WriteToDisk but checks to see if file/directory already exists.
+// Same as WriteToDisk but checks to see if file/directory already exists.
 func SafeWriteToDisk(inpath string, r io.Reader, fs afero.Fs) (err error) {
 	dir, _ := filepath.Split(inpath)
 	ospath := filepath.FromSlash(dir)
@@ -357,4 +366,29 @@ func WriteToDisk(inpath string, r io.Reader, fs afero.Fs) (err error) {
 
 	_, err = io.Copy(file, r)
 	return
+}
+
+// GetTempDir returns the OS default temp directory with trailing slash
+// if subPath is not empty then it will be created recursively
+func GetTempDir(subPath string, fs afero.Fs) string {
+	dir := os.TempDir()
+	if FilePathSeparator != dir[len(dir)-1:] {
+		dir = dir + FilePathSeparator
+	}
+	if subPath != "" {
+		dir = dir + MakePath(subPath)
+
+		if exists, _ := Exists(dir, fs); exists {
+			return dir
+		}
+
+		err := fs.MkdirAll(dir, 0777) // rwx, rw, r
+		if err != nil {
+			panic(err)
+		}
+		if FilePathSeparator != dir[len(dir)-1:] {
+			dir = dir + FilePathSeparator
+		}
+	}
+	return dir
 }

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -584,3 +584,31 @@ func TestWriteToDisk(t *testing.T) {
 		reader.Seek(0, 0)
 	}
 }
+
+func TestGetTempDir(t *testing.T) {
+	dir := os.TempDir()
+	if FilePathSeparator != dir[len(dir)-1:] {
+		dir = dir + FilePathSeparator
+	}
+	testDir := "hugoTestFolder" + FilePathSeparator
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", dir},
+		{testDir + "  Foo bar  ", dir + testDir + "--Foo-bar" + FilePathSeparator},
+		{testDir + "Foo.Bar/foo_Bar-Foo", dir + testDir + "Foo.Bar/foo_Bar-Foo" + FilePathSeparator},
+		{testDir + "fOO,bar:foo%bAR", dir + testDir + "fOObarfoobAR" + FilePathSeparator},
+		{testDir + "FOo/BaR.html", dir + testDir + "FOo/BaR.html" + FilePathSeparator},
+		{testDir + "трям/трям", dir + testDir + "трям/трям" + FilePathSeparator},
+		{testDir + "은행", dir + testDir + "은행" + FilePathSeparator},
+		{testDir + "Банковский кассир", dir + testDir + "Банковский-кассир" + FilePathSeparator},
+	}
+
+	for _, test := range tests {
+		output := GetTempDir(test.input, new(afero.MemMapFs))
+		if output != test.expected {
+			t.Errorf("Expected %#v, got %#v\n", test.expected, output)
+		}
+	}
+}

--- a/helpers/pygments.go
+++ b/helpers/pygments.go
@@ -25,7 +25,8 @@ import (
 
 const pygmentsBin = "pygmentize"
 
-//HasPygments checks to see if Pygments is installed and available on the system.
+// HasPygments checks to see if Pygments is installed and available
+// on the system.
 func HasPygments() bool {
 	if _, err := exec.LookPath(pygmentsBin); err != nil {
 		return false
@@ -33,7 +34,7 @@ func HasPygments() bool {
 	return true
 }
 
-//Highlight takes some code and returns highlighted code.
+// Highlight takes some code and returns highlighted code.
 func Highlight(code string, lexer string) string {
 
 	if !HasPygments() {

--- a/helpers/url.go
+++ b/helpers/url.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-//SanitizeUrl sanitizes the input URL string.
+// SanitizeUrl sanitizes the input URL string.
 func SanitizeUrl(in string) string {
 	url, err := purell.NormalizeURLString(in, purell.FlagsSafe|purell.FlagRemoveTrailingSlash|purell.FlagRemoveDotSegments|purell.FlagRemoveDuplicateSlashes|purell.FlagRemoveUnnecessaryHostDots|purell.FlagRemoveEmptyPortSeparator)
 	if err != nil {
@@ -111,10 +111,11 @@ func PrettifyUrl(in string) string {
 	return x
 }
 
-//PrettifyUrlPath takes a URL path to a content and converts it to enable pretty URLS.
-//	/section/name.html becomes /section/name/index.html
-//	/section/name/  becomes /section/name/index.html
-//	/section/name/index.html becomes /section/name/index.html
+// PrettifyUrlPath takes a URL path to a content and converts it
+// to enable pretty URLs.
+//     /section/name.html       becomes /section/name/index.html
+//     /section/name/           becomes /section/name/index.html
+//     /section/name/index.html becomes /section/name/index.html
 func PrettifyUrlPath(in string) string {
 	if path.Ext(in) == "" {
 		// /section/name/  -> /section/name/index.html
@@ -134,10 +135,10 @@ func PrettifyUrlPath(in string) string {
 	}
 }
 
-//Uglify does the opposite of PrettifyPath().
-// 	/section/name/index.html becomes /section/name.html
-// 	/section/name/  becomes /section/name.html
-// 	/section/name.html becomes /section/name.html
+// Uglify does the opposite of PrettifyUrlPath().
+//     /section/name/index.html becomes /section/name.html
+//     /section/name/           becomes /section/name.html
+//     /section/name.html       becomes /section/name.html
 func Uglify(in string) string {
 	if path.Ext(in) == "" {
 		if len(in) < 2 {
@@ -162,7 +163,7 @@ func Uglify(in string) string {
 	}
 }
 
-// Same as FileAndExt, but for Urls
+// Same as FileAndExt, but for URLs.
 func ResourceAndExt(in string) (name string, ext string) {
 	ext = path.Ext(in)
 	base := path.Base(in)

--- a/hugolib/menu_test.go
+++ b/hugolib/menu_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/hugo/hugofs"
 	"github.com/spf13/hugo/source"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -47,7 +48,11 @@ const (
 [[menu.tax]]
 	name = "Tax RSS"
     url = "/two/key.xml"
-	identifier="xml"`
+	identifier="xml"
+[[menu.unicode]]
+   name = "Unicode Russian"
+   identifier = "unicode-russian"
+   url = "/новости-проекта"` // Russian => "news-project"
 )
 
 var MENU_PAGE_1 = []byte(`+++
@@ -91,7 +96,10 @@ type testMenuState struct {
 	oldBaseUrl interface{}
 }
 
-func TestPageMenu(t *testing.T) {
+// temporarily disabled
+// will be enabled once the cast related build issues is fixed
+// todo bep
+func _TestPageMenu(t *testing.T) {
 	ts := setupMenuTests(t)
 	defer resetMenuTestState(ts)
 
@@ -134,6 +142,31 @@ func TestPageMenu(t *testing.T) {
 
 	}
 
+}
+
+// issue #719
+func TestMenuWithUnicodeUrls(t *testing.T) {
+	for _, uglyUrls := range []bool{true, false} {
+		doTestMenuWithUnicodeUrls(t, uglyUrls)
+	}
+}
+
+func doTestMenuWithUnicodeUrls(t *testing.T, uglyUrls bool) {
+	viper.Set("UglyUrls", uglyUrls)
+	ts := setupMenuTests(t)
+	defer resetMenuTestState(ts)
+
+	unicodeRussian := ts.findTestMenuEntryById("unicode", "unicode-russian")
+
+	expectedBase := "http://foo.local/zoo/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%BF%D1%80%D0%BE%D0%B5%D0%BA%D1%82%D0%B0"
+	var expected string
+	if uglyUrls {
+		expected = expectedBase + ".html"
+	} else {
+		expected = expectedBase + "/"
+	}
+
+	assert.Equal(t, expected, unicodeRussian.Url, "uglyUrls[%t]", uglyUrls)
 }
 
 func TestTaxonomyNodeMenu(t *testing.T) {

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -116,6 +116,8 @@ func New() Template {
 		"partial":     Partial,
 		"ref":         Ref,
 		"relref":      RelRef,
+		"getJson":     GetJson,
+		"getCsv":      GetCsv,
 	}
 
 	templates.Funcs(funcMap)
@@ -618,7 +620,7 @@ func Highlight(in interface{}, lang string) template.HTML {
 }
 
 func Markdownify(text string) template.HTML {
-	return template.HTML(helpers.RenderBytes([]byte(text), "markdown", ""))
+	return template.HTML(helpers.RenderBytes(helpers.RenderingContext{Content: []byte(text), PageFmt: "markdown"}))
 }
 
 func refPage(page interface{}, ref, methodName string) template.HTML {

--- a/tpl/template_resources.go
+++ b/tpl/template_resources.go
@@ -1,0 +1,220 @@
+// Copyright © 2013-14 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Simple Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://opensource.org/licenses/Simple-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpl
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/hugo/helpers"
+	"github.com/spf13/hugo/hugofs"
+	jww "github.com/spf13/jwalterweatherman"
+	"github.com/spf13/viper"
+)
+
+var remoteUrlLock = &remoteLock{m: make(map[string]*sync.Mutex)}
+
+type remoteLock struct {
+	sync.RWMutex
+	m map[string]*sync.Mutex
+}
+
+// resLock locks an URL during download
+func (l *remoteLock) UrlLock(url string) {
+	l.Lock()
+	if _, ok := l.m[url]; !ok {
+		l.m[url] = &sync.Mutex{}
+	}
+	l.Unlock() // call this Unlock before the next lock will be called. NFI why but defer doesn't work.
+	l.m[url].Lock()
+}
+
+// resUnlock unlocks an URL when the download has been finished. Use only in defer calls.
+func (l *remoteLock) UrlUnlock(url string) {
+	l.RLock()
+	defer l.RUnlock()
+	if um, ok := l.m[url]; ok {
+		um.Unlock()
+	}
+}
+
+// getFileID returns the cache ID for a string
+func getCacheFileID(id string) string {
+	return viper.GetString("CacheDir") + url.QueryEscape(id)
+}
+
+// resGetCache returns the content for an ID from the file cache or an error
+// if the file is not found returns nil,nil
+func resGetCache(id string, fs afero.Fs) ([]byte, error) {
+	fID := getCacheFileID(id)
+	isExists, err := helpers.Exists(fID, fs)
+	if err != nil {
+		return nil, err
+	}
+	if !isExists {
+		return nil, nil
+	}
+
+	f, err := fs.Open(fID)
+	if err != nil {
+		return nil, err
+	}
+
+	return ioutil.ReadAll(f)
+}
+
+// resWriteCache writes bytes to an ID into the file cache
+func resWriteCache(id string, c []byte, fs afero.Fs) error {
+	fID := getCacheFileID(id)
+	f, err := fs.Create(fID)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write(c)
+	if n == 0 {
+		return errors.New("No bytes written to file: " + fID)
+	}
+	return err
+}
+
+// resGetRemote loads the content of a remote file. This method is thread safe.
+func resGetRemote(url string, fs afero.Fs, hc *http.Client) ([]byte, error) {
+
+	c, err := resGetCache(url, fs)
+	if c != nil && err == nil {
+		return c, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// avoid race condition with locks, block other goroutines if the current url is processing
+	remoteUrlLock.UrlLock(url)
+	defer func() { remoteUrlLock.UrlUnlock(url) }()
+
+	// avoid multiple locks due to calling resGetCache twice
+	c, err = resGetCache(url, fs)
+	if c != nil && err == nil {
+		return c, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	jww.INFO.Printf("Downloading: %s ...", url)
+	res, err := hc.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	c, err = ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	err = resWriteCache(url, c, fs)
+	if err != nil {
+		return nil, err
+	}
+	jww.INFO.Printf("... and cached to: %s", getCacheFileID(url))
+	return c, nil
+}
+
+// resGetLocal loads the content of a local file
+func resGetLocal(url string, fs afero.Fs) ([]byte, error) {
+	p := ""
+	if viper.GetString("WorkingDir") != "" {
+		p = viper.GetString("WorkingDir")
+		if helpers.FilePathSeparator != p[len(p)-1:] {
+			p = p + helpers.FilePathSeparator
+		}
+	}
+	jFile := p + url
+	if e, err := helpers.Exists(jFile, fs); !e {
+		return nil, err
+	}
+
+	f, err := fs.Open(jFile)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(f)
+}
+
+// resGetResource loads the content of a local or remote file
+func resGetResource(url string) ([]byte, error) {
+	if url == "" {
+		return nil, nil
+	}
+	if strings.Contains(url, "://") {
+		return resGetRemote(url, hugofs.SourceFs, http.DefaultClient)
+	}
+	return resGetLocal(url, hugofs.SourceFs)
+}
+
+// GetJson expects the url to a resource which can either be a local or a remote one.
+// GetJson returns nil or parsed JSON to use in a short code.
+func GetJson(url string) interface{} {
+	c, err := resGetResource(url)
+	if err != nil {
+		jww.ERROR.Printf("Failed to get json resource %s with error message %s", url, err)
+		return nil
+	}
+
+	var v interface{}
+	err = json.Unmarshal(c, &v)
+	if err != nil {
+		jww.ERROR.Printf("Cannot read json from resource %s with error message %s", url, err)
+		return nil
+	}
+	return v
+}
+
+// parseCsv parses bytes of csv data into a slice slice string or an error
+func parseCsv(c []byte, sep string) ([][]string, error) {
+	if len(sep) != 1 {
+		return nil, errors.New("Incorrect length of csv separator: " + sep)
+	}
+	b := bytes.NewReader(c)
+	r := csv.NewReader(b)
+	rSep := []rune(sep)
+	r.Comma = rSep[0]
+	r.FieldsPerRecord = 0
+	return r.ReadAll()
+}
+
+// GetCsv expects the url to a resource which can either be a local or a remote one and the type
+// of the data separator which can be comma, semi-colon, pipe, but only one character.
+// GetCsv returns nil or a slice slice to use in a short code.
+func GetCsv(url string, sep string) [][]string {
+
+	c, err := resGetResource(url)
+	if err != nil {
+		jww.ERROR.Printf("Failed to get csv resource %s with error message %s", url, err)
+		return nil
+	}
+	d, err := parseCsv(c, sep)
+	if err != nil {
+		jww.ERROR.Printf("Failed to read csv resource %s with error message %s", url, err)
+		return nil
+	}
+	return d
+}

--- a/tpl/template_resources_test.go
+++ b/tpl/template_resources_test.go
@@ -1,0 +1,181 @@
+// Copyright © 2013-14 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Simple Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://opensource.org/licenses/Simple-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpl
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/hugo/helpers"
+)
+
+func TestScpCache(t *testing.T) {
+
+	tests := []struct {
+		path    string
+		content []byte
+	}{
+		{"http://Foo.Bar/foo_Bar-Foo", []byte(`T€st Content 123`)},
+		{"fOO,bar:foo%bAR", []byte(`T€st Content 123 fOO,bar:foo%bAR`)},
+		{"FOo/BaR.html", []byte(`FOo/BaR.html T€st Content 123`)},
+		{"трям/трям", []byte(`T€st трям/трям Content 123`)},
+		{"은행", []byte(`T€st C은행ontent 123`)},
+		{"Банковский кассир", []byte(`Банковский кассир T€st Content 123`)},
+	}
+
+	fs := new(afero.MemMapFs)
+
+	for _, test := range tests {
+		c, err := resGetCache(test.path, fs)
+		if err != nil {
+			t.Errorf("Error getting cache: %s", err)
+		}
+		if c != nil {
+			t.Errorf("There is content where there should not be anything: %s", string(c))
+		}
+
+		err = resWriteCache(test.path, test.content, fs)
+		if err != nil {
+			t.Errorf("Error writing cache: %s", err)
+		}
+
+		c, err = resGetCache(test.path, fs)
+		if err != nil {
+			t.Errorf("Error getting cache after writing: %s", err)
+		}
+		if bytes.Compare(c, test.content) != 0 {
+			t.Errorf("\nExpected: %s\nActual: %s\n", string(test.content), string(c))
+		}
+	}
+}
+
+func TestScpGetLocal(t *testing.T) {
+	fs := new(afero.MemMapFs)
+	ps := helpers.FilePathSeparator
+	tests := []struct {
+		path    string
+		content []byte
+	}{
+		{"testpath" + ps + "test.txt", []byte(`T€st Content 123 fOO,bar:foo%bAR`)},
+		{"FOo" + ps + "BaR.html", []byte(`FOo/BaR.html T€st Content 123`)},
+		{"трям" + ps + "трям", []byte(`T€st трям/трям Content 123`)},
+		{"은행", []byte(`T€st C은행ontent 123`)},
+		{"Банковский кассир", []byte(`Банковский кассир T€st Content 123`)},
+	}
+
+	for _, test := range tests {
+		r := bytes.NewReader(test.content)
+		err := helpers.WriteToDisk(test.path, r, fs)
+		if err != nil {
+			t.Error(err)
+		}
+
+		c, err := resGetLocal(test.path, fs)
+		if err != nil {
+			t.Errorf("Error getting resource content: %s", err)
+		}
+		if bytes.Compare(c, test.content) != 0 {
+			t.Errorf("\nExpected: %s\nActual: %s\n", string(test.content), string(c))
+		}
+	}
+
+}
+
+func getTestServer(handler func(w http.ResponseWriter, r *http.Request)) (*httptest.Server, *http.Client) {
+	testServer := httptest.NewServer(http.HandlerFunc(handler))
+	client := &http.Client{
+		Transport: &http.Transport{Proxy: func(*http.Request) (*url.URL, error) { return url.Parse(testServer.URL) }},
+	}
+	return testServer, client
+}
+
+func TestScpGetRemote(t *testing.T) {
+	fs := new(afero.MemMapFs)
+
+	tests := []struct {
+		path    string
+		content []byte
+	}{
+		{"http://Foo.Bar/foo_Bar-Foo", []byte(`T€st Content 123`)},
+		{"http://Doppel.Gänger/foo_Bar-Foo", []byte(`T€st Cont€nt 123`)},
+		{"http://Doppel.Gänger/Fizz_Bazz-Foo", []byte(`T€st Банковский кассир Cont€nt 123`)},
+	}
+
+	for _, test := range tests {
+
+		srv, cl := getTestServer(func(w http.ResponseWriter, r *http.Request) {
+			w.Write(test.content)
+		})
+		defer func() { srv.Close() }()
+
+		c, err := resGetRemote(test.path, fs, cl)
+		if err != nil {
+			t.Errorf("Error getting resource content: %s", err)
+		}
+		if bytes.Compare(c, test.content) != 0 {
+			t.Errorf("\nNet Expected: %s\nNet Actual: %s\n", string(test.content), string(c))
+		}
+		cc, cErr := resGetCache(test.path, fs)
+		if cErr != nil {
+			t.Error(cErr)
+		}
+		if bytes.Compare(cc, test.content) != 0 {
+			t.Errorf("\nCache Expected: %s\nCache Actual: %s\n", string(test.content), string(c))
+		}
+	}
+}
+
+func TestParseCsv(t *testing.T) {
+
+	tests := []struct {
+		csv []byte
+		sep string
+		exp string
+		err bool
+	}{
+		{[]byte("a,b,c\nd,e,f\n"), "", "", true},
+		{[]byte("a,b,c\nd,e,f\n"), "~/", "", true},
+		{[]byte("a,b,c\nd,e,f"), "|", "a,b,cd,e,f", false},
+		{[]byte("q,w,e\nd,e,f"), ",", "qwedef", false},
+		{[]byte("a|b|c\nd|e|f|g"), "|", "abcdefg", true},
+		{[]byte("z|y|c\nd|e|f"), "|", "zycdef", false},
+	}
+	for _, test := range tests {
+		csv, err := parseCsv(test.csv, test.sep)
+		if test.err && err == nil {
+			t.Error("Expecting an error")
+		}
+		if test.err {
+			continue
+		}
+		if !test.err && err != nil {
+			t.Error(err)
+		}
+
+		act := ""
+		for _, v := range csv {
+			act = act + strings.Join(v, "")
+		}
+
+		if act != test.exp {
+			t.Errorf("\nExpected: %s\nActual: %s\n%#v\n", test.exp, act, csv)
+		}
+
+	}
+}

--- a/transform/absurl.go
+++ b/transform/absurl.go
@@ -31,6 +31,31 @@ func AbsURL(absURL string) (trs []link, err error) {
 	return
 }
 
+func AbsURLInXML(absURL string) (trs []link, err error) {
+	var baseURL *url.URL
+
+	if baseURL, err = url.Parse(absURL); err != nil {
+		return
+	}
+
+	base := strings.TrimRight(baseURL.String(), "/")
+
+	var (
+		srcedq  = []byte(" src=&#34;" + base + "/")
+		hrefedq = []byte(" href=&#34;" + base + "/")
+		srcesq  = []byte(" src=&#39;" + base + "/")
+		hrefesq = []byte(" href=&#39;" + base + "/")
+	)
+	trs = append(trs, func(content []byte) []byte {
+		content = guardReplace(content, []byte(" src=&#34;//"), []byte(" src=&#34;/"), srcedq)
+		content = guardReplace(content, []byte(" src=&#39;//"), []byte(" src=&#39;/"), srcesq)
+		content = guardReplace(content, []byte(" href=&#34;//"), []byte(" href=&#34;/"), hrefedq)
+		content = guardReplace(content, []byte(" href=&#39;//"), []byte(" href=&#39;/"), hrefesq)
+		return content
+	})
+	return
+}
+
 func guardReplace(content, guard, match, replace []byte) []byte {
 	if !bytes.Contains(content, guard) {
 		content = bytes.Replace(content, match, replace, -1)

--- a/transform/chain_test.go
+++ b/transform/chain_test.go
@@ -9,8 +9,16 @@ const H5_JS_CONTENT_ABS_URL_WITH_NAV = "<!DOCTYPE html><html><head><script src=\
 
 const CORRECT_OUTPUT_SRC_HREF_WITH_NAV = "<!DOCTYPE html><html><head><script src=\"http://two/foobar.js\"></script></head><body><nav><ul><li hugo-nav=\"section_0\"></li><li hugo-nav=\"section_1\"></li></ul></nav><article>content <a href=\"http://two/foobar\">foobar</a>. Follow up</article></body></html>"
 
+const H5_XML_CONTENT_ABS_URL = "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?><feed xmlns=\"http://www.w3.org/2005/Atom\"><entry><content type=\"html\">&lt;p&gt;&lt;a href=&#34;/foobar&#34;&gt;foobar&lt;/a&gt;&lt;/p&gt; &lt;p&gt;A video: &lt;iframe src=&#39;/foo&#39;&gt;&lt;/iframe&gt;&lt;/p&gt;</content></entry></feed>"
+
+const CORRECT_OUTPUT_SRC_HREF_IN_XML = "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?><feed xmlns=\"http://www.w3.org/2005/Atom\"><entry><content type=\"html\">&lt;p&gt;&lt;a href=&#34;http://xml/foobar&#34;&gt;foobar&lt;/a&gt;&lt;/p&gt; &lt;p&gt;A video: &lt;iframe src=&#39;http://xml/foo&#39;&gt;&lt;/iframe&gt;&lt;/p&gt;</content></entry></feed>"
+
 var two_chain_tests = []test{
 	{H5_JS_CONTENT_ABS_URL_WITH_NAV, CORRECT_OUTPUT_SRC_HREF_WITH_NAV},
+}
+
+var xml_abs_url_tests = []test{
+	{H5_XML_CONTENT_ABS_URL, CORRECT_OUTPUT_SRC_HREF_IN_XML},
 }
 
 func TestChainZeroTransformers(t *testing.T) {
@@ -30,4 +38,10 @@ func BenchmarkChain(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		apply(b.Errorf, tr, two_chain_tests)
 	}
+}
+
+func TestXMLAbsUrl(t *testing.T) {
+	absURLInXML, _ := AbsURLInXML("http://xml")
+	tr := NewChain(absURLInXML...)
+	apply(t.Errorf, tr, xml_abs_url_tests)
 }


### PR DESCRIPTION
I have finished the integration of getJson and getCsv into hugo as far as I think it fits.

I'm not a hugo (and Go) expert of where to put these functions and correct naming of functions and vars.

I would be glad if you can comment on spotted errors, bugs, bad design, etc. or even help me to improve the code more.

All tests and the new tests are passing.

I have written a blog post about that new feature: [http://cyrillschumacher.com/2014/12/21/dynamic-pages-with-gohugo.io/](http://cyrillschumacher.com/2014/12/21/dynamic-pages-with-gohugo.io/)

There is not yet any official documentation because I want to get the code right. I think once this feature is merged as a hidden feature into hugo and some people tested it in the wild with no given complaints I will write the docs.

Looking forward for a successful merge :-)
