### PR TITLE
Update template_embedded.go

### DIFF
--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -183,8 +183,8 @@ func (t *templateHandler) embedTemplates() {
         (d.head || d.body).appendChild(s);
     })();
 </script>
-<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-<a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>{{end}}`)
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+<a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>{{end}}`)
 
 	// Add SEO & Social metadata
 	t.addInternalTemplate("", "opengraph.html", `<meta property="og:title" content="{{ .Title }}" />


### PR DESCRIPTION
Changed disqus urls from http to https. This fixes mixed content warnings on browsers when viewing Hugo websites over SSL (https).