### PR TITLE
Task list at beginning of markdown now renders properly

### DIFF
--- a/helpers/content_renderer.go
+++ b/helpers/content_renderer.go
@@ -100,11 +100,16 @@ func (r *HugoHTMLRenderer) List(out *bytes.Buffer, text func() bool, flags int) 
 	r.Renderer.List(out, text, flags)
 	if out.Len() > marker {
 		list := out.Bytes()[marker:]
+		if list[0] == 10 {
+			out.Write(list[:1])
+			list = list[1:]
+			marker++
+		}
 		if bytes.Contains(list, []byte("task-list-item")) {
 			// Rewrite the buffer from the marker
 			out.Truncate(marker)
 			// May be either dl, ul or ol
-			list := append(list[:4], append([]byte(` class="task-list"`), list[4:]...)...)
+			list := append(list[:3], append([]byte(` class="task-list"`), list[3:]...)...)
 			out.Write(list)
 		}
 	}

--- a/helpers/content_renderer_test.go
+++ b/helpers/content_renderer_test.go
@@ -118,6 +118,19 @@ END
 		{`- [x] On1`, false, `<ul>
 <li>[x] On1</li>
 </ul>
+`}, {`
+- [x] On1
+- [X] On2
+- [ ] Off
+
+END
+`, true, `<ul class="task-list">
+<li><input type="checkbox" checked disabled class="task-list-item"> On1</li>
+<li><input type="checkbox" checked disabled class="task-list-item"> On2</li>
+<li><input type="checkbox" disabled class="task-list-item"> Off</li>
+</ul>
+
+<p>END</p>
 `},
 	} {
 		blackFridayConfig := c.NewBlackfriday()


### PR DESCRIPTION
Fixes #3710

The problem was that when the task list is at the beginning of the output from blackFriday does not begin with a newline as this code expected. So I added code so that if there is a newline we forward past that before doing our operation.

This is the first time working on Hugo so please point out if this bug should be fixed somewhere else in the code.