### PR TITLE
add Title to MenuEntry

### DIFF
--- a/hugolib/menu.go
+++ b/hugolib/menu.go
@@ -25,7 +25,7 @@ import (
 // or in the site config.
 type MenuEntry struct {
 	URL        string
-	Page       *Page // probably only set when called from Page front matter
+	Page       *Page
 	Name       string
 	Menu       string
 	Identifier string
@@ -219,10 +219,13 @@ func (m Menu) Reverse() Menu {
 }
 
 func (m *MenuEntry) Title() string {
-	if m.title == "" {
-		if m.Page != nil {
-			return m.Page.LinkTitle()
-		}
+	if m.title != "" {
+		return m.title
 	}
-	return m.title
+
+	if m.Page != nil {
+		return m.Page.LinkTitle()
+	}
+
+	return ""
 }

--- a/hugolib/menu.go
+++ b/hugolib/menu.go
@@ -28,6 +28,7 @@ type MenuEntry struct {
 	Name       string
 	Menu       string
 	Identifier string
+	Title      string
 	Pre        template.HTML
 	Post       template.HTML
 	Weight     int
@@ -95,6 +96,8 @@ func (m *MenuEntry) marshallMap(ime map[string]interface{}) {
 			m.Weight = cast.ToInt(v)
 		case "name":
 			m.Name = cast.ToString(v)
+		case "title":
+			m.Title = cast.ToString(v)
 		case "pre":
 			m.Pre = template.HTML(cast.ToString(v))
 		case "post":

--- a/hugolib/menu.go
+++ b/hugolib/menu.go
@@ -25,10 +25,11 @@ import (
 // or in the site config.
 type MenuEntry struct {
 	URL        string
+	Page       *Page // probably only set when called from Page front matter
 	Name       string
 	Menu       string
 	Identifier string
-	Title      string
+	title      string
 	Pre        template.HTML
 	Post       template.HTML
 	Weight     int
@@ -97,7 +98,7 @@ func (m *MenuEntry) marshallMap(ime map[string]interface{}) {
 		case "name":
 			m.Name = cast.ToString(v)
 		case "title":
-			m.Title = cast.ToString(v)
+			m.title = cast.ToString(v)
 		case "pre":
 			m.Pre = template.HTML(cast.ToString(v))
 		case "post":
@@ -215,4 +216,13 @@ func (m Menu) Reverse() Menu {
 	}
 
 	return m
+}
+
+func (m *MenuEntry) Title() string {
+	if m.title == "" {
+		if m.Page != nil {
+			return m.Page.LinkTitle()
+		}
+	}
+	return m.title
 }

--- a/hugolib/menu_old_test.go
+++ b/hugolib/menu_old_test.go
@@ -83,7 +83,12 @@ const (
 [[menu.unicode]]
    name = "Unicode Russian"
    identifier = "unicode-russian"
-   url = "/новости-проекта"` // Russian => "news-project"
+   url = "/новости-проекта" # Russian => "news-project"
+[[menu.with_title]]
+  name="entry with title"
+  title="a menuentry title"
+  url="/title"
+  identifier="titled"`
 )
 
 var menuPage1 = []byte(`+++
@@ -386,6 +391,13 @@ func doTestMenuWithUnicodeURLs(t *testing.T, canonifyURLs bool) {
 	}
 
 	assert.Equal(t, expected, unicodeRussian.URL)
+}
+
+func TestMenuWithTitle(t *testing.T) {
+	s := setupMenuTests(t, menuPageSources)
+	titled := findTestMenuEntryByID(s, "with_title", "titled")
+	expected := "a menuentry title"
+	assert.Equal(t, expected, titled.Title)
 }
 
 // Issue #1114

--- a/hugolib/menu_old_test.go
+++ b/hugolib/menu_old_test.go
@@ -397,7 +397,7 @@ func TestMenuWithTitle(t *testing.T) {
 	s := setupMenuTests(t, menuPageSources)
 	titled := findTestMenuEntryByID(s, "with_title", "titled")
 	expected := "a menuentry title"
-	assert.Equal(t, expected, titled.Title)
+	assert.Equal(t, expected, titled.Title())
 }
 
 // Issue #1114

--- a/hugolib/menu_test.go
+++ b/hugolib/menu_test.go
@@ -29,6 +29,7 @@ title: %q
 weight: %d
 menu:
   %s:
+    title: %s
     weight: %d
 ---
 # Doc Menu
@@ -44,11 +45,15 @@ title = "Section Menu"
 sectionPagesMenu = "sect"
 `
 
-	th, h := newTestSitesFromConfig(t, afero.NewMemMapFs(), siteConfig,
-		"layouts/partials/menu.html", `{{- $p := .page -}}
+	th, h := newTestSitesFromConfig(
+		t,
+		afero.NewMemMapFs(),
+		siteConfig,
+		"layouts/partials/menu.html",
+		`{{- $p := .page -}}
 {{- $m := .menu -}}
 {{ range (index $p.Site.Menus $m) -}}
-{{- .URL }}|{{ .Name }}|{{ .Weight -}}|
+{{- .URL }}|{{ .Name }}|{{ .Title }}|{{ .Weight -}}|
 {{- if $p.IsMenuCurrent $m . }}IsMenuCurrent{{ else }}-{{ end -}}|
 {{- if $p.HasMenuCurrent $m . }}HasMenuCurrent{{ else }}-{{ end -}}|
 {{- end -}}
@@ -63,11 +68,11 @@ Menu Main:  {{ partial "menu.html" (dict "page" . "menu" "main") }}`,
 
 	fs := th.Fs
 
-	writeSource(t, fs, "content/sect1/p1.md", fmt.Sprintf(menuPageTemplate, "p1", 1, "main", 40))
-	writeSource(t, fs, "content/sect1/p2.md", fmt.Sprintf(menuPageTemplate, "p2", 2, "main", 30))
-	writeSource(t, fs, "content/sect2/p3.md", fmt.Sprintf(menuPageTemplate, "p3", 3, "main", 20))
-	writeSource(t, fs, "content/sect2/p4.md", fmt.Sprintf(menuPageTemplate, "p4", 4, "main", 10))
-	writeSource(t, fs, "content/sect3/p5.md", fmt.Sprintf(menuPageTemplate, "p5", 5, "main", 5))
+	writeSource(t, fs, "content/sect1/p1.md", fmt.Sprintf(menuPageTemplate, "p1", 1, "main", "atitle1", 40))
+	writeSource(t, fs, "content/sect1/p2.md", fmt.Sprintf(menuPageTemplate, "p2", 2, "main", "atitle2", 30))
+	writeSource(t, fs, "content/sect2/p3.md", fmt.Sprintf(menuPageTemplate, "p3", 3, "main", "atitle3", 20))
+	writeSource(t, fs, "content/sect2/p4.md", fmt.Sprintf(menuPageTemplate, "p4", 4, "main", "atitle4", 10))
+	writeSource(t, fs, "content/sect3/p5.md", fmt.Sprintf(menuPageTemplate, "p5", 5, "main", "atitle5", 5))
 
 	writeNewContentFile(t, fs, "Section One", "2017-01-01", "content/sect1/_index.md", 100)
 	writeNewContentFile(t, fs, "Section Five", "2017-01-01", "content/sect5/_index.md", 10)
@@ -86,11 +91,24 @@ Menu Main:  {{ partial "menu.html" (dict "page" . "menu" "main") }}`,
 	require.Len(t, p1, 1)
 
 	th.assertFileContent("public/sect1/p1/index.html", "Single",
-		"Menu Sect:  /sect5/|Section Five|10|-|-|/sect1/|Section One|100|-|HasMenuCurrent|/sect2/|Sect2s|0|-|-|/sect3/|Sect3s|0|-|-|",
-		"Menu Main:  /sect3/p5/|p5|5|-|-|/sect2/p4/|p4|10|-|-|/sect2/p3/|p3|20|-|-|/sect1/p2/|p2|30|-|-|/sect1/p1/|p1|40|IsMenuCurrent|-|",
+		"Menu Sect:  "+
+			"/sect5/|Section Five||10|-|-|"+
+			"/sect1/|Section One||100|-|HasMenuCurrent|"+
+			"/sect2/|Sect2s||0|-|-|"+
+			"/sect3/|Sect3s||0|-|-|",
+		"Menu Main:  "+
+			"/sect3/p5/|p5|atitle5|5|-|-|"+
+			"/sect2/p4/|p4|atitle4|10|-|-|"+
+			"/sect2/p3/|p3|atitle3|20|-|-|"+
+			"/sect1/p2/|p2|atitle2|30|-|-|"+
+			"/sect1/p1/|p1|atitle1|40|IsMenuCurrent|-|",
 	)
 
 	th.assertFileContent("public/sect2/p3/index.html", "Single",
-		"Menu Sect:  /sect5/|Section Five|10|-|-|/sect1/|Section One|100|-|-|/sect2/|Sect2s|0|-|HasMenuCurrent|/sect3/|Sect3s|0|-|-|")
+		"Menu Sect:  "+
+			"/sect5/|Section Five||10|-|-|"+
+			"/sect1/|Section One||100|-|-|"+
+			"/sect2/|Sect2s||0|-|HasMenuCurrent|"+
+			"/sect3/|Sect3s||0|-|-|")
 
 }

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1291,7 +1291,7 @@ func (p *Page) HasMenuCurrent(menuID string, me *MenuEntry) bool {
 
 	// The following logic is kept from back when Hugo had both Page and Node types.
 	// TODO(bep) consolidate / clean
-	nme := MenuEntry{Name: p.Title, URL: p.URL()}
+	nme := MenuEntry{Page: p, Name: p.Title, URL: p.URL()}
 
 	for _, child := range me.Children {
 		if nme.IsSameResource(child) {
@@ -1322,7 +1322,7 @@ func (p *Page) IsMenuCurrent(menuID string, inme *MenuEntry) bool {
 
 	// The following logic is kept from back when Hugo had both Page and Node types.
 	// TODO(bep) consolidate / clean
-	me := MenuEntry{Name: p.Title, URL: p.URL()}
+	me := MenuEntry{Page: p, Name: p.Title, URL: p.URL()}
 
 	if !me.IsSameResource(inme) {
 		return false
@@ -1369,7 +1369,7 @@ func (p *Page) Menus() PageMenus {
 		if ms, ok := p.Params["menu"]; ok {
 			link := p.RelPermalink()
 
-			me := MenuEntry{Name: p.LinkTitle(), Weight: p.Weight, URL: link}
+			me := MenuEntry{Page: p, Name: p.LinkTitle(), Weight: p.Weight, URL: link}
 
 			// Could be the name of the menu to attach it to
 			mname, err := cast.ToStringE(ms)
@@ -1399,7 +1399,7 @@ func (p *Page) Menus() PageMenus {
 			}
 
 			for name, menu := range menus {
-				menuEntry := MenuEntry{Name: p.LinkTitle(), URL: link, Weight: p.Weight, Menu: name}
+				menuEntry := MenuEntry{Page: p, Name: p.LinkTitle(), URL: link, Weight: p.Weight, Menu: name}
 				if menu != nil {
 					p.s.Log.DEBUG.Printf("found menu: %q, in %q\n", name, p.Title)
 					ime, err := cast.ToStringMapE(menu)


### PR DESCRIPTION
This PR allows to set a title for a MenuEntry in the site config menus.
This allows to render anchor links in menus which have a title attribute:

```
{{ range .Site.Menus.main }}
<!-- ... -->
            <a href="{{ .URL }}" title="{{ .Title }}">
                {{ .Pre }}
                <span>{{ .Name }}</span>
            </a>
<!-- ... -->
{{ end }}
``` 

This feature is useful for screenreaders and SEO.

I didn't implement the same in the frontmatter menu field, because the attribute `title` is too generic. `linkTitle` or `anchortitle` might be better names.

I would love if you could merge this and we figure out if the title attribute is something people need in frontmatter menues. I only use site config menues yet.