### PR TITLE
Don't link to empty taxonomy term pages

### DIFF
--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -287,7 +287,14 @@ func (s *Site) renderSitemap() error {
 	n := s.newNodePage(kindSitemap)
 
 	// Include all pages (regular, home page, taxonomies etc.)
-	pages := s.Pages
+	// but filter the empty taxonomies
+	var pages Pages
+	for _, p := range s.Pages {
+		if p.Kind == KindTaxonomyTerm && len(p.Pages) == 0 {
+			continue
+		}
+		pages = append(pages, p)
+	}
 
 	page := s.newNodePage(kindSitemap)
 	page.URLPath.URL = ""


### PR DESCRIPTION
Hi!

I've just started using hugo and when I created a simple single page with no tags the generated sitemap contained links to /categories/ and /tags/ but those weren't generated (I believe this is the same issue described on #2912). Here's a patch that "fixes" this by making `renderSitemap` skip taxonomy term pages that contain no children.

I'm not familiar at all with the codebase nor terminology, so here are my soft concerns with this patch:

* [Here][precond] I run an assertion for a test check assumption (i.e.: not the issue per se, but the side effect that explains the issue) - I haven't seen this pattern in the code, should I drop it and just keep the `NoContains()` assertion?
* As "categories" and "tags" are default taxonomy terms, one could argue that the correct fix is for hugo to render the empty pages, not skip them (so disabling this behaviour would happen via `disableKinds` only); but this doesn't seem super useful (the content in the page is "useless") nor intuitive to me. Thoughts?

And, of course, there might be a better way to achieve this so shout as needed ☺️ 

[precond]: https://github.com/gohugoio/hugo/compare/master...caio:issue2912?expand=1#diff-c95eda80f21abf0c6dd9391e209d2801R64