### PR TITLE
Improve the built-in Disqus template

### DIFF
--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -168,11 +168,15 @@ func (t *templateHandler) embedTemplates() {
 	t.addInternalTemplate("", "disqus.html", `{{ if .Site.DisqusShortname }}<div id="disqus_thread"></div>
 <script type="text/javascript">
     var disqus_shortname = '{{ .Site.DisqusShortname }}';
-    var disqus_identifier = '{{with .GetParam "disqus_identifier" }}{{ . }}{{ else }}{{ .Permalink }}{{end}}';
-    var disqus_title = '{{with .GetParam "disqus_title" }}{{ . }}{{ else }}{{ .Title }}{{end}}';
-    var disqus_url = '{{with .GetParam "disqus_url" }}{{ . | html  }}{{ else }}{{ .Permalink }}{{end}}';
+    {{with .GetParam "disqus_identifier" }}var disqus_identifier = '{{ . }}';{{end}}
+    {{with .GetParam "disqus_title" }}var disqus_title = '{{ . }}';{{end}}
+    {{with .GetParam "disqus_url" }}var disqus_url = '{{ . | html  }}';{{end}}
 
     (function() {
+        if (["localhost", "127.0.0.1"].indexOf(window.location.hostname) != -1) {
+            document.getElementById('disqus_thread').innerHTML = 'Disqus comments not available by default when the website is previewed locally.';
+            return;
+        }
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -167,18 +167,18 @@ func (t *templateHandler) embedTemplates() {
 
 	t.addInternalTemplate("", "disqus.html", `{{ if .Site.DisqusShortname }}<div id="disqus_thread"></div>
 <script type="text/javascript">
-    var disqus_shortname = '{{ .Site.DisqusShortname }}';
-    {{with .GetParam "disqus_identifier" }}var disqus_identifier = '{{ . }}';{{end}}
-    {{with .GetParam "disqus_title" }}var disqus_title = '{{ . }}';{{end}}
-    {{with .GetParam "disqus_url" }}var disqus_url = '{{ . | html  }}';{{end}}
-
+    var disqus_config = function () {
+    {{with .GetParam "disqus_identifier" }}this.page.identifier = '{{ . }}';{{end}}
+    {{with .GetParam "disqus_title" }}this.page.title = '{{ . }}';{{end}}
+    {{with .GetParam "disqus_url" }}this.page.url = '{{ . | html  }}';{{end}}
+    };
     (function() {
         if (["localhost", "127.0.0.1"].indexOf(window.location.hostname) != -1) {
             document.getElementById('disqus_thread').innerHTML = 'Disqus comments not available by default when the website is previewed locally.';
             return;
         }
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = '//' + {{ .Site.DisqusShortname }} + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>


### PR DESCRIPTION
1. Set `disqus_identifier`, `disqus_title`, and `disqus_url` only if the user has explicitly provided them in the metadata of a post. Two reasons:

    1. If Hugo does not set them explicitly, Disqus knows how to fetch them anyway. The shortname is the only required variable for Disqus, and all other variables are optional.

    1. If Hugo sets them, there are two problems:

        1. `disqus_identifier` is set to `.Permalink` by default, which is identical to `disqus_url` in the current template. This is not only redundant, but also defeats the purpose of `disqus_identifier`: the identifier is introduced to instruct Disqus to load the same discussion thread for a page even if its URL has been changed. In other words, it is supposed to be a fixed value, independent of the page URL. Ideally this should be provided by the user _explicitly_.

        1. `disqus_url` is redundant because Disqus also uses `.Permalink` as its default value. There is one scenario in which Hugo's `.Permalink` will fail Disqus: `baseurl = "/"` in config.toml.<sup>1</sup> In this case, `.Permalink` does not contain the full URL (e.g., `/2017/06/23/hello-world/`). However, if you do not hardcode `disqus_url` to `.Permalink`, Disqus will continue to work, because it basically uses `window.location.href`.

1. Do not load Disqus when the website is previewed locally, otherwise it is very confusing and even frustrating (e.g. comments sent to an unexpected URL by accident).

I believe these two changes will greatly improve the user experience with Disqus for those who just uses the default Disqus template in Hugo.

---

1. In case you wonder why I set `baseurl = "/"`: I know the disadvantages, e.g., sitemap.xml won't work, but I want all URLs on my website to be portable, i.e., not tied to my domain. The solution is `.RelPermalink` in the theme/templates but most theme authors just use `.Permalink` and I cannot fix these themes. The most important reason for making URLs portable is Netlify's preview for pull requests: the best way to make the preview websites work is `baseurl = "/"` before other theme authors change `.Permalink` to `.RelPermalink` and use `relURL`.