### PR TITLE
Change SummaryLength to be configurable

### DIFF
--- a/docs/content/getting-started/configuration.md
+++ b/docs/content/getting-started/configuration.md
@@ -111,6 +111,8 @@ googleAnalytics:            ""
 # if true, auto-detect Chinese/Japanese/Korean Languages in the content. (.Summary and .WordCount can work properly in CJKLanguage)
 hasCJKLanguage:             false
 languageCode:               ""
+# the length of text to show in a .Summary
+summaryLength:              70
 layoutDir:                  "layouts"
 # Enable Logging
 log:                        false
@@ -252,6 +254,8 @@ googleAnalytics =             ""
 # if true, auto-detect Chinese/Japanese/Korean Languages in the content. (.Summary and .WordCount can work properly in CJKLanguage)
 hasCJKLanguage =              false
 languageCode =                ""
+# the length of text to show in a .Summary
+summaryLength:              70
 layoutDir =                   "layouts"
 # Enable Logging
 log =                         false

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -76,20 +76,23 @@ func TestBytesToHTML(t *testing.T) {
 var benchmarkTruncateString = strings.Repeat("This is a sentence about nothing.", 20)
 
 func BenchmarkTestTruncateWordsToWholeSentence(b *testing.B) {
+	c := newTestContentSpec()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		TruncateWordsToWholeSentence(benchmarkTruncateString, SummaryLength)
+		c.TruncateWordsToWholeSentence(benchmarkTruncateString)
 	}
 }
 
 func BenchmarkTestTruncateWordsToWholeSentenceOld(b *testing.B) {
+	c := newTestContentSpec()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		truncateWordsToWholeSentenceOld(benchmarkTruncateString, SummaryLength)
+		c.truncateWordsToWholeSentenceOld(benchmarkTruncateString)
 	}
 }
 
 func TestTruncateWordsToWholeSentence(t *testing.T) {
+	c := newTestContentSpec()
 	type test struct {
 		input, expected string
 		max             int
@@ -104,9 +107,11 @@ func TestTruncateWordsToWholeSentence(t *testing.T) {
 		{"To be. Or not to be. That's the question.", "To be.", 1, true},
 		{" \nThis is not a sentence\nAnd this is another", "This is not a sentence", 4, true},
 		{"", "", 10, false},
+		{"This... is a more difficult test?", "This... is a more difficult test?", 1, false},
 	}
 	for i, d := range data {
-		output, truncated := TruncateWordsToWholeSentence(d.input, d.max)
+		c.summaryLength = d.max
+		output, truncated := c.TruncateWordsToWholeSentence(d.input)
 		if d.expected != output {
 			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
 		}
@@ -118,6 +123,7 @@ func TestTruncateWordsToWholeSentence(t *testing.T) {
 }
 
 func TestTruncateWordsByRune(t *testing.T) {
+	c := newTestContentSpec()
 	type test struct {
 		input, expected string
 		max             int
@@ -139,7 +145,8 @@ func TestTruncateWordsByRune(t *testing.T) {
 		{" \nThis is    not a sentence\n ", "This is not", 3, true},
 	}
 	for i, d := range data {
-		output, truncated := TruncateWordsByRune(strings.Fields(d.input), d.max)
+		c.summaryLength = d.max
+		output, truncated := c.TruncateWordsByRune(strings.Fields(d.input))
 		if d.expected != output {
 			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
 		}

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -135,6 +135,7 @@ func loadDefaultSettingsFor(v *viper.Viper) error {
 	v.SetDefault("newContentEditor", "")
 	v.SetDefault("paginate", 10)
 	v.SetDefault("paginatePath", "page")
+	v.SetDefault("summaryLength", 70)
 	v.SetDefault("blackfriday", c.NewBlackfriday())
 	v.SetDefault("rSSUri", "index.xml")
 	v.SetDefault("rssLimit", -1)

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -677,9 +677,9 @@ func (p *Page) setAutoSummary() error {
 	var summary string
 	var truncated bool
 	if p.isCJKLanguage {
-		summary, truncated = helpers.TruncateWordsByRune(p.PlainWords(), helpers.SummaryLength)
+		summary, truncated = p.s.ContentSpec.TruncateWordsByRune(p.PlainWords())
 	} else {
-		summary, truncated = helpers.TruncateWordsToWholeSentence(p.Plain(), helpers.SummaryLength)
+		summary, truncated = p.s.ContentSpec.TruncateWordsToWholeSentence(p.Plain())
 	}
 	p.Summary = template.HTML(summary)
 	p.Truncated = truncated


### PR DESCRIPTION
Move SummaryLength into the ContentSpec struct and refactor the
relevant summary functions to be methods of ContentSpec. The new
summaryLength struct member is configurable by the summaryLength config
value, and the default remains 70. Also updates hugolib/page to use the
refactored methods.

Resolves #3734