### PR TITLE
hugolib/site_render.go: Warn when missing layout files for content pages

### DIFF
--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -101,7 +101,6 @@ func loadDefaultSettingsFor(v *viper.Viper) {
 	v.SetDefault("canonifyURLs", false)
 	v.SetDefault("relativeURLs", false)
 	v.SetDefault("removePathAccents", false)
-	v.SetDefault("taxonomies", map[string]string{"tag": "tags", "category": "categories"})
 	v.SetDefault("permalinks", make(PermalinkOverrides, 0))
 	v.SetDefault("sitemap", Sitemap{Priority: -1, Filename: "sitemap.xml"})
 	v.SetDefault("pygmentsStyle", "monokai")


### PR DESCRIPTION
This is very much a work-in-progress, debugging printfs and all. I thought discussing code would be easier done here than on the Discourse instance. That said…

One of the things I've noticed is that I'll screw something up and [not be able to figure out what I did wrong](https://discuss.gohugo.io/t/adding-warnings-when-layoutless-content-exists/7000). I'd like this patch to tell the user, in the output of `hugo serve -w`, that content exists for which there is no layout. 

Since [the docs say `/tags/` and `/categories/` aren't built by default anymore](https://hugodocs.info/content-management/taxonomies/#hugo-taxonomy-defaults), I removed the line that adds them to the list of default taxonomies. That seems like the proper way.

With the current debugging printfs enabled, I get reasonable warning messages like the following:

    Started building sites ...
    No layout for "/about/" found in the usual places.
    Found a layout for "/"
    Found a layout for "/"
    Built site for language en:
    0 draft content
    0 future content
    0 expired content
    1 regular pages created
    2 other pages created
    0 non-page files copied
    0 paginator pages created
    total in 1 ms

The "Found a layout for…" messages aren't useful except for me debugging this patch, but what do you think of the changes I've made to get the "No layout for…" messages in the user-visible output?