### PR TITLE
hugolib: add new front matter field to use as the translation grouping key

### DIFF
--- a/docs/content/content-management/front-matter.md
+++ b/docs/content/content-management/front-matter.md
@@ -134,6 +134,9 @@ There are a few predefined variables that Hugo is aware of. See [Page Variables]
 `title`
 : the title for the content.
 
+`translationKey`
+: used to match the translated versions of the same content.
+
 `type`
 : the type of the content; this value will be automatically derived from the directory (i.e., the [section][]) if not specified in front matter.
 

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -156,6 +156,9 @@ type Page struct {
 	// whether the content is in a CJK language.
 	isCJKLanguage bool
 
+	// used to identify translated versions of the same content
+	translationKey string
+
 	shortcodeState *shortcodeHandler
 
 	// the content stripped for HTML
@@ -1093,6 +1096,9 @@ func (p *Page) update(f interface{}) error {
 		case "iscjklanguage":
 			isCJKLanguage = new(bool)
 			*isCJKLanguage = cast.ToBool(v)
+		case "translationkey":
+			p.translationKey = cast.ToString(v)
+			p.Params[loki] = p.translationKey
 		default:
 			// If not one of the explicit values, store in Params
 			switch vv := v.(type) {
@@ -1787,6 +1793,18 @@ func (p *Page) initLanguage() {
 
 func (p *Page) LanguagePrefix() string {
 	return p.Site.LanguagePrefix
+}
+
+func (p *Page) TranslationKey() string {
+	if p.translationKey != "" {
+		return p.translationKey
+	} else if p.IsNode() {
+		// TODO(bep) see https://github.com/gohugoio/hugo/issues/2699
+		// Must prepend the section and kind to the key to make it unique
+		return fmt.Sprintf("%s/%s/%s", p.Kind, p.sections, p.TranslationBaseName())
+	} else {
+		return p.TranslationBaseName()
+	}
 }
 
 func (p *Page) addLangPathPrefix(outfile string) string {

--- a/hugolib/translations.go
+++ b/hugolib/translations.go
@@ -13,10 +13,6 @@
 
 package hugolib
 
-import (
-	"fmt"
-)
-
 // Translations represent the other translations for a given page. The
 // string here is the language code, as affected by the `post.LANG.md`
 // filename.
@@ -26,7 +22,7 @@ func pagesToTranslationsMap(pages []*Page) map[string]Translations {
 	out := make(map[string]Translations)
 
 	for _, page := range pages {
-		base := createTranslationKey(page)
+		base := page.TranslationKey()
 
 		pageTranslation, present := out[base]
 		if !present {
@@ -45,22 +41,10 @@ func pagesToTranslationsMap(pages []*Page) map[string]Translations {
 	return out
 }
 
-func createTranslationKey(p *Page) string {
-	base := p.TranslationBaseName()
-
-	if p.IsNode() {
-		// TODO(bep) see https://github.com/gohugoio/hugo/issues/2699
-		// Must prepend the section and kind to the key to make it unique
-		base = fmt.Sprintf("%s/%s/%s", p.Kind, p.sections, base)
-	}
-
-	return base
-}
-
 func assignTranslationsToPages(allTranslations map[string]Translations, pages []*Page) {
 	for _, page := range pages {
 		page.translations = page.translations[:0]
-		base := createTranslationKey(page)
+		base := page.TranslationKey()
 		trans, exist := allTranslations[base]
 		if !exist {
 			continue


### PR DESCRIPTION
This commit implements the suggested solution in issue https://github.com/gohugoio/hugo/issues/2699

I'm not sure on the simplest way of writing an automated test for this: I thought about adding a new test case in site_output_test.go, but maybe a full integration test is too much for this?
 
As an aside: I'm not sure why the logic that uses the section as part of the translation key is only used for nodes and not for content pages (it seems a sensible default to me), so I left it that way in my patch. I can submit a follow-up pull request to change it if you think it makes sense.

Thanks!
Mattia