### PR TITLE
Update toml dep to fetch its latest master branch instead of v0.3.0

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,7 +2,7 @@
 
 [[constraint]]
   name = "github.com/BurntSushi/toml"
-  version = "0.3.0"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/PuerkitoBio/purell"


### PR DESCRIPTION
v0.3.0 was released in March 2017 and is missing few fixes made in toml package
after the fact. So use the master branch instead.

This fixes a regression when switch was made from govendor vendor.json dep
management to Go dep.

Fixes #3998