### PR TITLE
WIP: hugolib: Simplify shortcode mechanisms

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -606,19 +606,19 @@ func (h *HugoSites) Pages() Pages {
 }
 
 func handleShortcodes(p *Page, rawContentCopy []byte) ([]byte, error) {
-	if p.shortcodeState != nil && len(p.shortcodeState.contentShortcodes) > 0 {
-		p.s.Log.DEBUG.Printf("Replace %d shortcodes in %q", len(p.shortcodeState.contentShortcodes), p.BaseFileName())
-		err := p.shortcodeState.executeShortcodesForDelta(p)
+	if p.shortcodeState == nil || len(p.shortcodeState.contentShortcodes) == 0 {
+		return rawContentCopy, nil
+	}
 
-		if err != nil {
-			return rawContentCopy, err
-		}
+	p.s.Log.DEBUG.Printf("Replace %d shortcodes in %q", len(p.shortcodeState.contentShortcodes), p.BaseFileName())
+	err := p.shortcodeState.executeShortcodesForDelta(p)
+	if err != nil {
+		return rawContentCopy, err
+	}
 
-		rawContentCopy, err = replaceShortcodeTokens(rawContentCopy, shortcodePlaceholderPrefix, p.shortcodeState.renderedShortcodes)
-
-		if err != nil {
-			p.s.Log.FATAL.Printf("Failed to replace shortcode tokens in %s:\n%s", p.BaseFileName(), err.Error())
-		}
+	rawContentCopy, err = replaceShortcodeTokens(rawContentCopy, p.shortcodeState.renderedShortcodes)
+	if err != nil {
+		p.s.Log.FATAL.Printf("Failed to replace shortcode tokens in %s:\n%s", p.BaseFileName(), err.Error())
 	}
 
 	return rawContentCopy, nil

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1381,15 +1381,10 @@ func (p *Page) SaveSource() error {
 }
 
 func (p *Page) processShortcodes() error {
+	var err error
 	p.shortcodeState = newShortcodeHandler(p)
-	tmpContent, err := p.shortcodeState.extractShortcodes(string(p.workContent), p)
-	if err != nil {
-		return err
-	}
-	p.workContent = []byte(tmpContent)
-
-	return nil
-
+	p.workContent, err = p.shortcodeState.extractShortcodes(p.workContent, p)
+	return err
 }
 
 func (p *Page) FullFilePath() string {

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -73,46 +73,47 @@ func (scp *ShortcodeWithPage) Get(key interface{}) interface{} {
 	if scp.Params == nil {
 		return nil
 	}
-	if reflect.ValueOf(scp.Params).Len() == 0 {
+	paramsValue := reflect.ValueOf(scp.Params)
+	if paramsValue.Len() == 0 {
 		return nil
 	}
+	paramsType := reflect.TypeOf(scp.Params)
 
-	var x reflect.Value
-
+	var result reflect.Value
 	switch key.(type) {
 	case int64, int32, int16, int8, int:
-		if reflect.TypeOf(scp.Params).Kind() == reflect.Map {
+		if paramsType.Kind() == reflect.Map {
 			return "error: cannot access named params by position"
-		} else if reflect.TypeOf(scp.Params).Kind() == reflect.Slice {
+		} else if paramsType.Kind() == reflect.Slice {
 			idx := int(reflect.ValueOf(key).Int())
-			ln := reflect.ValueOf(scp.Params).Len()
+			ln := paramsValue.Len()
 			if idx > ln-1 {
 				helpers.DistinctErrorLog.Printf("No shortcode param at .Get %d in page %s, have params: %v", idx, scp.Page.FullFilePath(), scp.Params)
 				return fmt.Sprintf("error: index out of range for positional param at position %d", idx)
 			}
-			x = reflect.ValueOf(scp.Params).Index(idx)
+			result = paramsValue.Index(idx)
 		}
 	case string:
-		if reflect.TypeOf(scp.Params).Kind() == reflect.Map {
-			x = reflect.ValueOf(scp.Params).MapIndex(reflect.ValueOf(key))
-			if !x.IsValid() {
+		if paramsType.Kind() == reflect.Map {
+			result = paramsValue.MapIndex(reflect.ValueOf(key))
+			if !result.IsValid() {
 				return ""
 			}
-		} else if reflect.TypeOf(scp.Params).Kind() == reflect.Slice {
-			if reflect.ValueOf(scp.Params).Len() == 1 && reflect.ValueOf(scp.Params).Index(0).String() == "" {
+		} else if paramsType.Kind() == reflect.Slice {
+			if paramsValue.Len() == 1 && paramsValue.Index(0).String() == "" {
 				return nil
 			}
 			return "error: cannot access positional params by string name"
 		}
 	}
 
-	switch x.Kind() {
+	switch result.Kind() {
 	case reflect.String:
-		return x.String()
+		return result.String()
 	case reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8, reflect.Int:
-		return x.Int()
+		return result.Int()
 	default:
-		return x
+		return result
 	}
 
 }

--- a/hugolib/shortcodeparser.go
+++ b/hugolib/shortcodeparser.go
@@ -141,7 +141,6 @@ const eof = -1
 type stateFunc func(*pagelexer) stateFunc
 
 type pagelexer struct {
-	name    string
 	input   string
 	state   stateFunc
 	pos     pos // input position
@@ -164,9 +163,8 @@ type pagelexer struct {
 
 // note: the input position here is normally 0 (start), but
 // can be set if position of first shortcode is known
-func newShortcodeLexer(name, input string, inputPosition pos) *pagelexer {
+func newShortcodeLexer(input string, inputPosition pos) *pagelexer {
 	lexer := &pagelexer{
-		name:               name,
 		input:              input,
 		currLeftDelimItem:  tLeftDelimScNoMarkup,
 		currRightDelimItem: tRightDelimScNoMarkup,

--- a/hugolib/shortcodeparser_test.go
+++ b/hugolib/shortcodeparser_test.go
@@ -174,7 +174,7 @@ func BenchmarkShortcodeLexer(b *testing.B) {
 }
 
 func collect(t *shortCodeLexerTest) (items []item) {
-	l := newShortcodeLexer(t.name, t.input, 0)
+	l := newShortcodeLexer(t.input, 0)
 	for {
 		item := l.nextItem()
 		items = append(items, item)


### PR DESCRIPTION
Shortcodes can't leave me alone.

This change decreases some `[]byte`<->`string` convertions in [hugolib/page.go](https://github.com/spf13/hugo/pull/3550/files#diff-204b5518c5299155dd3b72a4299751f9), especially when there are no shortcodes in page:
```
name                                                                                                          old time/op    new time/op    delta
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10,tags_per_page=5,shortcodes=0,render=true-4       7.09ms ± 1%    7.15ms ± 4%    ~     (p=0.780 n=9+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10,tags_per_page=5,shortcodes=1,render=true-4       7.48ms ± 2%    7.55ms ± 2%    ~     (p=0.190 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=100,tags_per_page=5,shortcodes=0,render=true-4      44.7ms ± 2%    44.8ms ± 2%    ~     (p=0.573 n=10+8)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=100,tags_per_page=5,shortcodes=1,render=true-4      47.7ms ± 3%    50.3ms ±18%    ~     (p=0.182 n=10+9)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=500,tags_per_page=5,shortcodes=0,render=true-4       188ms ± 2%     188ms ± 3%    ~     (p=0.549 n=9+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=500,tags_per_page=5,shortcodes=1,render=true-4       203ms ± 3%     201ms ± 5%    ~     (p=0.165 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=1000,tags_per_page=5,shortcodes=0,render=true-4      362ms ± 5%     349ms ± 3%  -3.77%  (p=0.002 n=10+9)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=1000,tags_per_page=5,shortcodes=1,render=true-4      385ms ± 4%     385ms ± 7%    ~     (p=0.579 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=5000,tags_per_page=5,shortcodes=0,render=true-4      1.67s ± 5%     1.67s ± 2%    ~     (p=0.579 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=5000,tags_per_page=5,shortcodes=1,render=true-4      1.79s ± 2%     1.83s ± 2%  +1.85%  (p=0.003 n=10+9)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10000,tags_per_page=5,shortcodes=0,render=true-4     3.38s ± 2%     3.37s ± 3%    ~     (p=0.720 n=9+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10000,tags_per_page=5,shortcodes=1,render=true-4     3.73s ± 5%     3.63s ± 3%  -2.74%  (p=0.009 n=10+10)

name                                                                                                          old alloc/op   new alloc/op   delta
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10,tags_per_page=5,shortcodes=0,render=true-4       1.83MB ± 1%    1.80MB ± 0%  -1.27%  (p=0.000 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10,tags_per_page=5,shortcodes=1,render=true-4       1.91MB ± 0%    1.92MB ± 0%  +0.81%  (p=0.000 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=100,tags_per_page=5,shortcodes=0,render=true-4      15.0MB ± 1%    14.8MB ± 2%  -1.33%  (p=0.001 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=100,tags_per_page=5,shortcodes=1,render=true-4      15.9MB ± 2%    16.1MB ± 2%    ~     (p=0.063 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=500,tags_per_page=5,shortcodes=0,render=true-4      76.0MB ± 2%    74.3MB ± 2%  -2.26%  (p=0.000 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=500,tags_per_page=5,shortcodes=1,render=true-4      79.0MB ± 1%    80.1MB ± 2%  +1.41%  (p=0.003 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=1000,tags_per_page=5,shortcodes=0,render=true-4      153MB ± 3%     149MB ± 2%  -2.62%  (p=0.001 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=1000,tags_per_page=5,shortcodes=1,render=true-4      159MB ± 4%     161MB ± 4%    ~     (p=0.143 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=5000,tags_per_page=5,shortcodes=0,render=true-4      759MB ± 3%     747MB ± 3%    ~     (p=0.052 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=5000,tags_per_page=5,shortcodes=1,render=true-4      796MB ± 1%     817MB ± 3%  +2.72%  (p=0.001 n=9+9)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10000,tags_per_page=5,shortcodes=0,render=true-4    1.57GB ± 3%    1.55GB ± 2%    ~     (p=0.143 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10000,tags_per_page=5,shortcodes=1,render=true-4    1.64GB ± 3%    1.61GB ± 2%  -2.09%  (p=0.005 n=10+10)

name                                                                                                          old allocs/op  new allocs/op  delta
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10,tags_per_page=5,shortcodes=0,render=true-4        27.4k ± 0%     27.3k ± 0%    ~     (p=0.324 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10,tags_per_page=5,shortcodes=1,render=true-4        28.2k ± 0%     28.2k ± 0%    ~     (p=0.926 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=100,tags_per_page=5,shortcodes=0,render=true-4        174k ± 0%      173k ± 0%  -0.12%  (p=0.003 n=9+9)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=100,tags_per_page=5,shortcodes=1,render=true-4        182k ± 1%      182k ± 1%    ~     (p=1.000 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=500,tags_per_page=5,shortcodes=0,render=true-4        827k ± 0%      824k ± 0%  -0.32%  (p=0.019 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=500,tags_per_page=5,shortcodes=1,render=true-4        867k ± 1%      867k ± 1%    ~     (p=0.971 n=10+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=1000,tags_per_page=5,shortcodes=0,render=true-4      1.64M ± 0%     1.64M ± 0%  -0.21%  (p=0.000 n=10+8)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=1000,tags_per_page=5,shortcodes=1,render=true-4      1.72M ± 0%     1.73M ± 1%    ~     (p=0.101 n=8+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=5000,tags_per_page=5,shortcodes=0,render=true-4      8.16M ± 0%     8.16M ± 1%    ~     (p=0.360 n=8+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=5000,tags_per_page=5,shortcodes=1,render=true-4      8.58M ± 1%     8.56M ± 0%  -0.28%  (p=0.022 n=10+9)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10000,tags_per_page=5,shortcodes=0,render=true-4     16.3M ± 0%     16.3M ± 1%    ~     (p=0.278 n=9+10)
SiteBuilding/frontmatter=TOML,num_root_sections=5,num_pages=10000,tags_per_page=5,shortcodes=1,render=true-4     17.2M ± 0%     17.2M ± 1%    ~     (p=0.905 n=9+10)
```
One test is failing yet, but I will fix it after @bep said, if this PR convinces him.