### PR TITLE
Improvement for rss taxonomies, and fix for opengraph rendering

### DIFF
--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -206,7 +206,7 @@ func (t *templateHandler) embedTemplates() {
 {{ if not .Date.IsZero }}<meta property="og:updated_time" content="{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}"/>{{ end }}
 {{ end }}{{ with .Params.audio }}
 <meta property="og:audio" content="{{ . }}" />{{ end }}{{ with .Params.locale }}
-<meta property="og:locale" content="{{ . }}" />{{ end }}{{ with .Site.Params.title }}
+<meta property="og:locale" content="{{ . }}" />{{ end }}{{ with .Site.Title }}
 <meta property="og:site_name" content="{{ . }}" />{{ end }}{{ with .Params.videos }}
 {{ range .Params.videos }}
   <meta property="og:video" content="{{ . | absURL }}" />

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -81,7 +81,7 @@ func (t *templateHandler) embedTemplates() {
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | html }}</description>
+      <description>{{ .Content | html }}</description>
       {{ range $name, $taxonomy := $.Site.Taxonomies }}{{ range index $item.Params $name }}
       <category>{{ $name }}/{{ . }}</category>
       {{ end }}{{ end }}

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -82,6 +82,9 @@ func (t *templateHandler) embedTemplates() {
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
+      {{ range $name, $taxonomy := $.Site.Taxonomies }}{{ range index $item.Params $name }}
+      <category>{{ $name }}/{{ . }}</category>
+      {{ end }}{{ end }}
     </item>
     {{ end }}
   </channel>


### PR DESCRIPTION
According to the specification[1]:

> The value of the element is a forward-slash-separated string that
> identifies a hierarchic location in the indicated taxonomy.

So I've set this to report {taxonomy name}/{value} as the <category> for
each item.

[1] https://validator.w3.org/feed/docs/rss2.html#ltcategorygtSubelementOfLtitemgt