### PR TITLE
chroma: Fix highlight for diff files

### DIFF
--- a/helpers/pygments.go
+++ b/helpers/pygments.go
@@ -196,6 +196,8 @@ func chromaHighlight(w io.Writer, source, lexer, style string, f chroma.Formatte
 		s = styles.Fallback
 	}
 
+	source += "\n"
+
 	it, err := l.Tokenise(nil, source)
 	if err != nil {
 		return err

--- a/helpers/pygments_test.go
+++ b/helpers/pygments_test.go
@@ -144,7 +144,8 @@ func TestChromaHTMLHighlight(t *testing.T) {
 	result, err := spec.Highlight(`echo "Hello"`, "bash", "")
 	assert.NoError(err)
 
-	assert.Contains(result, `<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash"><span class="nb">echo</span> <span class="s2">&#34;Hello&#34;</span></code></pre></div>`)
+	assert.Contains(result, `<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash"><span class="nb">echo</span> <span class="s2">&#34;Hello&#34;</span>
+</code></pre></div>`)
 
 }
 


### PR DESCRIPTION
Chroma lexer does not like code that does not have a final `\n`,
so add it to the source code before passing it to the Tokenise()
function.

Fixes #4143