### PR TITLE
extras/shortcodes: Add Reuse Page Shortcode concept

### DIFF
--- a/docs/content/extras/shortcodes.md
+++ b/docs/content/extras/shortcodes.md
@@ -66,6 +66,44 @@ The `%` characters indicates that the shortcode's inner content needs further pr
 The `<` character indicates that the shortcode's inner content doesn't need any further rendering, this will typically be pure HTML:
 
     {{</* myshortcode */>}}<p>Hello <strong>World!</strong></p>{{</* /myshortcode */>}}
+    
+### Page Reuse shortcodes
+
+The `~` character indiciates that the shortcode's inner content must be taken from other referred page. For example, 
+this will take the rendered content (including shortcodes/images/links etc.) of the page "mypage.md" located by path "/path/to/page"
+starting from the content folder:
+ 
+    {{~/* myshortcode ref="/path/to/page/mypage" */~}}
+    
+Page Reuse shortcode must contain at least one parameter "ref" if _named parameters_ are used or the first one if _positional parameters_ are used
+indicating the page to be reused. The page can be referred by an absolute path (starting from slash) or by a relative to the current directory path.
+The page extension (.md) can be omitted as well as "/index.md" filename since it will be searched by Hugo engine if any.
+If search is failed then Hugo will output an error and the shortcode will not be handled at all.
+
+Page Reuse shortcodes don't require a template to be provided since they can act as built-in shortcodes just substituting themselves with the content
+of the reused pages.  
+Note: If a template is omitted a closing shortcode will be omitted as well.
+
+#### Page snippets
+In order to have possibility to create pages that can be reused in different places but don't have its own served page on the site, 
+a new concept of page snippets has been introduced. To mark the page as a snippet you must add a parameter "issnippet=true" inside the front matter of the page. 
+This page will not be served by Hugo and instead can be used only in Page Reuse shortcodes.
+When building your site you will see the output indicating how many page snippets your site will contain.
+
+#### Links resolution
+To provide flexibility in writing pages that can be reused in other pages there must be proper mechanism of links resolution.
+This only concerns relative links since absolute links (starting from slash or even from a scheme like https://) are not considered 
+to be modified in any way.
+So the relative links in the reused pages are resolved in 2 modes:
+* Dynamic resolution - the links are resolved in the context of the page that specifies a Reuse Page shortcode.
+* Relative resolution - the links are resolved in the context of the reused page.
+ 
+The first one has bigger precedence.  
+Hugo will try to find the corresponding page or file that is included to the current built site.
+If a link indicates a page and not a file (image/font etc.) the search will always expand to adding a .md, /index.md suffix
+to find the most appropriate page. Links can be relative to the current directory or the current page file 
+(since the filename will be transformed to a part of the URL path).
+If search is failed then Hugo will output a warning and won't transform the link.
 
 
 ## Built-in Shortcodes
@@ -251,6 +289,9 @@ parameters, named parameters work best.  Allowing both types of parameters is
 useful for complex layouts where you want to set default values that can be
 overridden.
 
+If you create a Reuse Page shortcode the first parameter will always be the "ref" parameter indicating the page to be reused.
+It can be also referred by the first index since it always must go first if _positional parameters_ are used.
+
 **Inside the template**
 
 To access a parameter by position, the `.Get` method can be used:
@@ -275,6 +316,8 @@ If a closing shortcode is used, the variable `.Inner` will be populated with all
 of the content between the opening and closing shortcodes. If a closing
 shortcode is required, you can check the length of `.Inner` and provide a warning
 to the user.
+
+If a Reuse Page shortcode is used, the variable `.InnerPage` will be populated with the content of the reused page for better control of the output.
 
 A shortcode with `.Inner` content can be used without the inline content, and without the closing shortcode, by using the self-closing syntax:
 

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -458,6 +458,10 @@ func (h *HugoSites) setupTranslations() {
 		for i, site := range h.Sites {
 			// The site is assigned by language when read.
 			if site == p.s {
+				if p.Kind == KindSnippet {
+					site.PageSnippets = append(site.PageSnippets, p)
+					continue
+				}
 				site.updateBuildStats(p)
 				if shouldBuild {
 					site.Pages = append(site.Pages, p)

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -47,7 +47,8 @@ var (
 )
 
 const (
-	KindPage = "page"
+	KindPage    = "page"
+	KindSnippet = "snippet"
 
 	// The rest are node types; home page, sections etc.
 	KindHome         = "home"
@@ -248,6 +249,7 @@ type pageInit struct {
 	plainInit           sync.Once
 	plainWordsInit      sync.Once
 	renderingConfigInit sync.Once
+	markupTypeInit      sync.Once
 }
 
 // IsNode returns whether this is an item of one of the list types in Hugo,
@@ -587,22 +589,50 @@ func (p *Page) setAutoSummary() error {
 }
 
 func (p *Page) renderContent(content []byte) []byte {
+	return p.renderContentWithResolvers(content, nil)
+}
+
+func (p *Page) renderReusedPage(content []byte, reusedPage *Page) []byte {
+	return p.renderContentWithResolvers(content, reusedPage)
+}
+
+func (p *Page) renderContentWithResolvers(content []byte, reusedPage *Page) []byte {
+	pageReuse := reusedPage != nil
+	resolveRelative := pageReuse || p.getRenderingConfig().SourceRelativeLinksEval
+	renderTOC := !pageReuse
 	var fn helpers.LinkResolverFunc
 	var fileFn helpers.FileResolverFunc
-	if p.getRenderingConfig().SourceRelativeLinksEval {
+	if resolveRelative {
 		fn = func(ref string) (string, error) {
-			return p.Site.SourceRelativeLink(ref, p)
+			// Trying to dynamically handle relative links (in case of page reuse).
+			// If not page reuse, just default handling
+			link, err := p.Site.SourceRelativeLink(ref, p, reusedPage)
+			if pageReuse && (err != nil || link == "") {
+				// If dynamic handling failed trying to handle relatively to reused page
+				return reusedPage.Site.SourceRelativeLink(ref, reusedPage, reusedPage)
+			}
+			return link, err
 		}
 		fileFn = func(ref string) (string, error) {
-			return p.Site.SourceRelativeLinkFile(ref, p)
+			// Trying to dynamically handle relative links (in case of page reuse).
+			// If not page reuse, just default handling
+			link, err := p.Site.SourceRelativeLinkFile(ref, p, reusedPage)
+			if pageReuse && (err != nil || link == "") {
+				// If dynamic handling failed trying to handle relatively to reused page
+				return reusedPage.Site.SourceRelativeLinkFile(ref, reusedPage, reusedPage)
+			}
+			return link, err
 		}
 	}
-
+	pageToRender := p
+	if pageReuse {
+		pageToRender = reusedPage
+	}
 	return p.s.ContentSpec.RenderBytes(&helpers.RenderingContext{
-		Content: content, RenderTOC: true, PageFmt: p.determineMarkupType(),
-		Cfg:        p.Language(),
-		DocumentID: p.UniqueID(), DocumentName: p.Path(),
-		Config: p.getRenderingConfig(), LinkResolver: fn, FileResolver: fileFn})
+		Content: content, RenderTOC: renderTOC, PageFmt: pageToRender.determineMarkupType(),
+		Cfg:        pageToRender.Language(),
+		DocumentID: pageToRender.UniqueID(), DocumentName: pageToRender.Path(),
+		Config: pageToRender.getRenderingConfig(), LinkResolver: fn, FileResolver: fileFn})
 }
 
 func (p *Page) getRenderingConfig() *helpers.Blackfriday {
@@ -962,6 +992,11 @@ func (p *Page) update(f interface{}) error {
 		case "iscjklanguage":
 			isCJKLanguage = new(bool)
 			*isCJKLanguage = cast.ToBool(v)
+		case "issnippet":
+			if cast.ToBool(v) {
+				p.Kind = KindSnippet
+			}
+
 		default:
 			// If not one of the explicit values, store in Params
 			switch vv := v.(type) {
@@ -1253,13 +1288,14 @@ func (p *Page) Menus() PageMenus {
 }
 
 func (p *Page) determineMarkupType() string {
-	// Try markup explicitly set in the frontmatter
-	p.Markup = helpers.GuessType(p.Markup)
-	if p.Markup == "unknown" {
-		// Fall back to file extension (might also return "unknown")
-		p.Markup = helpers.GuessType(p.Source.Ext())
-	}
-
+	p.markupTypeInit.Do(func() {
+		// Try markup explicitly set in the frontmatter
+		p.Markup = helpers.GuessType(p.Markup)
+		if p.Markup == "unknown" {
+			// Fall back to file extension (might also return "unknown")
+			p.Markup = helpers.GuessType(p.Source.Ext())
+		}
+	})
 	return p.Markup
 }
 

--- a/hugolib/page_collections.go
+++ b/hugolib/page_collections.go
@@ -35,6 +35,9 @@ type PageCollections struct {
 
 	// Includes absolute all pages (of all types), including drafts etc.
 	rawAllPages Pages
+
+	// Page snippets that can be used only for Page reuse. Ignored by default.
+	PageSnippets Pages
 }
 
 func (c *PageCollections) refreshPageCaches() {

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -48,10 +48,16 @@ func pageFromString(in, filename string, withTemplate ...func(templ tpl.Template
 }
 
 func CheckShortCodeMatch(t *testing.T, input, expected string, withTemplate func(templ tpl.Template) error) {
-	CheckShortCodeMatchAndError(t, input, expected, withTemplate, false)
+	CheckShortCodeMatchWithTestDataAndError(t, input, "", expected, withTemplate, false, nil, nil)
 }
 
-func CheckShortCodeMatchAndError(t *testing.T, input, expected string, withTemplate func(templ tpl.Template) error, expectError bool) {
+func CheckShortCodeMatchWithTestPages(t *testing.T, input, expected string, withTemplate func(templ tpl.Template) error,
+	testPages map[string]string) {
+	CheckShortCodeMatchWithTestDataAndError(t, input, "", expected, withTemplate, false, testPages, nil)
+}
+
+func CheckShortCodeMatchWithTestDataAndError(t *testing.T, input, inputPageDir string, expected string,
+	withTemplate func(templ tpl.Template) error, expectError bool, testPages map[string]string, testFiles map[string]string) {
 
 	cfg, fs := newTestCfg()
 
@@ -61,7 +67,23 @@ title: "Title"
 ---
 ` + input
 
-	writeSource(t, fs, "content/simple.md", contentFile)
+	var snippetCount int
+	for pageName, pageContent := range testPages {
+		if match, err := regexp.MatchString(".*\\.snippet\\.md", pageName); err == nil && match {
+			snippetCount += 1
+			pageContent = `---
+issnippet: true
+---
+` + pageContent
+		}
+		writeSource(t, fs, "content/"+pageName, pageContent)
+	}
+
+	for fileName, fileContent := range testFiles {
+		writeSource(t, fs, "content/"+fileName, fileContent)
+	}
+
+	writeSource(t, fs, "content/"+inputPageDir+"simple.md", contentFile)
 
 	h, err := NewHugoSites(deps.DepsCfg{Fs: fs, Cfg: cfg, WithTemplate: withTemplate})
 
@@ -78,13 +100,18 @@ title: "Title"
 		t.Fatalf("No error from shortcode")
 	}
 
-	require.Len(t, h.Sites[0].RegularPages, 1)
+	require.Len(t, h.Sites[0].PageSnippets, snippetCount)
+	require.Len(t, h.Sites[0].RegularPages, len(testPages)+1-snippetCount)
 
-	output := strings.TrimSpace(string(h.Sites[0].RegularPages[0].Content))
+	var output string
+	for _, page := range h.Sites[0].RegularPages {
+		if page.Source.Path() == filepath.FromSlash(inputPageDir+"simple.md") {
+			output = strings.TrimSpace(string(page.Content))
+		}
+	}
+
 	output = strings.TrimPrefix(output, "<p>")
 	output = strings.TrimSuffix(output, "</p>")
-
-	expected = strings.TrimSpace(expected)
 
 	if output != expected {
 		t.Fatalf("Shortcode render didn't match. got \n%q but expected \n%q", output, expected)
@@ -95,6 +122,163 @@ func TestNonSC(t *testing.T) {
 	t.Parallel()
 	// notice the syntax diff from 0.12, now comment delims must be added
 	CheckShortCodeMatch(t, "{{%/* movie 47238zzb */%}}", "{{% movie 47238zzb %}}", nil)
+}
+
+func TestReusePageSCWithPositionalPathParam(t *testing.T) {
+	t.Parallel()
+	pages := make(map[string]string)
+	pages["simple.snippet.md"] = "Simple Page\n"
+	CheckShortCodeMatchWithTestPages(t, `{{~ reuse "simple.snippet.md" ~}}`, "Simple Page", nil, pages)
+}
+
+// Reuse shortcode name could be anything. Closing tag will be ignored since there is no template
+func TestReusePageSCWithNamedPathParam(t *testing.T) {
+	t.Parallel()
+	pages := make(map[string]string)
+	pages["simple.snippet.md"] = "Simple Page\n"
+	CheckShortCodeMatchWithTestPages(t, `{{~ include ref="simple.snippet.md" ~}}Just plain text{{~ /include ~}}`,
+		"<p>Simple Page</p>\nJust plain text", nil, pages)
+}
+
+func TestReusePageSCWithDifferentPages(t *testing.T) {
+	t.Parallel()
+	pages := make(map[string]string)
+	pages["simple.snippet.md"] = "Simple page .md"
+	pages["simple2.snippet.md"] = "Simple page No .md"
+	pages["simple3/index.md"] = "Simple page index.md"
+	pages["other/simple.snippet.md"] = "Other page"
+	CheckShortCodeMatchWithTestDataAndError(t, "{{~ reuse ref=\"/simple.snippet.md\" ~}}{{~ reuse \"/simple2.snippet\" ~}}"+
+		"{{~ reuse \"/simple3\" ~}}{{~ reuse \"../simple.snippet\" ~}}{{~ reuse \"simple.snippet.md\" ~}}"+
+		"{{~ reuse ref=\"./simple.snippet\" ~}}",
+		"other/", "<p>Simple page .md</p>\n<p>Simple page No .md</p>\n"+
+			"<p>Simple page index.md</p>\n<p>Simple page .md</p>\n<p>Other page</p>\n<p>Other page</p>\n",
+		nil, false, pages, nil)
+}
+
+func TestReusePageSCReusePageNoFrontmatter(t *testing.T) {
+	t.Parallel()
+	pages := make(map[string]string)
+	pages["simple2.md"] = "Simple Page"
+	CheckShortCodeMatchWithTestPages(t, `{{~ reuse "simple2.md" ~}}`, "Simple Page", nil, pages)
+}
+
+func TestReusePageSCWithNoParam(t *testing.T) {
+	t.Parallel()
+	pages := make(map[string]string)
+	pages["simple.snippet.md"] = "Simple Page\n"
+	CheckShortCodeMatchWithTestPages(t, `{{~ reuse ~}}`, "", nil, pages)
+}
+
+func TestReusePageSCWithNoReusePage(t *testing.T) {
+	t.Parallel()
+	CheckShortCodeMatch(t, `{{~ reuse ~}}`, "", nil)
+}
+
+func TestReusePageSCWithIncorrectRefParam(t *testing.T) {
+	t.Parallel()
+	pages := make(map[string]string)
+	pages["simple.snippet.md"] = "Simple Page\n"
+	CheckShortCodeMatchWithTestPages(t, `{{~ reuse path="/simple.snippet.md" ~}}`, "", nil, pages)
+}
+
+// Reuse shortcode name matters when you use the template for it
+func TestReusePageSCWithTemplateAndPositionalParams(t *testing.T) {
+	t.Parallel()
+	pages := make(map[string]string)
+	pages["simple.snippet.md"] = "Simple Page\n"
+	wt := func(tem tpl.Template) error {
+		tem.AddInternalShortcode("reuse.html", "Inner page:\n{{ .InnerPage }}\nContent:\n{{ .Inner }}\n"+
+			"And here params are:\nPath to page:{{ .Get 0 }} and other:{{ .Get 1 }}")
+		return nil
+	}
+	CheckShortCodeMatchWithTestPages(t, `{{~ reuse "simple.snippet.md" for-fun ~}}This will be inner{{~ /reuse ~}}`,
+		"Inner page:\n<p>Simple Page</p>\n\nContent:\nThis will be inner\nAnd here params are:\n"+
+			"Path to page:simple.snippet.md and other:for-fun", wt, pages)
+}
+
+func TestReusePageSCWithTemplateAndNamedParams(t *testing.T) {
+	t.Parallel()
+	pages := make(map[string]string)
+	pages["simple.snippet.md"] = "Simple Page\n"
+	wt := func(tem tpl.Template) error {
+		tem.AddInternalShortcode("include.html", "Inner page:\n{{ .InnerPage }}\nContent:\n{{ .Inner }}\n"+
+			"And here params are:\nPath to page:{{ .Get \"ref\" }} and other:{{ .Get \"other\" }}")
+		return nil
+	}
+	CheckShortCodeMatchWithTestPages(t, `{{~ include ref="simple.snippet.md" other="for-fun" ~}}This will be inner{{~ /include ~}}`,
+		"Inner page:\n<p>Simple Page</p>\n\nContent:\nThis will be inner\nAnd here params are:\n"+
+			"Path to page:simple.snippet.md and other:for-fun", wt, pages)
+}
+
+func TestReusePageSCWithShortcodesInReusePage(t *testing.T) {
+	t.Parallel()
+	pages := make(map[string]string)
+	pages["simple.snippet.md"] = "Simple Page\n{{< custom \"I will be there\" >}}"
+	wt := func(tem tpl.Template) error {
+		tem.AddInternalShortcode("custom.html", "Custom shortcode: {{ .Get 0 }}")
+		return nil
+	}
+	CheckShortCodeMatchWithTestPages(t, `{{~ reuse ref="simple.snippet.md" ~}}`, "Simple Page\nCustom shortcode: I will be there",
+		wt, pages)
+}
+
+func TestReusePageSCWithRelativeLinks(t *testing.T) {
+	t.Parallel()
+	files := make(map[string]string)
+	// This will be taken since dynamical resolution has precedence
+	files["images/image.png"] = ""
+	files["direction1/images/image.png"] = ""
+	// This will be taken since dynamical resolution has precedence
+	files["direction2/images/image.png"] = ""
+	// This will be taken since no dynamical counterpart exists
+	files["direction1/images/image2.png"] = ""
+	pages := make(map[string]string)
+	// This will be taken since it is an absolute path
+	pages["direction1/absolute.md"] = "" // Content doesn't matter here
+	pages["direction2/absolute.md"] = ""
+	pages["direction1/dynamic.md"] = ""
+	// This will be taken since dynamical resolution has precedence
+	pages["direction2/dynamic.md"] = ""
+	pages["direction1/dynamic2/index.md"] = ""
+	// This will be taken since dynamical resolution has precedence
+	pages["direction2/dynamic2/index.md"] = ""
+	// This will be taken since dynamic resolution has precedence
+	pages["dynamic.md"] = ""
+	pages["root.md"] = ""
+	// This will be taken since no dynamical counterpart exists
+	pages["direction1/relative.md"] = ""
+	// This will be taken since no dynamical counterpart exists
+	pages["direction1/relative2/index.md"] = ""
+	pages["direction1/simple.snippet.md"] = "Simple Page\n[absoluteLink](/direction1/absolute)\n" +
+		"[dynamicLink1](dynamic)\n[dynamicLink2](dynamic.md)\n[dynamicLink3](dynamic2)\n" +
+		"[dynamicLink4](./dynamic)\n" +
+		"[dynamicLink5](../dynamic)\n[rootLink](../../root)\n" + //special cases for page reuse
+		"![dynamicLinkFile1](images/image.png)\n![dynamicLinkFile2](../images/image.png)\n" +
+		"[relativeLink1](relative)\n[relativeLink2](relative.md)\n[relativeLink3](relative2)\n" +
+		"[relativeLink4](./relative)\n" +
+		"[relativeLink5](../relative)\n" + //special case for page reuse
+		"![relativeLinkFile1](images/image2.png)\n![relativeLinkFile2](../images/image2.png)\n" +
+		"[noLink](unknownLink)\n![noLinkFile](unknownFile)"
+	pages["direction1/index/index.md"] = "---\ntitle: Other\n---\nOther Page\n" +
+		"[dynamicLink](../../dynamic)\n![dynamicImage](../../images/image.png)\n[rootLink](../../../root)\n" +
+		"[relativeLink](../../relative)\n![relativeImage](../../images/image2.png)"
+	CheckShortCodeMatchWithTestDataAndError(t, "{{~ reuse ref=\"/direction1/simple.snippet.md\" ~}}"+
+		"{{~ reuse \"/direction1/index\" ~}}", "direction2/",
+		"<p>Simple Page\n<a href=\"/direction1/absolute/\">absoluteLink</a>\n"+
+			"<a href=\"/direction2/dynamic/\">dynamicLink1</a>\n<a href=\"/direction2/dynamic/\">dynamicLink2</a>\n"+
+			"<a href=\"/direction2/dynamic2/index/\">dynamicLink3</a>\n<a href=\"/direction2/dynamic/\">dynamicLink4</a>\n"+
+			"<a href=\"/direction2/dynamic/\">dynamicLink5</a>\n<a href=\"/root/\">rootLink</a>\n"+
+			"<img src=\"/direction2/images/image.png\" alt=\"dynamicLinkFile1\" />\n"+
+			"<img src=\"/direction2/images/image.png\" alt=\"dynamicLinkFile2\" />\n"+
+			"<a href=\"/direction1/relative/\">relativeLink1</a>\n<a href=\"/direction1/relative/\">relativeLink2</a>\n"+
+			"<a href=\"/direction1/relative2/index/\">relativeLink3</a>\n<a href=\"/direction1/relative/\">relativeLink4</a>\n"+
+			"<a href=\"/direction1/relative/\">relativeLink5</a>\n"+
+			"<img src=\"/direction1/images/image2.png\" alt=\"relativeLinkFile1\" />\n"+
+			"<img src=\"/direction1/images/image2.png\" alt=\"relativeLinkFile2\" />\n"+
+			"<a href=\"unknownLink\">noLink</a>\n<img src=\"unknownFile\" alt=\"noLinkFile\" /></p>\n"+
+			"<p>Other Page\n<a href=\"/dynamic/\">dynamicLink</a>\n<img src=\"/images/image.png\" alt=\"dynamicImage\" />\n"+
+			"<a href=\"/root/\">rootLink</a>\n<a href=\"/direction1/relative/\">relativeLink</a>\n"+
+			"<img src=\"/direction1/images/image2.png\" alt=\"relativeImage\" /></p>\n", nil, false, pages, files)
 }
 
 // Issue #929
@@ -240,8 +424,8 @@ This is **plain** text.
 func TestEmbeddedSC(t *testing.T) {
 	t.Parallel()
 	CheckShortCodeMatch(t, "{{% test %}}", "This is a simple Test", nil)
-	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" %}}`, "\n<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" />\n    \n    \n</figure>\n", nil)
-	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" caption="This is a caption" %}}`, "\n<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" alt=\"This is a caption\" />\n    \n    \n    <figcaption>\n        <p>\n        This is a caption\n        \n            \n        \n        </p> \n    </figcaption>\n    \n</figure>\n", nil)
+	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" %}}`, "<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" />\n    \n    \n</figure>", nil)
+	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" caption="This is a caption" %}}`, "<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" alt=\"This is a caption\" />\n    \n    \n    <figcaption>\n        <p>\n        This is a caption\n        \n            \n        \n        </p> \n    </figcaption>\n    \n</figure>", nil)
 }
 
 func TestNestedSC(t *testing.T) {
@@ -281,13 +465,13 @@ func TestParentShortcode(t *testing.T) {
 		return nil
 	}
 	CheckShortCodeMatch(t, `{{< r1 pr1="p1" >}}1: {{< r2 pr2="p2" >}}2: {{< r3 pr3="p3" >}}{{< /r3 >}}{{< /r2 >}}{{< /r1 >}}`,
-		"1: p1 1: 2: p1p2 2: 3: p1p2p3 ", wt)
+		"1: p1 1: 2: p1p2 2: 3: p1p2p3", wt)
 
 }
 
 func TestFigureImgWidth(t *testing.T) {
 	t.Parallel()
-	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" alt="apple" width="100px" %}}`, "\n<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" alt=\"apple\" width=\"100px\" />\n    \n    \n</figure>\n", nil)
+	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" alt="apple" width="100px" %}}`, "<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" alt=\"apple\" width=\"100px\" />\n    \n    \n</figure>", nil)
 }
 
 const testScPlaceholderRegexp = "HAHAHUGOSHORTCODE-\\d+HBHB"

--- a/hugolib/shortcodeparser_test.go
+++ b/hugolib/shortcodeparser_test.go
@@ -24,18 +24,20 @@ type shortCodeLexerTest struct {
 }
 
 var (
-	tstEOF       = item{tEOF, 0, ""}
-	tstLeftNoMD  = item{tLeftDelimScNoMarkup, 0, "{{<"}
-	tstRightNoMD = item{tRightDelimScNoMarkup, 0, ">}}"}
-	tstLeftMD    = item{tLeftDelimScWithMarkup, 0, "{{%"}
-	tstRightMD   = item{tRightDelimScWithMarkup, 0, "%}}"}
-	tstSCClose   = item{tScClose, 0, "/"}
-	tstSC1       = item{tScName, 0, "sc1"}
-	tstSC2       = item{tScName, 0, "sc2"}
-	tstSC3       = item{tScName, 0, "sc3"}
-	tstParam1    = item{tScParam, 0, "param1"}
-	tstParam2    = item{tScParam, 0, "param2"}
-	tstVal       = item{tScParamVal, 0, "Hello World"}
+	tstEOF        = item{tEOF, 0, ""}
+	tstLeftNoMD   = item{tLeftDelimScNoMarkup, 0, "{{<"}
+	tstRightNoMD  = item{tRightDelimScNoMarkup, 0, ">}}"}
+	tstLeftMD     = item{tLeftDelimScWithMarkup, 0, "{{%"}
+	tstRightMD    = item{tRightDelimScWithMarkup, 0, "%}}"}
+	tstLeftReuse  = item{tLeftDelimScReuse, 0, "{{~"}
+	tstRightReuse = item{tRightDelimScReuse, 0, "~}}"}
+	tstSCClose    = item{tScClose, 0, "/"}
+	tstSC1        = item{tScName, 0, "sc1"}
+	tstSC2        = item{tScName, 0, "sc2"}
+	tstSC3        = item{tScName, 0, "sc3"}
+	tstParam1     = item{tScParam, 0, "param1"}
+	tstParam2     = item{tScParam, 0, "param2"}
+	tstVal        = item{tScParamVal, 0, "Hello World"}
 )
 
 var shortCodeLexerTests = []shortCodeLexerTest{
@@ -43,6 +45,9 @@ var shortCodeLexerTests = []shortCodeLexerTest{
 	{"spaces", " \t\n", []item{{tText, 0, " \t\n"}, tstEOF}},
 	{"text", `to be or not`, []item{{tText, 0, "to be or not"}, tstEOF}},
 	{"no markup", `{{< sc1 >}}`, []item{tstLeftNoMD, tstSC1, tstRightNoMD, tstEOF}},
+	{"reuse shortcode", `{{~ sc1 ~}}`, []item{tstLeftReuse, tstSC1, tstRightReuse, tstEOF}},
+	{"closed reuse shortcode", `{{~ sc1 ~}}text{{~ /sc1 ~}}`, []item{tstLeftReuse, tstSC1, tstRightReuse, {tText, 0, "text"},
+		tstLeftReuse, tstSCClose, tstSC1, tstRightReuse, tstEOF}},
 	{"with EOL", "{{< sc1 \n >}}", []item{tstLeftNoMD, tstSC1, tstRightNoMD, tstEOF}},
 
 	{"simple with markup", `{{% sc1 %}}`, []item{tstLeftMD, tstSC1, tstRightMD, tstEOF}},


### PR DESCRIPTION
Add a Reuse Page shortcode that allows tech writers to reuse same pages in different places without need in copy-pasting them every time.
It also adds a concept of Page snippets and dynamic links resolution.