### PR TITLE
Add Pandoc support, refactor external helpers

### DIFF
--- a/docs/content/content-management/formats.md
+++ b/docs/content/content-management/formats.md
@@ -6,7 +6,7 @@ date: 2017-01-10
 publishdate: 2017-01-10
 lastmod: 2017-04-06
 categories: [content management]
-keywords: [markdown,asciidoc,mmark,content format]
+keywords: [markdown,asciidoc,mmark,pandoc,content format]
 menu:
   docs:
     parent: "content-management"
@@ -195,11 +195,18 @@ With this setup, everything is in place for a natural usage of MathJax on pages 
 
 ## Additional Formats Through External Helpers
 
-Hugo has new concept called _external helpers_. It means that you can write your content using [Asciidoc][ascii], [reStructuredText][rest]. If you have files with associated extensions, Hugo will call external commands to generate the content. ([See the Hugo source code for external helpers][helperssource].)
+Hugo has a new concept called _external helpers_. It means that you can write your content using [Asciidoc][ascii], [reStructuredText][rest], or [pandoc]. If you have files with associated extensions, Hugo will call external commands to generate the content. ([See the Hugo source code for external helpers][helperssource].)
 
 For example, for Asciidoc files, Hugo will try to call the `asciidoctor` or `asciidoc` command. This means that you will have to install the associated tool on your machine to be able to use these formats. ([See the Asciidoctor docs for installation instructions](http://asciidoctor.org/docs/install-toolchain/)).
 
 To use these formats, just use the standard extension and the front matter exactly as you would do with natively supported `.md` files.
+
+Hugo passes reasonable default arguments to these external helpers by default:
+
+- `asciidoc`: `--no-header-footer --safe -`
+- `asciidoctor`: `--no-header-footer --safe --trace -`
+- `rst2html`: `--leave-comments --initial-header-level=2`
+- `pandoc`: `--mathjax`
 
 {{% warning "Performance of External Helpers" %}}
 Because additional formats are external commands generation performance will rely heavily on the performance of the external tool you are using. As this feature is still in its infancy, feedback is welcome.
@@ -235,6 +242,7 @@ Markdown syntax is simple enough to learn in a single sitting. The following are
 [mmark]: https://github.com/miekg/mmark
 [mmarkgh]: https://github.com/miekg/mmark/wiki/Syntax
 [org]: http://orgmode.org/
+[pandoc]: http://www.pandoc.org/
 [Pygments]: http://pygments.org/
 [rest]: http://docutils.sourceforge.net/rst.html
 [sc]: /content-management/shortcodes/

--- a/helpers/general.go
+++ b/helpers/general.go
@@ -78,6 +78,8 @@ func GuessType(in string) string {
 		return "mmark"
 	case "rst":
 		return "rst"
+	case "pandoc", "pdc":
+		return "pandoc"
 	case "html", "htm":
 		return "html"
 	case "org":

--- a/helpers/general_test.go
+++ b/helpers/general_test.go
@@ -34,6 +34,8 @@ func TestGuessType(t *testing.T) {
 		{"adoc", "asciidoc"},
 		{"ad", "asciidoc"},
 		{"rst", "rst"},
+		{"pandoc", "pandoc"},
+		{"pdc", "pandoc"},
 		{"mmark", "mmark"},
 		{"html", "html"},
 		{"htm", "html"},

--- a/hugolib/handler_page.go
+++ b/hugolib/handler_page.go
@@ -25,6 +25,7 @@ func init() {
 	RegisterHandler(new(htmlHandler))
 	RegisterHandler(new(asciidocHandler))
 	RegisterHandler(new(rstHandler))
+	RegisterHandler(new(pandocHandler))
 	RegisterHandler(new(mmarkHandler))
 	RegisterHandler(new(orgHandler))
 }
@@ -101,6 +102,15 @@ type rstHandler struct {
 
 func (h rstHandler) Extensions() []string { return []string{"rest", "rst"} }
 func (h rstHandler) PageConvert(p *Page) HandledResult {
+	return commonConvert(p)
+}
+
+type pandocHandler struct {
+	basicPageHandler
+}
+
+func (h pandocHandler) Extensions() []string { return []string{"pandoc", "pdc"} }
+func (h pandocHandler) PageConvert(p *Page) HandledResult {
 	return commonConvert(p)
 }
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -561,7 +561,7 @@ func testAllMarkdownEnginesForPages(t *testing.T,
 	}{
 		{"md", func() bool { return true }},
 		{"mmark", func() bool { return true }},
-		{"ad", func() bool { return helpers.HasAsciidoctor() || helpers.HasAsciidoc() }},
+		{"ad", func() bool { return helpers.HasAsciidoc() }},
 		// TODO(bep) figure a way to include this without too much work.{"html", func() bool { return true }},
 		{"rst", func() bool { return helpers.HasRst() }},
 	}

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -565,7 +565,7 @@ tags:
 	th := testHelper{s.Cfg, s.Fs, t}
 
 	for _, test := range tests {
-		if strings.HasSuffix(test.contentPath, ".ad") && !helpers.HasAsciidoctor() && !helpers.HasAsciidoc() {
+		if strings.HasSuffix(test.contentPath, ".ad") && !helpers.HasAsciidoc() {
 			fmt.Println("Skip Asciidoc test case as no Asciidoc present.")
 			continue
 		} else if strings.HasSuffix(test.contentPath, ".rst") && !helpers.HasRst() {


### PR DESCRIPTION
Recognize the Pandoc format under the file extension .pandoc or .pdc,
and shell out to pandoc as an external helper to format Pandoc content.

Add a configuration option, externalHelperArguments, that can be used to
override the additional arguments passed to external helpers.

Refactor out repeated code with external helpers. Change the error
output formatting. I did not see any of the external helpers print the
string "`<input>`" to represent stdin as a file; just prepending the file
name to error output is more general and doesn't sacrifice that much in
terms of readability.