### PR TITLE
hugolib: Add disableAliases

### DIFF
--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -131,4 +131,5 @@ func loadDefaultSettingsFor(v *viper.Viper) {
 	v.SetDefault("enableMissingTranslationPlaceholders", false)
 	v.SetDefault("enableGitInfo", false)
 	v.SetDefault("ignoreFiles", make([]string, 0))
+	v.SetDefault("disableAliases", false)
 }

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -987,14 +987,19 @@ func (s *Site) render(outFormatIdx int) (err error) {
 		}
 		s.timerStep("prepare pages")
 
-		// Aliases must be rendered before pages.
-		// Some sites, Hugo docs included, have faulty alias definitions that point
-		// to itself or another real page. These will be overwritten in the next
-		// step.
-		if err = s.renderAliases(); err != nil {
-			return
+		// Note that even if disableAliases is set, the aliases themselves are
+		// preserved on page. The motivation with this is to be able to generate
+		// 301 redirects in a .htacess file and similar using a custom output format.
+		if !s.Cfg.GetBool("disableAliases") {
+			// Aliases must be rendered before pages.
+			// Some sites, Hugo docs included, have faulty alias definitions that point
+			// to itself or another real page. These will be overwritten in the next
+			// step.
+			if err = s.renderAliases(); err != nil {
+				return
+			}
+			s.timerStep("render and write aliases")
 		}
-		s.timerStep("render and write aliases")
 
 	}
 


### PR DESCRIPTION
Note that even with this setting enabled, the aliases themselves are preserved on the pages.

The big motivation for this change is to be able to use the alias definitions to generate `.htaccess` or Netlify's `_redirect` files with server-side redirects.

Fixes #3613