### PR TITLE
commands, create: Add .Site to the archetype templates

### DIFF
--- a/create/content_test.go
+++ b/create/content_test.go
@@ -52,13 +52,17 @@ func TestNewContent(t *testing.T) {
 
 	for _, c := range cases {
 		cfg, fs := newTestCfg()
+		ps, err := helpers.NewPathSpec(fs, cfg)
+		require.NoError(t, err)
 		h, err := hugolib.NewHugoSites(deps.DepsCfg{Cfg: cfg, Fs: fs})
 		require.NoError(t, err)
 		require.NoError(t, initFs(fs))
 
-		s := h.Sites[0]
+		siteFactory := func(filename string, siteUsed bool) (*hugolib.Site, error) {
+			return h.Sites[0], nil
+		}
 
-		require.NoError(t, create.NewContent(s, c.kind, c.path))
+		require.NoError(t, create.NewContent(ps, siteFactory, c.kind, c.path))
 
 		fname := filepath.Join("content", filepath.FromSlash(c.path))
 		content := readFileFromFs(t, fs.Source, fname)

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -215,7 +215,7 @@ func (p *PathSpec) getThemeDirPath(path string) (string, error) {
 	}
 
 	themeDir := filepath.Join(p.GetThemeDir(), path)
-	if _, err := p.fs.Source.Stat(themeDir); os.IsNotExist(err) {
+	if _, err := p.Fs.Source.Stat(themeDir); os.IsNotExist(err) {
 		return "", fmt.Errorf("Unable to find %s directory for theme %s in %s", path, p.theme, themeDir)
 	}
 

--- a/helpers/pathspec.go
+++ b/helpers/pathspec.go
@@ -52,7 +52,10 @@ type PathSpec struct {
 	multilingual                   bool
 
 	// The file systems to use
-	fs *hugofs.Fs
+	Fs *hugofs.Fs
+
+	// The config provider to use
+	Cfg config.Provider
 }
 
 func (p PathSpec) String() string {
@@ -70,7 +73,8 @@ func NewPathSpec(fs *hugofs.Fs, cfg config.Provider) (*PathSpec, error) {
 	}
 
 	ps := &PathSpec{
-		fs:                             fs,
+		Fs:                             fs,
+		Cfg:                            cfg,
 		disablePathToLower:             cfg.GetBool("disablePathToLower"),
 		removePathAccents:              cfg.GetBool("removePathAccents"),
 		uglyURLs:                       cfg.GetBool("uglyURLs"),


### PR DESCRIPTION
This commit completes the "The Revival of the Archetypes!"

If `.Site` is used in the arcetype template, the site is built and added to the template context.

Note that this may be potentially time consuming for big sites.

A more complete example would then be for the section `newsletter` and the archetype file `archetypes/newsletter.md`:

```
---
title: "{{ replace .TranslationBaseName "-" " " | title }}"
date: {{ .Date }}
tags:
- x
categories:
- x
draft: true
---

<!--more-->

{{ range first 10 ( where .Site.RegularPages "Type" "cool" ) }}
* {{ .Title }}
{{ end }}
```

And then create a new post with:

```bash
hugo new newsletter/the-latest-cool.stuff.md
```

**Hot Tip:** If you set the `newContentEditor` configuration variable to an editor on your `PATH`, the newly created article will be opened.

The above _newsletter type archetype_ illustrates the possibilities: The full Hugo `.Site` and all of Hugo's template funcs can be used in the archetype file.

Fixes #1629