### PR TITLE
Fix multihost detection for sites without language definition

### DIFF
--- a/helpers/language.go
+++ b/helpers/language.go
@@ -100,9 +100,13 @@ func (l *Language) Params() map[string]interface{} {
 	return l.params
 }
 
-// IsMultihost returns whether the languages has baseURL specificed on the
-// language level.
+// IsMultihost returns whether there are more than one language and at least one of
+// the languages has baseURL specificed on the language level.
 func (l Languages) IsMultihost() bool {
+	if len(l) <= 1 {
+		return false
+	}
+
 	for _, lang := range l {
 		if lang.GetLocal("baseURL") != nil {
 			return true

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -134,25 +134,24 @@ func loadLanguageSettings(cfg config.Provider, oldLangs helpers.Languages) error
 	cfg.Set("languagesSorted", langs)
 	cfg.Set("multilingual", len(langs) > 1)
 
-	// The baseURL may be provided at the language level. If that is true,
-	// then every language must have a baseURL. In this case we always render
-	// to a language sub folder, which is then stripped from all the Permalink URLs etc.
-	var baseURLFromLang bool
+	multihost := langs.IsMultihost()
 
-	for _, l := range langs {
-		burl := l.GetLocal("baseURL")
-		if baseURLFromLang && burl == nil {
-			return errors.New("baseURL must be set on all or none of the languages")
-		}
-
-		if burl != nil {
-			baseURLFromLang = true
-		}
-	}
-
-	if baseURLFromLang {
+	if multihost {
 		cfg.Set("defaultContentLanguageInSubdir", true)
 		cfg.Set("multihost", true)
+	}
+
+	if multihost {
+		// The baseURL may be provided at the language level. If that is true,
+		// then every language must have a baseURL. In this case we always render
+		// to a language sub folder, which is then stripped from all the Permalink URLs etc.
+		for _, l := range langs {
+			burl := l.GetLocal("baseURL")
+			if burl == nil {
+				return errors.New("baseURL must be set on all or none of the languages")
+			}
+		}
+
 	}
 
 	return nil


### PR DESCRIPTION
Static content was wrongly put into the lang-code subfolder.

Fixes #4221