### PR TITLE
livereload: Maintain the scroll position if possible

### DIFF
--- a/livereload/livereload.go
+++ b/livereload/livereload.go
@@ -122,7 +122,12 @@ HugoReload.prototype.reload = function(path, options) {
 	}
 
 	path = path.substring(prefix.length);
-	window.location.href = path;
+
+	if (window.location.pathname === path) {
+		window.location.reload();
+	} else {
+		window.location.href = path;
+	}
 
 	return true;
 };


### PR DESCRIPTION
This fixes #3824: when the current pathname is the same as the one to be loaded, just call `location.reload()` so that the current scroll position can be preserved, instead of assigning to `location.href`, which will cause the scroll position to be lost.