### PR TITLE
tplimpl: Output xmlns:xhtml only if there are translations available

### DIFF
--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -87,8 +87,8 @@ func (t *templateHandler) embedTemplates() {
   </channel>
 </rss>`)
 
-	t.addInternalTemplate("_default", "sitemap.xml", `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+	t.addInternalTemplate("_default", "sitemap.xml", `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"{{ if .IsTranslated }}
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"{{ end }}>
   {{ range .Data.Pages }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}


### PR DESCRIPTION
This removes `xmlns:xhtml="http://www.w3.org/1999/xhtml"` from the default sitemap when there are no translation links available. The translation links were added in #3348.