### PR TITLE
livereload: Fix host comparison when ports aren't present

### DIFF
--- a/livereload/livereload.go
+++ b/livereload/livereload.go
@@ -62,6 +62,10 @@ var upgrader = &websocket.Upgrader{
 			return false
 		}
 
+		if u.Host == r.Host {
+			return true
+		}
+
 		h1, _, err := net.SplitHostPort(u.Host)
 		if err != nil {
 			return false


### PR DESCRIPTION
Compare the original hosts from 'Origin' and 'Host' headers before
attempting to do a port-less comparison.  This helps in the case when
hugo server was started with a '--port=80' so both headers do not
contain a port.

Fixes #4141