### PR TITLE
Allow "after" to skip all elements

### DIFF
--- a/tpl/tplimpl/template_funcs.go
+++ b/tpl/tplimpl/template_funcs.go
@@ -634,7 +634,7 @@ func after(index interface{}, seq interface{}) (interface{}, error) {
 	default:
 		return nil, errors.New("can't iterate over " + reflect.ValueOf(seq).Type().String())
 	}
-	if indexv >= seqv.Len() {
+	if indexv > seqv.Len() {
 		return nil, errors.New("no items left")
 	}
 	return seqv.Slice(indexv, seqv.Len()).Interface(), nil


### PR DESCRIPTION
Previously if after would skip all elements, it would return an error.  However, there's nothing wrong with skipping all elements and returning an empty list.