### PR TITLE
Log file path upon error when reading from buffers

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -790,7 +790,7 @@ func (s *Site) NewPage(name string) (*Page, error) {
 func (p *Page) ReadFrom(buf io.Reader) (int64, error) {
 	// Parse for metadata & body
 	if err := p.parse(buf); err != nil {
-		p.s.Log.ERROR.Print(err)
+		p.s.Log.ERROR.Printf("%s for %s", err, p.File.Path())
 		return 0, err
 	}
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1241,6 +1241,23 @@ func TestDraftAndPublishedFrontMatterError(t *testing.T) {
 	}
 }
 
+var pageWithBrokenFrontMatter = `---
+title: broken
+published: false
+draft: true
+-
+some content
+`
+
+func TestBrokenFrontMatterLogMessage(t *testing.T) {
+	t.Parallel()
+	s := newTestSite(t)
+	var buf bytes.Buffer
+	s.Log.SetLogOutput(&buf)
+	s.NewPageFrom(strings.NewReader(pageWithBrokenFrontMatter), "content/post/broken.md")
+	require.Contains(t, buf.String(), "content/post/broken.md")
+}
+
 var pagesWithPublishedFalse = `---
 title: okay
 published: false


### PR DESCRIPTION
Fixes #3696 

The error messages come from the parser package. Since the function generating the error does not have information about the file (it operates on buffers), I just included the missing information in the function logging the message, in the hugolib package.