### PR TITLE
compare, hugolib, tpl: Add Eqer interface

### DIFF
--- a/compare/eq.go
+++ b/compare/eq.go
@@ -1,0 +1,21 @@
+// Copyright 2017-present The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compare
+
+// Eqer can be used to determine if this value is equal to the other.
+// The semantics of equals is that the two value are interchangeable
+// in the Hugo templates.
+type Eqer interface {
+	Eq(other interface{}) bool
+}

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -38,6 +38,7 @@ import (
 	"unicode/utf8"
 
 	bp "github.com/gohugoio/hugo/bufferpool"
+	"github.com/gohugoio/hugo/compare"
 	"github.com/gohugoio/hugo/source"
 	"github.com/spf13/cast"
 )
@@ -49,6 +50,10 @@ var (
 	allKindsInPages = []string{KindPage, KindHome, KindSection, KindTaxonomy, KindTaxonomyTerm}
 
 	allKinds = append(allKindsInPages, []string{kindRSS, kindSitemap, kindRobotsTXT, kind404}...)
+
+	// Assert that it implements the Eqer interface.
+	_ compare.Eqer = (*Page)(nil)
+	_ compare.Eqer = (*PageOutput)(nil)
 )
 
 const (

--- a/tpl/compare/compare.go
+++ b/tpl/compare/compare.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/gohugoio/hugo/compare"
 )
 
 // New returns a new instance of the compare-namespaced template functions.
@@ -85,6 +87,14 @@ func (*Namespace) Default(dflt interface{}, given ...interface{}) (interface{}, 
 
 // Eq returns the boolean truth of arg1 == arg2.
 func (*Namespace) Eq(x, y interface{}) bool {
+
+	// hugolib.Page implements compare.Eqer to make Page and PageOutput comparable.
+	if e1, ok := x.(compare.Eqer); ok {
+		if e2, ok := y.(compare.Eqer); ok {
+			return e1.Eq(e2)
+		}
+	}
+
 	normalize := func(v interface{}) interface{} {
 		vv := reflect.ValueOf(v)
 		switch vv.Kind() {

--- a/tpl/compare/compare_test.go
+++ b/tpl/compare/compare_test.go
@@ -26,6 +26,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type tstEqerType1 string
+type tstEqerType2 string
+
+func (t tstEqerType2) Eq(other interface{}) bool {
+	return cast.ToString(t) == cast.ToString(other)
+}
+
+func (t tstEqerType2) String() string {
+	return string(t)
+}
+
+func (t tstEqerType1) Eq(other interface{}) bool {
+	return cast.ToString(t) == cast.ToString(other)
+}
+
+func (t tstEqerType1) String() string {
+	return string(t)
+}
+
 type tstCompareType int
 
 const (
@@ -148,6 +167,10 @@ func doTestCompare(t *testing.T, tp tstCompareType, funcUnderTest func(a, b inte
 		{"a", "a", 0},
 		{"a", "b", -1},
 		{"b", "a", 1},
+		{tstEqerType1("a"), tstEqerType1("a"), 0},
+		{tstEqerType1("a"), tstEqerType2("a"), 0},
+		{tstEqerType2("a"), tstEqerType1("a"), 0},
+		{tstEqerType2("a"), tstEqerType1("b"), -1},
 	} {
 		result := funcUnderTest(test.left, test.right)
 		success := false


### PR DESCRIPTION
And use it in `eq` and `ne` so `Page` values can be compared directly in the templates without thinking about it being a `Page` or a `PageOutput` wrapper.

Fixes #3807