### PR TITLE
snap: Add git to snap package for GitInfo

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -22,6 +22,7 @@ parts:
       - git
       - make
     stage-packages:
+      - git
       - python-pygments
     prepare: |
       export GOPATH=$(dirname $SNAPCRAFT_PART_INSTALL)/go


### PR DESCRIPTION
Include the git binaries in the generated snap package so that hugo --enableGitInfo works.

This patch was tested by building a new package with snapcraft, using hugo source at the v0.26 tag.

Fixes #3896