### PR TITLE
TESTING: Test experimental patch for fast YAML tags

### DIFF
--- a/parser/frontmatter.go
+++ b/parser/frontmatter.go
@@ -198,7 +198,26 @@ func removeTOMLIdentifier(datum []byte) []byte {
 // representing the encoded data structure.
 func HandleYAMLMetaData(datum []byte) (interface{}, error) {
 	m := map[string]interface{}{}
+
+	tagsIdx := bytes.Index(datum, []byte("tags"))
+	var tags []string
+	if tagsIdx != -1 {
+		eol := bytes.Index(datum[tagsIdx:], []byte("\n"))
+
+		if eol != -1 {
+			tagsLine := datum[tagsIdx : tagsIdx+eol]
+			startBracket := bytes.Index(tagsLine, []byte("["))
+			if startBracket != -1 {
+				endBracket := bytes.LastIndex(tagsLine, []byte("]"))
+				tags = strings.Split(string(tagsLine[startBracket+1:endBracket]), ",")
+				datum = append(datum[:tagsIdx], datum[tagsIdx+eol:]...)
+			}
+		}
+	}
 	err := yaml.Unmarshal(datum, &m)
+	if len(tags) > 0 {
+		m["tags"] = tags
+	}
 	return m, err
 }
 

--- a/parser/frontmatter_test.go
+++ b/parser/frontmatter_test.go
@@ -322,8 +322,8 @@ func TestRemoveTOMLIdentifier(t *testing.T) {
 
 func BenchmarkFrontmatterTags(b *testing.B) {
 
-	for _, frontmatter := range []string{"JSON", "YAML", "TOML"} {
-		for i := 1; i < 30; i += 10 {
+	for _, frontmatter := range []string{"JSON", "YAML", "YAML2", "TOML"} {
+		for i := 1; i < 60; i += 20 {
 			doBenchmarkFrontmatter(b, frontmatter, i)
 		}
 	}
@@ -334,6 +334,12 @@ func doBenchmarkFrontmatter(b *testing.B, fileformat string, numTags int) {
 name: "Tags"
 tags:
 %s
+---
+`
+
+	yaml2Template := `---
+name: "Tags"
+tags: %s
 ---
 `
 	tomlTemplate := `+++
@@ -363,6 +369,9 @@ tags = %s
 			tagsStr = strings.Replace(fmt.Sprintf("%q", tags), " ", ", ", -1)
 		} else if fileformat == "JSON" {
 			frontmatterTemplate = jsonTemplate
+			tagsStr = strings.Replace(fmt.Sprintf("%q", tags), " ", ", ", -1)
+		} else if fileformat == "YAML2" {
+			frontmatterTemplate = yaml2Template
 			tagsStr = strings.Replace(fmt.Sprintf("%q", tags), " ", ", ", -1)
 		} else {
 			frontmatterTemplate = yamlTemplate


### PR DESCRIPTION
This is quick and dirty and hardcoded for the tags taxonomy.

```
benchmark                               old ns/op     new ns/op     delta
BenchmarkFrontmatterTags/YAML:1-4       9578          9720          +1.48%
BenchmarkFrontmatterTags/YAML:21-4      33058         33498         +1.33%
BenchmarkFrontmatterTags/YAML:41-4      55317         56242         +1.67%
BenchmarkFrontmatterTags/YAML2:1-4      9430          6427          -31.85%
BenchmarkFrontmatterTags/YAML2:21-4     30950         7425          -76.01%
BenchmarkFrontmatterTags/YAML2:41-4     52169         8637          -83.44%

benchmark                               old allocs     new allocs     delta
BenchmarkFrontmatterTags/YAML:1-4       66             66             +0.00%
BenchmarkFrontmatterTags/YAML:21-4      211            211            +0.00%
BenchmarkFrontmatterTags/YAML:41-4      352            352            +0.00%
BenchmarkFrontmatterTags/YAML2:1-4      67             44             -34.33%
BenchmarkFrontmatterTags/YAML2:21-4     192            44             -77.08%
BenchmarkFrontmatterTags/YAML2:41-4     313            44             -85.94%

benchmark                               old bytes     new bytes     delta
BenchmarkFrontmatterTags/YAML:1-4       5928          5928          +0.00%
BenchmarkFrontmatterTags/YAML:21-4      10920         10920         +0.00%
BenchmarkFrontmatterTags/YAML:41-4      15944         15944         +0.00%
BenchmarkFrontmatterTags/YAML2:1-4      6040          5224          -13.51%
BenchmarkFrontmatterTags/YAML2:21-4     10880         5224          -51.99%
BenchmarkFrontmatterTags/YAML2:41-4     15744         5224          -66.82%
```