### PR TITLE
i18n: Allow custom language codes

### DIFF
--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -157,8 +157,8 @@ func doTestI18nTranslate(t *testing.T, test i18nTest, cfg config.Provider) strin
 	ids := []string{}
 
 	for file := range test.data {
-		id := strings.Split(file, ".toml")
-		ids = append(ids, id[0])
+		id := strings.TrimSuffix(file, ".toml")
+		ids = append(ids, id)
 	}
 
 	language.RegisterPluralSpec(ids, &language.PluralSpec{})

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/gohugoio/hugo/config"
 	"github.com/nicksnyder/go-i18n/i18n/bundle"
+	"github.com/nicksnyder/go-i18n/i18n/language"
 	jww "github.com/spf13/jwalterweatherman"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"strings"
 )
 
 var logger = jww.NewNotepad(jww.LevelError, jww.LevelError, os.Stdout, ioutil.Discard, "", log.Ldate|log.Ltime)
@@ -137,10 +139,29 @@ var i18nTests = []i18nTest{
 		expected:     "hello",
 		expectedFlag: "[i18n] hello",
 	},
+	// Non Unicode CLDR language code
+	{
+		data: map[string][]byte{
+			"dk.toml": []byte("[hello]\nother = \"hej\""),
+		},
+		args:         nil,
+		lang:         "dk",
+		id:           "hello",
+		expected:     "hej",
+		expectedFlag: "hej",
+	},
 }
 
 func doTestI18nTranslate(t *testing.T, test i18nTest, cfg config.Provider) string {
 	i18nBundle := bundle.New()
+	ids := []string{}
+
+	for file := range test.data {
+		id := strings.Split(file, ".toml")
+		ids = append(ids, id[0])
+	}
+
+	language.RegisterPluralSpec(ids, &language.PluralSpec{})
 
 	for file, content := range test.data {
 		err := i18nBundle.ParseTranslationFileBytes(file, content)

--- a/i18n/translationProvider.go
+++ b/i18n/translationProvider.go
@@ -55,8 +55,7 @@ func (tp *TranslationProvider) Update(d *deps.Deps) error {
 			langs = append(langs, r.BaseFileName())
 		}
 	}
-	// we need to register all language codes as "plural spec" to prevent errors
-	// with unknown language codes
+	// We need to register all language codes as "plural spec" to prevent errors with unknown language codes.
 	// see https://github.com/gohugoio/hugo/issues/3564
 	ps := &language.PluralSpec{}
 	language.RegisterPluralSpec(langs, ps)

--- a/i18n/translationProvider.go
+++ b/i18n/translationProvider.go
@@ -38,8 +38,6 @@ func (tp *TranslationProvider) Update(d *deps.Deps) error {
 	dir := d.PathSpec.AbsPathify(d.Cfg.GetString("i18nDir"))
 	sp := source.NewSourceSpec(d.Cfg, d.Fs)
 	sources := []source.Input{sp.NewFilesystem(dir)}
-	ps := &language.PluralSpec{}
-	langs := []string{}
 
 	themeI18nDir, err := d.PathSpec.GetThemeI18nDirPath()
 
@@ -51,12 +49,16 @@ func (tp *TranslationProvider) Update(d *deps.Deps) error {
 
 	i18nBundle := bundle.New()
 
+	langs := []string{}
 	for _, currentSource := range sources {
 		for _, r := range currentSource.Files() {
 			langs = append(langs, r.BaseFileName())
 		}
 	}
-
+	// we need to register all language codes as "plural spec" to prevent errors
+	// with unknown language codes
+	// see https://github.com/gohugoio/hugo/issues/3564
+	ps := &language.PluralSpec{}
 	language.RegisterPluralSpec(langs, ps)
 
 	for _, currentSource := range sources {

--- a/i18n/translationProvider.go
+++ b/i18n/translationProvider.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/source"
 	"github.com/nicksnyder/go-i18n/i18n/bundle"
-	"github.com/nicksnyder/go-i18n/i18n/language"
+	//"github.com/nicksnyder/go-i18n/i18n/language"
 )
 
 // TranslationProvider provides translation handling, i.e. loading
@@ -40,7 +40,7 @@ func (tp *TranslationProvider) Update(d *deps.Deps) error {
 	sources := []source.Input{sp.NewFilesystem(dir)}
 
 	themeI18nDir, err := d.PathSpec.GetThemeI18nDirPath()
-	ps := &language.PluralSpec{}
+	//ps := &language.PluralSpec{}
 
 	if err == nil {
 		sources = []source.Input{sp.NewFilesystem(themeI18nDir), sources[0]}
@@ -52,7 +52,7 @@ func (tp *TranslationProvider) Update(d *deps.Deps) error {
 
 	for _, currentSource := range sources {
 		for _, r := range currentSource.Files() {
-			language.RegisterPluralSpec([]string{r.BaseFileName()}, ps)
+			//language.RegisterPluralSpec([]string{r.BaseFileName()}, ps)
 			err := i18nBundle.ParseTranslationFileBytes(r.LogicalName(), r.Bytes())
 			if err != nil {
 				return fmt.Errorf("Failed to load translations in file %q: %s", r.LogicalName(), err)

--- a/i18n/translationProvider.go
+++ b/i18n/translationProvider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/source"
 	"github.com/nicksnyder/go-i18n/i18n/bundle"
+	"github.com/nicksnyder/go-i18n/i18n/language"
 )
 
 // TranslationProvider provides translation handling, i.e. loading
@@ -39,6 +40,7 @@ func (tp *TranslationProvider) Update(d *deps.Deps) error {
 	sources := []source.Input{sp.NewFilesystem(dir)}
 
 	themeI18nDir, err := d.PathSpec.GetThemeI18nDirPath()
+	ps := &language.PluralSpec{}
 
 	if err == nil {
 		sources = []source.Input{sp.NewFilesystem(themeI18nDir), sources[0]}
@@ -50,6 +52,7 @@ func (tp *TranslationProvider) Update(d *deps.Deps) error {
 
 	for _, currentSource := range sources {
 		for _, r := range currentSource.Files() {
+			language.RegisterPluralSpec([]string{r.BaseFileName()}, ps)
 			err := i18nBundle.ParseTranslationFileBytes(r.LogicalName(), r.Bytes())
 			if err != nil {
 				return fmt.Errorf("Failed to load translations in file %q: %s", r.LogicalName(), err)

--- a/i18n/translationProvider.go
+++ b/i18n/translationProvider.go
@@ -15,12 +15,17 @@ package i18n
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/source"
 	"github.com/nicksnyder/go-i18n/i18n/bundle"
 	"github.com/nicksnyder/go-i18n/i18n/language"
 )
+
+// Unfortunately this needs to be global, see
+// https://github.com/nicksnyder/go-i18n/issues/82
+var tpMu sync.Mutex
 
 // TranslationProvider provides translation handling, i.e. loading
 // of bundles etc.
@@ -35,6 +40,9 @@ func NewTranslationProvider() *TranslationProvider {
 
 // Update updates the i18n func in the provided Deps.
 func (tp *TranslationProvider) Update(d *deps.Deps) error {
+	tpMu.Lock()
+	defer tpMu.Unlock()
+
 	dir := d.PathSpec.AbsPathify(d.Cfg.GetString("i18nDir"))
 	sp := source.NewSourceSpec(d.Cfg, d.Fs)
 	sources := []source.Input{sp.NewFilesystem(dir)}

--- a/i18n/translationProvider.go
+++ b/i18n/translationProvider.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/source"
 	"github.com/nicksnyder/go-i18n/i18n/bundle"
-	//"github.com/nicksnyder/go-i18n/i18n/language"
+	"github.com/nicksnyder/go-i18n/i18n/language"
 )
 
 // TranslationProvider provides translation handling, i.e. loading
@@ -38,9 +38,10 @@ func (tp *TranslationProvider) Update(d *deps.Deps) error {
 	dir := d.PathSpec.AbsPathify(d.Cfg.GetString("i18nDir"))
 	sp := source.NewSourceSpec(d.Cfg, d.Fs)
 	sources := []source.Input{sp.NewFilesystem(dir)}
+	ps := &language.PluralSpec{}
+	langs := []string{}
 
 	themeI18nDir, err := d.PathSpec.GetThemeI18nDirPath()
-	//ps := &language.PluralSpec{}
 
 	if err == nil {
 		sources = []source.Input{sp.NewFilesystem(themeI18nDir), sources[0]}
@@ -52,7 +53,14 @@ func (tp *TranslationProvider) Update(d *deps.Deps) error {
 
 	for _, currentSource := range sources {
 		for _, r := range currentSource.Files() {
-			//language.RegisterPluralSpec([]string{r.BaseFileName()}, ps)
+			langs = append(langs, r.BaseFileName())
+		}
+	}
+
+	language.RegisterPluralSpec(langs, ps)
+
+	for _, currentSource := range sources {
+		for _, r := range currentSource.Files() {
 			err := i18nBundle.ParseTranslationFileBytes(r.LogicalName(), r.Bytes())
 			if err != nil {
 				return fmt.Errorf("Failed to load translations in file %q: %s", r.LogicalName(), err)


### PR DESCRIPTION
This PR uses the new `RegisterPluralSpec` function from [go-i18n](https://github.com/nicksnyder/go-i18n) to register all languages defined. Previously only language codes available within the Unicode CLDR  standard could be defined.