### PR TITLE
tpl: Add os.PathSeparator

### DIFF
--- a/tpl/os/os.go
+++ b/tpl/os/os.go
@@ -46,6 +46,11 @@ func (ns *Namespace) Getenv(key interface{}) (string, error) {
 	return _os.Getenv(skey), nil
 }
 
+// PathSeparator returns the OS-specific path separator.
+func (ns *Namespace) PathSeparator() string {
+	return string(_os.PathSeparator)
+}
+
 // readFile reads the file named by filename relative to the given basepath
 // and returns the contents as a string.
 // There is a upper size limit set at 1 megabytes.

--- a/tpl/os/os_test.go
+++ b/tpl/os/os_test.go
@@ -16,6 +16,7 @@ package os
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/gohugoio/hugo/deps"
@@ -25,6 +26,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPathSeparator(t *testing.T) {
+	t.Parallel()
+
+	ns := New(&deps.Deps{})
+
+	var expect string
+
+	switch runtime.GOOS {
+	case "windows":
+		expect = `\`
+	default:
+		expect = `/`
+	}
+
+	assert.Equal(t, expect, ns.PathSeparator())
+}
 
 func TestReadFile(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
os.PathSeparator returns the OS-specific path separator as a string.

Fixes #2394