### PR TITLE
hugolib: Fix handling of mixed-case taxonomy folders with content file

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -440,7 +440,11 @@ func (h *HugoSites) createMissingPages() error {
 							key = s.PathSpec.MakePathSanitized(key)
 						}
 						for _, p := range taxonomyPages {
-							if p.sections[0] == plural && p.sections[1] == key {
+							// Some people may have /authors/MaxMustermann etc. as paths.
+							// p.sections contains the raw values from the file system.
+							// See https://github.com/gohugoio/hugo/issues/4238
+							singularKey := s.PathSpec.MakePathSanitized(p.sections[1])
+							if p.sections[0] == plural && singularKey == key {
 								foundTaxonomyPage = true
 								break
 							}

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -116,7 +116,7 @@ permalinkeds:
 	writeSource(t, fs, "content/p4.md", fmt.Sprintf(pageTemplate, "Hello World", "", "", "- \"Hello Hugo world\"", "- pl1"))
 
 	writeNewContentFile(t, fs, "Category Terms", "2017-01-01", "content/categories/_index.md", 10)
-	writeNewContentFile(t, fs, "Tag1 List", "2017-01-01", "content/tags/tag1/_index.md", 10)
+	writeNewContentFile(t, fs, "Tag1 List", "2017-01-01", "content/tags/Tag1/_index.md", 10)
 
 	err := h.Build(BuildCfg{})
 


### PR DESCRIPTION
* We match by path vs taxonomy to determine if we have a content page for that taxonomy
* The taxonomy name is (if `preserveTaxonomyNames` is not set) normalized to `maxmustermann` while you have the disk folder called `MaxMustermann`.
* This isn't a new issue, but I suspect most people will just name the folder `authors/maxmustermann` and it will just work.
* The inconsistent behaviour you see here is that you will end up with two pages with the same target filename, so it is a little random who will win.

This fixes that by also normalizing the taxonomy path when doing the comparison.

Fixes #4238