### PR TITLE
Add internal shortcode 'table'

### DIFF
--- a/docs/content/content-management/shortcodes.md
+++ b/docs/content/content-management/shortcodes.md
@@ -107,6 +107,49 @@ The `figure` shortcode can use the following named parameters:
 </figure>
 {{< /output >}}
 
+### `table`
+
+`table` allows specifying `class` and `style` attributes to a Markdown table. This is useful for the cases where you do not want to apply styling for all tables globally.
+
+The `table` shortcode can use the following named parameters:
+
+- `class`
+- `style`
+
+If named parameters are not used, the *first* parameter is assigned to the
+`table` tag's `class` attribute, and the *second* parameter is assigned to the
+`style`. Both parameters are optional.
+
+#### Example `table` Input
+
+{{< code file="table-input-example.md" >}}
+{{%/* table class="toto" style="width:50%" */%}}
+| a | b |
+|---|---|
+| c | d |
+{{%/* /table */%}}
+{{< /code >}}
+
+#### Example `table` Output
+
+{{< output file="table-output-example.html" >}}
+<table class="toto" style="width:50%">
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td>c</td>
+<td>d</td>
+</tr>
+</tbody>
+</table>
+{{< /output >}}
+
 ### `gist`
 
 Bloggers often want to include GitHub gists when writing posts. Let's suppose we want to use the [gist at the following url][examplegist]:

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -309,6 +309,60 @@ func TestFigureImgWidthAndHeight(t *testing.T) {
 	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" alt="apple" width="50" height="100" %}}`, "\n<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" alt=\"apple\" width=\"50\" height=\"100\" />\n    \n    \n</figure>\n", nil)
 }
 
+func TestTableNoArgs(t *testing.T) {
+	t.Parallel()
+	CheckShortCodeMatch(t, `{{% table %}}
+| a | b |
+|---|---|
+| c | d |
+{{% /table %}}`, "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n\n<tbody>\n<tr>\n<td>c</td>\n<td>d</td>\n</tr>\n</tbody>\n</table>", nil)
+}
+
+func TestTableNamedStyleArg(t *testing.T) {
+	t.Parallel()
+	CheckShortCodeMatch(t, `{{% table style="width:50%" %}}
+| a | b |
+|---|---|
+| c | d |
+{{% /table %}}`, "<table style=\"width:50%\">\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n\n<tbody>\n<tr>\n<td>c</td>\n<td>d</td>\n</tr>\n</tbody>\n</table>", nil)
+}
+
+func TestTableNamedClassArg(t *testing.T) {
+	t.Parallel()
+	CheckShortCodeMatch(t, `{{% table class="toto" %}}
+| a | b |
+|---|---|
+| c | d |
+{{% /table %}}`, "<table class=\"toto\">\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n\n<tbody>\n<tr>\n<td>c</td>\n<td>d</td>\n</tr>\n</tbody>\n</table>", nil)
+}
+
+func TestTableNamedClassAndStyleArgs(t *testing.T) {
+	t.Parallel()
+	CheckShortCodeMatch(t, `{{% table class="toto" style="width:50%" %}}
+| a | b |
+|---|---|
+| c | d |
+{{% /table %}}`, "<table class=\"toto\" style=\"width:50%\">\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n\n<tbody>\n<tr>\n<td>c</td>\n<td>d</td>\n</tr>\n</tbody>\n</table>", nil)
+}
+
+func TestTablePositionClassArg(t *testing.T) {
+	t.Parallel()
+	CheckShortCodeMatch(t, `{{% table "zuzu" %}}
+| a | b |
+|---|---|
+| c | d |
+{{% /table %}}`, "<table class=\"zuzu\">\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n\n<tbody>\n<tr>\n<td>c</td>\n<td>d</td>\n</tr>\n</tbody>\n</table>", nil)
+}
+
+func TestTablePositionClassAndStyleArgs(t *testing.T) {
+	t.Parallel()
+	CheckShortCodeMatch(t, `{{% table "lala" "border:3px dashed red;" %}}
+| a | b |
+|---|---|
+| c | d |
+{{% /table %}}`, "<table class=\"lala\" style=\"border:3px dashed red;\">\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n\n<tbody>\n<tr>\n<td>c</td>\n<td>d</td>\n</tr>\n</tbody>\n</table>", nil)
+}
+
 const testScPlaceholderRegexp = "HAHAHUGOSHORTCODE-\\d+HBHB"
 
 func TestExtractShortcodes(t *testing.T) {

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -36,6 +36,24 @@ func (t *templateHandler) embedShortcodes() {
     {{ end }}
 </figure>
 <!-- image -->`)
+	t.addInternalShortcode("table.html", `{{ $.Scratch.Set "__table.class" "" }}
+{{ $.Scratch.Set "__table.style" "" }}
+{{ if .IsNamedParams }}
+    {{ with .Get "class" }}
+        {{ $.Scratch.Set "__table.class" (printf "%s%s%s" " class=\"" . "\"") }}
+    {{ end }}
+    {{ with .Get "style" }}
+        {{ $.Scratch.Set "__table.style" (printf "%s%s%s" " style=\"" . "\"") }}
+    {{ end }}
+{{ else }}
+    {{ if len .Params | le 1 }}
+        {{ $.Scratch.Set "__table.class" (printf "%s%s%s" " class=\"" (.Get 0) "\"") }}
+    {{ end }}
+    {{ if len .Params | eq 2 }}
+        {{ $.Scratch.Set "__table.style" (printf "%s%s%s" " style=\"" (.Get 1) "\"") }}
+    {{ end }}
+{{ end }}
+{{ replace .Inner "<table>" (printf "%s%s%s%s" "<table" ($.Scratch.Get "__table.class") ($.Scratch.Get "__table.style") ">") | markdownify }}`)
 	t.addInternalShortcode("speakerdeck.html", "<script async class='speakerdeck-embed' data-id='{{ index .Params 0 }}' data-ratio='1.33333333333333' src='//speakerdeck.com/assets/embed.js'></script>")
 	t.addInternalShortcode("youtube.html", `{{ if .IsNamedParams }}
 <div {{ if .Get "class" }}class="{{ .Get "class" }}"{{ else }}style="position: relative; padding-bottom: 56.25%; padding-top: 30px; height: 0; overflow: hidden;"{{ end }}>


### PR DESCRIPTION
This new shortcode allows specifying class and style for a Markdown table.