### PR TITLE
New flag to only generate content newer than maxAge days. See #3724

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -239,7 +239,7 @@ func initHugoBuildCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("canonifyURLs", false, "if true, all relative URLs will be canonicalized using baseURL")
 	cmd.Flags().StringVarP(&baseURL, "baseURL", "b", "", "hostname (and path) to the root, e.g. http://spf13.com/")
 	cmd.Flags().Bool("enableGitInfo", false, "add Git revision, date and author info to the pages")
-
+	cmd.Flags().Int("maxAge", 0, "max age in days for content to generate")
 	cmd.Flags().BoolVar(&nitro.AnalysisOn, "stepAnalysis", false, "display memory and timing of different steps of the program")
 	cmd.Flags().Bool("templateMetrics", false, "display metrics about template executions")
 	cmd.Flags().Bool("templateMetricsHints", false, "calculate some improvement hints when combined with --templateMetrics")
@@ -479,6 +479,7 @@ func (c *commandeer) initializeFlags(cmd *cobra.Command) {
 		"noChmod",
 		"templateMetrics",
 		"templateMetricsHints",
+		"maxAge",
 	}
 
 	// Remove these in Hugo 0.23.

--- a/docs/content/commands/hugo_server.md
+++ b/docs/content/commands/hugo_server.md
@@ -40,7 +40,7 @@ hugo server [flags]
       --cacheDir string         filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
       --canonifyURLs            if true, all relative URLs will be canonicalized using baseURL
       --cleanDestinationDir     remove files from destination not found in static directories
-      --contentAgeFilter N      do not generate older content then N days
+      --maxAge N                do not generate older content then N days
   -c, --contentDir string       filesystem path to content directory
   -d, --destination string      filesystem path to write files to
       --disable404              do not render 404 page

--- a/docs/content/commands/hugo_server.md
+++ b/docs/content/commands/hugo_server.md
@@ -40,6 +40,7 @@ hugo server [flags]
       --cacheDir string         filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
       --canonifyURLs            if true, all relative URLs will be canonicalized using baseURL
       --cleanDestinationDir     remove files from destination not found in static directories
+      --contentAgeFilter N      do not generate older content then N days
   -c, --contentDir string       filesystem path to content directory
   -d, --destination string      filesystem path to write files to
       --disable404              do not render 404 page

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -888,12 +888,16 @@ func (p *Page) LinkTitle() string {
 }
 
 func (p *Page) shouldBuild() bool {
+	useFilter := 0 < p.s.Cfg.GetInt("maxAge")
+	cutOff := time.Now().AddDate(0, 0, -p.s.Cfg.GetInt("maxAge"))
+
 	return shouldBuild(p.s.Cfg.GetBool("buildFuture"), p.s.Cfg.GetBool("buildExpired"),
-		p.s.Cfg.GetBool("buildDrafts"), p.Draft, p.PublishDate, p.ExpiryDate)
+		p.s.Cfg.GetBool("buildDrafts"), p.Draft, useFilter,
+		p.PublishDate, p.ExpiryDate, cutOff)
 }
 
 func shouldBuild(buildFuture bool, buildExpired bool, buildDrafts bool, Draft bool,
-	publishDate time.Time, expiryDate time.Time) bool {
+	ageFilter bool, publishDate time.Time, expiryDate time.Time, cutOff time.Time) bool {
 	if !(buildDrafts || !Draft) {
 		return false
 	}
@@ -901,6 +905,9 @@ func shouldBuild(buildFuture bool, buildExpired bool, buildDrafts bool, Draft bo
 		return false
 	}
 	if !buildExpired && !expiryDate.IsZero() && expiryDate.Before(time.Now()) {
+		return false
+	}
+	if ageFilter && publishDate.Before(cutOff) {
 		return false
 	}
 	return true


### PR DESCRIPTION
This proposed solution will only generate content newer than set age, e.g. this command will only generate pages published the last 42 days:
`hugo server --maxAge 42
`
