### PR TITLE
include update flag to mage installation;

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ started:
 **Note:** Hugo uses [mage](https://github.com/magefile/mage) to build. To install `mage` run
 
 ```bash
-go get github.com/magefile/mage
+go get -u github.com/magefile/mage
 ```
 
 `mage -l` lists all available commands with the corresponding description. To build Hugo run


### PR DESCRIPTION
I had problems with mage which required an update.
After searching around for a while, simply `go get -u...` solved the issue,
so seems reasonable to just include that flag in the basic documentation,
as it is elsewhere on this page.