### PR TITLE
hugolib: Fix TargetPath results with permalinks that contain '+'

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1409,7 +1409,6 @@ func (p *Page) FullFilePath() string {
 }
 
 func (p *Page) TargetPath() (outfile string) {
-
 	switch p.Kind {
 	case KindHome:
 		return p.addLangFilepathPrefix(helpers.FilePathSeparator)
@@ -1438,6 +1437,12 @@ func (p *Page) TargetPath() (outfile string) {
 		outfile, err = override.Expand(p)
 		if err == nil {
 			outfile, _ = url.QueryUnescape(outfile)
+
+			// QueryUnescape replaces '+' with ' '.
+			// In this case we need to put it back
+			re, _ := regexp.Compile(" ")
+			outfile = re.ReplaceAllString(outfile, "+")
+
 			if strings.HasSuffix(outfile, "/") {
 				outfile += "index.html"
 			}

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -331,6 +331,12 @@ date: '2013-10-15T06:16:13'
 ---
 Simple Page With Date`
 
+	simplePageWithDateAndPlus = `---
+title: X+Y
+date: '2013-10-15T06:16:13'
+---
+Simple Page With Date`
+
 	UTF8Page = `---
 title: ラーメン
 ---
@@ -1160,6 +1166,7 @@ func TestPagePaths(t *testing.T) {
 		{simplePageWithURL, "content/post/x.md", false, "simple/url/index.html"},
 		{simplePageWithSlug, "content/post/x.md", false, "content/post/simple-slug.html"},
 		{simplePageWithDate, "content/post/x.md", true, "2013/10/15/simple/index.html"},
+		{simplePageWithDateAndPlus, "content/post/x+y.md", true, "2013/10/15/x+y/index.html"},
 		{UTF8Page, "content/post/x.md", false, "content/post/x.html"},
 		{UTF8PageWithURL, "content/post/x.md", false, "ラーメン/url/index.html"},
 		{UTF8PageWithSlug, "content/post/x.md", false, "content/post/ラーメン-slug.html"},


### PR DESCRIPTION
It is now possible to have a page name/title/slug with permalinks that contains a '+'.

The reason I solved it as I did, was that "QueryUnescape" does its job right (replacing '+' with ' ') but here it is not what we want. An alternative would be to write a custom unescape function which seems like a bit overkill.

Fixes #2931.