### PR TITLE
helpers: Fix broken TaskList in Markdown

### DIFF
--- a/helpers/content_renderer.go
+++ b/helpers/content_renderer.go
@@ -101,10 +101,14 @@ func (r *HugoHTMLRenderer) List(out *bytes.Buffer, text func() bool, flags int) 
 	if out.Len() > marker {
 		list := out.Bytes()[marker:]
 		if bytes.Contains(list, []byte("task-list-item")) {
+			// Find the index of the first >, it might be 3 or 4 depending on whether
+			// there is a new line at the start, but this is safer than just hardcoding it.
+			closingBracketIndex := bytes.Index(list, []byte(">"))
 			// Rewrite the buffer from the marker
 			out.Truncate(marker)
+			// Safely assuming closingBracketIndex won't be -1 since there is a list
 			// May be either dl, ul or ol
-			list := append(list[:4], append([]byte(` class="task-list"`), list[4:]...)...)
+			list := append(list[:closingBracketIndex], append([]byte(` class="task-list"`), list[closingBracketIndex:]...)...)
 			out.Write(list)
 		}
 	}

--- a/helpers/content_renderer_test.go
+++ b/helpers/content_renderer_test.go
@@ -119,6 +119,14 @@ END
 <li>[x] On1</li>
 </ul>
 `},
+		{`* [ ] Off
+
+END`, true, `<ul class="task-list">
+<li><input type="checkbox" disabled class="task-list-item"> Off</li>
+</ul>
+
+<p>END</p>
+`},
 	} {
 		blackFridayConfig := c.NewBlackfriday()
 		blackFridayConfig.TaskLists = this.taskListEnabled


### PR DESCRIPTION
As per the referenced issue, if the task list in Markdown has
nothing before it, it will be rendered wrongly:

```
---
title: "My First Post"
date: 2017-07-29T20:21:57+02:00
draft: true
---

* [ ] TaskList

```

is rendered as:

```
<ul> class="task-list"
<li><input type="checkbox" disabled class="task-list-item"> TaskList</li>
</ul>
```

The problem lies in the `List` function of `HugoHTMLRenderer`, it had
a hardocded index of `4` for the first `>` of the list, it is used to
insert the class into the text before the closing bracket, but that
hardcoded index is only right when there is a newline before the
opening bracket, which is the case when there is anything in the
document before the task list, but if there is nothing, then there is
no newline, and the correct index of the first `>` will be `3`.

To fix that we're changing the hardcoded index to be dynamic by using
`bytes.Index` to find it properly. We're also adding a test case to
make sure this is tested against.

Fixes #3710