### PR TITLE
Make 'where' template function accepts dot chaining key argument

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -66,6 +66,19 @@ e.g.
        {{ .Content}}
     {{ end }}
 
+It can be used with dot chaining second argument to refer a nested element of a value.
+
+e.g.
+
+    // Front matter on some pages
+    +++
+    series: golang
+    +++
+
+    {{ range where .Site.Recent "Params.series" "golang" }}
+       {{ .Content}}
+    {{ end }}
+
 *where and first can be stacked*
 
 e.g.


### PR DESCRIPTION
'where' template function used to accept only each element's struct
field name, method name and map key name as its second argument. This
extends it to accept dot chaining key like 'Params.foo.bar' as the
argument. It evaluates sub elements of each array elements and checks it
matches the third argument value.

Typical use case would be for filtering Pages by user defined front
matter value. For example, to filter pages which have 'Params.foo.bar'
and its value is 'baz', it is used like

```
{{ range where .Data.Pages "Params.foo.bar" "baz" }}
    {{ .Content }}
{{ end }}
```

It ignores all leading and trailing dots so it can also be used with
".Params.foo.bar"

This would solve the issue reported at http://discuss.gohugo.io/t/listing-content-based-on-front-matter-variable/333

This `functions.md` document example may not be good because it can also be done by taxonomy described at http://gohugo.io/taxonomies/displaying/ but I couldn't find a good example so welcome suggestions.
