### PR TITLE
Add internal Google Tag Manager template

### DIFF
--- a/docs/content/templates/internal.md
+++ b/docs/content/templates/internal.md
@@ -54,6 +54,34 @@ You can then include the Google Analytics internal template:
 {{ template "_internal/google_analytics_async.html" . }}
 ```
 
+## Google Tag Manager
+
+Hugo also ships with internal templates for Google Tag Manager providing code for the `head` and `body` sections.
+
+### Configure Google Tag Manager
+
+Provide your id in your configuration file:
+
+```
+googleTagManager = "GTM-XXXX"
+```
+
+### Use the Google Tag Manager Template
+
+You can include the Google Tag Manager internal template:
+
+* `head` section
+```
+{{ template "_internal/google_tagmanager_head.html" . }}
+```
+
+* `body` section
+```
+{{ template "_internal/google_tagmanager_body.html" . }}
+```
+
+
+
 ## Disqus
 
 Hugo also ships with an internal template for [Disqus comments][disqus], a popular commenting system for both static and dynamic websites. In order to effectively use Disqus, you will need to secure a Disqus "shortname" by [signing up for the free service][disqussignup].

--- a/docs/content/variables/site.md
+++ b/docs/content/variables/site.md
@@ -49,6 +49,9 @@ The following is a list of site-level (aka "global") variables. Many of these va
 `.Site.GoogleAnalytics`
 : a string representing your tracking code for Google Analytics as defined in the site configuration.
 
+`.Site.GoogleTagManager`
+: a string representing your tracking code for Google Tag Manager as defined in the site configuration.
+
 `.Site.IsMultiLingual`
 : whether there are more than one language in this site. See [Multilingual](/content-management/multilingual/) for more information.
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -364,6 +364,7 @@ type SiteInfo struct {
 	LanguageCode          string
 	DisqusShortname       string
 	GoogleAnalytics       string
+	GoogleTagManager      string
 	Copyright             string
 	LastChange            time.Time
 	Permalinks            PermalinkOverrides
@@ -1036,6 +1037,7 @@ func (s *Site) initializeSiteInfo() {
 		defaultContentLanguageInSubdir: defaultContentInSubDir,
 		sectionPagesMenu:               lang.GetString("sectionPagesMenu"),
 		GoogleAnalytics:                lang.GetString("googleAnalytics"),
+		GoogleTagManager:               lang.GetString("googleTagManager"),
 		BuildDrafts:                    s.Cfg.GetBool("buildDrafts"),
 		canonifyURLs:                   s.Cfg.GetBool("canonifyURLs"),
 		relativeURLs:                   s.Cfg.GetBool("relativeURLs"),

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -290,4 +290,17 @@ ga('send', 'pageview');
 {{ end }}`)
 
 	t.addInternalTemplate("_default", "robots.txt", "User-agent: *")
+
+	t.addInternalTemplate("", "google_tagmanager_head.html", `{{ with .Site.GoogleTagManager }}
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ . }}');</script>
+{{ end }}`)
+
+	t.addInternalTemplate("", "google_tagmanager_body.html", `{{ with .Site.GoogleTagManager }}
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ . }}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+{{ end }}`)
 }


### PR DESCRIPTION
Add a Hugo internal template to insert code for Google Tag Manager.

- Users:
Simply populate the new `googleTagManager` site variable with the tracking code (`googleTagManager = GTM-XXXX`).
- Theme creators:
Themes need to include both template in any page:
   * `head` section
   `{{ template "_internal/google_tagmanager_head.html" . }}`
   * `body` section
   `{{ template "_internal/google_tagmanager_body.html" . }}`