### PR TITLE
import_jekyll: Only set 'url' if 'permalink' in metadata & remove duplicate confirm msg

### DIFF
--- a/commands/import_jekyll.go
+++ b/commands/import_jekyll.go
@@ -144,11 +144,6 @@ func importFromJekyll(cmd *cobra.Command, args []string) error {
 		"$ git clone https://github.com/spf13/herring-cove.git " + args[1] + "/themes/herring-cove")
 	jww.FEEDBACK.Println("$ cd " + args[1] + "\n$ hugo server --theme=herring-cove")
 
-	jww.FEEDBACK.Println("Congratulations!", fileCount, "post(s) imported!")
-	jww.FEEDBACK.Println("Now, start Hugo by yourself:\n" +
-		"$ git clone https://github.com/spf13/herring-cove.git " + args[1] + "/themes/herring-cove")
-	jww.FEEDBACK.Println("$ cd " + args[1] + "\n$ hugo server --theme=herring-cove")
-
 	return nil
 }
 
@@ -478,8 +473,6 @@ func convertJekyllPost(s *hugolib.Site, path, relPath, targetDir string, draft b
 }
 
 func convertJekyllMetaData(m interface{}, postName string, postDate time.Time, draft bool) (interface{}, error) {
-	url := postDate.Format("/2006/01/02/") + postName + "/"
-
 	metadata, err := cast.ToStringMapE(m)
 	if err != nil {
 		return nil, err
@@ -497,7 +490,7 @@ func convertJekyllMetaData(m interface{}, postName string, postDate time.Time, d
 			delete(metadata, key)
 		case "permalink":
 			if str, ok := value.(string); ok {
-				url = str
+				metadata["url"] = str
 			}
 			delete(metadata, key)
 		case "category":
@@ -526,7 +519,6 @@ func convertJekyllMetaData(m interface{}, postName string, postDate time.Time, d
 
 	}
 
-	metadata["url"] = url
 	metadata["date"] = postDate.Format(time.RFC3339)
 
 	return metadata, nil

--- a/commands/import_jekyll_test.go
+++ b/commands/import_jekyll_test.go
@@ -51,9 +51,9 @@ func TestConvertJekyllMetadata(t *testing.T) {
 		expect   string
 	}{
 		{map[interface{}]interface{}{}, "testPost", time.Date(2015, 10, 1, 0, 0, 0, 0, time.UTC), false,
-			`{"date":"2015-10-01T00:00:00Z","url":"/2015/10/01/testPost/"}`},
+			`{"date":"2015-10-01T00:00:00Z"}`},
 		{map[interface{}]interface{}{}, "testPost", time.Date(2015, 10, 1, 0, 0, 0, 0, time.UTC), true,
-			`{"date":"2015-10-01T00:00:00Z","draft":true,"url":"/2015/10/01/testPost/"}`},
+			`{"date":"2015-10-01T00:00:00Z","draft":true}`},
 		{map[interface{}]interface{}{"Permalink": "/permalink.html", "layout": "post"},
 			"testPost", time.Date(2015, 10, 1, 0, 0, 0, 0, time.UTC), false,
 			`{"date":"2015-10-01T00:00:00Z","url":"/permalink.html"}`},
@@ -62,13 +62,13 @@ func TestConvertJekyllMetadata(t *testing.T) {
 			`{"date":"2015-10-01T00:00:00Z","url":"/permalink.html"}`},
 		{map[interface{}]interface{}{"category": nil, "permalink": 123},
 			"testPost", time.Date(2015, 10, 1, 0, 0, 0, 0, time.UTC), false,
-			`{"date":"2015-10-01T00:00:00Z","url":"/2015/10/01/testPost/"}`},
+			`{"date":"2015-10-01T00:00:00Z"}`},
 		{map[interface{}]interface{}{"Excerpt_Separator": "sep"},
 			"testPost", time.Date(2015, 10, 1, 0, 0, 0, 0, time.UTC), false,
-			`{"date":"2015-10-01T00:00:00Z","excerpt_separator":"sep","url":"/2015/10/01/testPost/"}`},
+			`{"date":"2015-10-01T00:00:00Z","excerpt_separator":"sep"}`},
 		{map[interface{}]interface{}{"category": "book", "layout": "post", "Others": "Goods", "Date": "2015-10-01 12:13:11"},
 			"testPost", time.Date(2015, 10, 1, 0, 0, 0, 0, time.UTC), false,
-			`{"Others":"Goods","categories":["book"],"date":"2015-10-01T12:13:11Z","url":"/2015/10/01/testPost/"}`},
+			`{"Others":"Goods","categories":["book"],"date":"2015-10-01T12:13:11Z"}`},
 	}
 
 	for _, data := range testDataList {


### PR DESCRIPTION
When importing from Jekyll, Hugo adds the `url` attribute to the frontmatter for _all_ posts and assumes that the final desired permalink structure is `/:year/:month/:day/:title/`.

This may be the case for a lot of peeps, but poses a problem for those that don't use this permalink structure as the `url` attribute takes precedence over the `permalink` attribute in the site-wide configuration meaning it can't be overruled.

This PR resolves this by only setting the `url` attribute if the `permalink` attribute is set in the Jekyll frontmatter.

Tests have been updated to reflect this change in behaviour too.

Whilst I'm at it, I've also removed the duplication of the confirmation message:

Before:
```
Importing...
Congratulations! 459 post(s) imported!
Now, start Hugo by yourself:
$ git clone https://github.com/spf13/herring-cove.git hugo-gfr-test/themes/herring-cove
$ cd hugo-gfr-test
$ hugo server --theme=herring-cove
Congratulations! 459 post(s) imported!
Now, start Hugo by yourself:
$ git clone https://github.com/spf13/herring-cove.git hugo-gfr-test/themes/herring-cove
$ cd hugo-gfr-test
$ hugo server --theme=herring-cove
```

After:
```
Importing...
Congratulations! 459 post(s) imported!
Now, start Hugo by yourself:
$ git clone https://github.com/spf13/herring-cove.git hugo-gfr-test/themes/herring-cove
$ cd hugo-gfr-test
$ hugo server --theme=herring-cove
```

Fixes https://github.com/gohugoio/hugo/issues/1887

PS. This my first Hugo (and Go) PR. Go easy on me 😉