### PR TITLE
source: Normalize UniqueID between Windows & Linux

### DIFF
--- a/source/file.go
+++ b/source/file.go
@@ -155,7 +155,7 @@ func (sp SourceSpec) NewFile(relpath string) *File {
 	}
 
 	f.section = helpers.GuessSection(f.Dir())
-	f.uniqueID = helpers.Md5String(f.Path())
+	f.uniqueID = helpers.Md5String(filepath.ToSlash(f.relpath))
 
 	return f
 }

--- a/source/file_test.go
+++ b/source/file_test.go
@@ -37,6 +37,11 @@ func TestFileUniqueID(t *testing.T) {
 	f4 := ss.NewFile(filepath.FromSlash("test2/index.md"))
 
 	assert.NotEqual(t, f3.UniqueID(), f4.UniqueID())
+
+	f5l := ss.NewFile("test3/index.md")
+	f5w := ss.NewFile(filepath.FromSlash("test3/index.md"))
+
+	assert.Equal(t, f5l.UniqueID(), f5w.UniqueID())
 }
 
 func TestFileString(t *testing.T) {


### PR DESCRIPTION
Right now, the UniqueID is calculated with a `\` as path separator in Windows which cause the md5 sum to be different from a Linux build, and so anything relying on UniqueID to break with regards to portability (and local testing when using a different system). This fix this by simply using `filepath.ToSlash` for the md5 sum.