### PR TITLE
tpl/transform: Avoid removing p tags in markdownify when marked as blocks 

### DIFF
--- a/tpl/strings/init.go
+++ b/tpl/strings/init.go
@@ -29,6 +29,13 @@ func init() {
 			Context: func(args ...interface{}) interface{} { return ctx },
 		}
 
+		ns.AddMethodMapping(ctx.Blocks,
+			[]string{"blocks"},
+			[][2]string{
+				{`{{ "Hugo" | blocks }}`, `Hugo`},
+			},
+		)
+
 		ns.AddMethodMapping(ctx.Chomp,
 			[]string{"chomp"},
 			[][2]string{

--- a/tpl/strings/strings.go
+++ b/tpl/strings/strings.go
@@ -40,6 +40,24 @@ type Namespace struct {
 	deps      *deps.Deps
 }
 
+// Blocks is a marker type used to mark one or more blocks of text. It is used in
+// markdownify to prevent stripping of p tags.
+type Blocks string
+
+// Implements the Stringer interface.
+func (b Blocks) String() string {
+	return string(b)
+}
+
+// Blocks converts the given string to Blocks to identify blocks of text.
+func (ns *Namespace) Blocks(s interface{}) (Blocks, error) {
+	ss, err := cast.ToStringE(s)
+	if err != nil {
+		return "", fmt.Errorf("Failed to convert content to string: %s", err)
+	}
+	return Blocks(ss), nil
+}
+
 // CountRunes returns the number of runes in s, excluding whitepace.
 func (ns *Namespace) CountRunes(s interface{}) (int, error) {
 	ss, err := cast.ToStringE(s)

--- a/tpl/strings/strings_test.go
+++ b/tpl/strings/strings_test.go
@@ -28,6 +28,32 @@ var ns = New(&deps.Deps{Cfg: viper.New()})
 
 type tstNoStringer struct{}
 
+func TestBlocks(t *testing.T) {
+	t.Parallel()
+
+	for i, test := range []struct {
+		s      interface{}
+		expect interface{}
+	}{
+		{"text", Blocks("text")},
+		{123, Blocks("123")},
+		// errors
+		{tstNoStringer{}, false},
+	} {
+		errMsg := fmt.Sprintf("[%d] %v", i, test)
+
+		result, err := ns.Blocks(test.s)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			require.Error(t, err, errMsg)
+			continue
+		}
+
+		require.NoError(t, err, errMsg)
+		assert.Equal(t, test.expect, result, errMsg)
+	}
+}
+
 func TestChomp(t *testing.T) {
 	t.Parallel()
 

--- a/tpl/transform/init.go
+++ b/tpl/transform/init.go
@@ -78,6 +78,7 @@ func init() {
 			[]string{"markdownify"},
 			[][2]string{
 				{`{{ .Title | markdownify}}`, `<strong>BatMan</strong>`},
+				{`{{ "Blocks of *text*." | blocks | markdownify}}`, "<p>Blocks of <em>text</em>.</p>\n"},
 			},
 		)
 

--- a/tpl/transform/init_test.go
+++ b/tpl/transform/init_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/tpl/internal"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +27,7 @@ func TestInit(t *testing.T) {
 	var ns *internal.TemplateFuncsNamespace
 
 	for _, nsf := range internal.TemplateFuncsNamespaceRegistry {
-		ns = nsf(&deps.Deps{})
+		ns = nsf(&deps.Deps{Cfg: viper.New()})
 		if ns.Name == name {
 			found = true
 			break

--- a/tpl/transform/transform.go
+++ b/tpl/transform/transform.go
@@ -18,6 +18,8 @@ import (
 	"html"
 	"html/template"
 
+	"github.com/gohugoio/hugo/tpl/strings"
+
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/spf13/cast"
@@ -88,6 +90,7 @@ func (ns *Namespace) Markdownify(s interface{}) (template.HTML, error) {
 	if err != nil {
 		return "", err
 	}
+	_, isBlocks := s.(strings.Blocks)
 
 	m := ns.deps.ContentSpec.RenderBytes(
 		&helpers.RenderingContext{
@@ -97,8 +100,11 @@ func (ns *Namespace) Markdownify(s interface{}) (template.HTML, error) {
 			Config:  ns.deps.ContentSpec.NewBlackfriday(),
 		},
 	)
-	m = bytes.TrimPrefix(m, markdownTrimPrefix)
-	m = bytes.TrimSuffix(m, markdownTrimSuffix)
+
+	if !isBlocks {
+		m = bytes.TrimPrefix(m, markdownTrimPrefix)
+		m = bytes.TrimSuffix(m, markdownTrimSuffix)
+	}
 
 	return template.HTML(m), nil
 }

--- a/tpl/transform/transform_test.go
+++ b/tpl/transform/transform_test.go
@@ -18,6 +18,8 @@ import (
 	"html/template"
 	"testing"
 
+	"github.com/gohugoio/hugo/tpl/strings"
+
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/helpers"
@@ -166,6 +168,34 @@ func TestMarkdownify(t *testing.T) {
 		require.NoError(t, err, errMsg)
 		assert.Equal(t, test.expect, result, errMsg)
 	}
+}
+
+// Issue #3040
+func TestMarkdownifyBlocksOfText(t *testing.T) {
+	t.Parallel()
+
+	assert := require.New(t)
+
+	ns := New(newDeps(viper.New()))
+
+	text := `
+#First 
+
+This is some *bold* text.
+
+## Second
+
+This is some more text.
+
+And then some.
+`
+
+	result, err := ns.Markdownify(strings.Blocks(text))
+	assert.NoError(err)
+	assert.Equal(template.HTML(
+		"<p>#First</p>\n\n<p>This is some <em>bold</em> text.</p>\n\n<h2 id=\"second\">Second</h2>\n\n<p>This is some more text.</p>\n\n<p>And then some.</p>\n"),
+		result)
+
 }
 
 func TestPlainify(t *testing.T) {


### PR DESCRIPTION
  As in the example below:

```
{{ "Blocks of *text*." | blocks | markdownify}}
```
Fixes #3040

Note: The `block` keyword is reserved.