### PR TITLE
add option to render summary or full content in RSS feed

### DIFF
--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -174,6 +174,8 @@ along with their current, default values:
     pygmentsUseClasses:         false
     # maximum number of items in the RSS feed
     rssLimit:                   15
+    # if true RSS contains only article summaries
+    rssSummary:                 true
     # default sitemap configuration map
     sitemap:
     # filesystem path to read files relative from

--- a/docs/content/templates/rss.md
+++ b/docs/content/templates/rss.md
@@ -73,6 +73,12 @@ If the following values are specified in the site’s config file (`config.toml`
 By default, the RSS feed is limited to **15** items.
 You may override the default by using the `rssLimit` [site configuration variable](/overview/configuration/).
 
+### Choosing Content Format
+
+By default, the RSS feed contains only article summaries.
+You may override the default by using the `rssSummary` [site configuration variable](/overview/configuration/).
+
+
 ## The Embedded rss.xml
 This is the default RSS template that ships with Hugo. It adheres to the [RSS 2.0 Specification][RSS 2.0].
 
@@ -87,7 +93,9 @@ This is the default RSS template that ships with Hugo. It adheres to the [RSS 2.
         <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
         <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
         <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
-        <atom:link href="{{.Permalink}}" rel="self" type="application/rss+xml" />
+        {{ with .OutputFormats.Get "RSS" }}
+    	  {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+        {{ end }}
         {{ range .Data.Pages }}
         <item>
           <title>{{ .Title }}</title>
@@ -95,7 +103,7 @@ This is the default RSS template that ships with Hugo. It adheres to the [RSS 2.
           <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
           {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
           <guid>{{ .Permalink }}</guid>
-          <description>{{ .Content | html }}</description>
+          <description>{{ if .Site.RSSSummary }}{{ .Summary | html }}{{ else }}{{ .Content | html }}{{ end }}</description>
         </item>
         {{ end }}
       </channel>

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -102,6 +102,7 @@ func loadDefaultSettingsFor(v *viper.Viper) {
 	v.SetDefault("blackfriday", c.NewBlackfriday())
 	v.SetDefault("rSSUri", "index.xml")
 	v.SetDefault("rssLimit", -1)
+	v.SetDefault("rssSummary", true)
 	v.SetDefault("sectionPagesMenu", "")
 	v.SetDefault("disablePathToLower", false)
 	v.SetDefault("hasCJKLanguage", false)

--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -21,6 +21,19 @@ import (
 	"github.com/spf13/hugo/deps"
 )
 
+var lorem = `Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit
+amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
+et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+officia deserunt mollit anim id est laborum.`
+
 func TestRSSOutput(t *testing.T) {
 	t.Parallel()
 	var (
@@ -37,23 +50,32 @@ func TestRSSOutput(t *testing.T) {
 	cfg.Set("title", "RSSTest")
 	cfg.Set("rssLimit", rssLimit)
 
-	for _, src := range weightedSources {
-		writeSource(t, fs, filepath.Join("content", "sect", src.Name), string(src.Content))
-	}
+	for _, summary := range []bool{true, false} {
+		cfg.Set("rssSummary", summary)
 
-	buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{})
+		for _, src := range weightedSources {
+			writeSource(t, fs, filepath.Join("content", "sect", src.Name), string(src.Content)+lorem)
+		}
 
-	// Home RSS
-	th.assertFileContent(filepath.Join("public", rssURI), "<?xml", "rss version", "RSSTest")
-	// Section RSS
-	th.assertFileContent(filepath.Join("public", "sect", rssURI), "<?xml", "rss version", "Sects on RSSTest")
-	// Taxonomy RSS
-	th.assertFileContent(filepath.Join("public", "categories", "hugo", rssURI), "<?xml", "rss version", "Hugo on RSSTest")
+		buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{})
 
-	// RSS Item Limit
-	content := readDestination(t, fs, filepath.Join("public", rssURI))
-	c := strings.Count(content, "<item>")
-	if c != rssLimit {
-		t.Errorf("incorrect RSS item count: expected %d, got %d", rssLimit, c)
+		// Home RSS
+		th.assertFileContent(filepath.Join("public", rssURI), "<?xml", "rss version", "RSSTest")
+		// Section RSS
+		th.assertFileContent(filepath.Join("public", "sect", rssURI), "<?xml", "rss version", "Sects on RSSTest")
+		// Taxonomy RSS
+		th.assertFileContent(filepath.Join("public", "categories", "hugo", rssURI), "<?xml", "rss version", "Hugo on RSSTest")
+
+		// RSS Item Limit
+		content := readDestination(t, fs, filepath.Join("public", rssURI))
+		c := strings.Count(content, "<item>")
+		if c != rssLimit {
+			t.Errorf("incorrect RSS item count: expected %d, got %d", rssLimit, c)
+		}
+
+		full := strings.Count(content, lorem)
+		if (full == rssLimit) == summary {
+			t.Errorf("incorrect RSS item contents: expected summary: %t, got %t", summary, full != rssLimit)
+		}
 	}
 }

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -312,6 +312,7 @@ type SiteInfo struct {
 	relativeURLs          bool
 	uglyURLs              bool
 	preserveTaxonomyNames bool
+	RSSSummary            bool
 	Data                  *map[string]interface{}
 
 	owner                          *HugoSites
@@ -1076,6 +1077,7 @@ func (s *Site) initializeSiteInfo() {
 		canonifyURLs:                   s.Cfg.GetBool("canonifyURLs"),
 		relativeURLs:                   s.Cfg.GetBool("relativeURLs"),
 		uglyURLs:                       s.Cfg.GetBool("uglyURLs"),
+		RSSSummary:                     s.Cfg.GetBool("rssSummary"),
 		preserveTaxonomyNames:          lang.GetBool("preserveTaxonomyNames"),
 		PageCollections:                s.PageCollections,
 		Files:                          &s.Files,

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -81,7 +81,7 @@ func (t *templateHandler) embedTemplates() {
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | html }}</description>
+      <description>{{ if .Site.RSSSummary }}{{ .Summary | html }}{{ else }}{{ .Content | html }}{{ end }}</description>
     </item>
     {{ end }}
   </channel>


### PR DESCRIPTION
Added option to generate full feed or only summaries.

RSS feed generation changed in 0.20. Some prefer new behavior, some prefer old (at least me and there is also #3341 I just noticed), thus an option. It is set to `true` by default to honor current (new) behavior.

I believe a custom template is too complex for this task, because this is probably the only thing I'd like to change and maintaining yet another template will require much more attention. And there is already `rssLimit` option, so why not? 😃 