### PR TITLE
helpers: Remove (now) unused GetStaticDir

### DIFF
--- a/helpers/path.go
+++ b/helpers/path.go
@@ -167,12 +167,6 @@ func (p *PathSpec) GetLayoutDirPath() string {
 	return p.AbsPathify(p.layoutDir)
 }
 
-// GetStaticDirPath returns the absolute path to the static file dir
-// for the current Hugo project.
-func (p *PathSpec) GetStaticDirPath() string {
-	return p.AbsPathify(p.StaticDir())
-}
-
 // GetThemeDir gets the root directory of the current theme, if there is one.
 // If there is no theme, returns the empty string.
 func (p *PathSpec) GetThemeDir() string {
@@ -228,16 +222,6 @@ func (p *PathSpec) getThemeDirPath(path string) (string, error) {
 func (p *PathSpec) GetThemesDirPath() string {
 	dir, _ := p.getThemeDirPath("static")
 	return dir
-}
-
-// MakeStaticPathRelative makes a relative path to the static files directory.
-// It does so by taking either the project's static path or the theme's static
-// path into consideration.
-func (p *PathSpec) MakeStaticPathRelative(inPath string) (string, error) {
-	staticDir := p.GetStaticDirPath()
-	themeStaticDir := p.GetThemesDirPath()
-
-	return makePathRelative(inPath, staticDir, themeStaticDir)
 }
 
 func makePathRelative(inPath string, possibleDirectories ...string) (string, error) {

--- a/helpers/pathspec.go
+++ b/helpers/pathspec.go
@@ -133,11 +133,6 @@ func (p *PathSpec) WorkingDir() string {
 	return p.workingDir
 }
 
-// StaticDir returns the relative static dir in the current configuration.
-func (p *PathSpec) StaticDir() string {
-	return p.staticDirs[len(p.staticDirs)-1]
-}
-
 // StaticDirs returns the relative static dirs for the current configuration.
 func (p *PathSpec) StaticDirs() []string {
 	return p.staticDirs

--- a/helpers/pathspec_test.go
+++ b/helpers/pathspec_test.go
@@ -57,6 +57,5 @@ func TestNewPathSpecFromConfig(t *testing.T) {
 	require.Equal(t, "thethemes", p.themesDir)
 	require.Equal(t, "thelayouts", p.layoutDir)
 	require.Equal(t, "thework", p.workingDir)
-	require.Equal(t, "thestatic", p.StaticDir())
 	require.Equal(t, "thetheme", p.theme)
 }

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -977,10 +977,8 @@ func (s *Site) initialize() (err error) {
 		return err
 	}
 
-	staticDir := s.PathSpec.GetStaticDirPath() + "/"
-
 	sp := source.NewSourceSpec(s.Cfg, s.Fs)
-	s.Source = sp.NewFilesystem(s.absContentDir(), staticDir)
+	s.Source = sp.NewFilesystem(s.absContentDir())
 
 	return
 }


### PR DESCRIPTION
* In Hugo there is no single static dir
* It was used as a filter in the content dir, which makes no sense since any overlap here is impossible