### PR TITLE
helpers: specify asciidoctor extensions through asciidoctorRequires

### DIFF
--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -98,6 +98,8 @@ along with their current, default values:
 
     ---
     archetypeDir:               "archetypes"
+    # The below example will will use specified extensions when rendering content with asciidoctor
+    asciidoctorRequires = ["./extensions/custom-admonition-block.rb", "./extensions/copyright.rb"]
     # hostname (and path) to the root, e.g. http://spf13.com/
     baseURL:                    ""
     # include content marked as draft

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/hugo/config"
 	jww "github.com/spf13/jwalterweatherman"
 
+	"github.com/spf13/cast"
 	"strings"
 	"sync"
 )
@@ -544,20 +545,25 @@ func truncateWordsToWholeSentenceOld(content string, max int) (string, bool) {
 	return strings.Join(words[:max], " "), true
 }
 
-func getAsciidocExecPath() string {
+func getAsciidoctorExecPath() string {
 	path, err := exec.LookPath("asciidoctor")
 	if err != nil {
-		path, err = exec.LookPath("asciidoc")
-		if err != nil {
-			return ""
-		}
+		return ""
+	}
+	return path
+}
+
+func getAsciidocExecPath() string {
+	path, err := exec.LookPath("asciidoc")
+	if err != nil {
+		return ""
 	}
 	return path
 }
 
 // HasAsciidoc returns whether Asciidoctor or Asciidoc is installed on this computer.
 func HasAsciidoc() bool {
-	return getAsciidocExecPath() != ""
+	return getAsciidoctorExecPath() != "" || getAsciidocExecPath() != ""
 }
 
 // getAsciidocContent calls asciidoctor or asciidoc as an external helper
@@ -566,15 +572,31 @@ func getAsciidocContent(ctx *RenderingContext) []byte {
 	content := ctx.Content
 	cleanContent := bytes.Replace(content, SummaryDivider, []byte(""), 1)
 
-	path := getAsciidocExecPath()
+	path := getAsciidoctorExecPath()
+	hasAsciidoctor := true
 	if path == "" {
-		jww.ERROR.Println("asciidoctor / asciidoc not found in $PATH: Please install.\n",
-			"                 Leaving AsciiDoc content unrendered.")
-		return content
+		hasAsciidoctor = false
+		path = getAsciidocExecPath()
+		if path == "" {
+			jww.ERROR.Println("asciidoctor / asciidoc not found in $PATH: Please install.\n",
+				"                 Leaving AsciiDoc content unrendered.")
+			return content
+		}
 	}
 
 	jww.INFO.Println("Rendering", ctx.DocumentName, "with", path, "...")
-	cmd := exec.Command(path, "--no-header-footer", "--safe", "-")
+
+	args := []string{"--no-header-footer", "--safe"}
+	if hasAsciidoctor {
+		if ctx.Cfg.IsSet("asciidoctorRequires") {
+			for _, requirePath := range cast.ToStringSlice(ctx.Cfg.Get("asciidoctorRequires")) {
+				args = append(args, "--require", requirePath)
+			}
+		}
+	}
+	args = append(args, "-")
+
+	cmd := exec.Command(path, args...)
 	cmd.Stdin = bytes.NewReader(cleanContent)
 	var out, cmderr bytes.Buffer
 	cmd.Stdout = &out


### PR DESCRIPTION
Adds `asciidoctorRequires` configuration option to specify a list of extensions to pass to `asciidoctor` for rendering content.
Decided to name the option like so to match `asciidoctor` terminology.

Closes #3330