### PR TITLE
Sitemap: sitemap generation may not respect standards for <changefreq>, <priority>

### DIFF
--- a/hugolib/sitemap.go
+++ b/hugolib/sitemap.go
@@ -16,6 +16,7 @@ package hugolib
 import (
 	"github.com/spf13/cast"
 	jww "github.com/spf13/jwalterweatherman"
+	"strings"
 )
 
 // Sitemap configures the sitemap to be generated.
@@ -31,15 +32,18 @@ func parseSitemap(input map[string]interface{}) Sitemap {
 	for key, value := range input {
 		switch key {
 		case "changefreq":
-			if value == "always" ||
-			value == "hourly" ||
-			value == "daily" ||
-			value == "weekly" ||
-			value == "monthly" ||
-			value == "yearly" ||
-			value == "never" {
-				sitemap.ChangeFreq = cast.ToString(value)
-				break
+			if str, ok := value.(string); ok {
+				valueLowercase := strings.ToLower(str)
+				if valueLowercase == "always" ||
+				valueLowercase == "hourly" ||
+				valueLowercase == "daily" ||
+				valueLowercase == "weekly" ||
+				valueLowercase == "monthly" ||
+				valueLowercase == "yearly" ||
+				valueLowercase == "never" {
+					sitemap.ChangeFreq = valueLowercase
+					break
+				}
 			}
 			jww.WARN.Printf("value '%s' for sitemap.changefreq is invalid, accepted values are: always, hourly, daily, weekly, monthly, yearly, never\n", value)
 		case "priority":

--- a/hugolib/sitemap.go
+++ b/hugolib/sitemap.go
@@ -47,11 +47,15 @@ func parseSitemap(input map[string]interface{}) Sitemap {
 			}
 			jww.WARN.Printf("value '%s' for sitemap.changefreq is invalid, accepted values are: always, hourly, daily, weekly, monthly, yearly, never\n", value)
 		case "priority":
-			priority := cast.ToFloat64(value)
-			if priority >= 0 &&
-			priority <= 1.0 {
-				sitemap.Priority = priority
-				break
+			if _, ok := value.(string); ok {
+				//value is a string... do nothing.
+			} else {
+				priority := cast.ToFloat64(value)
+				if priority >= 0 &&
+				priority <= 1.0 {
+					sitemap.Priority = priority
+					break
+				}
 			}
 			jww.WARN.Printf("value '%s' for sitemap.priority is invalid, value should be between 0 and 1.0 and have a maximum of 1 decimal\n", value)
 		case "filename":

--- a/hugolib/sitemap.go
+++ b/hugolib/sitemap.go
@@ -16,8 +16,8 @@ package hugolib
 import (
 	"github.com/spf13/cast"
 	jww "github.com/spf13/jwalterweatherman"
-	"strings"
 	"math"
+	"strings"
 )
 
 // Sitemap configures the sitemap to be generated.
@@ -36,12 +36,12 @@ func parseSitemap(input map[string]interface{}) Sitemap {
 			if str, ok := value.(string); ok {
 				valueLowercase := strings.ToLower(str)
 				if valueLowercase == "always" ||
-				valueLowercase == "hourly" ||
-				valueLowercase == "daily" ||
-				valueLowercase == "weekly" ||
-				valueLowercase == "monthly" ||
-				valueLowercase == "yearly" ||
-				valueLowercase == "never" {
+					valueLowercase == "hourly" ||
+					valueLowercase == "daily" ||
+					valueLowercase == "weekly" ||
+					valueLowercase == "monthly" ||
+					valueLowercase == "yearly" ||
+					valueLowercase == "never" {
 					sitemap.ChangeFreq = valueLowercase
 					break
 				}
@@ -53,7 +53,7 @@ func parseSitemap(input map[string]interface{}) Sitemap {
 			} else {
 				priority := cast.ToFloat64(value)
 				if priority >= 0 &&
-				priority <= 1.0 {
+					priority <= 1.0 {
 					if checkDecimalPlaces(1, priority) {
 						sitemap.Priority = priority
 						break
@@ -75,6 +75,6 @@ func checkDecimalPlaces(i int, value float64) bool {
 	valuef := value * float64(math.Pow(10.0, float64(i)))
 	println(valuef)
 	extra := valuef - float64(int(valuef))
-	
+
 	return extra == 0
 }

--- a/hugolib/sitemap.go
+++ b/hugolib/sitemap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cast"
 	jww "github.com/spf13/jwalterweatherman"
 	"strings"
+	"math"
 )
 
 // Sitemap configures the sitemap to be generated.
@@ -53,8 +54,10 @@ func parseSitemap(input map[string]interface{}) Sitemap {
 				priority := cast.ToFloat64(value)
 				if priority >= 0 &&
 				priority <= 1.0 {
-					sitemap.Priority = priority
-					break
+					if checkDecimalPlaces(1, priority) {
+						sitemap.Priority = priority
+						break
+					}
 				}
 			}
 			jww.WARN.Printf("value '%s' for sitemap.priority is invalid, value should be between 0 and 1.0 and have a maximum of 1 decimal\n", value)
@@ -66,4 +69,12 @@ func parseSitemap(input map[string]interface{}) Sitemap {
 	}
 
 	return sitemap
+}
+
+func checkDecimalPlaces(i int, value float64) bool {
+	valuef := value * float64(math.Pow(10.0, float64(i)))
+	println(valuef)
+	extra := valuef - float64(int(valuef))
+	
+	return extra == 0
 }

--- a/hugolib/sitemap.go
+++ b/hugolib/sitemap.go
@@ -26,14 +26,30 @@ type Sitemap struct {
 }
 
 func parseSitemap(input map[string]interface{}) Sitemap {
-	sitemap := Sitemap{Priority: -1, Filename: "sitemap.xml"}
+	sitemap := Sitemap{Priority: 0.5, Filename: "sitemap.xml"}
 
 	for key, value := range input {
 		switch key {
 		case "changefreq":
-			sitemap.ChangeFreq = cast.ToString(value)
+			if value == "always" ||
+			value == "hourly" ||
+			value == "daily" ||
+			value == "weekly" ||
+			value == "monthly" ||
+			value == "yearly" ||
+			value == "never" {
+				sitemap.ChangeFreq = cast.ToString(value)
+				break
+			}
+			jww.WARN.Printf("value '%s' for sitemap.changefreq is invalid, accepted values are: always, hourly, daily, weekly, monthly, yearly, never\n", value)
 		case "priority":
-			sitemap.Priority = cast.ToFloat64(value)
+			priority := cast.ToFloat64(value)
+			if priority >= 0 &&
+			priority <= 1.0 {
+				sitemap.Priority = priority
+				break
+			}
+			jww.WARN.Printf("value '%s' for sitemap.priority is invalid, value should be between 0 and 1.0 and have a maximum of 1 decimal\n", value)
 		case "filename":
 			sitemap.Filename = cast.ToString(value)
 		default:

--- a/hugolib/sitemap_test.go
+++ b/hugolib/sitemap_test.go
@@ -124,6 +124,10 @@ func TestParseSitemapChangefreq(t *testing.T) {
 			parseSitemap(map[string]interface{}{"changefreq": "never"}),
 		},
 		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml", ChangeFreq: "never"},
+			parseSitemap(map[string]interface{}{"changefreq": "NEVER"}),
+		},
+		{
 			Sitemap{Priority: 0.5, Filename: "sitemap.xml"},
 			parseSitemap(map[string]interface{}{"changefreq": "invalid"}),
 		},

--- a/hugolib/sitemap_test.go
+++ b/hugolib/sitemap_test.go
@@ -80,8 +80,8 @@ func doTestSitemapOutput(t *testing.T, internal bool) {
 func TestParseSitemapUnknownAndFilename(t *testing.T) {
 	expected := Sitemap{Filename: "doo.xml", Priority: 0.5}
 	input := map[string]interface{}{
-		"filename":   "doo.xml",
-		"unknown":    "ignore",
+		"filename": "doo.xml",
+		"unknown":  "ignore",
 	}
 	result := parseSitemap(input)
 
@@ -92,8 +92,8 @@ func TestParseSitemapUnknownAndFilename(t *testing.T) {
 
 func TestParseSitemapChangefreq(t *testing.T) {
 	var sitemaps = []struct {
-	expected Sitemap
-	result Sitemap
+		expected Sitemap
+		result   Sitemap
 	}{
 		{
 			Sitemap{Priority: 0.5, Filename: "sitemap.xml", ChangeFreq: "always"},
@@ -136,14 +136,14 @@ func TestParseSitemapChangefreq(t *testing.T) {
 	for _, s := range sitemaps {
 		if !reflect.DeepEqual(s.expected, s.result) {
 			t.Errorf("Got \n%v expected \n%v", s.result, s.expected)
-		}	
+		}
 	}
 }
 
 func TestParseSitemapPriority(t *testing.T) {
 	var sitemaps = []struct {
-	expected Sitemap
-	result Sitemap
+		expected Sitemap
+		result   Sitemap
 	}{
 		{
 			Sitemap{Priority: 0.5, Filename: "sitemap.xml"},
@@ -186,6 +186,6 @@ func TestParseSitemapPriority(t *testing.T) {
 	for _, s := range sitemaps {
 		if !reflect.DeepEqual(s.expected, s.result) {
 			t.Errorf("Got \n%v expected \n%v", s.result, s.expected)
-		}	
+		}
 	}
 }

--- a/hugolib/sitemap_test.go
+++ b/hugolib/sitemap_test.go
@@ -77,11 +77,9 @@ func doTestSitemapOutput(t *testing.T, internal bool) {
 
 }
 
-func TestParseSitemap(t *testing.T) {
-	expected := Sitemap{Priority: 3.0, Filename: "doo.xml", ChangeFreq: "3"}
+func TestParseSitemapUnknownAndFilename(t *testing.T) {
+	expected := Sitemap{Filename: "doo.xml", Priority: 0.5}
 	input := map[string]interface{}{
-		"changefreq": "3",
-		"priority":   3.0,
 		"filename":   "doo.xml",
 		"unknown":    "ignore",
 	}
@@ -90,5 +88,100 @@ func TestParseSitemap(t *testing.T) {
 	if !reflect.DeepEqual(expected, result) {
 		t.Errorf("Got \n%v expected \n%v", result, expected)
 	}
+}
 
+func TestParseSitemapChangefreq(t *testing.T) {
+	var sitemaps = []struct {
+	expected Sitemap
+	result Sitemap
+	}{
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml", ChangeFreq: "always"},
+			parseSitemap(map[string]interface{}{"changefreq": "always"}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml", ChangeFreq: "hourly"},
+			parseSitemap(map[string]interface{}{"changefreq": "hourly"}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml", ChangeFreq: "daily"},
+			parseSitemap(map[string]interface{}{"changefreq": "daily"}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml", ChangeFreq: "weekly"},
+			parseSitemap(map[string]interface{}{"changefreq": "weekly"}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml", ChangeFreq: "monthly"},
+			parseSitemap(map[string]interface{}{"changefreq": "monthly"}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml", ChangeFreq: "yearly"},
+			parseSitemap(map[string]interface{}{"changefreq": "yearly"}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml", ChangeFreq: "never"},
+			parseSitemap(map[string]interface{}{"changefreq": "never"}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml"},
+			parseSitemap(map[string]interface{}{"changefreq": "invalid"}),
+		},
+	}
+
+	for _, s := range sitemaps {
+		if !reflect.DeepEqual(s.expected, s.result) {
+			t.Errorf("Got \n%v expected \n%v", s.result, s.expected)
+		}	
+	}
+}
+
+func TestParseSitemapPriority(t *testing.T) {
+	var sitemaps = []struct {
+	expected Sitemap
+	result Sitemap
+	}{
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml"},
+			parseSitemap(map[string]interface{}{"priority": -1.0}),
+		},
+		{
+			Sitemap{Priority: 0, Filename: "sitemap.xml"},
+			parseSitemap(map[string]interface{}{"priority": 0}),
+		},
+		{
+			Sitemap{Priority: 0.1, Filename: "sitemap.xml"},
+			parseSitemap(map[string]interface{}{"priority": 0.1}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml"},
+			parseSitemap(map[string]interface{}{"priority": 0.5}),
+		},
+		{
+			Sitemap{Priority: 1.0, Filename: "sitemap.xml"},
+			parseSitemap(map[string]interface{}{"priority": 1.0}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml"},
+			parseSitemap(map[string]interface{}{"priority": 1.1}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml"},
+			parseSitemap(map[string]interface{}{"priority": 0.01}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml"},
+			parseSitemap(map[string]interface{}{"priority": 1.01}),
+		},
+		{
+			Sitemap{Priority: 0.5, Filename: "sitemap.xml"},
+			parseSitemap(map[string]interface{}{"priority": "text"}),
+		},
+	}
+
+	for _, s := range sitemaps {
+		if !reflect.DeepEqual(s.expected, s.result) {
+			t.Errorf("Got \n%v expected \n%v", s.result, s.expected)
+		}	
+	}
 }


### PR DESCRIPTION
Still needs some work to handle #.## and strings in sitemap.priority correctly.

I'm a novice in Go, so it may not respect standards fully and it's unfortunately incomplete at the moment.

I created tests and did my best to complete it, but I've had difficulties to handle #.## and strings correctly for sitemap.priority.

I think it should be a good start for someone to pick from and finish. I did as best as I could.

Tests should be complete.

(*) I didn't handle "loc" yet and I would probably suggest splitting handling that one in another issue and another fix as it doesn't seem at the same place in the code.