### PR TITLE
Add/3rd party libs paths to config

### DIFF
--- a/helpers/content_renderer_test.go
+++ b/helpers/content_renderer_test.go
@@ -42,8 +42,8 @@ func (c ContentSpec) renderWithMmark(input string) string {
 }
 
 func TestCodeFence(t *testing.T) {
-
-	if !HasPygments() {
+	v := viper.New()
+	if !HasPygments(v) {
 		t.Skip("Skipping Pygments test as Pygments is not installed or available.")
 		return
 	}

--- a/helpers/pygments.go
+++ b/helpers/pygments.go
@@ -29,11 +29,10 @@ import (
 	jww "github.com/spf13/jwalterweatherman"
 )
 
-const pygmentsBin = "pygmentize"
-
 // HasPygments checks to see if Pygments is installed and available
 // on the system.
-func HasPygments() bool {
+func HasPygments(cfg config.Provider) bool {
+	pygmentsBin := cfg.GetString("pygmentsPath")
 	if _, err := exec.LookPath(pygmentsBin); err != nil {
 		return false
 	}
@@ -42,11 +41,11 @@ func HasPygments() bool {
 
 // Highlight takes some code and returns highlighted code.
 func Highlight(cfg config.Provider, code, lang, optsStr string) string {
-	if !HasPygments() {
+	if !HasPygments(cfg) {
 		jww.WARN.Println("Highlighting requires Pygments to be installed and in the path")
 		return code
 	}
-
+	pygmentsBin := cfg.GetString("pygmentsPath")
 	options, err := parsePygmentsOpts(cfg, optsStr)
 
 	if err != nil {

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -117,6 +117,7 @@ func loadDefaultSettingsFor(v *viper.Viper) {
 	v.SetDefault("taxonomies", map[string]string{"tag": "tags", "category": "categories"})
 	v.SetDefault("permalinks", make(PermalinkOverrides, 0))
 	v.SetDefault("sitemap", Sitemap{Priority: -1, Filename: "sitemap.xml"})
+	v.SetDefault("pygmentsPath", "pygments")
 	v.SetDefault("pygmentsStyle", "monokai")
 	v.SetDefault("pygmentsUseClasses", false)
 	v.SetDefault("pygmentsCodeFences", false)

--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/tpl"
-	"github.com/stretchr/testify/require"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/tpl"
 	"github.com/stretchr/testify/require"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -79,8 +80,8 @@ func doTestShortcodeCrossrefs(t *testing.T, relative bool) {
 
 func TestShortcodeHighlight(t *testing.T) {
 	t.Parallel()
-
-	if !helpers.HasPygments() {
+	v := viper.New()
+	if !helpers.HasPygments(v) {
 		t.Skip("Skip test as Pygments is not installed")
 	}
 

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -561,7 +561,7 @@ tags:
 		} else if strings.HasSuffix(test.contentPath, ".rst") && !helpers.HasRst() {
 			fmt.Println("Skip Rst test case as no rst2html present.")
 			continue
-		} else if strings.Contains(test.expected, "code") && !helpers.HasPygments() {
+		} else if strings.Contains(test.expected, "code") && !helpers.HasPygments(cfg) {
 			fmt.Println("Skip Pygments test case as no pygments present.")
 			continue
 		}


### PR DESCRIPTION
Allows to specify the path of third party libs in the config file. Handy if you need to install such tools in a folder that is not included in PATH.
As per https://discourse.gohugo.io/t/specify-the-path-of-pygmentize/8242/6 

This is just for pygmentize. 
I'd like to know if you like this approach/style before going on with rst2html and asciidoc.

Cheers.