### PR TITLE
Fix index typo

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -33,7 +33,7 @@ features:
     copy: Hugo allows you to output your content in multiple formats, including JSON or AMP, and makes it easy to create your own.
 sections:
   - heading: "100s of Themes"
-    cta: Check out the Hugo's themes.
+    cta: Check out the Hugo themes.
     link: http://themes.gohugo.io/
     color_classes: bg-accent-color white
     image: /images/homepage-screenshot-hugo-themes.jpg


### PR DESCRIPTION
This could either be "check out Hugo's themes" or "check out the Hugo themes". I think the latter reads better.