### PR TITLE
commands: Clean layoutDir

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -368,6 +368,7 @@ func InitializeConfig(subCmdVs ...*cobra.Command) (*deps.DepsCfg, error) {
 	if layoutDir != "" {
 		config.Set("layoutDir", layoutDir)
 	}
+	config.Set("layoutDir", filepath.Clean(config.GetString("layoutDir")))
 
 	if cacheDir != "" {
 		config.Set("cacheDir", cacheDir)


### PR DESCRIPTION
Due to some path parsing and calculations in
tpl/tplimpl/templateHandler.loadTemplates, ensure that the layoutDir
configuration setting is a clean path.

Fixes #4024