### PR TITLE
hugolib: Allow url in front matter for list type pages

### DIFF
--- a/hugolib/node_as_page_test.go
+++ b/hugolib/node_as_page_test.go
@@ -591,7 +591,7 @@ func TestNodesWithURLs(t *testing.T) {
 
 	writeSource(t, fs, filepath.Join("content", "sect", "_index.md"), `---
 title: MySection
-url: foo.html
+url: /my-section/
 ---
 My Section Content
 `)
@@ -602,7 +602,8 @@ My Section Content
 
 	require.NoError(t, h.Build(BuildCfg{}))
 
-	th.assertFileContent(filepath.Join("public", "sect", "index.html"), "My Section")
+	th.assertFileContent(filepath.Join("public", "my-section", "index.html"), "My Section")
+	th.assertFileContent(filepath.Join("public", "my-section", "page", "1", "index.html"), `content="0; url=http://bep.is/base/my-section/"`)
 
 	s := h.Sites[0]
 
@@ -610,11 +611,11 @@ My Section Content
 
 	require.Equal(t, "/base/sect1/regular1/", p.URL())
 
-	// Section with front matter and url set (which should not be used)
+	// Section with front matter and url set
 	sect := s.getPage(KindSection, "sect")
-	require.Equal(t, "/base/sect/", sect.URL())
-	require.Equal(t, "http://bep.is/base/sect/", sect.Permalink())
-	require.Equal(t, "/base/sect/", sect.RelPermalink())
+	require.Equal(t, "/base/my-section/", sect.URL())
+	require.Equal(t, "http://bep.is/base/my-section/", sect.Permalink())
+	require.Equal(t, "/base/my-section/", sect.RelPermalink())
 
 	// Home page without front matter
 	require.Equal(t, "/base/", s.getPage(KindHome).URL())

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -223,7 +223,6 @@ type Page struct {
 	Lastmod time.Time
 
 	Sitemap Sitemap
-
 	URLPath
 	permalink    string
 	relPermalink string
@@ -1111,6 +1110,7 @@ func (p *Page) update(f interface{}) error {
 				return fmt.Errorf("Only relative URLs are supported, %v provided", url)
 			}
 			p.URLPath.URL = cast.ToString(v)
+			p.URLPath.frontMatterURL = p.URLPath.URL
 			p.Params[loki] = p.URLPath.URL
 		case "type":
 			p.contentType = cast.ToString(v)
@@ -1809,10 +1809,11 @@ func (p *Page) String() string {
 }
 
 type URLPath struct {
-	URL       string
-	Permalink string
-	Slug      string
-	Section   string
+	URL            string
+	frontMatterURL string
+	Permalink      string
+	Slug           string
+	Section        string
 }
 
 // Scratch returns the writable context associated with this Page.
@@ -1991,7 +1992,9 @@ func (p *Page) setValuesForKind(s *Site) {
 		p.URLPath.URL = "/"
 	case KindPage:
 	default:
-		p.URLPath.URL = "/" + path.Join(p.sections...) + "/"
+		if p.URLPath.URL == "" {
+			p.URLPath.URL = "/" + path.Join(p.sections...) + "/"
+		}
 	}
 }
 


### PR DESCRIPTION
This enables some potential foot-shooting, but is needed for some special URL requirements.

Fixes #4263