### PR TITLE
Support offline builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,42 +88,42 @@ new default function more useful for Hugo users.
 Fixes #1949
 ```
 
-### Vendored Dependencies
-
-Hugo uses [Go Dep](https://github.com/golang/dep) to vendor dependencies, but we don't commit the vendored packages themselves to the Hugo git repository.
-Therefore, a simple `go get` is not supported since `go get` is not vendor-aware.
-
-You **must use Go Dep** to fetch and manage Hugo's dependencies.
-
-###  Fetch the Sources From GitHub
+###  Fetching the Sources From GitHub
 
 Due to the way Go handles package imports, the best approach for working on a
 Hugo fork is to use Git Remotes.  Here's a simple walk-through for getting
 started:
 
-1. Install Go Dep and get the Hugo source:
+1. Get the Hugo source:
 
+    ```bash
+    go get -u -v -d github.com/gohugoio/hugo
     ```
-	go get -u -v github.com/golang/dep/cmd/dep
-	go get -u -v -d github.com/gohugoio/hugo
-	```
+
+1. Install Mage:
+
+    ```bash
+    go get github.com/magefile/mage
+    ```
 
 1. Change to the Hugo source directory and fetch the dependencies:
 
-    ```
+    ```bash
     cd $HOME/go/src/github.com/gohugoio/hugo
-	dep ensure
+    mage vendor
     ```
+
+    Note that Hugo uses [Go Dep](https://github.com/golang/dep) to vendor dependencies, rather than a a simple `go get`. We don't commit the vendored packages themselves to the Hugo git repository. The call to `mage vendor` takes care of all this for you.
 
 1. Create a new branch for your changes (the branch name is arbitrary):
 
-    ```
+    ```bash
     git checkout -b iss1234
     ```
 
 1. After making your changes, commit them to your new branch:
 
-    ```
+    ```bash
     git commit -a -v
     ```
 
@@ -131,33 +131,49 @@ started:
 
 1. Add your fork as a new remote (the remote name, "fork" in this example, is arbitrary):
 
-    ```
+    ```bash
     git remote add fork git://github.com/USERNAME/hugo.git
     ```
 
 1. Push the changes to your new remote:
 
-    ```
+    ```bash
     git push --set-upstream fork iss1234
     ```
 
 1. You're now ready to submit a PR based upon the new branch in your forked repository.
 
-### Build Hugo with Your Changes
+### Building Hugo with Your Changes
 
-**Note:** Hugo uses [mage](https://github.com/magefile/mage) to build. To install `mage` run
-
-```bash
-go get github.com/magefile/mage
-```
-
-`mage -l` lists all available commands with the corresponding description. To build Hugo run
+Hugo uses [mage](https://github.com/magefile/mage) to sync vendor dependencies, build Hugo, run the test suite and other things. You must run mage from the Hugo directory.
 
 ```bash
 cd $HOME/go/src/github.com/gohugoio/hugo
+```
+
+To build Hugo: 
+
+```bash
 mage hugo
-# or to install in $HOME/go/bin:
+```
+
+To install hugo in `$HOME/go/bin`:
+
+```bash
 mage install
+```
+
+To run the tests:
+
+```bash
+mage hugoRace
+mage -v check
+```
+
+To list all available commands along with descriptions:
+
+```bash
+mage -l
 ```
 
 ### Updating the Hugo Sources
@@ -166,7 +182,7 @@ If you want to stay in sync with the Hugo repository, you can easily pull down
 the source changes, but you'll need to keep the vendored packages up-to-date as
 well.
 
-```
+```bash
 git pull
 mage vendor
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
   - go get github.com/magefile/mage
 
 build_script:
-  - mage hugoRace
+  - mage vendor hugoRace
   - mage -v check
   - hugo -s docs/
   - hugo --renderToMemory -s docs/

--- a/magefile.go
+++ b/magefile.go
@@ -45,19 +45,16 @@ func Vendor() error {
 
 // Build hugo binary
 func Hugo() error {
-	mg.Deps(Vendor)
 	return sh.RunWith(flagEnv(), goexe, "build", "-ldflags", ldflags, packageName)
 }
 
 // Build hugo binary with race detector enabled
 func HugoRace() error {
-	mg.Deps(Vendor)
 	return sh.RunWith(flagEnv(), goexe, "build", "-race", "-ldflags", ldflags, packageName)
 }
 
 // Install hugo binary
 func Install() error {
-	mg.Deps(Vendor)
 	return sh.RunWith(flagEnv(), goexe, "install", "-ldflags", ldflags, packageName)
 }
 
@@ -115,13 +112,11 @@ func Test386() error {
 
 // Run tests
 func Test() error {
-	mg.Deps(getDep)
 	return sh.Run(goexe, "test", "./...")
 }
 
 // Run tests with race detector
 func TestRace() error {
-	mg.Deps(getDep)
 	return sh.Run(goexe, "test", "-race", "./...")
 }
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,8 +29,7 @@ parts:
       export PATH=$GOPATH/bin:$PATH
       cd $GOPATH/src/github.com/gohugoio/hugo
       go get github.com/magefile/mage
-      mage vendor
-      mage test
+      mage vendor test
       rm -f $GOPATH/bin/dep
       rm -f $GOPATH/bin/mage
     install: |


### PR DESCRIPTION
Currently Hugo's mage build targets depend on the Vendor target, meaning that `go get -u github.com/golang/dep/cmd/dep` is executed each and every time. Not only does this unnecessarily slow builds, it prevents builds when one's machine is offline (no internet access). 

Since Mage now supports invoking multiple build targets, there is no longer a need to hardcode the dependency on the Vendor target. For example:

- offline build: `mage Hugo`
- online build, with updated dependencies: `mage Vendor Hugo`
  