### PR TITLE
metrics: Detect partialCached candidates

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -135,7 +135,9 @@ func (s *Store) WriteMetrics(w io.Writer) {
 		fmt.Fprintf(w, "%1s %13s  %12s  %12s  %5d  %s\n", rec, v.sum, v.avg, v.max, v.count, v.key)
 	}
 
-	fmt.Fprintf(w, "\n* = this partial always generates the same output; consider using partialCached\n")
+	if len(candidates) > 0 {
+		fmt.Fprintf(w, "\n* = this partial always generates the same output; consider using partialCached\n")
+	}
 }
 
 // A result represents the calculated results for a given metric.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -24,8 +24,8 @@ import (
 
 // The Provider interface defines an interface for measuring metrics.
 type Provider interface {
-	// RecordPartialChecksum records the checksum of a partial template's output.
-	RecordPartialChecksum(name, checksum string)
+	// AddTemplateChecksum records the checksum of a partial template's output.
+	AddTemplateChecksum(name, checksum string)
 
 	// MeasureSince adds a measurement for key to the metric store.
 	// Used with defer and time.Now().
@@ -61,8 +61,8 @@ func (s *Store) Reset() {
 	s.mu.Unlock()
 }
 
-// RecordPartialChecksum records the checksum of a partial template's output.
-func (s *Store) RecordPartialChecksum(name, checksum string) {
+// AddTemplateChecksum records the checksum of a partial template's output.
+func (s *Store) AddTemplateChecksum(name, checksum string) {
 	s.mu.Lock()
 
 	mm, ok := s.partialChecksums[name]

--- a/tpl/partials/partials.go
+++ b/tpl/partials/partials.go
@@ -14,6 +14,7 @@
 package partials
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"html/template"
 	"strings"
@@ -76,12 +77,15 @@ func (ns *Namespace) Include(name string, contextList ...interface{}) (interface
 				return "", err
 			}
 
+			if ns.deps.Metrics != nil {
+				ns.deps.Metrics.RecordPartialChecksum(templ.Name(), fmt.Sprintf("%x", sha1.Sum(b.Bytes())))
+			}
+
 			if _, ok := templ.Template.(*texttemplate.Template); ok {
 				return b.String(), nil
 			}
 
 			return template.HTML(b.String()), nil
-
 		}
 	}
 

--- a/tpl/partials/partials.go
+++ b/tpl/partials/partials.go
@@ -78,7 +78,7 @@ func (ns *Namespace) Include(name string, contextList ...interface{}) (interface
 			}
 
 			if ns.deps.Metrics != nil {
-				ns.deps.Metrics.RecordPartialChecksum(templ.Name(), fmt.Sprintf("%x", sha1.Sum(b.Bytes())))
+				ns.deps.Metrics.AddTemplateChecksum(templ.Name(), fmt.Sprintf("%x", sha1.Sum(b.Bytes())))
 			}
 
 			if _, ok := templ.Template.(*texttemplate.Template); ok {


### PR DESCRIPTION
When template metrics are enabled, calculate a checksum for the output
of every partial and identify partials that always generate the same
output.