### PR TITLE
helpers: Remove style and script tags in plainify output

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"html/template"
 	"os/exec"
+	"regexp"
 	"unicode"
 	"unicode/utf8"
 
@@ -187,6 +188,7 @@ func StripHTML(s string) string {
 		return s
 	}
 	s = stripHTMLReplacer.Replace(s)
+	s = stripHTMLContainers(s)
 
 	// Walk through the string removing all tags
 	b := bp.GetBuffer()
@@ -220,6 +222,22 @@ func StripHTML(s string) string {
 // stripEmptyNav strips out empty <nav> tags from content.
 func stripEmptyNav(in []byte) []byte {
 	return bytes.Replace(in, []byte("<nav>\n</nav>\n\n"), []byte(``), -1)
+}
+
+// stripHTMLContainers strips out script and style tags including
+// content contained within the element.
+func stripHTMLContainers(s string) string {
+	var tagsToStrip = []string{"script", "style"}
+
+	// Build a regular expression from tagsToStrip
+	var patternsToStrip = make([]string, len(tagsToStrip))
+	for i, tag := range tagsToStrip {
+		patternsToStrip[i] = "<" + tag + ">(.+?)</" + tag + ">"
+	}
+	rePattern := strings.Join(patternsToStrip, "|")
+
+	stripHTMLRegexp := regexp.MustCompile(rePattern)
+	return stripHTMLRegexp.ReplaceAllLiteralString(s, "")
 }
 
 // BytesToHTML converts bytes to type template.HTML.

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -48,6 +48,8 @@ func TestStripHTML(t *testing.T) {
 More text here.</p>
 
 <p>Some more text</p>`, "Summary Next Line.  . More text here.\nSome more text\n"},
+		{"<style>.red {color:red;}</style>strip <span>style</span> tag", "strip style tag"},
+		{"<script>alert('1');</script>strip script tags<script>alert('2');</script>", "strip script tags"},
 	}
 	for i, d := range data {
 		output := StripHTML(d.input)

--- a/tpl/transform/transform_test.go
+++ b/tpl/transform/transform_test.go
@@ -206,6 +206,7 @@ func TestPlainify(t *testing.T) {
 		expect interface{}
 	}{
 		{"<em>Note:</em> blah <b>blah</b>", "Note: blah blah"},
+		{"style <style>body{font-size:1.1em;}</style> and script <script>console.log();</script> tags are removed", "style and script tags are removed"},
 		// errors
 		{tstNoStringer{}, false},
 	} {


### PR DESCRIPTION
Add new stripHTMLContainers function that strips out specific HTML tags including the contents contained within the element.

Fixes #3235

I originally wanted to see if I could implement this logic while walking through the string, but it seemed excessively complex to detect specific tags while walking through each codepoint in the string.  I ended up with this implementation because it felt easier to reason about.

