### PR TITLE
Fix symlink handling in templates

### DIFF
--- a/tpl/tplimpl/template.go
+++ b/tpl/tplimpl/template.go
@@ -413,9 +413,9 @@ func (t *templateHandler) loadTemplates(absPath string, prefix string) {
 
 		t.Log.DEBUG.Println("Template path", path)
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-			link, err := filepath.EvalSymlinks(absPath)
+			link, err := filepath.EvalSymlinks(path)
 			if err != nil {
-				t.Log.ERROR.Printf("Cannot read symbolic link '%s', error was: %s", absPath, err)
+				t.Log.ERROR.Printf("Cannot read symbolic link '%s', error was: %s", path, err)
 				return nil
 			}
 
@@ -427,8 +427,8 @@ func (t *templateHandler) loadTemplates(absPath string, prefix string) {
 
 			if !linkfi.Mode().IsRegular() {
 				t.Log.ERROR.Printf("Symbolic links for directories not supported, skipping '%s'", absPath)
+				return nil
 			}
-			return nil
 		}
 
 		if !fi.IsDir() {


### PR DESCRIPTION
There are two logic errors here:
- First, when the template currently being processed is a symlink,
symlink target is retreived from the wrong path - the root path of
template directory
- Second, if the template is really a symlink, regardless of whether
it's target is a directory or a regular file, the processing is
finished. Fix it to only happen if the symlink target is not a regular
file