### PR TITLE
Remove unused dependencies from vendor.json

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -166,12 +166,6 @@
 			"revisionTime": "2017-05-10T13:15:34Z"
 		},
 		{
-			"checksumSHA1": "KQhA4EQp4Ldwj9nJZnEURlE6aQw=",
-			"path": "github.com/kr/fs",
-			"revision": "2788f0dbd16903de03cb8186e5c7d97b69ad387b",
-			"revisionTime": "2013-11-06T22:25:44Z"
-		},
-		{
 			"checksumSHA1": "u6Fh5nWSW70Yi2/hq/zxPinakD4=",
 			"path": "github.com/kyokomi/emoji",
 			"revision": "ddd4753eac3f6480ca86b16cc6c98d26a0935d17",
@@ -214,12 +208,6 @@
 			"revisionTime": "2017-05-12T15:20:54Z"
 		},
 		{
-			"checksumSHA1": "TkXI1L27/2icLlcE/4wTZCfxLeM=",
-			"path": "github.com/opennota/urlesc",
-			"revision": "bbf7a2afc14f93e1e0a5c06df524fbd75e5031e5",
-			"revisionTime": "2017-03-24T14:02:28Z"
-		},
-		{
 			"checksumSHA1": "F1IYMLBLAZaTOWnmXsgaxTGvrWI=",
 			"path": "github.com/pelletier/go-buffruneio",
 			"revision": "c37440a7cf42ac63b919c752ca73a85067e05992",
@@ -230,18 +218,6 @@
 			"path": "github.com/pelletier/go-toml",
 			"revision": "69d355db5304c0f7f809a2edc054553e7142f016",
 			"revisionTime": "2017-06-28T01:26:37Z"
-		},
-		{
-			"checksumSHA1": "rJab1YdNhQooDiBWNnt7TLWPyBU=",
-			"path": "github.com/pkg/errors",
-			"revision": "c605e284fe17294bda444b34710735b29d1a9d90",
-			"revisionTime": "2017-05-05T04:36:39Z"
-		},
-		{
-			"checksumSHA1": "9cEiTG5TwzUp46TTQ9e0fPkYzWM=",
-			"path": "github.com/pkg/sftp",
-			"revision": "22f089b9c4056cf774ebd695b687d469f2ad4650",
-			"revisionTime": "2017-07-26T04:04:32Z"
 		},
 		{
 			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
@@ -341,30 +317,6 @@
 			"revisionTime": "2016-07-28T07:45:28Z"
 		},
 		{
-			"checksumSHA1": "MlEHIE/60sB86Lmf0MPTIXHzKzE=",
-			"path": "golang.org/x/crypto/curve25519",
-			"revision": "2faea1465de239e4babd8f5905cc25b781712442",
-			"revisionTime": "2017-07-23T05:00:11Z"
-		},
-		{
-			"checksumSHA1": "i3dNaI+oCYeDGIsNj7LwecTsIAs=",
-			"path": "golang.org/x/crypto/ed25519",
-			"revision": "2faea1465de239e4babd8f5905cc25b781712442",
-			"revisionTime": "2017-07-23T05:00:11Z"
-		},
-		{
-			"checksumSHA1": "LXFcVx8I587SnWmKycSDEq9yvK8=",
-			"path": "golang.org/x/crypto/ed25519/internal/edwards25519",
-			"revision": "2faea1465de239e4babd8f5905cc25b781712442",
-			"revisionTime": "2017-07-23T05:00:11Z"
-		},
-		{
-			"checksumSHA1": "+cJ5DMdWg6q//21EKgxcaQ5vZaI=",
-			"path": "golang.org/x/crypto/ssh",
-			"revision": "2faea1465de239e4babd8f5905cc25b781712442",
-			"revisionTime": "2017-07-23T05:00:11Z"
-		},
-		{
 			"checksumSHA1": "zdekzNuFGSoxAZ8cURGsrhBObZs=",
 			"path": "golang.org/x/image/riff",
 			"revision": "426cfd8eeb6e08ab1932954e09e3c2cb2bc6e36d",
@@ -401,44 +353,8 @@
 			"revisionTime": "2017-07-27T13:28:57Z"
 		},
 		{
-			"checksumSHA1": "DWHpSSH7hmB31XvpQqFDshcRU+4=",
-			"path": "golang.org/x/text/cases",
-			"revision": "836efe42bb4aa16aaa17b9c155d8813d336ed720",
-			"revisionTime": "2017-07-09T00:38:22Z"
-		},
-		{
-			"checksumSHA1": "iYRxxQY7bvIJc/13siNdYHjavR8=",
-			"path": "golang.org/x/text/internal",
-			"revision": "836efe42bb4aa16aaa17b9c155d8813d336ed720",
-			"revisionTime": "2017-07-09T00:38:22Z"
-		},
-		{
-			"checksumSHA1": "hyNCcTwMQnV6/MK8uUW9E5H0J0M=",
-			"path": "golang.org/x/text/internal/tag",
-			"revision": "836efe42bb4aa16aaa17b9c155d8813d336ed720",
-			"revisionTime": "2017-07-09T00:38:22Z"
-		},
-		{
-			"checksumSHA1": "ZHdB8O+CObx3nAFnXrFHRWcHNMs=",
-			"path": "golang.org/x/text/language",
-			"revision": "836efe42bb4aa16aaa17b9c155d8813d336ed720",
-			"revisionTime": "2017-07-09T00:38:22Z"
-		},
-		{
-			"checksumSHA1": "IV4MN7KGBSocu/5NR3le3sxup4Y=",
-			"path": "golang.org/x/text/runes",
-			"revision": "836efe42bb4aa16aaa17b9c155d8813d336ed720",
-			"revisionTime": "2017-07-09T00:38:22Z"
-		},
-		{
 			"checksumSHA1": "faFDXp++cLjLBlvsr+izZ+go1WU=",
 			"path": "golang.org/x/text/secure/bidirule",
-			"revision": "836efe42bb4aa16aaa17b9c155d8813d336ed720",
-			"revisionTime": "2017-07-09T00:38:22Z"
-		},
-		{
-			"checksumSHA1": "VTmxkt7aLHalK9vddUBt2ViSWKo=",
-			"path": "golang.org/x/text/secure/precis",
 			"revision": "836efe42bb4aa16aaa17b9c155d8813d336ed720",
 			"revisionTime": "2017-07-09T00:38:22Z"
 		},


### PR DESCRIPTION
I realized that some dependencies are not in use anymore. To see which dependencies are still in use I ran [`dep init`](https://github.com/golang/dep) and compared [the results](https://github.com/gohugoio/hugo/files/1187802/Gopkg.toml.txt) to the `vendor.json` file.
All unused dependencies are removed now. All `make` commands are still working.
Hope I'm not missing anything.