### PR TITLE
tpl: Use hash for cache key

### DIFF
--- a/tpl/data/cache.go
+++ b/tpl/data/cache.go
@@ -15,8 +15,9 @@ package data
 
 import (
 	"errors"
-	"net/url"
 	"sync"
+	"crypto/md5"
+	"encoding/hex"
 
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/helpers"
@@ -27,7 +28,8 @@ var cacheMu sync.RWMutex
 
 // getCacheFileID returns the cache ID for a string.
 func getCacheFileID(cfg config.Provider, id string) string {
-	return cfg.GetString("cacheDir") + url.QueryEscape(id)
+	hash := md5.Sum([]byte(id))
+	return cfg.GetString("cacheDir") + hex.EncodeToString(hash[:])
 }
 
 // getCache returns the content for an ID from the file cache or an error.

--- a/tpl/data/cache.go
+++ b/tpl/data/cache.go
@@ -14,10 +14,10 @@
 package data
 
 import (
-	"errors"
-	"sync"
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
+	"sync"
 
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/helpers"


### PR DESCRIPTION
Use a hash for the cache key, to fix 'file name too long' errors when retrieving from long urls

Fixes #3690