### PR TITLE
Standardize author data

### DIFF
--- a/hugolib/author.go
+++ b/hugolib/author.go
@@ -13,6 +13,14 @@
 
 package hugolib
 
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cast"
+)
+
 // AuthorList is a list of all authors and their metadata.
 type AuthorList map[string]Author
 
@@ -43,3 +51,131 @@ type Author struct {
 // - linkedin
 // - skype
 type AuthorSocial map[string]string
+
+// URL is a convenience function that provides the correct canonical URL
+// for a specific social network given a username. If an unsupported network
+// is requested, only the username is returned
+func (as AuthorSocial) URL(key string) string {
+	switch key {
+	case "github":
+		return fmt.Sprintf("https://github.com/%s", as[key])
+	case "facebook":
+		return fmt.Sprintf("https://www.facebook.com/%s", as[key])
+	case "twitter":
+		return fmt.Sprintf("https://twitter.com/%s", as[key])
+	case "googleplus":
+		isNumeric := onlyNumbersRegExp.Match([]byte(as[key]))
+		if isNumeric {
+			return fmt.Sprintf("https://plus.google.com/%s", as[key])
+		}
+		return fmt.Sprintf("https://plus.google.com/+%s", as[key])
+	case "pinterest":
+		return fmt.Sprintf("https://www.pinterest.com/%s/", as[key])
+	case "instagram":
+		return fmt.Sprintf("https://www.instagram.com/%s/", as[key])
+	case "youtube":
+		return fmt.Sprintf("https://www.youtube.com/user/%s", as[key])
+	case "linkedin":
+		return fmt.Sprintf("https://www.linkedin.com/in/%s", as[key])
+	default:
+		return as[key]
+	}
+}
+
+func mapToAuthors(m map[string]interface{}) Authors {
+	authors := make(Authors, 0, len(m))
+	for authorID, data := range m {
+		authorMap, ok := data.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		a := mapToAuthor(authorID, authorMap)
+		if a.ID != "" {
+			authors = append(authors, a)
+		}
+	}
+	sort.Stable(authors)
+	return authors
+}
+
+func mapToAuthor(id string, m map[string]interface{}) Author {
+	if id == "" {
+		return Author{}
+	}
+
+	author := Author{ID: id}
+	for k, data := range m {
+		switch k {
+		case "givenName", "firstName":
+			author.GivenName = cast.ToString(data)
+			author.FirstName = author.GivenName
+		case "familyName", "lastName":
+			author.FamilyName = cast.ToString(data)
+			author.LastName = author.FamilyName
+		case "displayName":
+			author.DisplayName = cast.ToString(data)
+		case "thumbnail":
+			author.Thumbnail = cast.ToString(data)
+		case "image":
+			author.Image = cast.ToString(data)
+		case "shortBio":
+			author.ShortBio = cast.ToString(data)
+		case "bio":
+			author.Bio = cast.ToString(data)
+		case "email":
+			author.Email = cast.ToString(data)
+		case "weight":
+			author.Weight = cast.ToInt(data)
+		case "social":
+			author.Social = normalizeSocial(cast.ToStringMapString(data))
+		case "params":
+			author.Params = cast.ToStringMapString(data)
+		}
+	}
+
+	// set a reasonable default for DisplayName
+	if author.DisplayName == "" {
+		author.DisplayName = author.GivenName + " " + author.FamilyName
+	}
+
+	return author
+}
+
+// normalizeSocial makes a naive attempt to normalize social media usernames
+// and strips out extraneous characters or url info
+func normalizeSocial(m map[string]string) map[string]string {
+	for network, username := range m {
+		if !isSupportedSocialNetwork(network) {
+			continue
+		}
+
+		username = strings.TrimSpace(username)
+		username = strings.TrimSuffix(username, "/")
+		strs := strings.Split(username, "/")
+		username = strs[len(strs)-1]
+		username = strings.TrimPrefix(username, "@")
+		username = strings.TrimPrefix(username, "+")
+		m[network] = username
+	}
+	return m
+}
+
+func isSupportedSocialNetwork(network string) bool {
+	switch network {
+	case
+		"github",
+		"facebook",
+		"twitter",
+		"googleplus",
+		"pinterest",
+		"instagram",
+		"youtube",
+		"linkedin":
+		return true
+	}
+	return false
+}
+
+func (a Authors) Len() int           { return len(a) }
+func (a Authors) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a Authors) Less(i, j int) bool { return a[i].Weight < a[j].Weight }

--- a/hugolib/author.go
+++ b/hugolib/author.go
@@ -15,14 +15,35 @@ package hugolib
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/spf13/cast"
 )
 
-// AuthorList is a list of all authors and their metadata.
-type AuthorList map[string]Author
+var (
+	onlyNumbersRegExp = regexp.MustCompile("^[0-9]*$")
+)
+
+// Authors is a list of all authors and their metadata.
+type Authors []Author
+
+// Get returns an author from an ID
+func (a Authors) Get(id string) Author {
+	for _, author := range a {
+		if author.ID == id {
+			return author
+		}
+	}
+	return Author{}
+}
+
+// Sort sorts the authors by weight
+func (a Authors) Sort() Authors {
+	sort.Stable(a)
+	return a
+}
 
 // Author contains details about the author of a page.
 type Author struct {
@@ -43,7 +64,7 @@ type Author struct {
 	languages   map[string]Author
 }
 
-// AuthorSocial is a place to put social details per author. These are the
+// AuthorSocial is a place to put social usernames per author. These are the
 // standard keys that themes will expect to have available, but can be
 // expanded to any others on a per site basis
 // - website

--- a/hugolib/author.go
+++ b/hugolib/author.go
@@ -132,20 +132,20 @@ func mapToAuthor(id string, m map[string]interface{}) Author {
 
 	author := Author{ID: id}
 	for k, data := range m {
-		switch k {
-		case "givenName", "firstName":
+		switch strings.ToLower(k) {
+		case "givenname", "firstname":
 			author.GivenName = cast.ToString(data)
 			author.FirstName = author.GivenName
-		case "familyName", "lastName":
+		case "familyname", "lastname":
 			author.FamilyName = cast.ToString(data)
 			author.LastName = author.FamilyName
-		case "displayName":
+		case "displayname":
 			author.DisplayName = cast.ToString(data)
 		case "thumbnail":
 			author.Thumbnail = cast.ToString(data)
 		case "image":
 			author.Image = cast.ToString(data)
-		case "shortBio":
+		case "shortbio":
 			author.ShortBio = cast.ToString(data)
 		case "bio":
 			author.Bio = cast.ToString(data)

--- a/hugolib/author_test.go
+++ b/hugolib/author_test.go
@@ -222,7 +222,7 @@ func TestPageAuthor(t *testing.T) {
 				Params: map[string]interface{}{
 					"author": "derek",
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			authorDerek,
 		},
@@ -232,7 +232,7 @@ func TestPageAuthor(t *testing.T) {
 				Params: map[string]interface{}{
 					"author": "tanner",
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			authorTanner,
 		},
@@ -242,7 +242,7 @@ func TestPageAuthor(t *testing.T) {
 				Params: map[string]interface{}{
 					"author": "abc",
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Author{},
 		},
@@ -250,7 +250,7 @@ func TestPageAuthor(t *testing.T) {
 			"no ID",
 			&Page{
 				Params: map[string]interface{}{},
-				Node:   Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Author{},
 		},
@@ -260,7 +260,7 @@ func TestPageAuthor(t *testing.T) {
 				Params: map[string]interface{}{
 					"author": "",
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Author{},
 		},
@@ -270,7 +270,7 @@ func TestPageAuthor(t *testing.T) {
 				Params: map[string]interface{}{
 					"authors": []string{"derek"},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			authorDerek,
 		},
@@ -280,7 +280,7 @@ func TestPageAuthor(t *testing.T) {
 				Params: map[string]interface{}{
 					"authors": []string{"abc"},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Author{},
 		},
@@ -290,7 +290,7 @@ func TestPageAuthor(t *testing.T) {
 				Params: map[string]interface{}{
 					"authors": []string{""},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Author{},
 		},
@@ -300,7 +300,7 @@ func TestPageAuthor(t *testing.T) {
 				Params: map[string]interface{}{
 					"author": "derek",
 				},
-				Node: Node{Site: &SiteInfo{Authors: Authors{}}},
+				Site: &SiteInfo{Authors: Authors{}},
 			},
 			Author{},
 		},
@@ -326,7 +326,7 @@ func TestPageAuthors(t *testing.T) {
 				Params: map[string]interface{}{
 					"authors": []string{"derek"},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{authorDerek},
 		},
@@ -336,7 +336,7 @@ func TestPageAuthors(t *testing.T) {
 				Params: map[string]interface{}{
 					"authors": []string{"tanner", "derek"},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			defaultAuthors,
 		},
@@ -346,7 +346,7 @@ func TestPageAuthors(t *testing.T) {
 				Params: map[string]interface{}{
 					"authors": []string{"derek", "tanner"},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{authorDerek, authorTanner},
 		},
@@ -356,7 +356,7 @@ func TestPageAuthors(t *testing.T) {
 				Params: map[string]interface{}{
 					"authors": []string{"abc"},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{},
 		},
@@ -366,7 +366,7 @@ func TestPageAuthors(t *testing.T) {
 				Params: map[string]interface{}{
 					"authors": []string{""},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{},
 		},
@@ -376,7 +376,7 @@ func TestPageAuthors(t *testing.T) {
 				Params: map[string]interface{}{
 					"authors": []string{},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{},
 		},
@@ -384,7 +384,7 @@ func TestPageAuthors(t *testing.T) {
 			"no authors param",
 			&Page{
 				Params: map[string]interface{}{},
-				Node:   Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{},
 		},
@@ -394,7 +394,7 @@ func TestPageAuthors(t *testing.T) {
 				Params: map[string]interface{}{
 					"author": "derek",
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{authorDerek},
 		},
@@ -404,7 +404,7 @@ func TestPageAuthors(t *testing.T) {
 				Params: map[string]interface{}{
 					"author": "abc",
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{},
 		},
@@ -414,7 +414,7 @@ func TestPageAuthors(t *testing.T) {
 				Params: map[string]interface{}{
 					"author": "",
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{},
 		},
@@ -425,7 +425,7 @@ func TestPageAuthors(t *testing.T) {
 					"author":  "tanner",
 					"authors": []string{"derek"},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{authorTanner},
 		},
@@ -436,7 +436,7 @@ func TestPageAuthors(t *testing.T) {
 					"author":  "abc",
 					"authors": []string{"derek"},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{authorDerek},
 		},
@@ -447,7 +447,7 @@ func TestPageAuthors(t *testing.T) {
 					"author":  "abc",
 					"authors": []string{"abc"},
 				},
-				Node: Node{Site: defaultAuthorSiteInfo},
+				Site: defaultAuthorSiteInfo,
 			},
 			Authors{},
 		},
@@ -457,7 +457,7 @@ func TestPageAuthors(t *testing.T) {
 				Params: map[string]interface{}{
 					"authors": []string{"derek"},
 				},
-				Node: Node{Site: &SiteInfo{Authors: Authors{}}},
+				Site: &SiteInfo{Authors: Authors{}},
 			},
 			Authors{},
 		},
@@ -465,58 +465,6 @@ func TestPageAuthors(t *testing.T) {
 
 	for _, test := range tests {
 		authors := test.page.Authors()
-		if !reflect.DeepEqual(authors, test.expected) {
-			t.Errorf("author: expected:\n%#v\ngot:\n%#v", test.expected, authors)
-		}
-	}
-}
-
-func TestNodeAuthor(t *testing.T) {
-	tests := []struct {
-		desc     string
-		node     *Node
-		expected Author
-	}{
-		{
-			"valid",
-			&Node{Site: defaultAuthorSiteInfo},
-			authorTanner,
-		},
-		{
-			"no site authors",
-			&Node{Site: &SiteInfo{Authors: Authors{}}},
-			Author{},
-		},
-	}
-
-	for _, test := range tests {
-		author := test.node.Author()
-		if !reflect.DeepEqual(author, test.expected) {
-			t.Errorf("author: expected:\n%#v\ngot:\n%#v", test.expected, author)
-		}
-	}
-}
-
-func TestNodeAuthors(t *testing.T) {
-	tests := []struct {
-		desc     string
-		node     *Node
-		expected Authors
-	}{
-		{
-			"valid",
-			&Node{Site: defaultAuthorSiteInfo},
-			defaultAuthors,
-		},
-		{
-			"no site authors",
-			&Node{Site: &SiteInfo{Authors: Authors{}}},
-			Authors{},
-		},
-	}
-
-	for _, test := range tests {
-		authors := test.node.Authors()
 		if !reflect.DeepEqual(authors, test.expected) {
 			t.Errorf("author: expected:\n%#v\ngot:\n%#v", test.expected, authors)
 		}

--- a/hugolib/author_test.go
+++ b/hugolib/author_test.go
@@ -1,0 +1,590 @@
+package hugolib
+
+import (
+	"reflect"
+	"testing"
+)
+
+var (
+	defaultAuthorsMap = map[string]interface{}{
+		"derek": map[string]interface{}{
+			"givenName":   "Derek",
+			"familyName":  "Perkins",
+			"displayName": "Derek Perkins",
+			"thumbnail":   "https://www.google.com/images/branding/googlelogo/googlelogo_color_272x92dp.png",
+			"image":       "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+			"shortBio":    "Derek loves Hugo",
+			"bio":         "Derek really loves Hugo",
+			"email":       "derek@email.com",
+			"weight":      2,
+			"social": map[string]interface{}{
+				"facebook":   "derekperkins",
+				"github":     "derekperkins",
+				"twitter":    "@derekperkins",
+				"googleplus": "+derekperkins",
+				"pinterest":  "derekperkins",
+				"instagram":  "derekperkins",
+				"youtube":    "derekperkins",
+				"linkedin":   "derekperkins",
+			},
+			"params": map[string]interface{}{
+				"myParamInt": 1234,
+				"myParamStr": "5678",
+			},
+		},
+		// test firstName and lastName as aliases of givenName and familyName
+		// leave displayName blank to test default concatenation
+		// test stripping down the built in social network supported URLs to usernames
+		"tanner": map[string]interface{}{
+			"firstName": "Tanner",
+			"lastName":  "Linsley",
+			"thumbnail": "https://www.google.com/images/branding/googlelogo/googlelogo_color_272x92dp.png",
+			"image":     "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+			"shortBio":  "Tanner loves Hugo",
+			"bio":       "Tanner really loves Hugo",
+			"email":     "tanner@email.com",
+			"weight":    1,
+			"social": map[string]interface{}{
+				"facebook":       "https://www.facebook.com/tannerlinsley/",
+				"github":         "https://github.com/tannerlinsley/",
+				"twitter":        "https://twitter.com/tannerlinsley/",
+				"googleplus":     "https://plus.google.com/12345678/",
+				"pinterest":      "https://www.pinterest.com/tannerlinsley/",
+				"instagram":      "https://www.instagram.com/tannerlinsley/",
+				"youtube":        "https://www.youtube.com/user/tannerlinsley/",
+				"linkedin":       "https://www.linkedin.com/in/tannerlinsley/",
+				"unknownNetwork": "https://www.unknownNetwork.com/tannerlinsley/",
+			},
+			"params": map[string]interface{}{
+				"myParamInt": 1234,
+				"myParamStr": "5678",
+			},
+		},
+	}
+
+	authorDerek = Author{
+		ID:          "derek",
+		GivenName:   "Derek",
+		FirstName:   "Derek",
+		FamilyName:  "Perkins",
+		LastName:    "Perkins",
+		DisplayName: "Derek Perkins",
+		Thumbnail:   "https://www.google.com/images/branding/googlelogo/googlelogo_color_272x92dp.png",
+		Image:       "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+		ShortBio:    "Derek loves Hugo",
+		Bio:         "Derek really loves Hugo",
+		Email:       "derek@email.com",
+		Weight:      2,
+		Social: AuthorSocial{
+			"facebook":   "derekperkins",
+			"github":     "derekperkins",
+			"twitter":    "derekperkins",
+			"googleplus": "derekperkins",
+			"pinterest":  "derekperkins",
+			"instagram":  "derekperkins",
+			"youtube":    "derekperkins",
+			"linkedin":   "derekperkins",
+		},
+		Params: map[string]string{
+			"myParamInt": "1234",
+			"myParamStr": "5678",
+		},
+	}
+
+	authorTanner = Author{
+		ID:          "tanner",
+		GivenName:   "Tanner",
+		FirstName:   "Tanner",
+		FamilyName:  "Linsley",
+		LastName:    "Linsley",
+		DisplayName: "Tanner Linsley",
+		Thumbnail:   "https://www.google.com/images/branding/googlelogo/googlelogo_color_272x92dp.png",
+		Image:       "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+		ShortBio:    "Tanner loves Hugo",
+		Bio:         "Tanner really loves Hugo",
+		Email:       "tanner@email.com",
+		Weight:      1,
+		Social: AuthorSocial{
+			"facebook":       "tannerlinsley",
+			"github":         "tannerlinsley",
+			"twitter":        "tannerlinsley",
+			"googleplus":     "12345678",
+			"pinterest":      "tannerlinsley",
+			"instagram":      "tannerlinsley",
+			"youtube":        "tannerlinsley",
+			"linkedin":       "tannerlinsley",
+			"unknownNetwork": "https://www.unknownNetwork.com/tannerlinsley/",
+		},
+		Params: map[string]string{
+			"myParamInt": "1234",
+			"myParamStr": "5678",
+		},
+	}
+
+	// ordered by Weight
+	defaultAuthors = Authors{authorTanner, authorDerek}
+
+	defaultAuthorSiteInfo = &SiteInfo{
+		Authors: defaultAuthors,
+	}
+)
+
+func TestMapToAuthors(t *testing.T) {
+	tests := []struct {
+		desc      string
+		authorMap map[string]interface{}
+		expected  Authors
+	}{
+		{
+			"valid authors",
+			defaultAuthorsMap,
+			defaultAuthors,
+		},
+		{
+			"no author info",
+			map[string]interface{}{},
+			Authors{},
+		},
+		{
+			"invalid author",
+			map[string]interface{}{
+				"derek": "",
+			},
+			Authors{},
+		},
+		{
+			"blank author id",
+			map[string]interface{}{
+				"": map[string]interface{}{},
+			},
+			Authors{},
+		},
+	}
+
+	for _, test := range tests {
+		authors := mapToAuthors(test.authorMap)
+		if !reflect.DeepEqual(authors, test.expected) {
+			t.Errorf("authors: expected:\n%#v\ngot:\n%#v", test.expected, authors)
+		}
+	}
+}
+
+func TestAuthorsGet(t *testing.T) {
+	tests := []struct {
+		desc     string
+		authors  Authors
+		id       string
+		expected Author
+	}{
+		{
+			"valid ID",
+			defaultAuthors,
+			"derek",
+			authorDerek,
+		},
+		{
+			"valid ID",
+			defaultAuthors,
+			"tanner",
+			authorTanner,
+		},
+		{
+			"invalid ID",
+			defaultAuthors,
+			"abc",
+			Author{},
+		},
+		{
+			"blank ID",
+			defaultAuthors,
+			"",
+			Author{},
+		},
+	}
+
+	for _, test := range tests {
+		author := test.authors.Get(test.id)
+		if !reflect.DeepEqual(author, test.expected) {
+			t.Errorf("author: expected:\n%#v\ngot:\n%#v", test.expected, author)
+		}
+	}
+}
+
+func TestPageAuthor(t *testing.T) {
+	tests := []struct {
+		desc     string
+		page     *Page
+		expected Author
+	}{
+		{
+			"valid ID",
+			&Page{
+				Params: map[string]interface{}{
+					"author": "derek",
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			authorDerek,
+		},
+		{
+			"valid ID",
+			&Page{
+				Params: map[string]interface{}{
+					"author": "tanner",
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			authorTanner,
+		},
+		{
+			"invalid ID",
+			&Page{
+				Params: map[string]interface{}{
+					"author": "abc",
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Author{},
+		},
+		{
+			"no ID",
+			&Page{
+				Params: map[string]interface{}{},
+				Node:   Node{Site: defaultAuthorSiteInfo},
+			},
+			Author{},
+		},
+		{
+			"blank ID",
+			&Page{
+				Params: map[string]interface{}{
+					"author": "",
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Author{},
+		},
+		{
+			"valid authors instead of author",
+			&Page{
+				Params: map[string]interface{}{
+					"authors": []string{"derek"},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			authorDerek,
+		},
+		{
+			"invalid authors instead of author",
+			&Page{
+				Params: map[string]interface{}{
+					"authors": []string{"abc"},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Author{},
+		},
+		{
+			"blank authors instead of author",
+			&Page{
+				Params: map[string]interface{}{
+					"authors": []string{""},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Author{},
+		},
+		{
+			"no site authors",
+			&Page{
+				Params: map[string]interface{}{
+					"author": "derek",
+				},
+				Node: Node{Site: &SiteInfo{Authors: Authors{}}},
+			},
+			Author{},
+		},
+	}
+
+	for _, test := range tests {
+		author := test.page.Author()
+		if !reflect.DeepEqual(author, test.expected) {
+			t.Errorf("author: expected:\n%#v\ngot:\n%#v", test.expected, author)
+		}
+	}
+}
+
+func TestPageAuthors(t *testing.T) {
+	tests := []struct {
+		desc     string
+		page     *Page
+		expected Authors
+	}{
+		{
+			"single author in array",
+			&Page{
+				Params: map[string]interface{}{
+					"authors": []string{"derek"},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{authorDerek},
+		},
+		{
+			"verify author ordering",
+			&Page{
+				Params: map[string]interface{}{
+					"authors": []string{"tanner", "derek"},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			defaultAuthors,
+		},
+		{
+			"verify author ordering",
+			&Page{
+				Params: map[string]interface{}{
+					"authors": []string{"derek", "tanner"},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{authorDerek, authorTanner},
+		},
+		{
+			"invalid ID authors param",
+			&Page{
+				Params: map[string]interface{}{
+					"authors": []string{"abc"},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{},
+		},
+		{
+			"blank string ID authors param",
+			&Page{
+				Params: map[string]interface{}{
+					"authors": []string{""},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{},
+		},
+		{
+			"empty authors param",
+			&Page{
+				Params: map[string]interface{}{
+					"authors": []string{},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{},
+		},
+		{
+			"no authors param",
+			&Page{
+				Params: map[string]interface{}{},
+				Node:   Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{},
+		},
+		{
+			"author instead of authors param with valid ID",
+			&Page{
+				Params: map[string]interface{}{
+					"author": "derek",
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{authorDerek},
+		},
+		{
+			"author instead of authors param with invalid ID",
+			&Page{
+				Params: map[string]interface{}{
+					"author": "abc",
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{},
+		},
+		{
+			"author instead of authors param with blank ID",
+			&Page{
+				Params: map[string]interface{}{
+					"author": "",
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{},
+		},
+		{
+			"author AND authors param with valid IDs",
+			&Page{
+				Params: map[string]interface{}{
+					"author":  "tanner",
+					"authors": []string{"derek"},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{authorTanner},
+		},
+		{
+			"author AND authors param with invalid author ID",
+			&Page{
+				Params: map[string]interface{}{
+					"author":  "abc",
+					"authors": []string{"derek"},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{authorDerek},
+		},
+		{
+			"author AND authors param with invalid author IDs",
+			&Page{
+				Params: map[string]interface{}{
+					"author":  "abc",
+					"authors": []string{"abc"},
+				},
+				Node: Node{Site: defaultAuthorSiteInfo},
+			},
+			Authors{},
+		},
+		{
+			"no site authors",
+			&Page{
+				Params: map[string]interface{}{
+					"authors": []string{"derek"},
+				},
+				Node: Node{Site: &SiteInfo{Authors: Authors{}}},
+			},
+			Authors{},
+		},
+	}
+
+	for _, test := range tests {
+		authors := test.page.Authors()
+		if !reflect.DeepEqual(authors, test.expected) {
+			t.Errorf("author: expected:\n%#v\ngot:\n%#v", test.expected, authors)
+		}
+	}
+}
+
+func TestNodeAuthor(t *testing.T) {
+	tests := []struct {
+		desc     string
+		node     *Node
+		expected Author
+	}{
+		{
+			"valid",
+			&Node{Site: defaultAuthorSiteInfo},
+			authorTanner,
+		},
+		{
+			"no site authors",
+			&Node{Site: &SiteInfo{Authors: Authors{}}},
+			Author{},
+		},
+	}
+
+	for _, test := range tests {
+		author := test.node.Author()
+		if !reflect.DeepEqual(author, test.expected) {
+			t.Errorf("author: expected:\n%#v\ngot:\n%#v", test.expected, author)
+		}
+	}
+}
+
+func TestNodeAuthors(t *testing.T) {
+	tests := []struct {
+		desc     string
+		node     *Node
+		expected Authors
+	}{
+		{
+			"valid",
+			&Node{Site: defaultAuthorSiteInfo},
+			defaultAuthors,
+		},
+		{
+			"no site authors",
+			&Node{Site: &SiteInfo{Authors: Authors{}}},
+			Authors{},
+		},
+	}
+
+	for _, test := range tests {
+		authors := test.node.Authors()
+		if !reflect.DeepEqual(authors, test.expected) {
+			t.Errorf("author: expected:\n%#v\ngot:\n%#v", test.expected, authors)
+		}
+	}
+}
+
+func TestAuthorSocialURL(t *testing.T) {
+	tests := []struct {
+		authorSocial AuthorSocial
+		network      string
+		expected     string
+	}{
+		{
+			authorTanner.Social,
+			"facebook",
+			"https://www.facebook.com/tannerlinsley",
+		},
+		{
+			authorTanner.Social,
+			"github",
+			"https://github.com/tannerlinsley",
+		},
+		{
+			authorTanner.Social,
+			"twitter",
+			"https://twitter.com/tannerlinsley",
+		},
+		{
+			authorTanner.Social,
+			"googleplus",
+			"https://plus.google.com/12345678",
+		},
+		{
+			authorDerek.Social,
+			"googleplus",
+			"https://plus.google.com/+derekperkins",
+		},
+		{
+			authorTanner.Social,
+			"pinterest",
+			"https://www.pinterest.com/tannerlinsley/",
+		},
+		{
+			authorTanner.Social,
+			"instagram",
+			"https://www.instagram.com/tannerlinsley/",
+		},
+		{
+			authorTanner.Social,
+			"youtube",
+			"https://www.youtube.com/user/tannerlinsley",
+		},
+		{
+			authorTanner.Social,
+			"linkedin",
+			"https://www.linkedin.com/in/tannerlinsley",
+		},
+		{
+			authorTanner.Social,
+			"unknownNetwork",
+			"https://www.unknownNetwork.com/tannerlinsley/",
+		},
+	}
+
+	for _, test := range tests {
+		u := test.authorSocial.URL(test.network)
+		if test.expected != u {
+			t.Errorf("url: expected:\n%#v\ngot:\n%#v", test.expected, u)
+		}
+	}
+}

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -409,12 +409,10 @@ func traverse(keys []string, m map[string]interface{}) interface{} {
 
 func (p *Page) Author() Author {
 	authors := p.Authors()
-
-	for _, author := range authors {
-		return author
+	if len(authors) > 0 {
+		return authors[0].languageOverride(p.Node.lang)
 	}
-
-	return authors[0].languageOverride(p.Node.lang)
+	return Author{}
 }
 
 // Authors returns all listed authors for a page in the order they

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -429,9 +429,10 @@ func (p *Page) Authors() Authors {
 			return Authors{a.languageOverride(p.Node.lang)}
 		}
 	}
-	authors := authorKeys.([]string)
-	if len(authors) < 1 || len(p.Site.Authors) < 1 {
-		return AuthorList{}
+
+	authorIDs, ok := p.Params["authors"].([]string)
+	if !ok || len(authorIDs) == 0 || len(p.Site.Authors) == 0 {
+		return Authors{}
 	}
 
 	authors := make([]Author, 0, len(authorIDs))
@@ -445,7 +446,8 @@ func (p *Page) Authors() Authors {
 			authors = append(authors, a.languageOverride(p.Node.lang))
 		}
 	}
-	return al
+
+	return authors
 }
 
 func (p *Page) UniqueID() string {

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -416,21 +416,32 @@ func (p *Page) Author() Author {
 	return Author{}
 }
 
-func (p *Page) Authors() AuthorList {
-	authorKeys, ok := p.Params["authors"]
-	if !ok {
-		return AuthorList{}
+// Authors returns all listed authors for a page in the order they
+// are defined in the front matter. It first checks for a single author
+// since that it the most common use case, then checks for multiple authors.
+func (p *Page) Authors() Authors {
+	authorID, ok := p.Params["author"].(string)
+
+	if ok && authorID != "" {
+		a := p.Site.Authors.Get(authorID)
+		if a.ID == authorID {
+			return Authors{a}
+		}
 	}
 	authors := authorKeys.([]string)
 	if len(authors) < 1 || len(p.Site.Authors) < 1 {
 		return AuthorList{}
 	}
 
-	al := make(AuthorList)
-	for _, author := range authors {
-		a, ok := p.Site.Authors[author]
-		if ok {
-			al[author] = a
+	authors := make([]Author, 0, len(authorIDs))
+	for _, authorID := range authorIDs {
+		if authorID == "" {
+			continue
+		}
+
+		a := p.Site.Authors.Get(authorID)
+		if a.ID == authorID {
+			authors = append(authors, a)
 		}
 	}
 	return al

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -413,7 +413,8 @@ func (p *Page) Author() Author {
 	for _, author := range authors {
 		return author
 	}
-	return Author{}
+
+	return authors[0].languageOverride(p.Node.lang)
 }
 
 // Authors returns all listed authors for a page in the order they
@@ -425,7 +426,7 @@ func (p *Page) Authors() Authors {
 	if ok && authorID != "" {
 		a := p.Site.Authors.Get(authorID)
 		if a.ID == authorID {
-			return Authors{a}
+			return Authors{a.languageOverride(p.Node.lang)}
 		}
 	}
 	authors := authorKeys.([]string)
@@ -441,7 +442,7 @@ func (p *Page) Authors() Authors {
 
 		a := p.Site.Authors.Get(authorID)
 		if a.ID == authorID {
-			authors = append(authors, a)
+			authors = append(authors, a.languageOverride(p.Node.lang))
 		}
 	}
 	return al

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -410,7 +410,7 @@ func traverse(keys []string, m map[string]interface{}) interface{} {
 func (p *Page) Author() Author {
 	authors := p.Authors()
 	if len(authors) > 0 {
-		return authors[0].languageOverride(p.Node.lang)
+		return authors[0].languageOverride(p.lang)
 	}
 	return Author{}
 }
@@ -424,7 +424,7 @@ func (p *Page) Authors() Authors {
 	if ok && authorID != "" {
 		a := p.Site.Authors.Get(authorID)
 		if a.ID == authorID {
-			return Authors{a.languageOverride(p.Node.lang)}
+			return Authors{a.languageOverride(p.lang)}
 		}
 	}
 
@@ -441,7 +441,7 @@ func (p *Page) Authors() Authors {
 
 		a := p.Site.Authors.Get(authorID)
 		if a.ID == authorID {
-			authors = append(authors, a.languageOverride(p.Node.lang))
+			authors = append(authors, a.languageOverride(p.lang))
 		}
 	}
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -300,7 +300,6 @@ type SiteInfo struct {
 	Hugo                  *HugoInfo
 	Title                 string
 	RSSLink               string
-	Author                map[string]interface{}
 	LanguageCode          string
 	DisqusShortname       string
 	GoogleAnalytics       string

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -104,6 +104,7 @@ type Site struct {
 	expiredCount int
 	Data         map[string]interface{}
 	Language     *helpers.Language
+	authorInit     sync.Once
 
 	disabledKinds map[string]bool
 
@@ -897,6 +898,14 @@ func (s *Site) readDataFromSourceFS() error {
 	}
 
 	err = s.loadData(dataSources)
+
+	// extract author data from /data/_authors then delete it from .Data
+	// only do it once per site
+	s.authorInit.Do(func() {
+		s.Info.Authors = mapToAuthors(cast.ToStringMap(s.Data["_authors"]))
+		delete(s.Data, "_authors")
+	})
+
 	s.timerStep("load data")
 	return err
 }

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -291,7 +291,8 @@ type SiteInfo struct {
 	paginationPageCount uint64
 
 	Taxonomies TaxonomyList
-	Authors    AuthorList
+	Authors    Authors
+	Author     map[string]interface{}
 	Social     SiteSocial
 	Sections   Taxonomy
 	*PageCollections

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -215,7 +215,7 @@ func (t *templateHandler) embedTemplates() {
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}"/>
 {{ with .Site.Social.twitter }}<meta name="twitter:site" content="@{{ . }}"/>{{ end }}
 {{ range .Site.Authors }}
-  {{ with .twitter }}<meta name="twitter:creator" content="@{{ . }}"/>{{ end }}
+  {{ with .Social.twitter }}<meta name="twitter:creator" content="@{{ . }}"/>{{ end }}
 {{ end }}{{ end }}`)
 
 	t.addInternalTemplate("", "google_news.html", `{{ if .IsPage }}{{ with .Params.news_keywords }}


### PR DESCRIPTION
Here's the first attempt at standardizing Hugo author details.
1. Data lives in `/data/authors` with one file per author. I thought about nesting it in `/data/site/authors` or `/data/hugo/authors`, but those seemed unnecessarily hidden.
2. Author front matter is an array to support multiple authors, though it will be up to themes to support multiple authors or not. There is a convenience `.Author` method to return a single author. 
   _if there are multiple authors and this is used, there is no guarantee which author will be returned_
3. I changed `.Site.Author` from `map[string]interface{}` to `Author`, though I don't know if that is in use outside of the embedded RSS feed
4. Social data should only be the username
5. For Author social details, I added a `.URL()` convenience method that returns canonical urls for major social networks
6. I added a params section to the author, though as of right now it is `map[string]string` instead of `map[string]interface{}`
7. I use snake_case in the data files but templates will access them with PascalCase
8. Here's a sample author file

```
given_name      = "Derek"
family_name     = "Perkins"
display_name    = "Derek Perkins"
thumbnail       = "img link"
image           = "img link"
short_bio       = "super short bio"
bio             = "Here's Derek's awesome bio"
email           = "derek@email.com"

[social]
    facebook    = "derekperkins"
    github      = "derekperkins"
    twitter     = "derek_perkins"
    googleplus  = "DerekPerkins1"

[params]
   random       = "whatever you want"
```
