### PR TITLE
doc: RSS uses .Summary instead of .Content since 0.20.

### DIFF
--- a/docs/content/templates/rss.md
+++ b/docs/content/templates/rss.md
@@ -95,7 +95,7 @@ This is the default RSS template that ships with Hugo. It adheres to the [RSS 2.
           <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
           {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
           <guid>{{ .Permalink }}</guid>
-          <description>{{ .Content | html }}</description>
+          <description>{{ .Summary | html }}</description>
         </item>
         {{ end }}
       </channel>


### PR DESCRIPTION
Release notes for 0.20 say:

> `RSS` description in the built-in template is changed from full `.Content` to `.Summary`. This is a somewhat breaking change, but is what most people expect from their RSS feeds. If you want full content, please provide your own RSS template.

However, docs had not been updated. This fixes that.

I noticed one other difference on the template:

    <atom:link href="{{.Permalink}}" rel="self" type="application/rss+xml" />

instead of

     {{ with .OutputFormats.Get "RSS" }}
        {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
    {{ end }}
