### PR TITLE
Add a TocEntries variable to Page

### DIFF
--- a/docs/content/extras/toc.md
+++ b/docs/content/extras/toc.md
@@ -19,10 +19,10 @@ Simply create content like you normally would with the appropriate
 headers.
 
 Hugo will take this Markdown and create a table of contents stored in the
-[content variable](/layout/variables/) `.TableOfContents`
+[content variable](/layout/variables/) `.TableOfContents`.
 
 
-## Template Example
+### Template Example
 
 This is example code of a [single.html template](/layout/content/).
 
@@ -35,3 +35,29 @@ This is example code of a [single.html template](/layout/content/).
     {{ partial "footer.html" . }}
 
 
+## Styling your own Table Of Contents
+
+If the automatically generated `.TableOfContents` variable doesn't
+meet your needs, you may use the `.TocEntries` array to generate your
+own.
+
+### Template Example
+
+This is an example partial for rendering the top two levels of the
+`.TocEntries`:
+
+    <div class="toc">
+	  <ul>
+	    {{ $currentUrl := .URL }}
+		{{ range .TocEntries }}
+		<li><a href="{{$currentUrl}}#{{ .Id }}">{{ .Text }}</a>
+		  {{ if .Contents }}
+		  <ul>
+		    {{ range .Contents }}
+			<li><a href="{{$currentUrl}}#{{ .Id }}">{{ .Text }}</a>
+			{{ end }}
+		  </ul>
+		  {{ end }}
+		{{ end}}
+      </ul>
+	</div>

--- a/docs/content/templates/variables.md
+++ b/docs/content/templates/variables.md
@@ -64,6 +64,7 @@ matter, content or derived from file location.
 **.Summary** A generated summary of the content for easily showing a snippet in a summary view. Note that the breakpoint can be set manually by inserting <code>&lt;!&#x2d;&#x2d;more&#x2d;&#x2d;&gt;</code> at the appropriate place in the content page.  See [Summaries](/content/summaries/) for more details.<br>
 **.TableOfContents** The rendered table of contents for this content.<br>
 **.Title**  The title for this page.<br>
+**.TocEntries** A list of the top-level entries in the table of contents. See [Table of Contents]({{< relref "extras/toc.md" >}}) for more details.<br>
 **.Translations** A list of translated versions of the current page. See [Multilingual]({{< relref "content/multilingual.md" >}}) for more info.<br>
 **.Truncated** A boolean, `true` if the `.Summary` is truncated.  Useful for showing a "Read more..." link only if necessary.  See [Summaries](/content/summaries/) for more details.<br>
 **.Type** The content [type](/content/types/) (e.g. post).<br>

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -355,6 +355,21 @@ func ExtractTOC(content []byte) (newcontent []byte, toc []byte) {
 	return
 }
 
+type TocEntry struct {
+	Placeholder bool
+	Text        string
+	Id          string
+	Contents    []*TocEntry
+}
+
+func (c TocEntry) Clone() *TocEntry {
+	clonedContents := make([]*TocEntry, len(c.Contents))
+	for i, _ := range c.Contents {
+		clonedContents[i] = c.Contents[i].Clone()
+	}
+	return &TocEntry{c.Placeholder, c.Text, c.Id, clonedContents}
+}
+
 // RenderingContext holds contextual information, like content and configuration,
 // for a given content rendering.
 type RenderingContext struct {
@@ -368,6 +383,7 @@ type RenderingContext struct {
 	LinkResolver   LinkResolverFunc
 	ConfigProvider ConfigProvider
 	configInit     sync.Once
+	TocRoot        *TocEntry
 }
 
 func newViperProvidedRenderingContext() *RenderingContext {

--- a/hugolib/handler_page.go
+++ b/hugolib/handler_page.go
@@ -127,7 +127,7 @@ func commonConvert(p *Page, t tpl.Template) HandledResult {
 	// rendering engines.
 	// TODO(bep) inline replace
 	p.workContent = bytes.Replace(p.workContent, []byte(helpers.SummaryDivider), internalSummaryDivider, 1)
-	p.workContent = p.renderContent(p.workContent)
+	p.workContent, p.workTOC = p.renderContent(p.workContent)
 
 	return HandledResult{err: nil}
 }

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -369,13 +369,22 @@ func (s *Site) preparePagesForRender(cfg *BuildCfg) {
 				// If in watch mode, we need to keep the original so we can
 				// repeat this process on rebuild.
 				var workContentCopy []byte
+				workTocEntriesCopy := []*helpers.TocEntry{}
 				if cfg.Watching {
 					workContentCopy = make([]byte, len(p.workContent))
 					copy(workContentCopy, p.workContent)
+					if p.workTOC != nil {
+						workTocEntriesCopy = p.workTOC.Clone().Contents
+					}
 				} else {
 					// Just reuse the same slice.
 					workContentCopy = p.workContent
+					if p.workTOC != nil {
+						workTocEntriesCopy = p.workTOC.Contents
+					}
 				}
+
+				p.TocEntries = workTocEntriesCopy
 
 				if p.Markup == "markdown" {
 					tmpContent, tmpTableOfContents := helpers.ExtractTOC(workContentCopy)

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -520,6 +520,12 @@ func checkPageTOC(t *testing.T, page *Page, toc string) {
 	}
 }
 
+func checkWorkTOC(t *testing.T, page *Page, toc helpers.TocEntry) {
+	if page.workTOC == nil || !reflect.DeepEqual(*page.workTOC, toc) {
+		t.Fatalf("Page workTOC is: %v.\nExpected %v", page.workTOC, toc)
+	}
+}
+
 func checkPageSummary(t *testing.T, page *Page, summary string, msg ...interface{}) {
 	a := normalizeContent(string(page.Summary))
 	b := normalizeContent(summary)
@@ -828,6 +834,15 @@ func TestTableOfContents(t *testing.T) {
 
 	checkPageContent(t, p, "\n\n<p>For some moments the old man did not reply. He stood with bowed head, buried in deep thought. But at last he spoke.</p>\n\n<h2 id=\"aa\">AA</h2>\n\n<p>I have no idea, of course, how long it took me to reach the limit of the plain,\nbut at last I entered the foothills, following a pretty little canyon upward\ntoward the mountains. Beside me frolicked a laughing brooklet, hurrying upon\nits noisy way down to the silent sea. In its quieter pools I discovered many\nsmall fish, of four-or five-pound weight I should imagine. In appearance,\nexcept as to size and color, they were not unlike the whale of our own seas. As\nI watched them playing about I discovered, not only that they suckled their\nyoung, but that at intervals they rose to the surface to breathe as well as to\nfeed upon certain grasses and a strange, scarlet lichen which grew upon the\nrocks just above the water line.</p>\n\n<h3 id=\"aaa\">AAA</h3>\n\n<p>I remember I felt an extraordinary persuasion that I was being played with,\nthat presently, when I was upon the very verge of safety, this mysterious\ndeath&ndash;as swift as the passage of light&ndash;would leap after me from the pit about\nthe cylinder and strike me down. ## BB</p>\n\n<h3 id=\"bbb\">BBB</h3>\n\n<p>&ldquo;You&rsquo;re a great Granser,&rdquo; he cried delightedly, &ldquo;always making believe them little marks mean something.&rdquo;</p>\n")
 	checkPageTOC(t, p, "<nav id=\"TableOfContents\">\n<ul>\n<li>\n<ul>\n<li><a href=\"#aa\">AA</a>\n<ul>\n<li><a href=\"#aaa\">AAA</a></li>\n<li><a href=\"#bbb\">BBB</a></li>\n</ul></li>\n</ul></li>\n</ul>\n</nav>")
+	checkWorkTOC(t, p,
+		helpers.TocEntry{true, "", "", []*helpers.TocEntry{
+			&helpers.TocEntry{true, "", "", []*helpers.TocEntry{
+				&helpers.TocEntry{false, "AA", "aa", []*helpers.TocEntry{
+					&helpers.TocEntry{false, "AAA", "aaa", []*helpers.TocEntry{}},
+					&helpers.TocEntry{false, "BBB", "bbb", []*helpers.TocEntry{}},
+				}},
+			}},
+		}})
 }
 
 func TestPageWithMoreTag(t *testing.T) {


### PR DESCRIPTION
This is generated by recording the headers processed during markdown
rendering.

This allows rendering the TOC using a template rather than relying on
the built-in markdown formatted TOC.