### PR TITLE
Add GOEXE to support building with different versions of `go`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,21 +6,24 @@ BUILD_DATE = `date +%FT%T%z`
 LDFLAGS = -ldflags "-X ${PACKAGE}/hugolib.CommitHash=${COMMIT_HASH} -X ${PACKAGE}/hugolib.BuildDate=${BUILD_DATE}"
 NOGI_LDFLAGS = -ldflags "-X ${PACKAGE}/hugolib.BuildDate=${BUILD_DATE}"
 
+# allow user to override go executable by running as GOEXE=xxx make ... on unix-like systems
+GOEXE ?= go
+
 .PHONY: vendor docker check fmt lint test test-race vet test-cover-html help
 .DEFAULT_GOAL := help
 
 vendor: ## Install govendor and sync Hugo's vendored dependencies
-	go get github.com/kardianos/govendor
+	${GOEXE} get github.com/kardianos/govendor
 	govendor sync ${PACKAGE}
 
 hugo: vendor ## Build hugo binary
-	go build ${LDFLAGS} ${PACKAGE}
+	${GOEXE} build ${LDFLAGS} ${PACKAGE}
 
 hugo-race: vendor ## Build hugo binary with race detector enabled
-	go build -race ${LDFLAGS} ${PACKAGE}
+	${GOEXE} build -race ${LDFLAGS} ${PACKAGE}
 
 install: vendor ## Install hugo binary
-	go install ${LDFLAGS} ${PACKAGE}
+	${GOEXE} install ${LDFLAGS} ${PACKAGE}
 
 hugo-no-gitinfo: LDFLAGS = ${NOGI_LDFLAGS}
 hugo-no-gitinfo: vendor hugo ## Build hugo without git info
@@ -74,7 +77,7 @@ test-cover-html: ## Generate test coverage report
 	$(foreach pkg,$(PACKAGES),\
 		govendor test -coverprofile=coverage.out -covermode=count $(pkg);\
 		tail -n +2 coverage.out >> coverage-all.out;)
-	go tool cover -html=coverage-all.out
+	${GOEXE} tool cover -html=coverage-all.out
 
 check-vendor: ## Verify that vendored packages match git HEAD
 	@git diff-index --quiet HEAD vendor/ || (echo "check-vendor target failed: vendored packages out of sync" && echo && git diff vendor/ && exit 1)

--- a/bench.sh
+++ b/bench.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# allow user to override go executable by running as GOEXE=xxx make ...
+GOEXE="${GOEXE-go}"
 
 # Convenience script to
 # - For a given branch
@@ -26,10 +28,10 @@ BRANCH=$1
 PACKAGE=$2
 
 git checkout $BRANCH
-go test -test.run=NONE -bench="$benchFilter" -test.benchmem=true ./$PACKAGE > /tmp/bench-$PACKAGE-$BRANCH.txt
+"${GOEXE}" test -test.run=NONE -bench="$benchFilter" -test.benchmem=true ./$PACKAGE > /tmp/bench-$PACKAGE-$BRANCH.txt
 
 git checkout master
-go test -test.run=NONE -bench="$benchFilter" -test.benchmem=true ./$PACKAGE > /tmp/bench-$PACKAGE-master.txt
+"${GOEXE}" test -test.run=NONE -bench="$benchFilter" -test.benchmem=true ./$PACKAGE > /tmp/bench-$PACKAGE-master.txt
 
 
 benchcmp /tmp/bench-$PACKAGE-master.txt /tmp/bench-$PACKAGE-$BRANCH.txt

--- a/benchSite.sh
+++ b/benchSite.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+# allow user to override go executable by running as GOEXE=xxx make ...
+GOEXE="${GOEXE-go}"
+
 # Send in a regexp mathing the benchmarks you want to run, i.e. './benchSite.sh "YAML"'. 
 # Note the quotes, which will be needed for more complex expressions.
 # The above will run all variations, but only for front matter YAML.
 
 echo "Running with BenchmarkSiteBuilding/${1}"
 
-go test -run="NONE" -bench="BenchmarkSiteBuilding/${1}$" -test.benchmem=true ./hugolib -memprofile mem.prof -cpuprofile cpu.prof
+"${GOEXE}" test -run="NONE" -bench="BenchmarkSiteBuilding/${1}$" -test.benchmem=true ./hugolib -memprofile mem.prof -cpuprofile cpu.prof


### PR DESCRIPTION
Add a variable to the makefile and benchmark scripts to let users change the command used to build. Doesn't impact tools like govendor.