### PR TITLE
Make the two common Taxonomy templates explicit.

### DIFF
--- a/docs/content/taxonomies/templates.md
+++ b/docs/content/taxonomies/templates.md
@@ -13,14 +13,23 @@ title: Taxonomy Templates
 weight: 30
 ---
 
-There are two different templates that the use of taxonomies will require you to provide.
 
-Both templates are covered in detail in the templates section.
+Taxonomy templates should be placed in the folder '/layouts/taxonomy'.
+When Taxonomy term template is provided for a Taxonomy, a section is rendered for it at /SINGULAR/. (eg. '/tag/' or '/category/')
 
-A [list template](/templates/list/) is any template that will be used to render multiple pieces of
-content in a single html page. This template will be used to generate
-all the automatically created taxonomy pages.
+There are two different templates that the use of taxonomies will require you to provide:
 
-A [taxonomy terms template](/templates/terms/) is a template used to
-generate the list of terms for a given template.
+### All content attached to taxonomy
+A [taxonomy terms template](/templates/terms/) is a template which has access to all the full Taxonomy structure.
+This Template is commonly used to generate the list of terms for a given template.
 
+/layouts/taxonomy/SINGULAR.terms.html
+For example: 'tag.terms.html', 'category.terms.html', or your custom Taxonomy: 'actor.terms.html'
+
+### All content attached to term
+A [list template](/templates/list/) is used to automatically generate pages for each unique term found.
+
+/layouts/taxonomy/SINGULAR.html
+For example: 'tag.html', 'category.html', or your custom Taxonomy: 'actor.html'
+
+Terms are rendered at /SINGULAR/TERM/. (eg. '/tag/book/' or '/category/news/')


### PR DESCRIPTION
Hi there,
https://gohugo.io/taxonomies/overview/ introduces the definitions 'Term' as a Key within that taxonomy.

The filename Hugo accepts for Taxonomy terms can be confusing:
SINGULAR**.terms.**html -> Renders at /SINGULAR/
SINGULAR.html -> Renders at /SINGULAR**/TERM/**

Ideally the filenames Hugo accepts for templates are swapped:
SINGULAR.html -> Renders at /SINGULAR/
SINGULAR**.terms.**html -> Renders at /SINGULAR**/TERM/**
