### PR TITLE
Do not exit server watch on error

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -397,7 +397,7 @@ func NewWatcher(port int) error {
 					fmt.Print("\nChange detected, rebuilding site\n")
 					const layout = "2006-01-02 15:04 -0700"
 					fmt.Println(time.Now().Format(layout))
-					utils.StopOnErr(buildSite(true))
+					utils.CheckErr(buildSite(true))
 
 					if !BuildWatch && !viper.GetBool("DisableLiveReload") {
 						// Will block forever trying to write to a channel that nobody is reading if livereload isn't initalized


### PR DESCRIPTION
Before this commit any error (typically a YAML typing error in front matter) would exit server on rebuild when running `hugo server -w`.

This is very annoying as it doesn't give you any chance to fix the typo other than doing a manual restart.

This commit fixes that by just logging these errors when these rebuilds happen when changes are detected.

Fixes #781
