### PR TITLE
transform: Adds --optimize and MinifyHTML

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -225,6 +225,7 @@ func initHugoBuildCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("canonifyURLs", false, "if true, all relative URLs will be canonicalized using baseURL")
 	cmd.Flags().StringVarP(&baseURL, "baseURL", "b", "", "hostname (and path) to the root, e.g. http://spf13.com/")
 	cmd.Flags().Bool("enableGitInfo", false, "Add Git revision, date and author info to the pages")
+	cmd.Flags().Bool("optimize", false, "Minify HTML")
 
 	cmd.Flags().BoolVar(&nitro.AnalysisOn, "stepAnalysis", false, "display memory and timing of different steps of the program")
 	cmd.Flags().Bool("pluralizeListTitles", true, "Pluralize titles in lists using inflect")
@@ -395,6 +396,7 @@ func initializeFlags(cmd *cobra.Command) {
 		"forceSyncStatic",
 		"noTimes",
 		"noChmod",
+		"optimize",
 	}
 
 	for _, key := range persFlagKeys {

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -57,6 +57,7 @@ func loadDefaultSettings() {
 	viper.SetDefault("disable404", false)
 	viper.SetDefault("disableRSS", false)
 	viper.SetDefault("disableSitemap", false)
+	viper.SetDefault("optimize", false)
 	viper.SetDefault("disableRobotsTXT", false)
 	viper.SetDefault("contentDir", "content")
 	viper.SetDefault("layoutDir", "layouts")

--- a/hugolib/hugo_sites_build_test.go
+++ b/hugolib/hugo_sites_build_test.go
@@ -777,6 +777,7 @@ var multiSiteTOMLConfigTemplate = `
 defaultExtension = "html"
 baseURL = "http://example.com/blog"
 disableSitemap = false
+optimize = false
 disableRSS = false
 rssURI = "index.xml"
 
@@ -836,6 +837,7 @@ var multiSiteYAMLConfig = `
 defaultExtension: "html"
 baseURL: "http://example.com/blog"
 disableSitemap: false
+optimize: false
 disableRSS: false
 rssURI: "index.xml"
 
@@ -896,6 +898,7 @@ var multiSiteJSONConfig = `
   "defaultExtension": "html",
   "baseURL": "http://example.com/blog",
   "disableSitemap": false,
+  "optimize": false,
   "disableRSS": false,
   "rssURI": "index.xml",
   "paginate": 1,

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1764,6 +1764,10 @@ func (s *Site) renderAndWritePage(name string, dest string, d interface{}, layou
 		path = []byte(s)
 	}
 
+	if viper.GetBool("optimize") {
+		transformLinks = append(transformLinks, transform.MinifyHTML)
+	}
+
 	transformer := transform.NewChain(transformLinks...)
 	transformer.Apply(outBuffer, renderBuffer, path)
 

--- a/transform/minifyhtml.go
+++ b/transform/minifyhtml.go
@@ -1,0 +1,48 @@
+// Copyright 2016 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transform
+
+import (
+	"bytes"
+	"regexp"
+
+	"github.com/pkg/errors"
+	"github.com/tdewolff/minify"
+	"github.com/tdewolff/minify/css"
+	"github.com/tdewolff/minify/html"
+	"github.com/tdewolff/minify/js"
+	"github.com/tdewolff/minify/json"
+)
+
+var minifier *minify.M
+
+func init() {
+	minifier = minify.New()
+	minifier.AddFunc("text/css", css.Minify)
+	minifier.Add("text/html", &html.Minifier{
+		KeepDefaultAttrVals: true,
+		KeepWhitespace:      true,
+		KeepDocumentTags:    true,
+	})
+	minifier.AddFunc("text/javascript", js.Minify)
+	minifier.AddFuncRegexp(regexp.MustCompile("[/+]json$"), json.Minify)
+}
+
+// MinifyHTML minifies the HTML and the embedded CSS, JS and JSON.
+func MinifyHTML(ct contentTransformer) {
+	buf := bytes.NewReader(ct.Content())
+	if err := minifier.Minify("text/html", ct, buf); err != nil {
+		panic(errors.Wrap(err, "error minifying html"))
+	}
+}

--- a/transform/minifyhtml_test.go
+++ b/transform/minifyhtml_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transform
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestMinifyHTML(t *testing.T) {
+	testCases := []struct {
+		in, expected string
+	}{
+		{"", ""},
+		{"<br>    <br>", "<br> <br>"},
+		{"<br>\n\n<br>", "<br>\n<br>"},
+		{"<p></p>", "<p>"},
+		{
+			"<style> body { color: black; any: 0s 0px; } </style>",
+			"<style>body{color:#000;any:0s 0}</style>",
+		},
+		{
+			"<html><head></head><body></body></html>",
+			"<html><head></head><body></body></html>",
+		},
+		{
+			`<script> console.log( "duck" );
+			 // foo
+			 debugger;
+			 </script>`,
+			`<script>console.log("duck");debugger;</script>`,
+		},
+		{
+			`<script type="application/json">
+			{
+				"a": 10,
+				"b": [1, 2, 3]
+			}
+			</script>`,
+			`<script type=application/json>{"a":10,"b":[1,2,3]}</script>`,
+		},
+	}
+	tr := NewChain(MinifyHTML)
+	for i, tc := range testCases {
+		in := strings.NewReader(tc.in)
+		out := new(bytes.Buffer)
+
+		tr.Apply(out, in, []byte("path"))
+		if string(out.Bytes()) != tc.expected {
+			t.Errorf("%d. Expected %q got %q", i, tc.expected, string(out.Bytes()))
+		}
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -317,6 +317,78 @@
 			"revisionTime": "2016-12-17T20:04:45Z"
 		},
 		{
+			"checksumSHA1": "ItM9x14tp2vRPEwTufY42XkJFe8=",
+			"path": "github.com/tdewolff/buffer",
+			"revision": "0edfcb7b750146ff879e95831de2ef53605a5cb5",
+			"revisionTime": "2016-04-27T18:11:22Z"
+		},
+		{
+			"checksumSHA1": "aYOP+Gtn+AK81aMpgqGKkrt+rMI=",
+			"path": "github.com/tdewolff/minify",
+			"revision": "5788bd40c07d1e1d4fc4eb8a955760d509c3159c",
+			"revisionTime": "2016-11-05T17:17:08Z"
+		},
+		{
+			"checksumSHA1": "uRo+3Qy3vwfbwBsjQNEprWBHKHo=",
+			"path": "github.com/tdewolff/minify/css",
+			"revision": "5788bd40c07d1e1d4fc4eb8a955760d509c3159c",
+			"revisionTime": "2016-11-05T17:17:08Z"
+		},
+		{
+			"checksumSHA1": "Ytcf7dKpnLbz62zxwB/VdSCBS7w=",
+			"path": "github.com/tdewolff/minify/html",
+			"revision": "5788bd40c07d1e1d4fc4eb8a955760d509c3159c",
+			"revisionTime": "2016-11-05T17:17:08Z"
+		},
+		{
+			"checksumSHA1": "8Vj9VTxgIn/BaZuGuwi1u/ckWZ8=",
+			"path": "github.com/tdewolff/minify/js",
+			"revision": "5788bd40c07d1e1d4fc4eb8a955760d509c3159c",
+			"revisionTime": "2016-11-05T17:17:08Z"
+		},
+		{
+			"checksumSHA1": "w9vp7arHrzUEi6KyAM9K8hAP3hM=",
+			"path": "github.com/tdewolff/minify/json",
+			"revision": "5788bd40c07d1e1d4fc4eb8a955760d509c3159c",
+			"revisionTime": "2016-11-05T17:17:08Z"
+		},
+		{
+			"checksumSHA1": "dW3/qMmvhmqylTirRfPK0by6bVE=",
+			"path": "github.com/tdewolff/parse",
+			"revision": "5c35632ca368ebf46247ede2b96e9f6c0258fae0",
+			"revisionTime": "2016-10-09T09:18:41Z"
+		},
+		{
+			"checksumSHA1": "QnZ3/9oDs+BrgtD/gS7x1oeNI2U=",
+			"path": "github.com/tdewolff/parse/css",
+			"revision": "5c35632ca368ebf46247ede2b96e9f6c0258fae0",
+			"revisionTime": "2016-10-09T09:18:41Z"
+		},
+		{
+			"checksumSHA1": "+gDXaHsyhgy8EB9beJKKH932qAk=",
+			"path": "github.com/tdewolff/parse/html",
+			"revision": "5c35632ca368ebf46247ede2b96e9f6c0258fae0",
+			"revisionTime": "2016-10-09T09:18:41Z"
+		},
+		{
+			"checksumSHA1": "tZNYHHm8NPAA/MKMzH9ThJgRdZs=",
+			"path": "github.com/tdewolff/parse/js",
+			"revision": "5c35632ca368ebf46247ede2b96e9f6c0258fae0",
+			"revisionTime": "2016-10-09T09:18:41Z"
+		},
+		{
+			"checksumSHA1": "kVJVV52ifqE4j6vNiWi9UiXOscs=",
+			"path": "github.com/tdewolff/parse/json",
+			"revision": "5c35632ca368ebf46247ede2b96e9f6c0258fae0",
+			"revisionTime": "2016-10-09T09:18:41Z"
+		},
+		{
+			"checksumSHA1": "hR7GEsOkEtR/doq2kiCmOF8spEg=",
+			"path": "github.com/tdewolff/strconv",
+			"revision": "3e8091f4417ebaaa3910da63a45ea394ebbfb0e3",
+			"revisionTime": "2016-04-27T18:05:39Z"
+		},
+		{
 			"checksumSHA1": "U4bWGZ3c9p8FHrgU5l4l5i7A6bo=",
 			"path": "github.com/yosssi/ace",
 			"revision": "ea038f4770b6746c3f8f84f14fa60d9fe1205b56",


### PR DESCRIPTION
When --optimize is set, MinifyHTML uses github.com/tdewolff/minify to minify all the
 pages being rendered. It minifies the HTML as well as the embedded CSS, JS and JSON.

In the case of CSS, there is a check if "-amp-start" is present and if so, it won't
minimize. This is to avoid breaking amp-boilerplate.

https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md

See #1251

I'm not entirely sure if the AMP check is a good fit for this. Would probably be better to structure it in some other way, but it was the quickest way to get this working for my use case.