### PR TITLE
add --debug option to be improved on over time

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -143,6 +143,7 @@ var (
 	renderToMemory bool // for benchmark testing
 	verbose        bool
 	verboseLog     bool
+	debug          bool
 	quiet          bool
 )
 
@@ -263,6 +264,7 @@ func initBenchmarkBuildingFlags(cmd *cobra.Command) {
 // init initializes flags.
 func init() {
 	HugoCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	HugoCmd.PersistentFlags().BoolVarP(&debug, "debug", "", false, "debug output")
 	HugoCmd.PersistentFlags().BoolVar(&logging, "log", false, "enable Logging")
 	HugoCmd.PersistentFlags().StringVar(&logFile, "logFile", "", "log File path (if set, logging enabled automatically)")
 	HugoCmd.PersistentFlags().BoolVar(&verboseLog, "verboseLog", false, "verbose logging")
@@ -432,8 +434,15 @@ func createLogger(cfg config.Provider) (*jww.Notepad, error) {
 		stdoutThreshold = jww.LevelInfo
 	}
 
+	if cfg.GetBool("debug") {
+		stdoutThreshold = jww.LevelDebug
+	}
+
 	if verboseLog {
 		logThreshold = jww.LevelInfo
+		if cfg.GetBool("debug") {
+			logThreshold = jww.LevelDebug
+		}
 	}
 
 	// The global logger is used in some few cases.
@@ -446,7 +455,7 @@ func createLogger(cfg config.Provider) (*jww.Notepad, error) {
 }
 
 func (c *commandeer) initializeFlags(cmd *cobra.Command) {
-	persFlagKeys := []string{"verbose", "logFile"}
+	persFlagKeys := []string{"debug", "verbose", "logFile"}
 	flagKeys := []string{
 		"cleanDestinationDir",
 		"buildDrafts",

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -132,4 +132,5 @@ func loadDefaultSettingsFor(v *viper.Viper) {
 	v.SetDefault("enableGitInfo", false)
 	v.SetDefault("ignoreFiles", make([]string, 0))
 	v.SetDefault("disableAliases", false)
+	v.SetDefault("debug", false)
 }


### PR DESCRIPTION
Why:

 * first time using hugo I got very little info from --verbose output
   but I noticed there is quite a lot of useful DEBUG logging
 * asked for in other issues like https://github.com/gohugoio/hugo/issues/3514

This change addreses the need by:

 * adding a simple --debug flag which simply turns on debug level in stdout
   and logoutput if enabled.