### PR TITLE
 tpl: Add errorf template function

### DIFF
--- a/docs/content/functions/errorf.md
+++ b/docs/content/functions/errorf.md
@@ -1,0 +1,26 @@
+---
+title: errorf
+linktitle: errorf
+description: Evaluates a format string and logs it to ERROR.
+date: 2017-09-30
+publishdate: 2017-09-30
+lastmod: 2017-09-30
+categories: [functions]
+menu:
+  docs:
+    parent: "functions"
+keywords: [strings, log, error]
+signature: ["errorf FORMAT INPUT"]
+workson: []
+hugoversion:
+relatedfuncs: [printf]
+deprecated: false
+aliases: []
+---
+
+`errorf` will evaluate a format string, then output the result to the ERROR log.
+This will also cause the build to fail.
+
+```
+{{ errorf "Something went horribly wrong! %s" err }}
+```

--- a/tpl/fmt/fmt.go
+++ b/tpl/fmt/fmt.go
@@ -15,15 +15,17 @@ package fmt
 
 import (
 	_fmt "fmt"
+	"github.com/gohugoio/hugo/helpers"
 )
 
 // New returns a new instance of the fmt-namespaced template functions.
 func New() *Namespace {
-	return &Namespace{}
+	return &Namespace{helpers.NewDistinctErrorLogger()}
 }
 
 // Namespace provides template functions for the "fmt" namespace.
 type Namespace struct {
+	errorLogger *helpers.DistinctLogger
 }
 
 // Print returns string representation of the passed arguments.
@@ -40,4 +42,9 @@ func (ns *Namespace) Printf(format string, a ...interface{}) string {
 // Println returns string representation of the passed arguments ending with a newline.
 func (ns *Namespace) Println(a ...interface{}) string {
 	return _fmt.Sprintln(a...)
+}
+
+func (ns *Namespace) Errorf(format string, a ...interface{}) string {
+	ns.errorLogger.Printf(format, a...)
+	return _fmt.Sprintf(format, a...)
 }

--- a/tpl/fmt/init.go
+++ b/tpl/fmt/init.go
@@ -50,8 +50,14 @@ func init() {
 			},
 		)
 
-		return ns
+		ns.AddMethodMapping(ctx.Errorf,
+			[]string{"errorf"},
+			[][2]string{
+				{`{{ errorf "%s." "failed" }}`, `failed.`},
+			},
+		)
 
+		return ns
 	}
 
 	internal.AddTemplateFuncsNamespace(f)


### PR DESCRIPTION
Add template function that will build a string from the given format
string and arguments, then log it to ERROR. This has an intended
side-effect of causing the build to fail, when executed.

Resolves #3817 

I'm not 100% confident everything is done properly. Things I'm unsure about:

1. Could logging to error during `go test` have bad side effects?
2. Is `jww.ERROR` the correct logger to use for this? I tried to copy the style i saw in tpl/data.
3. Is there a way I can also log the template/content that executed the `errorf` call? I think it should be more verbose.