### PR TITLE
Replace toc_token with table of contents if present

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -14,6 +14,7 @@
 package hugolib
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -473,6 +474,11 @@ func (s *Site) preparePagesForRender(cfg BuildCfg, changed whatChanged) {
 				if p.Markup == "markdown" {
 					tmpContent, tmpTableOfContents := helpers.ExtractTOC(p.rawContentCopy)
 					p.TableOfContents = helpers.BytesToHTML(tmpTableOfContents)
+
+					if viper.Get("toctoken") != nil {
+						tmpContent = bytes.Replace(tmpContent, []byte(viper.GetString("toctoken")), tmpTableOfContents, 1)
+					}
+
 					p.rawContentCopy = tmpContent
 				}
 


### PR DESCRIPTION
In the process of migrating my blog from Jekyll to Hugo, I couldn't find an easy way to place a table of contents inline in the middle of content.

Jekyll allows you to specify a magic token (I use `{:toc}`) in the middle of your content that will be replaced with the table of contents. The associated code in Jekyll is here: https://github.com/jekyll/jekyll/blob/master/lib/jekyll/converters/markdown/rdiscount_parser.rb#L18.

I wanted the same thing in Hugo, so I wrote it.
