### PR TITLE
tpl: Cleanup strings.TrimPrefix and TrimSuffix

### DIFF
--- a/tpl/strings/init.go
+++ b/tpl/strings/init.go
@@ -119,10 +119,26 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.TrimPrefix,
+			nil,
+			[][2]string{
+				{`{{ "aabbaa" | strings.TrimPrefix "a" }}`, `abbaa`},
+				{`{{ "aabbaa" | strings.TrimPrefix "aa" }}`, `bbaa`},
+			},
+		)
+
 		ns.AddMethodMapping(ctx.TrimRight,
 			nil,
 			[][2]string{
 				{`{{ "aabbaa" | strings.TrimRight "a" }}`, `aabb`},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.TrimSuffix,
+			nil,
+			[][2]string{
+				{`{{ "aabbaa" | strings.TrimSuffix "a" }}`, `aabba`},
+				{`{{ "aabbaa" | strings.TrimSuffix "aa" }}`, `aabb`},
 			},
 		)
 

--- a/tpl/strings/strings.go
+++ b/tpl/strings/strings.go
@@ -365,7 +365,7 @@ func (ns *Namespace) TrimLeft(cutset, s interface{}) (string, error) {
 
 // TrimPrefix returns s without the provided leading prefix string. If s doesn't
 // start with prefix, s is returned unchanged.
-func (ns *Namespace) TrimPrefix(s, prefix interface{}) (string, error) {
+func (ns *Namespace) TrimPrefix(prefix, s interface{}) (string, error) {
 	ss, err := cast.ToStringE(s)
 	if err != nil {
 		return "", err
@@ -397,7 +397,7 @@ func (ns *Namespace) TrimRight(cutset, s interface{}) (string, error) {
 
 // TrimSuffix returns s without the provided trailing suffix string. If s
 // doesn't end with suffix, s is returned unchanged.
-func (ns *Namespace) TrimSuffix(s, suffix interface{}) (string, error) {
+func (ns *Namespace) TrimSuffix(suffix, s interface{}) (string, error) {
 	ss, err := cast.ToStringE(s)
 	if err != nil {
 		return "", err

--- a/tpl/strings/strings_test.go
+++ b/tpl/strings/strings_test.go
@@ -627,7 +627,7 @@ func TestTrimPrefix(t *testing.T) {
 	} {
 		errMsg := fmt.Sprintf("[%d] %v", i, test)
 
-		result, err := ns.TrimPrefix(test.s, test.prefix)
+		result, err := ns.TrimPrefix(test.prefix, test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
 			require.Error(t, err, errMsg)
@@ -692,7 +692,7 @@ func TestTrimSuffix(t *testing.T) {
 	} {
 		errMsg := fmt.Sprintf("[%d] %v", i, test)
 
-		result, err := ns.TrimSuffix(test.s, test.suffix)
+		result, err := ns.TrimSuffix(test.suffix, test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
 			require.Error(t, err, errMsg)


### PR DESCRIPTION
These funcs were added during the move to namespaces but were
undocumented.  This commit fixes the order of the arguments and adds the
funcs to the method mapping.