### PR TITLE
tplimpl: Add gtag.js template that is new google analytics tracking code.

### DIFF
--- a/docs/content/templates/internal.md
+++ b/docs/content/templates/internal.md
@@ -27,7 +27,7 @@ While the following internal templates are called similar to partials, they do *
 
 ## Google Analytics
 
-Hugo ships with internal templates for Google Analytics tracking, including both synchronous and asynchronous tracking codes.
+Hugo ships with internal templates for Google Analytics tracking, including both [analytics.js](https://developers.google.com/analytics/devguides/collection/analyticsjs/) and [gtag.js](https://developers.google.com/analytics/devguides/collection/gtagjs/) tracking codes.
 
 ### Configure Google Analytics
 
@@ -45,6 +45,7 @@ googleAnalytics: "UA-123-45"
 
 You can then include the Google Analytics internal template:
 
+#### analytics.js
 ```
 {{ template "_internal/google_analytics.html" . }}
 ```
@@ -52,6 +53,11 @@ You can then include the Google Analytics internal template:
 
 ```
 {{ template "_internal/google_analytics_async.html" . }}
+```
+
+#### gtag.js
+```
+{{ template "_internal/google_analytics_gtag.html" . }}
 ```
 
 ## Disqus

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -289,5 +289,16 @@ ga('send', 'pageview');
 <script async src='//www.google-analytics.com/analytics.js'></script>
 {{ end }}`)
 
+	t.addInternalTemplate("", "google_analytics_gtag.html", `{{ with .Site.GoogleAnalytics }}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ . }}');
+</script>
+{{ end }}`)
+
 	t.addInternalTemplate("_default", "robots.txt", "User-agent: *")
 }


### PR DESCRIPTION
This PR add new internal template gtag.js template that is new google analytics tracking code.

Currently, [Google Analytics](https://analytics.google.com/) show only gtag.js for tracking code.
I think that should replace `google_analytics.html` implementation in the future. But Google will support both analytics.js and gtag.js tracking code for the while, so I add new template at the moment.

FYI
- https://developers.google.com/analytics/devguides/collection/gtagjs/ 