### PR TITLE
Improve docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM golang:1.9.0-alpine3.6 AS build
 
 RUN apk add --no-cache --virtual git musl-dev
 RUN go get github.com/kardianos/govendor
-RUN govendor get github.com/gohugoio/hugo
+
+ADD vendor/vendor.json /go/src/github.com/gohugoio/hugo/vendor/vendor.json
 WORKDIR /go/src/github.com/gohugoio/hugo
-RUN rm -f $GOPATH/bin/hugo
+RUN govendor sync
+ADD . /go/src/github.com/gohugoio/hugo/
 RUN go install -ldflags '-s -w'
 
 FROM alpine:3.6


### PR DESCRIPTION
Hi, Thanks for this project, very nice using it.

I noticed the Dockerfile at the root of the project, which is nice, and found some little optimisations thanks to  [latest docker updates (17.05:)](https://docs.docker.com/engine/userguide/eng-image/multistage-build/)

This pull request adds support for multi-stage build allowing to have shorter build time when updating hugo code itself.

As a side effect it builds the image from the working directory instead of getting master from github and reduces, in my measurements, the size of the image from 20MB to 16MB

On another hand, I didn't find an _official_ image in the docker registry. Would it be an option to create an automated build from this repo?