### PR TITLE
Index Pages in the cache by their Title, if available

### DIFF
--- a/hugolib/page_collections.go
+++ b/hugolib/page_collections.go
@@ -61,12 +61,20 @@ func (c *PageCollections) refreshPageCaches() {
 				// shortcodes. If the user says "sect/doc1.en.md", he/she knows
 				// what he/she is looking for.
 				for _, p := range c.AllRegularPages {
+					// If the Page has a Title, cache by that as well as by the filepath.
+					if p.Title != "" {
+						cache[p.Title] = p
+					}
 					cache[filepath.ToSlash(p.Source.Path())] = p
 					// Ref/Relref supports this potentially ambiguous lookup.
 					cache[p.Source.LogicalName()] = p
 				}
 			default:
 				for _, p := range c.indexPages {
+					// If the Page has a Title, cache by that as well as by the filepath.
+					if p.Title != "" {
+						cache[p.Title] = p
+					}
 					key := path.Join(p.sections...)
 					cache[key] = p
 				}

--- a/hugolib/page_collections_test.go
+++ b/hugolib/page_collections_test.go
@@ -133,8 +133,16 @@ func TestGetPage(t *testing.T) {
 		errorMsg := fmt.Sprintf("Test %d", i)
 		page := s.getPage(test.kind, test.path...)
 		assert.NotNil(page, errorMsg)
-		assert.Equal(test.kind, page.Kind)
-		assert.Equal(test.expectedTitle, page.Title)
+		assert.Equal(test.kind, page.Kind, errorMsg)
+		assert.Equal(test.expectedTitle, page.Title, errorMsg)
+
+		if page.Title != "" {
+			// Try retrieving the page by Title as well.
+			pageByTitle := s.getPage(test.kind, page.Title)
+			assert.NotNil(pageByTitle, errorMsg)
+			assert.Equal(test.kind, pageByTitle.Kind, errorMsg)
+			assert.Equal(test.expectedTitle, pageByTitle.Title, errorMsg)
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes #4118

By adding pages to the cache index keyed by Title, I can look up an existing Taxonomy Term page by the un-sanitized term (in the same way that auto-generated Taxonomy Term pages can be looked-up).