### PR TITLE
Update link to 'multilingual site tutorial' to a valid destination

### DIFF
--- a/examples/multilingual/README.md
+++ b/examples/multilingual/README.md
@@ -10,6 +10,6 @@ Please see relevant discussions below:
 * https://github.com/gohugoio/hugo/issues/129 Multiple languages
 * https://github.com/gohugoio/hugo/issues/134 Example of a multilingual site
 
-Alternatively follow our [multilingual site tutorial](http://gohugo.io/tutorials/create-a-multilingual-site/).
+Alternatively follow our [multilingual site tutorial](http://gohugo.io/content-management/multilingual/).
 
 All contributions are welcome!


### PR DESCRIPTION
The new target doesn't have 'tutorial' in the title, but its content is perfect for the purpose

Fixes #4112