### PR TITLE
print gofmt errors in mage

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -121,14 +122,25 @@ func Fmt() error {
 		return err
 	}
 	failed := false
+	first := true
 	for _, pkg := range pkgs {
 		files, err := filepath.Glob(filepath.Join(pkg, "*.go"))
 		if err != nil {
 			return nil
 		}
 		for _, f := range files {
-			if err := sh.Run("gofmt", "-l", f); err != nil {
-				failed = false
+			s, err := sh.Output("gofmt", "-l", f)
+			if err != nil {
+				fmt.Println("error running gofmt on %q: %v", f, err)
+				failed = true
+			}
+			if s != "" {
+				if first {
+					fmt.Println("The following files are not gofmt'ed:")
+					first = false
+				}
+				failed = true
+				fmt.Println(s)
 			}
 		}
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -131,7 +131,7 @@ func Fmt() error {
 		for _, f := range files {
 			s, err := sh.Output("gofmt", "-l", f)
 			if err != nil {
-				fmt.Println("error running gofmt on %q: %v", f, err)
+				fmt.Printf("ERROR: running gofmt on %q: %v\n", f, err)
 				failed = true
 			}
 			if s != "" {
@@ -173,12 +173,13 @@ func Lint() error {
 	}
 	failed := false
 	for _, pkg := range pkgs {
-		if _, err := sh.Exec(nil, os.Stderr, os.Stderr, "golint", "-set_exit_status", pkg); err != nil {
+		if _, err := sh.Exec(nil, os.Stderr, nil, "golint", pkg); err != nil {
+			fmt.Printf("ERROR: running go lint on %q: %v\n", pkg, err)
 			failed = true
 		}
 	}
 	if failed {
-		return errors.New("golint errors!")
+		return errors.New("errors running golint")
 	}
 	return nil
 }


### PR DESCRIPTION
fixes #3990 - gofmt doesn't actually exit with non-zero when it finds unformatted
stuff so we have to check it for non-empty output, and fail on that.