### PR TITLE
Added support for multiple config files via --config a.toml,b.toml,c.toml

### DIFF
--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/viper"
 	"io"
-	"os"
 	"strings"
 )
 
@@ -52,7 +51,7 @@ func LoadConfig(fs afero.Fs, relativeSourcePath, configFilename string) (*viper.
 	for _, configFile := range configFilenames[1:] {
 		var r io.Reader
 		var err error
-		if r, err = os.Open(configFile); err != nil {
+		if r, err = fs.Open(configFile); err != nil {
 			return nil, fmt.Errorf("Unable to open Config file.\n (%s)\n", err)
 		}
 		if err = v.MergeConfig(r); err != nil {

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -19,6 +19,9 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/viper"
+	"io"
+	"os"
+	"strings"
 )
 
 // LoadConfig loads Hugo configuration into a new Viper and then adds
@@ -29,10 +32,10 @@ func LoadConfig(fs afero.Fs, relativeSourcePath, configFilename string) (*viper.
 	if relativeSourcePath == "" {
 		relativeSourcePath = "."
 	}
-
+	configFilenames := strings.Split(configFilename, ",")
 	v.AutomaticEnv()
 	v.SetEnvPrefix("hugo")
-	v.SetConfigFile(configFilename)
+	v.SetConfigFile(configFilenames[0])
 	// See https://github.com/spf13/viper/issues/73#issuecomment-126970794
 	if relativeSourcePath == "" {
 		v.AddConfigPath(".")
@@ -45,6 +48,16 @@ func LoadConfig(fs afero.Fs, relativeSourcePath, configFilename string) (*viper.
 			return nil, err
 		}
 		return nil, fmt.Errorf("Unable to locate Config file. Perhaps you need to create a new site.\n       Run `hugo help new` for details. (%s)\n", err)
+	}
+	for _, configFile := range configFilenames[1:] {
+		var r io.Reader
+		var err error
+		if r, err = os.Open(configFile); err != nil {
+			return nil, fmt.Errorf("Unable to open Config file.\n (%s)\n", err)
+		}
+		if err = v.MergeConfig(r); err != nil {
+			return nil, fmt.Errorf("Unable to parse/merge Config file (%s).\n (%s)\n", configFile, err)
+		}
 	}
 
 	v.RegisterAlias("indexes", "taxonomies")

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -41,3 +41,27 @@ func TestLoadConfig(t *testing.T) {
 	// default
 	assert.Equal(t, "layouts", cfg.GetString("layoutDir"))
 }
+func TestLoadMultiConfig(t *testing.T) {
+	t.Parallel()
+
+	// Add a random config variable for testing.
+	// side = page in Norwegian.
+	configContentBase := `
+	DontChange = "same"
+	PaginatePath = "side"
+	`
+	configContentSub := `
+	PaginatePath = "top"
+	`
+	mm := afero.NewMemMapFs()
+
+	writeToFs(t, mm, "base.toml", configContentBase)
+
+	writeToFs(t, mm, "override.toml", configContentSub)
+
+	cfg, err := LoadConfig(mm, "", "base.toml,override.toml")
+	require.NoError(t, err)
+
+	assert.Equal(t, "top", cfg.GetString("paginatePath"))
+	assert.Equal(t, "same", cfg.GetString("DontChange"))
+}


### PR DESCRIPTION
Our team needs multiple configs for the same doc site to support different delivery channels.
We'd like to have a base config.toml and one or more child config.tomls overriding properties in the config.

I didn't see support for repeating command-line options in Cobra.  
I've added the ability pass multiple config files via `--config` as a comma delimited string.
For example: `hugo --config=base.toml,child1.toml,child2.toml`
Use viper's MergeConfig() to merge changes.