### PR TITLE
tpl/tplimpl: Fix escaped HTML Go 1.9 multioutput issue

### DIFF
--- a/hugolib/site_output_test.go
+++ b/hugolib/site_output_test.go
@@ -125,6 +125,9 @@ outputs: %s
 # Doc
 
 {{< myShort >}}
+
+{{< myOtherShort >}}
+
 `
 
 	mf := afero.NewMemMapFs()
@@ -144,6 +147,7 @@ other = "Olboge"
 		"layouts/partials/GoHugo.html", `Go Hugo Partial`,
 		"layouts/_default/baseof.json", `START JSON:{{block "main" .}}default content{{ end }}:END JSON`,
 		"layouts/_default/baseof.html", `START HTML:{{block "main" .}}default content{{ end }}:END HTML`,
+		"layouts/shortcodes/myOtherShort.html", `OtherShort: {{ "<h1>Hi!</h1>" | safeHTML }}`,
 		"layouts/shortcodes/myShort.html", `ShortHTML`,
 		"layouts/shortcodes/myShort.json", `ShortJSON`,
 
@@ -210,6 +214,7 @@ Content: {{ .Content }}
 			"Output/Rel: HTML/canonical|",
 			"en: Elbow",
 			"ShortJSON",
+			"OtherShort: <h1>Hi!</h1>",
 		)
 
 		th.assertFileContent("public/index.html",
@@ -218,6 +223,7 @@ Content: {{ .Content }}
 			`List HTML|JSON Home|<atom:link href=http://example.com/blog/ rel="self" type="text/html&#43;html" />`,
 			"en: Elbow",
 			"ShortHTML",
+			"OtherShort: <h1>Hi!</h1>",
 		)
 		th.assertFileContent("public/nn/index.html",
 			"List HTML|JSON Nynorsk Heim|",
@@ -228,6 +234,7 @@ Content: {{ .Content }}
 			// JSON is plain text, so no need to safeHTML this and that
 			`<atom:link href=http://example.com/blog/index.json rel="self" type="application/json+json" />`,
 			"ShortJSON",
+			"OtherShort: <h1>Hi!</h1>",
 		)
 		th.assertFileContent("public/nn/index.json",
 			"List JSON|JSON Nynorsk Heim|",

--- a/tpl/tplimpl/template.go
+++ b/tpl/tplimpl/template.go
@@ -305,7 +305,8 @@ func (t *htmlTemplates) addTemplateIn(tt *template.Template, name, tpl string) e
 		// We need to keep track of one ot the output format's shortcode template
 		// without knowing the rendering context.
 		withoutExt := strings.TrimSuffix(name, path.Ext(name))
-		tt.AddParseTree(withoutExt, templ.Tree)
+		clone := template.Must(templ.Clone())
+		tt.AddParseTree(withoutExt, clone.Tree)
 	}
 
 	return nil
@@ -334,7 +335,8 @@ func (t *textTemplates) addTemplateIn(tt *texttemplate.Template, name, tpl strin
 		// We need to keep track of one ot the output format's shortcode template
 		// without knowing the rendering context.
 		withoutExt := strings.TrimSuffix(name, path.Ext(name))
-		tt.AddParseTree(withoutExt, templ.Tree)
+		clone := texttemplate.Must(templ.Clone())
+		tt.AddParseTree(withoutExt, clone.Tree)
 	}
 
 	return nil

--- a/tpl/tplimpl/template_test.go
+++ b/tpl/tplimpl/template_test.go
@@ -1,0 +1,64 @@
+// Copyright 2017-present The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tplimpl
+
+import (
+	"testing"
+
+	"github.com/gohugoio/hugo/deps"
+	"github.com/gohugoio/hugo/hugofs"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+type handler interface {
+	addTemplate(name, tpl string) error
+}
+
+// #3876
+func TestHTMLEscape(t *testing.T) {
+	assert := require.New(t)
+
+	data := map[string]string{
+		"html":  "<h1>Hi!</h1>",
+		"other": "<h1>Hi!</h1>",
+	}
+	v := viper.New()
+	fs := hugofs.NewMem(v)
+
+	//afero.WriteFile(fs.Source, filepath.Join(workingDir, "README.txt"), []byte("Hugo Rocks!"), 0755)
+
+	depsCfg := newDepsConfig(v)
+	depsCfg.Fs = fs
+	d, err := deps.New(depsCfg)
+	assert.NoError(err)
+
+	tpl := `{{ "<h1>Hi!</h1>" | safeHTML }}`
+
+	provider := DefaultTemplateProvider
+	provider.Update(d)
+
+	h := d.Tmpl.(handler)
+
+	assert.NoError(h.addTemplate("shortcodes/myShort.html", tpl))
+
+	s, err := d.Tmpl.Lookup("shortcodes/myShort.html").ExecuteToString(data)
+	assert.NoError(err)
+	assert.Contains(s, "<h1>Hi!</h1>")
+
+	s, err = d.Tmpl.Lookup("shortcodes/myShort").ExecuteToString(data)
+	assert.NoError(err)
+	assert.Contains(s, "<h1>Hi!</h1>")
+
+}


### PR DESCRIPTION
Fixes #3876