### PR TITLE
Image resizing/cropping

### DIFF
--- a/helpers/general.go
+++ b/helpers/general.go
@@ -471,18 +471,20 @@ func ParseImageResize(filename string) (props ImageResizeProps) {
 		return
 	}
 	params := strings.Split(splits[len(splits)-1], "-")
-
-	numRe := regexp.MustCompile(`\d+`)
-	for i, p := range params {
-		val, _ := strconv.Atoi(numRe.FindString(p))
-		switch i {
-		case 0:
+	re := regexp.MustCompile(`([a-zA-Z])(\d+)`)
+	for _, p := range params {
+		matches := re.FindStringSubmatch(p)
+		key := matches[1]
+		val, _ := strconv.Atoi(matches[2])
+		switch key {
+		case "w":
 			props.Width = val
-		case 1:
+		case "h":
 			props.Height = val
-		case 2:
+		case "c":
 			props.Crop = true
 		}
 	}
+
 	return
 }

--- a/helpers/general.go
+++ b/helpers/general.go
@@ -23,6 +23,8 @@ import (
 	"net"
 	"path/filepath"
 	"reflect"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode"
@@ -455,4 +457,32 @@ func NormalizeHugoFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		break
 	}
 	return pflag.NormalizedName(name)
+}
+
+type ImageResizeProps struct {
+	Width  int
+	Height int
+	Crop   bool
+}
+
+func ParseImageResize(filename string) (props ImageResizeProps) {
+	splits := strings.Split(filename, ".")
+	if len(splits) == 1 {
+		return
+	}
+	params := strings.Split(splits[len(splits)-1], "-")
+
+	numRe := regexp.MustCompile(`\d+`)
+	for i, p := range params {
+		val, _ := strconv.Atoi(numRe.FindString(p))
+		switch i {
+		case 0:
+			props.Width = val
+		case 1:
+			props.Height = val
+		case 2:
+			props.Crop = true
+		}
+	}
+	return
 }

--- a/helpers/general.go
+++ b/helpers/general.go
@@ -465,7 +465,7 @@ type ImageResizeProps struct {
 	Crop   bool
 }
 
-func ParseImageResize(filename string) (props ImageResizeProps) {
+func ParseImageProps(filename string) (props ImageResizeProps) {
 	splits := strings.Split(filename, ".")
 	if len(splits) == 1 {
 		return

--- a/helpers/general.go
+++ b/helpers/general.go
@@ -473,16 +473,18 @@ func ParseImageResize(filename string) (props ImageResizeProps) {
 	params := strings.Split(splits[len(splits)-1], "-")
 	re := regexp.MustCompile(`([a-zA-Z])(\d+)`)
 	for _, p := range params {
+		if p == "c" {
+			props.Crop = true
+			break
+		}
+
 		matches := re.FindStringSubmatch(p)
-		key := matches[1]
 		val, _ := strconv.Atoi(matches[2])
-		switch key {
+		switch matches[1] {
 		case "w":
 			props.Width = val
 		case "h":
 			props.Height = val
-		case "c":
-			props.Crop = true
 		}
 	}
 

--- a/hugolib/handler_file.go
+++ b/hugolib/handler_file.go
@@ -68,7 +68,7 @@ func (h imageHandler) FileConvert(f *source.File, s *Site) HandledResult {
 	props := helpers.ParseImageResize(f.BaseFileName())
 	file := f
 
-	if props.Width != 0 && props.Height != 0 {
+	if props.Width != 0 || props.Height != 0 {
 		input, ext, _ := image.Decode(f.Contents)
 		inputRect := input.Bounds()
 

--- a/hugolib/handler_file.go
+++ b/hugolib/handler_file.go
@@ -15,10 +15,10 @@ package hugolib
 
 import (
 	"bytes"
-	"fmt"
 	"image"
 	"image/jpeg"
 	"image/png"
+	"regexp"
 
 	"log"
 
@@ -105,7 +105,10 @@ func (h imageHandler) FileConvert(file *source.File, s *Site) HandledResult {
 		case "png":
 			_ = png.Encode(buf, output)
 		}
-		path := fmt.Sprintf("images/%s.%s", file.UniqueID(), file.Extension())
+
+		re := regexp.MustCompile(`\.(w|h)\d(-)?.+\.`)
+		path := file.Path()
+		path = re.ReplaceAllString(path, ".")
 		file = source.NewFileWithContents(path, bytes.NewReader(buf.Bytes()))
 	}
 	s.WriteDestFile(file.Path(), file.Contents)

--- a/hugolib/handler_file.go
+++ b/hugolib/handler_file.go
@@ -14,6 +14,12 @@
 package hugolib
 
 import (
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+
+	"log"
+
 	"github.com/dchest/cssmin"
 	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/hugo/source"
@@ -22,6 +28,7 @@ import (
 
 func init() {
 	RegisterHandler(new(cssHandler))
+	RegisterHandler(new(imageHandler))
 	RegisterHandler(new(defaultHandler))
 }
 
@@ -49,5 +56,15 @@ func (h cssHandler) Extensions() []string { return []string{"css"} }
 func (h cssHandler) FileConvert(f *source.File, s *Site) HandledResult {
 	x := cssmin.Minify(f.Bytes())
 	s.WriteDestFile(f.Path(), helpers.BytesToReader(x))
+	return HandledResult{file: f}
+}
+
+type imageHandler struct{ basicFileHandler }
+
+func (h imageHandler) Extensions() []string { return []string{"jpg", "jpeg", "png", "gif"} }
+func (h imageHandler) FileConvert(f *source.File, s *Site) HandledResult {
+	_, ext, err := image.Decode(f.Contents)
+	log.Println(ext, err)
+	s.WriteDestFile(f.Path(), f.Contents)
 	return HandledResult{file: f}
 }

--- a/hugolib/handler_file.go
+++ b/hugolib/handler_file.go
@@ -63,6 +63,8 @@ type imageHandler struct{ basicFileHandler }
 
 func (h imageHandler) Extensions() []string { return []string{"jpg", "jpeg", "png", "gif"} }
 func (h imageHandler) FileConvert(f *source.File, s *Site) HandledResult {
+	resizeProps := helpers.ParseImageResize(f.BaseFileName())
+	log.Println(resizeProps)
 	_, ext, err := image.Decode(f.Contents)
 	log.Println(ext, err)
 	s.WriteDestFile(f.Path(), f.Contents)

--- a/hugolib/handler_file.go
+++ b/hugolib/handler_file.go
@@ -15,6 +15,7 @@ package hugolib
 
 import (
 	"bytes"
+	"fmt"
 	"image"
 	"image/jpeg"
 	"image/png"
@@ -104,8 +105,8 @@ func (h imageHandler) FileConvert(file *source.File, s *Site) HandledResult {
 		case "png":
 			_ = png.Encode(buf, output)
 		}
-
-		file = source.NewFileWithContents(file.Path(), bytes.NewReader(buf.Bytes()))
+		path := fmt.Sprintf("images/%s.%s", file.UniqueID(), file.Extension())
+		file = source.NewFileWithContents(path, bytes.NewReader(buf.Bytes()))
 	}
 	s.WriteDestFile(file.Path(), file.Contents)
 	return HandledResult{file: file}

--- a/tpl/template_embedded.go
+++ b/tpl/template_embedded.go
@@ -59,6 +59,7 @@ func (t *GoHTMLTemplate) EmbedShortcodes() {
 {{ end }}`)
 	t.AddInternalShortcode("gist.html", `<script src="//gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js"></script>`)
 	t.AddInternalShortcode("tweet.html", `{{ (getJSON "https://api.twitter.com/1/statuses/oembed.json?id=" (index .Params 0)).html | safeHTML }}`)
+	t.AddInternalShortcode("resizedImage.html", `<image src="{{ (resizedImage (.Get 0) ) }}" />`)
 }
 
 func (t *GoHTMLTemplate) EmbedTemplates() {

--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -1533,5 +1533,6 @@ func init() {
 			}
 			return inflect.Singularize(word), nil
 		},
+		"resizedImage": ResizedImage,
 	}
 }

--- a/tpl/template_resources.go
+++ b/tpl/template_resources.go
@@ -18,6 +18,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -286,4 +287,8 @@ func ReadDir(path string) []os.FileInfo {
 		return nil
 	}
 	return list
+}
+
+func ResizedImage(img string) string {
+	return fmt.Sprintf("../%s", img)
 }


### PR DESCRIPTION
Looking for feedback on this image resizing/cropping feature #1014.

The image should sit right next to the markdown files with the syntax instruction based on [this](https://github.com/spf13/hugo/issues/1014#issue-65254220):

```
hero.w400-h500-c.jpg // crops image from the upper left
hero.h500.jpg // resize to height, keeping the original width
```
### Example Usage:
##### Content Folder:

```
post/golang-tips.md
post/gopher.w400-c.jpg
```
##### Shortcode Usage:

```
{{ < resizedImage "gopher.jpg" > }}
```

The use of `resizedImage` shortcode is necessary to relatively reach the photo one folder back. It is due to how `Page` write destination is wrapped inside it's own folder.
##### Output Public Folder:

```
post/golang-tips/index.html
post/gopher.jpg
```

There's a few things I plan on implementing:
- Image resize based on ratio
- Image crop target (upper left, center, etc..)
- Without the use of shortcode
- Have the image sit right inside the post folder, next to `index.html`

Please provide feedback and guidance, happy holidays!
