### PR TITLE
Throw a noisy error when a post has no layout (Fixes #1313)

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -2032,7 +2032,7 @@ func (s *Site) renderAndWritePage(name string, dest string, d interface{}, layou
 func (s *Site) render(name string, d interface{}, w io.Writer, layouts ...string) error {
 	layout, found := s.findFirstLayout(layouts...)
 	if found == false {
-		jww.WARN.Printf("Unable to locate layout for %s: %s\n", name, layouts)
+		jww.ERROR.Printf("Unable to locate layout for %s: %s\n", name, layouts)
 		return nil
 	}
 


### PR DESCRIPTION
The output looks like this:

```
$ hugo server
Started building site
ERROR: 2016/03/12 15:23:47 site.go:2035: Unable to locate layout for page about.md: [page/single.html _default/single.html theme/page/single.html theme/_default/single.html _default/single.html]
ERROR: 2016/03/12 15:23:47 site.go:2035: Unable to locate layout for 404 page: [404.html]
0 draft content
0 future content
5 pages created
0 non-page files copied
...
```
