### PR TITLE
media, hugolib: Support extension-less media types

### DIFF
--- a/hugolib/page_paths.go
+++ b/hugolib/page_paths.go
@@ -164,7 +164,7 @@ func createTargetPath(d targetPathDescriptor) string {
 		if d.URL != "" {
 			pagePath = filepath.Join(pagePath, d.URL)
 			if strings.HasSuffix(d.URL, "/") || !strings.Contains(d.URL, ".") {
-				pagePath = filepath.Join(pagePath, d.Type.BaseName+"."+d.Type.MediaType.Suffix)
+				pagePath = filepath.Join(pagePath, d.Type.BaseName+d.Type.MediaType.FullSuffix())
 			}
 		} else {
 			if d.ExpandedPermalink != "" {
@@ -184,9 +184,9 @@ func createTargetPath(d targetPathDescriptor) string {
 			}
 
 			if isUgly {
-				pagePath += "." + d.Type.MediaType.Suffix
+				pagePath += d.Type.MediaType.Delimiter + d.Type.MediaType.Suffix
 			} else {
-				pagePath = filepath.Join(pagePath, d.Type.BaseName+"."+d.Type.MediaType.Suffix)
+				pagePath = filepath.Join(pagePath, d.Type.BaseName+d.Type.MediaType.FullSuffix())
 			}
 
 			if d.LangPrefix != "" {
@@ -207,7 +207,7 @@ func createTargetPath(d targetPathDescriptor) string {
 			base = helpers.FilePathSeparator + d.Type.BaseName
 		}
 
-		pagePath += base + "." + d.Type.MediaType.Suffix
+		pagePath += base + d.Type.MediaType.FullSuffix()
 
 		if d.LangPrefix != "" {
 			pagePath = filepath.Join(d.LangPrefix, pagePath)

--- a/hugolib/page_paths_test.go
+++ b/hugolib/page_paths_test.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gohugoio/hugo/media"
+
 	"fmt"
 
 	"github.com/gohugoio/hugo/output"
@@ -26,6 +28,17 @@ import (
 func TestPageTargetPath(t *testing.T) {
 
 	pathSpec := newTestDefaultPathSpec()
+
+	noExtNoDelimMediaType := media.TextType
+	noExtNoDelimMediaType.Suffix = ""
+	noExtNoDelimMediaType.Delimiter = ""
+
+	// Netlify style _redirects
+	noExtDelimFormat := output.Format{
+		Name:      "NER",
+		MediaType: noExtNoDelimMediaType,
+		BaseName:  "_redirects",
+	}
 
 	for _, langPrefix := range []string{"", "no"} {
 		for _, uglyURLs := range []bool{false, true} {
@@ -40,6 +53,7 @@ func TestPageTargetPath(t *testing.T) {
 						{"JSON home", targetPathDescriptor{Kind: KindHome, Type: output.JSONFormat}, "/index.json"},
 						{"AMP home", targetPathDescriptor{Kind: KindHome, Type: output.AMPFormat}, "/amp/index.html"},
 						{"HTML home", targetPathDescriptor{Kind: KindHome, BaseName: "_index", Type: output.HTMLFormat}, "/index.html"},
+						{"Netlify redirects", targetPathDescriptor{Kind: KindHome, BaseName: "_index", Type: noExtDelimFormat}, "/_redirects"},
 						{"HTML section list", targetPathDescriptor{
 							Kind:     KindSection,
 							Sections: []string{"sect1"},

--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -22,6 +22,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+const (
+	defaultDelimiter = "."
+)
+
 // A media type (also known as MIME type and content type) is a two-part identifier for
 // file formats and format contents transmitted on the Internet.
 // For Hugo's use case, we use the top-level type name / subtype name + suffix.
@@ -29,9 +33,10 @@ import (
 // If suffix is not provided, the sub type will be used.
 // See // https://en.wikipedia.org/wiki/Media_type
 type Type struct {
-	MainType string // i.e. text
-	SubType  string // i.e. html
-	Suffix   string // i.e html
+	MainType  string // i.e. text
+	SubType   string // i.e. html
+	Suffix    string // i.e html
+	Delimiter string // defaults to "."
 }
 
 // FromTypeString creates a new Type given a type sring on the form MainType/SubType and
@@ -54,7 +59,7 @@ func FromString(t string) (Type, error) {
 		suffix = subParts[1]
 	}
 
-	return Type{MainType: mainType, SubType: subType, Suffix: suffix}, nil
+	return Type{MainType: mainType, SubType: subType, Suffix: suffix, Delimiter: defaultDelimiter}, nil
 }
 
 // Type returns a string representing the main- and sub-type of a media type, i.e. "text/css".
@@ -72,16 +77,21 @@ func (m Type) String() string {
 	return fmt.Sprintf("%s/%s", m.MainType, m.SubType)
 }
 
+// FullSuffix returns the file suffix with any delimiter prepended.
+func (m Type) FullSuffix() string {
+	return m.Delimiter + m.Suffix
+}
+
 var (
-	CalendarType   = Type{"text", "calendar", "ics"}
-	CSSType        = Type{"text", "css", "css"}
-	CSVType        = Type{"text", "csv", "csv"}
-	HTMLType       = Type{"text", "html", "html"}
-	JavascriptType = Type{"application", "javascript", "js"}
-	JSONType       = Type{"application", "json", "json"}
-	RSSType        = Type{"application", "rss", "xml"}
-	XMLType        = Type{"application", "xml", "xml"}
-	TextType       = Type{"text", "plain", "txt"}
+	CalendarType   = Type{"text", "calendar", "ics", defaultDelimiter}
+	CSSType        = Type{"text", "css", "css", defaultDelimiter}
+	CSVType        = Type{"text", "csv", "csv", defaultDelimiter}
+	HTMLType       = Type{"text", "html", "html", defaultDelimiter}
+	JavascriptType = Type{"application", "javascript", "js", defaultDelimiter}
+	JSONType       = Type{"application", "json", "json", defaultDelimiter}
+	RSSType        = Type{"application", "rss", "xml", defaultDelimiter}
+	XMLType        = Type{"application", "xml", "xml", defaultDelimiter}
+	TextType       = Type{"text", "plain", "txt", defaultDelimiter}
 )
 
 var DefaultTypes = Types{

--- a/media/mediaType_test.go
+++ b/media/mediaType_test.go
@@ -40,6 +40,7 @@ func TestDefaultTypes(t *testing.T) {
 		require.Equal(t, test.expectedMainType, test.tp.MainType)
 		require.Equal(t, test.expectedSubType, test.tp.SubType)
 		require.Equal(t, test.expectedSuffix, test.tp.Suffix)
+		require.Equal(t, defaultDelimiter, test.tp.Delimiter)
 
 		require.Equal(t, test.expectedType, test.tp.Type())
 		require.Equal(t, test.expectedString, test.tp.String())
@@ -66,11 +67,11 @@ func TestFromTypeString(t *testing.T) {
 
 	f, err = FromString("application/custom")
 	require.NoError(t, err)
-	require.Equal(t, Type{MainType: "application", SubType: "custom", Suffix: "custom"}, f)
+	require.Equal(t, Type{MainType: "application", SubType: "custom", Suffix: "custom", Delimiter: defaultDelimiter}, f)
 
 	f, err = FromString("application/custom+pdf")
 	require.NoError(t, err)
-	require.Equal(t, Type{MainType: "application", SubType: "custom", Suffix: "pdf"}, f)
+	require.Equal(t, Type{MainType: "application", SubType: "custom", Suffix: "pdf", Delimiter: defaultDelimiter}, f)
 
 	f, err = FromString("noslash")
 	require.Error(t, err)

--- a/output/layout_test.go
+++ b/output/layout_test.go
@@ -21,13 +21,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var ampType = Format{
-	Name:      "AMP",
-	MediaType: media.HTMLType,
-	BaseName:  "index",
-}
-
 func TestLayout(t *testing.T) {
+
+	noExtNoDelimMediaType := media.TextType
+	noExtNoDelimMediaType.Suffix = ""
+	noExtNoDelimMediaType.Delimiter = ""
+
+	noExtMediaType := media.TextType
+	noExtMediaType.Suffix = ""
+
+	var (
+		ampType = Format{
+			Name:      "AMP",
+			MediaType: media.HTMLType,
+			BaseName:  "index",
+		}
+
+		noExtDelimFormat = Format{
+			Name:      "NEM",
+			MediaType: noExtNoDelimMediaType,
+			BaseName:  "_redirects",
+		}
+		noExt = Format{
+			Name:      "NEX",
+			MediaType: noExtMediaType,
+			BaseName:  "next",
+		}
+	)
 
 	for _, this := range []struct {
 		name           string
@@ -39,6 +59,12 @@ func TestLayout(t *testing.T) {
 	}{
 		{"Home", LayoutDescriptor{Kind: "home"}, true, "", ampType,
 			[]string{"index.amp.html", "index.html", "_default/list.amp.html", "_default/list.html", "theme/index.amp.html", "theme/index.html"}},
+		{"Home, no ext or delim", LayoutDescriptor{Kind: "home"}, true, "", noExtDelimFormat,
+			[]string{"index.nem", "_default/list.nem"}},
+		{"Home, no ext", LayoutDescriptor{Kind: "home"}, true, "", noExt,
+			[]string{"index.nex", "_default/list.nex"}},
+		{"Page, no ext or delim", LayoutDescriptor{Kind: "page"}, true, "", noExtDelimFormat,
+			[]string{"_default/single.nem", "theme/_default/single.nem"}},
 		{"Section", LayoutDescriptor{Kind: "section", Section: "sect1"}, false, "", ampType,
 			[]string{"section/sect1.amp.html", "section/sect1.html"}},
 		{"Taxonomy", LayoutDescriptor{Kind: "taxonomy", Section: "tag"}, false, "", ampType,


### PR DESCRIPTION
This change is motivated by Netlify's `_redirects` files, which is currently not possible to generate with Hugo.

This commit adds a `Delimiter` field to media type, which defaults to ".", but can be blanked out.

Fixes #3614