### PR TITLE
docs: Remove defaultExtension from configuration doc

### DIFF
--- a/docs/content/getting-started/configuration.md
+++ b/docs/content/getting-started/configuration.md
@@ -73,7 +73,6 @@ canonifyURLs:               false
 config:                     "config.toml"
 contentDir:                 "content"
 dataDir:                    "data"
-defaultExtension:           "html"
 defaultLayout:              "post"
 # Missing translations will default to this content language
 defaultContentLanguage:     "en"
@@ -216,7 +215,6 @@ canonifyURLs =                false
 config =                     "config.toml"
 contentDir =                  "content"
 dataDir =                     "data"
-defaultExtension =            "html"
 defaultLayout =               "post"
 # Missing translations will default to this content language
 defaultContentLanguage =      "en"


### PR DESCRIPTION
As far as I tested, `defaultExtension` in config has no effect with v0.31.1.
It might be deprecated in https://github.com/gohugoio/hugo/commit/ee75e2999b66bd9f258a241c487b6677cf2fa071.
It is misleading to leave the descriptions about `defaultExtensions` in docs.
Removed them.
