### PR TITLE
Make `--navigateToChanged` more robust on Windows

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -1028,13 +1028,15 @@ func (c *commandeer) newWatcher(port int) error {
 }
 
 func pickOneWritePath(events []fsnotify.Event) string {
+	name := ""
+
 	for _, ev := range events {
-		if ev.Op&fsnotify.Write == fsnotify.Write {
-			return ev.Name
+		if ev.Op&fsnotify.Write == fsnotify.Write && len(ev.Name) > len(name) {
+			name = ev.Name
 		}
 	}
 
-	return ""
+	return name
 }
 
 func (c *commandeer) isStatic(path string) bool {


### PR DESCRIPTION
This ensures the new "open 'current content page' in browser" works
on Windows, especially with Emacs and Vim.

Special thanks to @bep for coming up with the idea of the fix.

See #3645