### PR TITLE
hugolib: Fix .IsTranslated  with identical filenames

### DIFF
--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1440,6 +1440,29 @@ func TestKind(t *testing.T) {
 
 }
 
+func TestTranslationKey(t *testing.T) {
+	t.Parallel()
+	assert := require.New(t)
+	cfg, fs := newTestCfg()
+
+	writeSource(t, fs, filepath.Join("content", filepath.FromSlash("sect/simple.no.md")), "---\ntitle: \"A1\"\ntranslationKey: \"k1\"\n---\nContent\n")
+	writeSource(t, fs, filepath.Join("content", filepath.FromSlash("sect/simple.en.md")), "---\ntitle: \"A2\"\n---\nContent\n")
+
+	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{SkipRender: true})
+
+	require.Len(t, s.RegularPages, 2)
+
+	home, _ := s.Info.Home()
+	assert.NotNil(home)
+	assert.Equal("home", home.TranslationKey())
+	assert.Equal("page/k1", s.RegularPages[0].TranslationKey())
+	p2 := s.RegularPages[1]
+
+	// This is a single language setup
+	assert.Equal("page/sect/simple.en", p2.TranslationKey())
+
+}
+
 func TestChompBOM(t *testing.T) {
 	t.Parallel()
 	const utf8BOM = "\xef\xbb\xbf"

--- a/hugolib/translations.go
+++ b/hugolib/translations.go
@@ -13,10 +13,6 @@
 
 package hugolib
 
-import (
-	"fmt"
-)
-
 // Translations represent the other translations for a given page. The
 // string here is the language code, as affected by the `post.LANG.md`
 // filename.
@@ -26,7 +22,7 @@ func pagesToTranslationsMap(pages []*Page) map[string]Translations {
 	out := make(map[string]Translations)
 
 	for _, page := range pages {
-		base := createTranslationKey(page)
+		base := page.TranslationKey()
 
 		pageTranslation, present := out[base]
 		if !present {
@@ -45,22 +41,10 @@ func pagesToTranslationsMap(pages []*Page) map[string]Translations {
 	return out
 }
 
-func createTranslationKey(p *Page) string {
-	base := p.TranslationBaseName()
-
-	if p.IsNode() {
-		// TODO(bep) see https://github.com/gohugoio/hugo/issues/2699
-		// Must prepend the section and kind to the key to make it unique
-		base = fmt.Sprintf("%s/%s/%s", p.Kind, p.sections, base)
-	}
-
-	return base
-}
-
 func assignTranslationsToPages(allTranslations map[string]Translations, pages []*Page) {
 	for _, page := range pages {
 		page.translations = page.translations[:0]
-		base := createTranslationKey(page)
+		base := page.TranslationKey()
 		trans, exist := allTranslations[base]
 		if !exist {
 			continue


### PR DESCRIPTION
This commit refines the key used to map translations:

* Use `translationKey` set in front matter
* Fall back to path + base filename (i.e. the filename without extension and language code)

Note that the Page Kinde will be prepended to both cases above. It does not make sense to have a section as translation for the home page.

Fixes #2699