### PR TITLE
tpl: Add os.fileExists template function

### DIFF
--- a/docs/content/functions/fileExists.md
+++ b/docs/content/functions/fileExists.md
@@ -1,0 +1,29 @@
+---
+title: "fileExists"
+linktitle: "fileExists"
+date: 2017-08-31T22:38:22+02:00
+description: Checks whether a file exists under the given path.
+godocref:
+publishdate: 2017-08-31T22:38:22+02:00
+lastmod: 2017-08-31T22:38:22+02:00
+categories: [functions]
+menu:
+  docs:
+    parent: "functions"
+signature: ["fileExists PATH"]
+workson: []
+hugoversion:
+relatedfuncs: []
+deprecated: false
+aliases: []
+---
+
+`fileExists` allows you to check if a file exists under a given path, e.g. before inserting code into a template:
+
+```
+{{ if (fileExists "static/img/banner.jpg") -}}
+<img src="{{ "img/banner.jpg" | absURL }}" />
+{{- end }}
+```
+
+In the example above, a banner from the `static` folder should be shown if the given path points to an existing file.

--- a/tpl/os/init.go
+++ b/tpl/os/init.go
@@ -51,7 +51,7 @@ func init() {
 		ns.AddMethodMapping(ctx.FileExists,
 			[]string{"fileExists"},
 			[][2]string{
-				{`{{ fileExists "foo.txt" }}`, `true`},
+				{`{{ fileExists "foo.txt" }}`, `false`},
 			},
 		)
 

--- a/tpl/os/init.go
+++ b/tpl/os/init.go
@@ -48,6 +48,13 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.FileExists,
+			[]string{"fileExists"},
+			[][2]string{
+				{`{{ fileExists "foo.txt" }}`, `true`},
+			},
+		)
+
 		return ns
 
 	}

--- a/tpl/os/os.go
+++ b/tpl/os/os.go
@@ -96,3 +96,22 @@ func (ns *Namespace) ReadDir(i interface{}) ([]_os.FileInfo, error) {
 
 	return list, nil
 }
+
+// FileExists checks whether a file exists under the given path.
+func (ns *Namespace) FileExists(i interface{}) (bool, error) {
+	path, err := cast.ToStringE(i)
+	if err != nil {
+		return false, err
+	}
+
+	if path == "" {
+		return false, errors.New("fileExists needs a path to a file")
+	}
+
+	status, err := afero.Exists(ns.deps.Fs.WorkingDir, path)
+	if err != nil {
+		return false, err
+	}
+
+	return status, nil
+}

--- a/tpl/os/os_test.go
+++ b/tpl/os/os_test.go
@@ -64,7 +64,6 @@ func TestReadFile(t *testing.T) {
 	}
 }
 
-
 func TestFileExists(t *testing.T) {
 	t.Parallel()
 
@@ -85,13 +84,13 @@ func TestFileExists(t *testing.T) {
 		{filepath.FromSlash("/f/f1.txt"), true},
 		{filepath.FromSlash("f/f1.txt"), true},
 		{filepath.FromSlash("../f2.txt"), false},
-		{"", false},
 		{"b", false},
+		{"", nil},
 	} {
 		errMsg := fmt.Sprintf("[%d] %v", i, test)
 		result, err := ns.FileExists(test.filename)
 
-		if b, ok := test.expect.(bool); ok && !b {
+		if test.expect == nil {
 			require.Error(t, err, errMsg)
 			continue
 		}


### PR DESCRIPTION
This pull request is intended to fix #3839

Currently, I've an issue with the test cases. `fileExists` returns a boolean and an error / `nil`.

Due to the type assertion `false` can become ambiguous: it can either mean that a file does not exist or that an error is expected.  

If the file does not exist, `fileExists` returns `false` (correctly), implicating that no error occurred, but the test fails because `false` is interpreted like an expected error.

Any ideas how this ambiguity can be circumvented?