### PR TITLE
Implementing path-segment sanitization rules

### DIFF
--- a/docs/content/functions/findRe.md
+++ b/docs/content/functions/findRe.md
@@ -45,3 +45,4 @@ If you are just learning RegEx, or at least Golang's flavor, you can practice pa
 [`plainify`]: /functions/plainify/
 [toc]: /content-management/toc/
 [`urlize`]: /functions/urlize
+[`urlizeSegment`]: /functions/urlizeSegment

--- a/docs/content/functions/urlizeSegment.md
+++ b/docs/content/functions/urlizeSegment.md
@@ -1,21 +1,21 @@
 ---
-title: urlize
-# linktitle: urlize
-description: Takes a string, sanitizes it for usage in URLs, and converts spaces to hyphens.
-date: 2017-02-01
-publishdate: 2017-02-01
-lastmod: 2017-02-01
+title: urlizeSegment
+# linktitle: urlizeSegment
+description: Takes a string, sanitizes it for usage in URLs, and converts spaces, slashes, and pound signs to hyphens.
+date: 2017-10-21
+publishdate: 2017-10-21
+lastmod: 2017-10-21
 categories: [functions]
 menu:
   docs:
     parent: "functions"
 keywords: [urls,strings]
 godocref:
-signature: ["urlize INPUT"]
+signature: ["urlizeSegment INPUT"]
 hugoversion:
 deprecated: false
 workson: []
-relatedfuncs: [urlizeSegment]
+relatedfuncs: [urlize]
 ---
 
 The following examples pull from a content file with the following front matter:
@@ -23,8 +23,8 @@ The following examples pull from a content file with the following front matter:
 {{< code file="content/blog/greatest-city.md" copy="false">}}
 +++
 title = "The World's Greatest City"
-location = "Chicago IL"
-tags = ["pizza","beer","hot dogs"]
+location = "Chicago IL/USA"
+tags = ["food/pizza","drink/beer","food/hot dogs","we're #1"]
 +++
 {{< /code >}}
 
@@ -34,14 +34,14 @@ The following might be used as a partial within a [single page template][singlet
 <header>
     <h1>{{.Title}}</h1>
     {{ with .Params.location }}
-        <div><a href="/locations/{{ . | urlize}}">{{.}}</a></div>
+        <div><a href="/locations/{{ . | urlizeSegment}}">{{.}}</a></div>
     {{ end }}
     <!-- Creates a list of tags for the content and links to each of their pages -->
     {{ with .Params.tags }}
     <ul>
         {{range .}}
             <li>
-                <a href="/tags/{{ . | urlize }}">{{ . }}</a>
+                <a href="/tags/{{ . | urlizeSegment }}">{{ . }}</a>
             </li>
         {{end}}
     </ul>
@@ -54,16 +54,19 @@ The preceding partial would then output to the rendered page as follows, assumin
 {{< output file="/blog/greatest-city/index.html" >}}
 <header>
     <h1>The World's Greatest City</h1>
-    <div><a href="/locations/chicago-il/">Chicago IL</a></div>
+    <div><a href="/locations/chicago-il-usa/">Chicago IL/USA</a></div>
     <ul>
         <li>
-            <a href="/tags/pizza">pizza</a>
+            <a href="/tags/food-pizza">food/pizza</a>
         </li>
         <li>
-            <a href="/tags/beer">beer</a>
+            <a href="/tags/drink-beer">drink/beer</a>
         </li>
         <li>
-            <a href="/tags/hot-dogs">hot dogs</a>
+            <a href="/tags/food-hot-dogs">food/hot dogs</a>
+        </li>
+        <li>
+            <a href="/tags/were--1">we're #1</a>
         </li>
     </ul>
 </header>

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -34,6 +34,9 @@ var (
 
 	// ErrWalkRootTooShort is returned when the root specified for a file walk is shorter than 4 characters.
 	ErrWalkRootTooShort = errors.New("Path too short. Stop walking.")
+
+	// This replacer is used in calls to MakePathSegmentSanitized.
+	SegmentReplacer = strings.NewReplacer("/", "-", "#", "-")
 )
 
 // filepathPathBridge is a bridge for common functionality in filepath vs path
@@ -90,6 +93,12 @@ func (p *PathSpec) MakePathSanitized(s string) string {
 		return p.MakePath(s)
 	}
 	return strings.ToLower(p.MakePath(s))
+}
+
+// MakePathSegmentSanitized, in addition to MakePathSanitized,
+// replaces slashes and pound signs with hyphens.
+func (p *PathSpec) MakePathSegmentSanitized(s string) string {
+	return p.MakePathSanitized(SegmentReplacer.Replace(s))
 }
 
 // MakeTitle converts the path given to a suitable title, trimming whitespace

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -81,12 +81,39 @@ func TestMakePathSanitized(t *testing.T) {
 		{"Foo.Bar/fOO_bAr-Foo", "foo.bar/foo_bar-foo"},
 		{"FOO,bar:FooBar", "foobarfoobar"},
 		{"foo/BAR.HTML", "foo/bar.html"},
+		{"foo#BAR", "foo#bar"},
 		{"трям/трям", "трям/трям"},
 		{"은행", "은행"},
 	}
 
 	for _, test := range tests {
 		output := p.MakePathSanitized(test.input)
+		if output != test.expected {
+			t.Errorf("Expected %#v, got %#v\n", test.expected, output)
+		}
+	}
+}
+
+func TestMakePathSegmentSanitized(t *testing.T) {
+	v := viper.New()
+	l := NewDefaultLanguage(v)
+	p, _ := NewPathSpec(hugofs.NewMem(v), l)
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"  FOO bar  ", "foo-bar"},
+		{"Foo.Bar/fOO_bAr-Foo", "foo.bar-foo_bar-foo"},
+		{"FOO,bar:FooBar", "foobarfoobar"},
+		{"foo/BAR.HTML", "foo-bar.html"},
+		{"foo#BAR", "foo-bar"},
+		{"трям/трям", "трям-трям"},
+		{"은행", "은행"},
+	}
+
+	for _, test := range tests {
+		output := p.MakePathSegmentSanitized(test.input)
 		if output != test.expected {
 			t.Errorf("Expected %#v, got %#v\n", test.expected, output)
 		}

--- a/helpers/url.go
+++ b/helpers/url.go
@@ -103,7 +103,14 @@ func SanitizeURLKeepTrailingSlash(in string) string {
 //     urlize: vim-text-editor
 func (p *PathSpec) URLize(uri string) string {
 	return p.URLEscape(p.MakePathSanitized(uri))
+}
 
+// URLizeSegment is URLize + slashes and pound signs become hyphens
+// Example:
+//     uri: Vi/Vim (text editor)
+//     urlizeSegment: vi-vim-text-editor
+func (p *PathSpec) URLizeSegment(uri string) string {
+	return p.URLEscape(p.MakePathSegmentSanitized(uri))
 }
 
 // URLizeFilename creates an URL from a filename by esacaping unicode letters

--- a/helpers/url_test.go
+++ b/helpers/url_test.go
@@ -38,12 +38,40 @@ func TestURLize(t *testing.T) {
 		{"foo.bar/foo_bar-foo", "foo.bar/foo_bar-foo"},
 		{"foo,bar:foobar", "foobarfoobar"},
 		{"foo/bar.html", "foo/bar.html"},
+		{"foo#bar", "foo#bar"},
 		{"трям/трям", "%D1%82%D1%80%D1%8F%D0%BC/%D1%82%D1%80%D1%8F%D0%BC"},
 		{"100%-google", "100-google"},
 	}
 
 	for _, test := range tests {
 		output := p.URLize(test.input)
+		if output != test.expected {
+			t.Errorf("Expected %#v, got %#v\n", test.expected, output)
+		}
+	}
+}
+
+func TestURLizeSegment(t *testing.T) {
+
+	v := viper.New()
+	l := NewDefaultLanguage(v)
+	p, _ := NewPathSpec(hugofs.NewMem(v), l)
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"  foo bar  ", "foo-bar"},
+		{"foo.bar/foo_bar-foo", "foo.bar-foo_bar-foo"},
+		{"foo,bar:foobar", "foobarfoobar"},
+		{"foo/bar.html", "foo-bar.html"},
+		{"foo#bar", "foo-bar"},
+		{"трям/трям", "%D1%82%D1%80%D1%8F%D0%BC-%D1%82%D1%80%D1%8F%D0%BC"},
+		{"100%-google", "100-google"},
+	}
+
+	for _, test := range tests {
+		output := p.URLizeSegment(test.input)
 		if output != test.expected {
 			t.Errorf("Expected %#v, got %#v\n", test.expected, output)
 		}

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -395,7 +395,7 @@ func (h *HugoSites) createMissingPages() error {
 						origKey := key
 
 						if s.Info.preserveTaxonomyNames {
-							key = s.PathSpec.MakePathSanitized(key)
+							key = s.PathSpec.MakePathSegmentSanitized(key)
 						}
 						for _, p := range taxonomyPages {
 							if p.sections[0] == plural && p.sections[1] == key {

--- a/hugolib/page_paths.go
+++ b/hugolib/page_paths.go
@@ -161,7 +161,13 @@ func createTargetPath(d targetPathDescriptor) string {
 		if d.ExpandedPermalink != "" {
 			pagePath = filepath.Join(pagePath, d.ExpandedPermalink)
 		} else {
-			pagePath = filepath.Join(d.Sections...)
+			pagePath = ""
+			for index, section := range d.Sections {
+				if index > 0 {
+					pagePath += helpers.FilePathSeparator
+				}
+				pagePath += d.PathSpec.MakePathSegmentSanitized(section)
+			}
 		}
 		needsBase = false
 	}

--- a/hugolib/permalinks.go
+++ b/hugolib/permalinks.go
@@ -151,7 +151,7 @@ func pageToPermalinkDate(p *Page, dateField string) (string, error) {
 func pageToPermalinkTitle(p *Page, _ string) (string, error) {
 	// Page contains Node which has Title
 	// (also contains URLPath which has Slug, sometimes)
-	return p.s.PathSpec.URLize(p.Title), nil
+	return p.s.PathSpec.URLizeSegment(p.Title), nil
 }
 
 // pageToPermalinkFilename returns the URL-safe form of the filename

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1568,7 +1568,7 @@ func (s *Site) getTaxonomyKey(key string) string {
 		// Keep as is
 		return key
 	}
-	return s.PathSpec.MakePathSanitized(key)
+	return s.PathSpec.MakePathSegmentSanitized(key)
 }
 
 // We need to create the top level taxonomy early in the build process
@@ -1605,7 +1605,7 @@ func (s *Site) assembleTaxonomies() {
 						s.Taxonomies[plural].add(s.getTaxonomyKey(idx), x)
 						if s.Info.preserveTaxonomyNames {
 							// Need to track the original
-							s.taxonomiesOrigKey[fmt.Sprintf("%s-%s", plural, s.PathSpec.MakePathSanitized(idx))] = idx
+							s.taxonomiesOrigKey[fmt.Sprintf("%s-%s", plural, s.PathSpec.MakePathSegmentSanitized(idx))] = idx
 						}
 					}
 				} else if v, ok := vals.(string); ok {
@@ -1613,7 +1613,7 @@ func (s *Site) assembleTaxonomies() {
 					s.Taxonomies[plural].add(s.getTaxonomyKey(v), x)
 					if s.Info.preserveTaxonomyNames {
 						// Need to track the original
-						s.taxonomiesOrigKey[fmt.Sprintf("%s-%s", plural, s.PathSpec.MakePathSanitized(v))] = v
+						s.taxonomiesOrigKey[fmt.Sprintf("%s-%s", plural, s.PathSpec.MakePathSegmentSanitized(v))] = v
 					}
 				} else {
 					s.Log.ERROR.Printf("Invalid %s in %s\n", plural, p.File.Path())
@@ -2030,7 +2030,7 @@ func (s *Site) newTaxonomyPage(plural, key string) *Page {
 		// We make the first character upper case, mostly because
 		// it is easier to reason about in the tests.
 		p.Title = helpers.FirstUpper(key)
-		key = s.PathSpec.MakePathSanitized(key)
+		key = s.PathSpec.MakePathSegmentSanitized(key)
 	} else {
 		p.Title = strings.Replace(s.titleFunc(key), "-", " ", -1)
 	}

--- a/tpl/urls/init.go
+++ b/tpl/urls/init.go
@@ -58,6 +58,10 @@ func init() {
 			[]string{"urlize"},
 			[][2]string{},
 		)
+		ns.AddMethodMapping(ctx.URLizeSegment,
+			[]string{"urlizeSegment"},
+			[][2]string{},
+		)
 
 		return ns
 

--- a/tpl/urls/urls.go
+++ b/tpl/urls/urls.go
@@ -18,9 +18,15 @@ import (
 	"fmt"
 	"html/template"
 	"net/url"
+	"strings"
 
 	"github.com/gohugoio/hugo/deps"
 	"github.com/spf13/cast"
+)
+
+var (
+	// This replacer is used in calls to UrlizeSegment.
+	SegmentReplacer = strings.NewReplacer("/", "-", "#", "-")
 )
 
 // New returns a new instance of the urls-namespaced template functions.
@@ -74,6 +80,15 @@ func (ns *Namespace) URLize(a interface{}) (string, error) {
 		return "", nil
 	}
 	return ns.deps.PathSpec.URLize(s), nil
+}
+
+// URLizeSegment is a URLize + slashes and pound signs become hyphens.
+func (ns *Namespace) URLizeSegment(a interface{}) (string, error) {
+	s, err := cast.ToStringE(a)
+	if err != nil {
+		return "", nil
+	}
+	return ns.deps.PathSpec.URLize(SegmentReplacer.Replace(s)), nil
 }
 
 type reflinker interface {


### PR DESCRIPTION
Implementing path-segment sanitization rules, for things like taxonomy terms and titles in permalinks, so that slashes and pound signs get replaced (with hyphens) rather than considered as part of a filesystem or URL path

Includes a new template function urlizeSegment (and corresponding documentation) which can be used in content to emulate said path-segment sanitization

Fixes #4090