### PR TITLE
tpl: Support slices of uncomparable types in union and intersect

### DIFF
--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -348,6 +348,10 @@ func TestIntersect(t *testing.T) {
 		{pagesVals{}, pagesVals{p1v, p3v, p3v}, pagesVals{}},
 		{[]interface{}{p1, p4, p2, p3}, []interface{}{}, []interface{}{}},
 		{[]interface{}{}, []interface{}{p1v, p3v, p3v}, []interface{}{}},
+
+		// #3820 - slices of uncomparable types
+		{[][]int{{1, 1}, {1, 2}}, [][]int{{1, 2}, {1, 2}, {1, 3}}, [][]int{{1, 2}}},
+		{[]map[int]int{{1: 1}, {2: 2}}, []map[int]int{{2: 2}, {3: 3}}, []map[int]int{{2: 2}}},
 	} {
 
 		errMsg := fmt.Sprintf("[%d]", test)
@@ -371,6 +375,20 @@ func BenchmarkIntersect(b *testing.B) {
 
 	l1 := []interface{}{"a", "b", "c", "c", "c", "x", "o", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "k", "l", "q", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z"}
 	l2 := []string{"a", "b", "d", "x", "x", "x", "z", "z", "z"}
+
+	for i := 0; i < b.N; i++ {
+		_, err := ns.Intersect(l1, l2)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkIntersectSlices(b *testing.B) {
+	ns := New(&deps.Deps{})
+
+	l1 := [][]int{{1, 1}, {1, 2}, {1, 2}, {1, 2, 3}, {1}, {1, 3, 5, 7, 11}, {2}, {10, 11}, {1, 2}, {22, 22}}
+	l2 := [][]int{{1, 2}, {1, 3}, {3, 3}, {1, 2}, {1, 2, 3}, {1, 3, 5, 7, 11}, {2}, {9, 10}, {10, 11}, {22, 22}, {22, 22}, {99}}
 
 	for i := 0; i < b.N; i++ {
 		_, err := ns.Intersect(l1, l2)
@@ -692,6 +710,10 @@ func TestUnion(t *testing.T) {
 		{pagesPtr{}, pagesPtr{p1}, pagesPtr{p1}, false},
 		{pagesVals{}, pagesVals{p1v}, pagesVals{p1v}, false},
 
+		// #3820 - uncomparable types
+		{[]map[string]int{{"K1": 1}}, []map[string]int{{"K2": 2}, {"K2": 2}}, []map[string]int{{"K1": 1}, {"K2": 2}}, false},
+		{[][]int{{1, 1}, {1, 2}}, [][]int{{2, 1}, {2, 2}}, [][]int{{1, 1}, {1, 2}, {2, 1}, {2, 2}}, false},
+
 		// errors
 		{"not array or slice", []string{"a"}, false, true},
 		{[]string{"a"}, "not array or slice", false, true},
@@ -717,6 +739,20 @@ func BenchmarkUnion(b *testing.B) {
 
 	l1 := []interface{}{"a", "b", "c", "c", "c", "x", "o", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "k", "l", "q", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z"}
 	l2 := []string{"a", "b", "d", "x", "x", "x", "z", "z", "z"}
+
+	for i := 0; i < b.N; i++ {
+		_, err := ns.Union(l1, l2)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnionSlices(b *testing.B) {
+	ns := New(&deps.Deps{})
+
+	l1 := [][]int{{1, 1}, {1, 2}, {1, 2}, {1, 2, 3}, {1}, {1, 3, 5, 7, 11}, {2}, {10, 11}, {1, 2}, {22, 22}}
+	l2 := [][]int{{1, 2}, {1, 3}, {3, 3}, {1, 2}, {1, 2, 3}, {1, 3, 5, 7, 11}, {2}, {9, 10}, {10, 11}, {22, 22}, {22, 22}, {99}}
 
 	for i := 0; i < b.N; i++ {
 		_, err := ns.Union(l1, l2)

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -366,6 +366,20 @@ func TestIntersect(t *testing.T) {
 	}
 }
 
+func BenchmarkIntersect(b *testing.B) {
+	ns := New(&deps.Deps{})
+
+	l1 := []interface{}{"a", "b", "c", "c", "c", "x", "o", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "k", "l", "q", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z"}
+	l2 := []string{"a", "b", "d", "x", "x", "x", "z", "z", "z"}
+
+	for i := 0; i < b.N; i++ {
+		_, err := ns.Intersect(l1, l2)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestIsSet(t *testing.T) {
 	t.Parallel()
 
@@ -694,6 +708,20 @@ func TestUnion(t *testing.T) {
 		assert.NoError(t, err, errMsg)
 		if !reflect.DeepEqual(result, test.expect) {
 			t.Fatalf("[%d] Got\n%v expected\n%v", i, result, test.expect)
+		}
+	}
+}
+
+func BenchmarkUnion(b *testing.B) {
+	ns := New(&deps.Deps{})
+
+	l1 := []interface{}{"a", "b", "c", "c", "c", "x", "o", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "k", "l", "q", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z", "a", "b", "c", "c", "c", "x", "y", "z"}
+	l2 := []string{"a", "b", "d", "x", "x", "x", "z", "z", "z"}
+
+	for i := 0; i < b.N; i++ {
+		_, err := ns.Union(l1, l2)
+		if err != nil {
+			b.Fatal(err)
 		}
 	}
 }

--- a/tpl/compare/compare.go
+++ b/tpl/compare/compare.go
@@ -87,7 +87,10 @@ func (*Namespace) Default(dflt interface{}, given ...interface{}) (interface{}, 
 
 // Eq returns the boolean truth of arg1 == arg2.
 func (*Namespace) Eq(x, y interface{}) bool {
+	return Eq(x, y)
+}
 
+func Eq(x, y interface{}) bool {
 	if e, ok := x.(compare.Eqer); ok {
 		return e.Eq(y)
 	}


### PR DESCRIPTION
This PR continues to use a map for comparable types but adds a
slower option for comparing uncomparable types, such as maps and slices.
    
Fixes #3820