### PR TITLE
docs: Add documentation for the .HasShortcode function

### DIFF
--- a/docs/content/templates/shortcode-templates.md
+++ b/docs/content/templates/shortcode-templates.md
@@ -137,6 +137,10 @@ You can also use the variable `.Page` to access all the normal [page variables][
 
 A shortcodes can also be nested. In a nested shortcode, you can access the parent shortcode context with [`.Parent` variable][shortcodesvars]. This can be very useful for inheritance of common shortcode parameters from the root.
 
+### Checking for Existence
+
+You can check if a specific shortcode is used on a page by calling `.HasShortcode` in that page template, providing the name of the shortcode. This is sometimes useful when you want to include specific scripts or styles in the header that are only used by that shortcode.
+
 ## Custom Shortcode Examples
 
 The following are examples of the different types of shortcodes you can create via shortcode template files in `/layouts/shortcodes`.


### PR DESCRIPTION
This function was sorely needed and I was surprised to find out it existed but was not documented. I've added a section in "Creating Your Own Shortcodes" because it's needed when creating shortcodes. I would have added a dedicated method description, too, but I'm not sure where. I found only documentation for variables of pages, not methods of pages.