### PR TITLE
Add support for --destination sftp://.. style urls the hugo cmd

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -127,6 +127,12 @@
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/kr/fs"
+  packages = ["."]
+  revision = "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+
+[[projects]]
   name = "github.com/kyokomi/emoji"
   packages = ["."]
   revision = "7e06b236c489543f53868841f188a294e3383eab"
@@ -175,6 +181,18 @@
   version = "v1.0.1"
 
 [[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  name = "github.com/pkg/sftp"
+  packages = ["."]
+  revision = "98203f5a8333288eb3163b7c667d4260fe1333e9"
+  version = "1.0.0"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
@@ -195,7 +213,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [".","mem","sftpfs"]
   revision = "5660eeed305fe5f69c8fc6cf899132a459a97064"
 
 [[projects]]
@@ -254,6 +272,12 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh","ssh/knownhosts"]
+  revision = "bd6f299fb381e4c3393d1c4b1f0b94f5e77650c8"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/image"
   packages = ["riff","vp8","vp8l","webp"]
   revision = "f7e31b4ea2e3413ab91b4e7d2dc83e5f8d19a44c"
@@ -285,6 +309,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9046d783e19de319d8829a48dd75d8eee659c79b4b71215d34ab1a62c8210d79"
+  inputs-digest = "f42bf33dea8bfeb46931e75e918354e80f29b885cd7a10e44c01577596235199"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docs/content/commands/hugo.md
+++ b/docs/content/commands/hugo.md
@@ -35,7 +35,7 @@ hugo [flags]
       --config string           config file (default is path/config.yaml|json|toml)
   -c, --contentDir string       filesystem path to content directory
       --debug                   debug output
-  -d, --destination string      filesystem path to write files to
+  -d, --destination string      filesystem or sftp path to write files to
       --disable404              do not render 404 page
       --disableKinds strings    disable different kind of pages (home, RSS etc.)
       --disableRSS              do not build RSS files

--- a/hugofs/fs.go
+++ b/hugofs/fs.go
@@ -62,6 +62,15 @@ func NewFrom(fs afero.Fs, cfg config.Provider) *Fs {
 	return newFs(fs, cfg)
 }
 
+func NewFromSrcDst(src, dst afero.Fs, cfg config.Provider) *Fs {
+	return &Fs{
+		Source:      src,
+		Destination: dst,
+		Os:          &afero.OsFs{},
+		WorkingDir:  getWorkingDirFs(src, cfg),
+	}
+}
+
 func newFs(base afero.Fs, cfg config.Provider) *Fs {
 	return &Fs{
 		Source:      base,

--- a/hugofs/fs_sftp.go
+++ b/hugofs/fs_sftp.go
@@ -1,0 +1,123 @@
+package hugofs
+
+import (
+	"errors"
+	"github.com/pkg/sftp"
+	"github.com/spf13/afero"
+	"github.com/spf13/afero/sftpfs"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+	"io/ioutil"
+	"net/url"
+	"os/user"
+	"strings"
+)
+
+type SftpFsContext struct {
+	sshc   *ssh.Client
+	sshcfg *ssh.ClientConfig
+	sftpc  *sftp.Client
+}
+
+func readPrivateKey(dir string) (auth ssh.AuthMethod, err error) {
+	pemBytes, err := ioutil.ReadFile(dir + "/.ssh/id_rsa")
+	if err != nil {
+		err = errors.New("no password provided and couln't read private ssh key file: " + err.Error())
+		return
+	}
+
+	signer, err := ssh.ParsePrivateKey(pemBytes)
+
+	if err != nil {
+		err = errors.New("no password provided and couln't parse private ssh key file: " + err.Error())
+		return
+	}
+	auth = ssh.PublicKeys(signer)
+	return
+}
+
+func SftpConnect(username, password, host string) (ctx *SftpFsContext, err error) {
+
+	_user, err := user.Current()
+
+	if username == "" {
+		username = _user.Username
+	}
+
+	// initialize key database from "~/.ssl/knowh_hosts"
+	hostkeyCB, err :=
+		knownhosts.New(_user.HomeDir + "/.ssh/known_hosts")
+
+	if err != nil {
+		return
+	}
+
+	var auth ssh.AuthMethod
+
+	if password == "" {
+		auth, err = readPrivateKey(_user.HomeDir)
+		if err != nil {
+			return
+		}
+	} else {
+		auth = ssh.Password(password)
+	}
+
+	sshcfg := &ssh.ClientConfig{
+		User:            username,
+		Auth:            []ssh.AuthMethod{auth},
+		HostKeyCallback: hostkeyCB,
+	}
+
+	if !strings.Contains(host, ":") {
+		host = host + ":22"
+	}
+
+	sshc, err := ssh.Dial("tcp", host, sshcfg)
+
+	if err != nil {
+		return nil, err
+	}
+
+	sftpc, err := sftp.NewClient(sshc)
+
+	if err != nil {
+		return nil, err
+	}
+
+	ctx = &SftpFsContext{
+		sshc:   sshc,
+		sshcfg: sshcfg,
+		sftpc:  sftpc,
+	}
+
+	return ctx, nil
+}
+
+func (ctx *SftpFsContext) Disconnect() error {
+	ctx.sftpc.Close()
+	ctx.sshc.Close()
+	return nil
+}
+
+func NewSftpFs(url *url.URL) (fs afero.Fs, err error) {
+	var user, pwd string
+
+	if url.User != nil {
+		user = url.User.Username()
+		pwd, _ = url.User.Password()
+	} else {
+		user = ""
+		pwd = ""
+	}
+
+	ctx, err := SftpConnect(user, pwd, url.Host)
+	if err != nil {
+		return
+	}
+	// TODO: fix afero.sftp.Fs to
+	// be able to call client Disconnect by
+	// adding a Method to Fs or making
+	// client a public field
+	return sftpfs.New(ctx.sftpc), err
+}


### PR DESCRIPTION
This commit adds support for `sftp://[user[:pwd]@]host[:port]/destination/path` style urls as
the `--destination` flag when building a site with hugo.

The sftp implementation is based upon [spf13/afero/sftpfs](https://github.com/spf13/afero/blob/master/sftpfs/sftp.go) virtual file system. The `hugo` command
checks if the `--destination` (`-d`) flag provided is a valid sftp url. If so it  initializes
a connection to the server and a `afero/sftpfs.FS` and sets a `hugofs` with the sftpfs as the
Destination.

If username and/or password are not provided within the url the systemuser name will be
used and authentication is tried with the `~/.ssh/id_rsa` private ssh key.

Host certificates are validated against `~/.ssh/known_hosts`. 