### PR TITLE
helpers: add --initial-header-level=2 to rst2html

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -637,7 +637,7 @@ func getRstContent(ctx *RenderingContext) []byte {
 	}
 
 	jww.INFO.Println("Rendering", ctx.DocumentName, "with", path, "...")
-	cmd := exec.Command(python, path, "--leave-comments")
+	cmd := exec.Command(python, path, "--leave-comments", "--initial-header-level=2")
 	cmd.Stdin = bytes.NewReader(cleanContent)
 	var out, cmderr bytes.Buffer
 	cmd.Stdout = &out


### PR DESCRIPTION
reStructuredText doesn't have explicit section levels but sets them in
the order of appearance. Since level 1 is already set from the title in
the front matter it makes more sense to start with level 2 when
converting with rst2html.