### PR TITLE
tpl: Accommodate gccgo in TestMethodToName

### DIFF
--- a/tpl/internal/templatefuncRegistry_test.go
+++ b/tpl/internal/templatefuncRegistry_test.go
@@ -14,6 +14,7 @@
 package internal
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,5 +30,9 @@ func (t *Test) MyTestMethod() string {
 func TestMethodToName(t *testing.T) {
 	test := &Test{}
 
-	require.Equal(t, "MyTestMethod", methodToName(test.MyTestMethod))
+	if runtime.Compiler == "gccgo" {
+		require.Equal(t, "$thunk0", methodToName(test.MyTestMethod))
+	} else {
+		require.Equal(t, "MyTestMethod", methodToName(test.MyTestMethod))
+	}
 }


### PR DESCRIPTION
Fixes #3744