### PR TITLE
Handle Taxonomy permalinks

### DIFF
--- a/docs/content/content-management/taxonomies.md
+++ b/docs/content/content-management/taxonomies.md
@@ -132,7 +132,7 @@ Note that if you use `preserveTaxonomyNames` and intend to manually construct UR
 {{% note %}}
 You can add content and front matter to your taxonomy list and taxonomy terms pages. See [Content Organization](/content-management/organization/) for more information on how to add an `_index.md` for this purpose.
 
-Note also that taxonomy [permalinks](/content-management/urls/) are *not* configurable.
+Much like regular pages, taxonomy list [permalinks](/content-management/urls/) are configurable, but taxonomy term page permalinks are not.
 {{% /note %}}
 
 ## Add Taxonomies to Content

--- a/docs/content/content-management/urls.md
+++ b/docs/content/content-management/urls.md
@@ -45,6 +45,8 @@ permalinks:
 
 Only the content under `post/` will have the new URL structure. For example, the file `content/post/sample-entry.md` with `date: 2017-02-27T19:20:00-05:00` in its front matter will render to `public/2017/02/sample-entry/index.html` at build time and therefore be reachable at `https://example.com/2013/11/sample-entry/`.
 
+You can also configure permalinks of taxonomies with the same syntax, by using the plural form of the taxonomy instead of the section. You will probably only want to use the configuration values `:slug` or `:title`.
+
 ### Permalink Configuration Values
 
 The following is a list of values that can be used in a `permalink` definition in your site `config` file. All references to time are dependent on the content's date.

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -758,7 +758,7 @@ func (p *Page) Type() string {
 // since Hugo 0.22 we support nested sections, but this will always be the first
 // element of any nested path.
 func (p *Page) Section() string {
-	if p.Kind == KindSection {
+	if p.Kind == KindSection || p.Kind == KindTaxonomy || p.Kind == KindTaxonomyTerm {
 		return p.sections[0]
 	}
 	return p.Source.Section()

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -77,6 +77,10 @@ tag = "tags"
 category = "categories"
 other = "others"
 empty = "empties"
+permalinked = "permalinkeds"
+
+[permalinks]
+permalinkeds = "/perma/:slug/"
 `
 
 	pageTemplate := `---
@@ -86,6 +90,8 @@ tags:
 categories:
 %s
 others:
+%s
+permalinkeds:
 %s
 ---
 # Doc
@@ -99,15 +105,15 @@ others:
 	fs := th.Fs
 
 	if preserveTaxonomyNames {
-		writeSource(t, fs, "content/p1.md", fmt.Sprintf(pageTemplate, "t1/c1", "- tag1", "- cat1", "- o1"))
+		writeSource(t, fs, "content/p1.md", fmt.Sprintf(pageTemplate, "t1/c1", "- tag1", "- cat1", "- o1", "- pl1"))
 	} else {
 		// Check lower-casing of tags
-		writeSource(t, fs, "content/p1.md", fmt.Sprintf(pageTemplate, "t1/c1", "- Tag1", "- cAt1", "- o1"))
+		writeSource(t, fs, "content/p1.md", fmt.Sprintf(pageTemplate, "t1/c1", "- Tag1", "- cAt1", "- o1", "- pl1"))
 
 	}
-	writeSource(t, fs, "content/p2.md", fmt.Sprintf(pageTemplate, "t2/c1", "- tag2", "- cat1", "- o1"))
-	writeSource(t, fs, "content/p3.md", fmt.Sprintf(pageTemplate, "t2/c12", "- tag2", "- cat2", "- o1"))
-	writeSource(t, fs, "content/p4.md", fmt.Sprintf(pageTemplate, "Hello World", "", "", "- \"Hello Hugo world\""))
+	writeSource(t, fs, "content/p2.md", fmt.Sprintf(pageTemplate, "t2/c1", "- tag2", "- cat1", "- o1", "- pl1"))
+	writeSource(t, fs, "content/p3.md", fmt.Sprintf(pageTemplate, "t2/c12", "- tag2", "- cat2", "- o1", "- pl1"))
+	writeSource(t, fs, "content/p4.md", fmt.Sprintf(pageTemplate, "Hello World", "", "", "- \"Hello Hugo world\"", "- pl1"))
 
 	writeNewContentFile(t, fs, "Category Terms", "2017-01-01", "content/categories/_index.md", 10)
 	writeNewContentFile(t, fs, "Tag1 List", "2017-01-01", "content/tags/tag1/_index.md", 10)
@@ -146,10 +152,11 @@ others:
 	// Make sure that each KindTaxonomyTerm page has an appropriate number
 	// of KindTaxonomy pages in its Pages slice.
 	taxonomyTermPageCounts := map[string]int{
-		"tags":       2,
-		"categories": 2,
-		"others":     2,
-		"empties":    0,
+		"tags":         2,
+		"categories":   2,
+		"others":       2,
+		"empties":      0,
+		"permalinkeds": 1,
 	}
 
 	for taxonomy, count := range taxonomyTermPageCounts {
@@ -168,6 +175,14 @@ others:
 		require.Equal(t, "/blog/categories/cat1.html", cat1.RelPermalink())
 	} else {
 		require.Equal(t, "/blog/categories/cat1/", cat1.RelPermalink())
+	}
+
+	pl1 := s.getPage(KindTaxonomy, "permalinkeds", "pl1")
+	require.NotNil(t, pl1)
+	if uglyURLs {
+		require.Equal(t, "/blog/perma/pl1.html", pl1.RelPermalink())
+	} else {
+		require.Equal(t, "/blog/perma/pl1/", pl1.RelPermalink())
 	}
 
 	// Issue #3070 preserveTaxonomyNames


### PR DESCRIPTION
Return the correct virtual Section for Taxonomy and TaxonomyTerm.
Restrict permalink expansion to only Pages and Taxonomies, but then
actually use expanded permalinks even for non-Pages.

Fixes #1208.