### PR TITLE
feat(docker): hugo from scratch + dockhub & quay account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-# GitHub:  https://github.com/gohugoio/
-# Docker:  https://hub.docker.com/r/gohugoio/
-# Twitter: https://twitter.com/gohugoio
+# GitHub:       https://github.com/gohugoio/
+# DockerHub:    https://hub.docker.com/r/gohugoio/
+# Quay:         https://quay.io/user/gohugoio
+# Twitter:      https://twitter.com/gohugoio
+# Website:      https://gohugo.io/
 
 FROM golang:1.10-rc-alpine3.7 AS build
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
 
 RUN \
   apk add --no-cache \
@@ -17,19 +22,12 @@ RUN \
 
 # ---
 
-FROM alpine:3.7
+FROM scratch
 
-COPY --from=build /go/bin/hugo /bin/hugo
+COPY --from=build /go/bin/hugo /hugo
 
-RUN \
-  adduser -h /site -s /sbin/nologin -u 1000 -D hugo && \
-  apk add --no-cache dumb-init
-
-USER    hugo
-WORKDIR /site
-VOLUME  /site
 EXPOSE  1313
 
-ENTRYPOINT [ "/usr/bin/dumb-init", "--", "hugo" ]
+ENTRYPOINT [ "/hugo" ]
 CMD [ "--help" ]
 


### PR DESCRIPTION
Hello Hugo's,

i optimized our Hugo Docker Image to run [FROM scratch](https://docs.docker.com/engine/userguide/eng-image/baseimages/#create-a-simple-parent-image-using-scratch) instead of [Alpine Linux](https://hub.docker.com/r/_/alpine/) and with that another optimization from 27MB to [6MB](https://hub.docker.com/r/gohugoio/hugo/tags/). Pretty sweet optimization when thinking that we started with [428MB](https://github.com/gohugoio/hugo/pull/3674)!

The good thing with that is we don't need to worry about security patches and image updates in the future anymore. Looking at the latest Version 3.7 of [Alpine](https://hub.docker.com/r/library/alpine/tags/3.7/) there are 3  unpatched [vulnerabilities](https://hub.docker.com/r/library/alpine/tags/) mentioned with the root cause in the underlaying Busybox:

- [CVE-2017-16544](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16544)
- [CVE-2017-15873](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15873)
- [CVE-2017-15874](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15874)

**Hugo DockerHub**

I ask on [26 Jul](https://github.com/gohugoio/hugo/pull/3738#issuecomment-318174847) about the topic to configure DockerHub with [Automated Builds](https://docs.docker.com/docker-cloud/builds/automated-build/) for the Hugo Project. Since there is still no official Hugo Repo i was so free and created one myself.

DockerHub Account: [gohugoio](https://hub.docker.com/u/gohugoio/)
Repository: [hugo](https://hub.docker.com/r/gohugoio/hugo)
Pull Command: `docker pull gohugoio/hugo`

**Quay Account**

Quay Account: [gohugoio](https://quay.io/user/gohugoio)
Repository: [hugo](https://quay.io/repository/gohugoio/hugo)
Pull Command: `docker pull quay.io/gohugoio/hugo`

The nice thing on Quay is that they run under the hood [Clair](https://github.com/coreos/clair) (Vulnerability Static Analysis for Containers) and we can define to trigger notifications when problems are found.

**Current Status**

Searching today on DockerHub there are currently [892](https://hub.docker.com/search/?isAutomated=0&isOfficial=0&page=1&pullCount=0&q=hugo&starCount=0) separate maintained versions of Hugo. Since Hugo is such a great project with a very big community i would love to work together with you guys to make an official image maintained by the project. I configured DockerHub and Quay with Automatic Builds for maximum transparency with the nice side effect that pushing to a defined branch (currently master) the Docker Image will be build automatically.
On Quay i also configured notification on found vulnerabilities (currently with risk level medium).

**Next Steps**

If you guys like the idea to create a official Docker and Quay Repo for the Hugo Project we should discuss the next steps. Since I'm not a project member i had to fork the repository to configure the automatic build. Problem is that i can't trigger new builds when changes were made in the original repository here. We could solve that by setting up a Webhook but the better way would be in my opinion to use the official repo here for that instead. You can read about how to setup a Automated Build [here](https://docs.docker.com/docker-hub/builds/#prerequisites).

> The system prompts you to choose between Public and Private and Limited Access. The Public and Private connection type is required if you want to use the Automated Builds.

Let me know if you are interested then i can create users in both accounts for you and we could setup the repository here to be used for automated builds. When all is working and tested for a while we could then try to apply to become a [official Docker Repository](https://docs.docker.com/docker-hub/official_repos/).

Have a nice weeked!

![peace-out](https://media.giphy.com/media/26AHG5KGFxSkUWw1i/giphy.gif)

Cheers Maik
