### PR TITLE
Replaced unused 'viper' variable in server log

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -391,7 +391,7 @@ func InitializeConfig(subCmdVs ...*cobra.Command) (*deps.DepsCfg, error) {
 		return nil, err
 	}
 
-	cfg.Logger.INFO.Println("Using config file:", viper.ConfigFileUsed())
+	cfg.Logger.INFO.Println("Using config file:", config.ConfigFileUsed())
 
 	themeDir := c.PathSpec().GetThemeDir()
 	if themeDir != "" {


### PR DESCRIPTION
The verbose output for server was not displaying the current
configuration file name. The log used a global 'viper'
variable. Replaced that with the 'config' variable.

With this change, the verbose log now shows:

  INFO 2017/10/08 22:21:00 Using config file: config.toml

Note that there's still an issue when using multiple config
files. The routine is hard coded to show only the first file
read.