### PR TITLE
docs: Added build command to manual install

### DIFF
--- a/docs/content/overview/installing.md
+++ b/docs/content/overview/installing.md
@@ -117,9 +117,11 @@ You **must use govendor** to fetch Hugo's dependencies.
 
     go get github.com/kardianos/govendor
     govendor get github.com/spf13/hugo
+    go build github.com/spf13/hugo
 
 `govendor get` will fetch Hugo and all its dependent libraries to
-`$HOME/go/src/github.com/spf13/hugo`, and compile everything into a final `hugo`
+`$HOME/go/src/github.com/spf13/hugo`.
+ `go build github.com/spf13/hugo` will compile everything into a final `hugo`
 (or `hugo.exe`) executable, which you will find sitting inside
 `$HOME/go/bin/`, all ready to go!
 


### PR DESCRIPTION
During the installation I found that govendor does not compile the package by itself. 
Running `go build github.com/spf13/hugo` fixed that.