### PR TITLE
output: Support templates per site/language

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -250,6 +250,7 @@ func (p *Page) createLayoutDescriptor() output.LayoutDescriptor {
 	return output.LayoutDescriptor{
 		Kind:    p.Kind,
 		Type:    p.Type(),
+		Lang:    p.Lang(),
 		Layout:  p.Layout,
 		Section: section,
 	}

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -837,8 +837,8 @@ func TestReplaceShortcodeTokens(t *testing.T) {
 func TestScKey(t *testing.T) {
 	require.Equal(t, scKey{Suffix: "xml", ShortcodePlaceholder: "ABCD"},
 		newScKey(media.XMLType, "ABCD"))
-	require.Equal(t, scKey{Suffix: "html", OutputFormat: "AMP", ShortcodePlaceholder: "EFGH"},
-		newScKeyFromOutputFormat(output.AMPFormat, "EFGH"))
+	require.Equal(t, scKey{Lang: "en", Suffix: "html", OutputFormat: "AMP", ShortcodePlaceholder: "EFGH"},
+		newScKeyFromLangAndOutputFormat("en", output.AMPFormat, "EFGH"))
 	require.Equal(t, scKey{Suffix: "html", ShortcodePlaceholder: "IJKL"},
 		newDefaultScKey("IJKL"))
 

--- a/output/docshelper.go
+++ b/output/docshelper.go
@@ -44,6 +44,7 @@ func createLayoutExamples() interface{} {
 		f              Format
 	}{
 		{`AMP home, with theme "demoTheme".`, LayoutDescriptor{Kind: "home"}, true, "", AMPFormat},
+		{`AMP home, French language".`, LayoutDescriptor{Kind: "home", Lang: "fr"}, false, "", AMPFormat},
 		{"JSON home, no theme.", LayoutDescriptor{Kind: "home"}, false, "", JSONFormat},
 		{fmt.Sprintf(`CSV regular, "layout: %s" in front matter.`, demoLayout), LayoutDescriptor{Kind: "page", Layout: demoLayout}, false, "", CSVFormat},
 		{fmt.Sprintf(`JSON regular, "type: %s" in front matter.`, demoType), LayoutDescriptor{Kind: "page", Type: demoType}, false, "", JSONFormat},

--- a/output/layout_test.go
+++ b/output/layout_test.go
@@ -59,6 +59,8 @@ func TestLayout(t *testing.T) {
 	}{
 		{"Home", LayoutDescriptor{Kind: "home"}, true, "", ampType,
 			[]string{"index.amp.html", "index.html", "_default/list.amp.html", "_default/list.html", "theme/index.amp.html", "theme/index.html"}},
+		{"Home, french language", LayoutDescriptor{Kind: "home", Lang: "fr"}, true, "", ampType,
+			[]string{"index.fr.amp.html", "index.amp.html", "index.fr.html", "index.html", "_default/list.fr.amp.html", "_default/list.amp.html", "_default/list.fr.html", "_default/list.html", "theme/index.fr.amp.html", "theme/index.amp.html", "theme/index.fr.html"}},
 		{"Home, no ext or delim", LayoutDescriptor{Kind: "home"}, true, "", noExtDelimFormat,
 			[]string{"index.nem", "_default/list.nem"}},
 		{"Home, no ext", LayoutDescriptor{Kind: "home"}, true, "", noExt,


### PR DESCRIPTION
This applies to both regular templates and shortcodes. So, if the site language is French and the output format is AMP, this is the (start) of the lookup order for the home page:

1. index.fr.amp.html
2. index.amp.html
3. index.fr.html
4. index.html
5. ...

Fixes #3360