### PR TITLE
Added template function 'asciidocify'

### DIFF
--- a/docs/data/docs.json
+++ b/docs/data/docs.json
@@ -1627,6 +1627,21 @@
             ]
           ]
         },
+        "Asciidocify": {
+          "Description": "Asciidocify renders a given input from AsciiDoc to HTML.",
+          "Args": [
+            "s"
+          ],
+          "Aliases": [
+            "asciidocify"
+          ],
+          "Examples": [
+            [
+              "{{ .Title | asciidocify}}",
+              "\u003cstrong\u003eBatMan\u003c/strong\u003e"
+            ]
+          ]
+        },
         "Plainify": {
           "Description": "Plainify returns a copy of s with all HTML tags removed.",
           "Args": [

--- a/tpl/transform/init.go
+++ b/tpl/transform/init.go
@@ -81,6 +81,13 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.Asciidocify,
+			[]string{"asciidocify"},
+			[][2]string{
+				{`{{ .Title | asciidocify}}`, `<strong>BatMan</strong>`},
+			},
+		)
+
 		ns.AddMethodMapping(ctx.Plainify,
 			[]string{"plainify"},
 			[][2]string{

--- a/tpl/transform/transform.go
+++ b/tpl/transform/transform.go
@@ -112,3 +112,27 @@ func (ns *Namespace) Plainify(s interface{}) (string, error) {
 
 	return helpers.StripHTML(ss), nil
 }
+
+
+var asciidocTrimPrefix = []byte("<p>")
+var asciidocTrimSuffix = []byte("</p>\n")
+
+// Asciidocify renders a given input from AsciiDoc to HTML.
+func (ns *Namespace) Asciidocify(s interface{}) (template.HTML, error) {
+	ss, err := cast.ToStringE(s)
+	if err != nil {
+		return "", err
+	}
+
+	m := ns.deps.ContentSpec.RenderBytes(
+		&helpers.RenderingContext{
+			Content: []byte(ss),
+			PageFmt: "asciidoc",
+			DocumentName: "snippet",
+		},
+	)
+	m = bytes.TrimPrefix(m, asciidocTrimPrefix)
+	m = bytes.TrimSuffix(m, asciidocTrimSuffix)
+
+	return template.HTML(m), nil
+}

--- a/tpl/transform/transform_test.go
+++ b/tpl/transform/transform_test.go
@@ -168,6 +168,33 @@ func TestMarkdownify(t *testing.T) {
 	}
 }
 
+func TestAsciidocify(t *testing.T) {
+	t.Parallel()
+
+	ns := New(newDeps(viper.New()))
+
+	for i, test := range []struct {
+		s      interface{}
+		expect interface{}
+	}{
+		{"Hello *World!*", template.HTML("Hello <strong>World!</strong>")},
+		{[]byte("Hello **Bytes World!**"), template.HTML("Hello <strong>Bytes World!</strong>")},
+		{tstNoStringer{}, false},
+	} {
+		errMsg := fmt.Sprintf("[%d] %s", i, test.s)
+
+		result, err := ns.Markdownify(test.s)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			require.Error(t, err, errMsg)
+			continue
+		}
+
+		require.NoError(t, err, errMsg)
+		assert.Equal(t, test.expect, result, errMsg)
+	}
+}
+
 func TestPlainify(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
In order to use AsciiDoc in shortcodes and other template places, I have added 'asciidocify' as a new template function similar to 'markdownify'