### PR TITLE
resource: Add front matter metadata to Resource

### DIFF
--- a/hugolib/hugo_sites_build_test.go
+++ b/hugolib/hugo_sites_build_test.go
@@ -225,7 +225,7 @@ func doTestMultiSitesBuild(t *testing.T, configTemplate, configSuffix string) {
 
 	gp1 := sites.GetContentPage(filepath.FromSlash("content/sect/doc1.en.md"))
 	require.NotNil(t, gp1)
-	require.Equal(t, "doc1", gp1.Title)
+	require.Equal(t, "doc1", gp1.title)
 	gp2 := sites.GetContentPage(filepath.FromSlash("content/dummysect/notfound.md"))
 	require.Nil(t, gp2)
 
@@ -317,9 +317,9 @@ func doTestMultiSitesBuild(t *testing.T, configTemplate, configSuffix string) {
 	require.Len(t, homeEn.Translations(), 3)
 	require.Equal(t, "fr", homeEn.Translations()[0].Lang())
 	require.Equal(t, "nn", homeEn.Translations()[1].Lang())
-	require.Equal(t, "På nynorsk", homeEn.Translations()[1].Title)
+	require.Equal(t, "På nynorsk", homeEn.Translations()[1].title)
 	require.Equal(t, "nb", homeEn.Translations()[2].Lang())
-	require.Equal(t, "På bokmål", homeEn.Translations()[2].Title, configSuffix)
+	require.Equal(t, "På bokmål", homeEn.Translations()[2].title, configSuffix)
 	require.Equal(t, "Bokmål", homeEn.Translations()[2].Language().LanguageName, configSuffix)
 
 	sectFr := frSite.getPage(KindSection, "sect")
@@ -328,7 +328,7 @@ func doTestMultiSitesBuild(t *testing.T, configTemplate, configSuffix string) {
 	require.Equal(t, "fr", sectFr.Lang())
 	require.Len(t, sectFr.Translations(), 1)
 	require.Equal(t, "en", sectFr.Translations()[0].Lang())
-	require.Equal(t, "Sects", sectFr.Translations()[0].Title)
+	require.Equal(t, "Sects", sectFr.Translations()[0].title)
 
 	nnSite := sites.Sites[2]
 	require.Equal(t, "nn", nnSite.Language.Lang)
@@ -495,9 +495,9 @@ func TestMultiSitesRebuild(t *testing.T) {
 				require.Len(t, enSite.RegularPages, 6)
 				require.Len(t, enSite.AllPages, 34)
 				require.Len(t, frSite.RegularPages, 5)
-				require.Equal(t, "new_fr_1", frSite.RegularPages[3].Title)
-				require.Equal(t, "new_en_2", enSite.RegularPages[0].Title)
-				require.Equal(t, "new_en_1", enSite.RegularPages[1].Title)
+				require.Equal(t, "new_fr_1", frSite.RegularPages[3].title)
+				require.Equal(t, "new_en_2", enSite.RegularPages[0].title)
+				require.Equal(t, "new_en_1", enSite.RegularPages[1].title)
 
 				rendered := readDestination(t, fs, "public/en/new1/index.html")
 				require.True(t, strings.Contains(rendered, "new_en_1"), rendered)
@@ -531,7 +531,7 @@ func TestMultiSitesRebuild(t *testing.T) {
 			},
 			func(t *testing.T) {
 				require.Len(t, enSite.RegularPages, 6, "Rename")
-				require.Equal(t, "new_en_1", enSite.RegularPages[1].Title)
+				require.Equal(t, "new_en_1", enSite.RegularPages[1].title)
 				rendered := readDestination(t, fs, "public/en/new1renamed/index.html")
 				require.True(t, strings.Contains(rendered, "new_en_1"), rendered)
 			}},
@@ -683,7 +683,7 @@ title = "Svenska"
 	// Veriy Swedish site
 	require.Len(t, svSite.RegularPages, 1)
 	svPage := svSite.RegularPages[0]
-	require.Equal(t, "Swedish Contentfile", svPage.Title)
+	require.Equal(t, "Swedish Contentfile", svPage.title)
 	require.Equal(t, "sv", svPage.Lang())
 	require.Len(t, svPage.Translations(), 2)
 	require.Len(t, svPage.AllTranslations(), 3)

--- a/hugolib/node_as_page_test.go
+++ b/hugolib/node_as_page_test.go
@@ -104,7 +104,7 @@ func doTestNodeAsPage(t *testing.T, ugly, preserveTaxonomyNames bool) {
 	require.True(t, home.Path() != "")
 
 	section2 := nodes[5]
-	require.Equal(t, "Section2", section2.Title)
+	require.Equal(t, "Section2", section2.title)
 
 	pages := sites.findAllPagesByKind(KindPage)
 	require.Len(t, pages, 4)
@@ -252,9 +252,9 @@ func doTestNodesWithNoContentFile(t *testing.T, ugly bool) {
 	for _, p := range pages {
 		var want string
 		if ugly {
-			want = "/" + p.s.PathSpec.URLize(p.Title) + ".html"
+			want = "/" + p.s.PathSpec.URLize(p.title) + ".html"
 		} else {
-			want = "/" + p.s.PathSpec.URLize(p.Title) + "/"
+			want = "/" + p.s.PathSpec.URLize(p.title) + "/"
 		}
 		if p.URL() != want {
 			t.Errorf("Taxonomy term URL mismatch: want %q, got %q", want, p.URL())

--- a/hugolib/pageGroup_test.go
+++ b/hugolib/pageGroup_test.go
@@ -49,8 +49,8 @@ func preparePageGroupTestPages(t *testing.T) Pages {
 		p.Date = cast.ToTime(src.date)
 		p.PublishDate = cast.ToTime(src.date)
 		p.ExpiryDate = cast.ToTime(src.date)
-		p.Params["custom_param"] = src.param
-		p.Params["custom_date"] = cast.ToTime(src.date)
+		p.params["custom_param"] = src.param
+		p.params["custom_date"] = cast.ToTime(src.date)
 		pages = append(pages, p)
 	}
 	return pages
@@ -253,7 +253,7 @@ func TestGroupByParamCalledWithCapitalLetterString(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to prepare test page %s", f)
 	}
-	p.Params["custom_param"] = testStr
+	p.params["custom_param"] = testStr
 	pages := Pages{p}
 
 	groups, err := pages.GroupByParam("custom_param")
@@ -268,9 +268,9 @@ func TestGroupByParamCalledWithCapitalLetterString(t *testing.T) {
 func TestGroupByParamCalledWithSomeUnavailableParams(t *testing.T) {
 	t.Parallel()
 	pages := preparePageGroupTestPages(t)
-	delete(pages[1].Params, "custom_param")
-	delete(pages[3].Params, "custom_param")
-	delete(pages[4].Params, "custom_param")
+	delete(pages[1].params, "custom_param")
+	delete(pages[3].params, "custom_param")
+	delete(pages[4].params, "custom_param")
 
 	expect := PagesGroup{
 		{Key: "foo", Pages: Pages{pages[0], pages[2]}},

--- a/hugolib/pageSort.go
+++ b/hugolib/pageSort.go
@@ -129,7 +129,7 @@ func (p Pages) ByTitle() Pages {
 	key := "pageSort.ByTitle"
 
 	title := func(p1, p2 *Page) bool {
-		return p1.Title < p2.Title
+		return p1.title < p2.title
 	}
 
 	pages, _ := spc.get(key, p, pageBy(title).Sort)

--- a/hugolib/pageSort_test.go
+++ b/hugolib/pageSort_test.go
@@ -74,7 +74,7 @@ func TestSortByN(t *testing.T) {
 		assertFunc func(p Pages) bool
 	}{
 		{(Pages).ByWeight, func(p Pages) bool { return p[0].Weight == 1 }},
-		{(Pages).ByTitle, func(p Pages) bool { return p[0].Title == "ab" }},
+		{(Pages).ByTitle, func(p Pages) bool { return p[0].title == "ab" }},
 		{(Pages).ByLinkTitle, func(p Pages) bool { return p[0].LinkTitle() == "abl" }},
 		{(Pages).ByDate, func(p Pages) bool { return p[0].Date == d4 }},
 		{(Pages).ByPublishDate, func(p Pages) bool { return p[0].PublishDate == d4 }},
@@ -124,7 +124,7 @@ func TestPageSortByParam(t *testing.T) {
 	s := newTestSite(t)
 
 	unsorted := createSortTestPages(s, 10)
-	delete(unsorted[9].Params, "arbitrarily")
+	delete(unsorted[9].params, "arbitrarily")
 
 	firstSetValue, _ := unsorted[0].Param(k)
 	secondSetValue, _ := unsorted[1].Param(k)
@@ -163,9 +163,9 @@ func setSortVals(dates [4]time.Time, titles [4]string, weights [4]int, pages Pag
 		pages[i].Date = dates[i]
 		pages[i].Lastmod = dates[i]
 		pages[i].Weight = weights[i]
-		pages[i].Title = titles[i]
+		pages[i].title = titles[i]
 		// make sure we compare apples and ... apples ...
-		pages[len(dates)-1-i].linkTitle = pages[i].Title + "l"
+		pages[len(dates)-1-i].linkTitle = pages[i].title + "l"
 		pages[len(dates)-1-i].PublishDate = dates[i]
 		pages[len(dates)-1-i].ExpiryDate = dates[i]
 		pages[len(dates)-1-i].Content = template.HTML(titles[i] + "_content")
@@ -180,7 +180,7 @@ func createSortTestPages(s *Site, num int) Pages {
 
 	for i := 0; i < num; i++ {
 		p := s.newPage(filepath.FromSlash(fmt.Sprintf("/x/y/p%d.md", i)))
-		p.Params = map[string]interface{}{
+		p.params = map[string]interface{}{
 			"arbitrarily": map[string]interface{}{
 				"nested": ("xyz" + fmt.Sprintf("%v", 100-i)),
 			},

--- a/hugolib/page_bundler_handlers.go
+++ b/hugolib/page_bundler_handlers.go
@@ -254,6 +254,12 @@ func (c *contentHandlers) parsePage(h contentHandler) contentHandler {
 
 				return p.Resources[i].RelPermalink() < p.Resources[j].RelPermalink()
 			})
+
+			// Assign metadata from front matter if set
+			if len(p.resourcesMetadata) > 0 {
+				resource.AssignMetadata(p.resourcesMetadata, p.Resources...)
+			}
+
 		}
 
 		return h(ctx)

--- a/hugolib/page_collections_test.go
+++ b/hugolib/page_collections_test.go
@@ -134,7 +134,7 @@ func TestGetPage(t *testing.T) {
 		page := s.getPage(test.kind, test.path...)
 		assert.NotNil(page, errorMsg)
 		assert.Equal(test.kind, page.Kind, errorMsg)
-		assert.Equal(test.expectedTitle, page.Title)
+		assert.Equal(test.expectedTitle, page.title)
 	}
 
 }

--- a/hugolib/page_paths.go
+++ b/hugolib/page_paths.go
@@ -74,7 +74,7 @@ type targetPathDescriptor struct {
 // and URLs for this Page.
 func (p *Page) createTargetPathDescriptor(t output.Format) (targetPathDescriptor, error) {
 	if p.targetPathDescriptorPrototype == nil {
-		panic(fmt.Sprintf("Must run initTargetPathDescriptor() for page %q, kind %q", p.Title, p.Kind))
+		panic(fmt.Sprintf("Must run initTargetPathDescriptor() for page %q, kind %q", p.title, p.Kind))
 	}
 	d := *p.targetPathDescriptorPrototype
 	d.Type = t
@@ -271,9 +271,9 @@ func (p *Page) createRelativeTargetPath() string {
 
 	if len(p.outputFormats) == 0 {
 		if p.Kind == kindUnknown {
-			panic(fmt.Sprintf("Page %q has unknown kind", p.Title))
+			panic(fmt.Sprintf("Page %q has unknown kind", p.title))
 		}
-		panic(fmt.Sprintf("Page %q missing output format(s)", p.Title))
+		panic(fmt.Sprintf("Page %q missing output format(s)", p.title))
 	}
 
 	// Choose the main output format. In most cases, this will be HTML.

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -468,8 +468,8 @@ func TestDegenerateEmptyPage(t *testing.T) {
 }
 
 func checkPageTitle(t *testing.T, page *Page, title string) {
-	if page.Title != title {
-		t.Fatalf("Page title is: %s.  Expected %s", page.Title, title)
+	if page.title != title {
+		t.Fatalf("Page title is: %s.  Expected %s", page.title, title)
 	}
 }
 
@@ -1066,8 +1066,8 @@ func TestCalendarParamsVariants(t *testing.T) {
 	pageTOML, _ := s.NewPage("test/fileTOML.md")
 	_, _ = pageTOML.ReadFrom(strings.NewReader(pageWithCalendarTOMLFrontmatter))
 
-	assert.True(t, compareObjects(pageJSON.Params, pageYAML.Params))
-	assert.True(t, compareObjects(pageJSON.Params, pageTOML.Params))
+	assert.True(t, compareObjects(pageJSON.params, pageYAML.params))
+	assert.True(t, compareObjects(pageJSON.params, pageTOML.params))
 
 }
 
@@ -1095,10 +1095,10 @@ func TestDifferentFrontMatterVarTypes(t *testing.T) {
 	}
 	param := page.getParamToLower("a_table")
 	if param == nil {
-		t.Errorf("frontmatter not handling tables correctly should be type of %v, got: type of %v", reflect.TypeOf(page.Params["a_table"]), reflect.TypeOf(param))
+		t.Errorf("frontmatter not handling tables correctly should be type of %v, got: type of %v", reflect.TypeOf(page.params["a_table"]), reflect.TypeOf(param))
 	}
 	if cast.ToStringMap(param)["a_key"] != "a_value" {
-		t.Errorf("frontmatter not handling values inside a table correctly should be %s, got: %s", "a_value", cast.ToStringMap(page.Params["a_table"])["a_key"])
+		t.Errorf("frontmatter not handling values inside a table correctly should be %s, got: %s", "a_value", cast.ToStringMap(page.params["a_table"])["a_key"])
 	}
 }
 
@@ -1370,7 +1370,7 @@ func TestPageParams(t *testing.T) {
 		p, err := s.NewPageFrom(strings.NewReader(c), "content/post/params.md")
 		require.NoError(t, err, "err during parse", "#%d", i)
 		for key := range wantedMap {
-			assert.Equal(t, wantedMap[key], p.Params[key], "#%d", key)
+			assert.Equal(t, wantedMap[key], p.params[key], "#%d", key)
 		}
 	}
 }

--- a/hugolib/pages_related_test.go
+++ b/hugolib/pages_related_test.go
@@ -54,22 +54,22 @@ Content
 
 	assert.NoError(err)
 	assert.Len(result, 2)
-	assert.Equal("Page 2", result[0].Title)
-	assert.Equal("Page 1", result[1].Title)
+	assert.Equal("Page 2", result[0].title)
+	assert.Equal("Page 1", result[1].title)
 
 	result, err = s.RegularPages.Related(s.RegularPages[0])
 	assert.Len(result, 2)
-	assert.Equal("Page 2", result[0].Title)
-	assert.Equal("Page 3", result[1].Title)
+	assert.Equal("Page 2", result[0].title)
+	assert.Equal("Page 3", result[1].title)
 
 	result, err = s.RegularPages.RelatedIndices(s.RegularPages[0], "keywords")
 	assert.Len(result, 2)
-	assert.Equal("Page 2", result[0].Title)
-	assert.Equal("Page 3", result[1].Title)
+	assert.Equal("Page 2", result[0].title)
+	assert.Equal("Page 3", result[1].title)
 
 	result, err = s.RegularPages.RelatedTo(types.NewKeyValuesStrings("keywords", "bep", "rocks"))
 	assert.NoError(err)
 	assert.Len(result, 2)
-	assert.Equal("Page 2", result[0].Title)
-	assert.Equal("Page 3", result[1].Title)
+	assert.Equal("Page 2", result[0].title)
+	assert.Equal("Page 3", result[1].title)
 }

--- a/hugolib/pagination.go
+++ b/hugolib/pagination.go
@@ -270,7 +270,7 @@ func (p *Page) Paginator(options ...interface{}) (*Pager, error) {
 // If it's not, one will be created with all pages in Data["Pages"].
 func (p *PageOutput) Paginator(options ...interface{}) (*Pager, error) {
 	if !p.IsNode() {
-		return nil, fmt.Errorf("Paginators not supported for pages of type %q (%q)", p.Kind, p.Title)
+		return nil, fmt.Errorf("Paginators not supported for pages of type %q (%q)", p.Kind, p.title)
 	}
 	pagerSize, err := resolvePagerSize(p.s.Cfg, options...)
 
@@ -321,7 +321,7 @@ func (p *Page) Paginate(seq interface{}, options ...interface{}) (*Pager, error)
 // Note that repeated calls will return the same result, even if the sequence is different.
 func (p *PageOutput) Paginate(seq interface{}, options ...interface{}) (*Pager, error) {
 	if !p.IsNode() {
-		return nil, fmt.Errorf("Paginators not supported for pages of type %q (%q)", p.Kind, p.Title)
+		return nil, fmt.Errorf("Paginators not supported for pages of type %q (%q)", p.Kind, p.title)
 	}
 
 	pagerSize, err := resolvePagerSize(p.s.Cfg, options...)

--- a/hugolib/permalinks.go
+++ b/hugolib/permalinks.go
@@ -154,7 +154,7 @@ func pageToPermalinkDate(p *Page, dateField string) (string, error) {
 func pageToPermalinkTitle(p *Page, _ string) (string, error) {
 	// Page contains Node which has Title
 	// (also contains URLPath which has Slug, sometimes)
-	return p.s.PathSpec.URLize(p.Title), nil
+	return p.s.PathSpec.URLize(p.title), nil
 }
 
 // pageToPermalinkFilename returns the URL-safe form of the filename

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1877,7 +1877,7 @@ func (s *Site) newNodePage(typ string, sections ...string) *Page {
 
 func (s *Site) newHomePage() *Page {
 	p := s.newNodePage(KindHome)
-	p.Title = s.Info.Title
+	p.title = s.Info.Title
 	pages := Pages{}
 	p.Data["Pages"] = pages
 	p.Pages = pages
@@ -1892,10 +1892,10 @@ func (s *Site) newTaxonomyPage(plural, key string) *Page {
 		// Keep (mostly) as is in the title
 		// We make the first character upper case, mostly because
 		// it is easier to reason about in the tests.
-		p.Title = helpers.FirstUpper(key)
+		p.title = helpers.FirstUpper(key)
 		key = s.PathSpec.MakePathSanitized(key)
 	} else {
-		p.Title = strings.Replace(s.titleFunc(key), "-", " ", -1)
+		p.title = strings.Replace(s.titleFunc(key), "-", " ", -1)
 	}
 
 	return p
@@ -1906,15 +1906,15 @@ func (s *Site) newSectionPage(name string) *Page {
 
 	sectionName := helpers.FirstUpper(name)
 	if s.Cfg.GetBool("pluralizeListTitles") {
-		p.Title = inflect.Pluralize(sectionName)
+		p.title = inflect.Pluralize(sectionName)
 	} else {
-		p.Title = sectionName
+		p.title = sectionName
 	}
 	return p
 }
 
 func (s *Site) newTaxonomyTermsPage(plural string) *Page {
 	p := s.newNodePage(KindTaxonomyTerm, plural)
-	p.Title = s.titleFunc(plural)
+	p.title = s.titleFunc(plural)
 	return p
 }

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -212,7 +212,7 @@ func (s *Site) renderPaginator(p *PageOutput) error {
 
 			if err := s.renderAndWritePage(
 				&s.PathSpec.ProcessingStats.PaginatorPages,
-				pagerNode.Title,
+				pagerNode.title,
 				targetPath, pagerNode, layouts...); err != nil {
 				return err
 			}
@@ -252,7 +252,7 @@ func (s *Site) renderRSS(p *PageOutput) error {
 		return err
 	}
 
-	return s.renderAndWriteXML(&s.PathSpec.ProcessingStats.Pages, p.Title,
+	return s.renderAndWriteXML(&s.PathSpec.ProcessingStats.Pages, p.title,
 		targetPath, p, layouts...)
 }
 
@@ -267,7 +267,7 @@ func (s *Site) render404() error {
 
 	p := s.newNodePage(kind404)
 
-	p.Title = "404 Page not found"
+	p.title = "404 Page not found"
 	p.Data["Pages"] = s.Pages
 	p.Pages = s.Pages
 	p.URLPath.URL = "404.html"

--- a/hugolib/site_sections_test.go
+++ b/hugolib/site_sections_test.go
@@ -143,13 +143,13 @@ PAG|{{ .Title }}|{{ $sect.InSection . }}
 			// > b,c,d where b and d have content files.
 			b := p.s.getPage(KindSection, "empty2", "b")
 			assert.NotNil(b)
-			assert.Equal("T40_-1", b.Title)
+			assert.Equal("T40_-1", b.title)
 			c := p.s.getPage(KindSection, "empty2", "b", "c")
 			assert.NotNil(c)
-			assert.Equal("Cs", c.Title)
+			assert.Equal("Cs", c.title)
 			d := p.s.getPage(KindSection, "empty2", "b", "c", "d")
 			assert.NotNil(d)
-			assert.Equal("T41_-1", d.Title)
+			assert.Equal("T41_-1", d.title)
 
 			assert.False(c.Eq(d))
 			assert.True(c.Eq(c))
@@ -165,7 +165,7 @@ PAG|{{ .Title }}|{{ $sect.InSection . }}
 
 		}},
 		{"top", func(p *Page) {
-			assert.Equal("Tops", p.Title)
+			assert.Equal("Tops", p.title)
 			assert.Len(p.Pages, 2)
 			assert.Equal("mypage2.md", p.Pages[0].LogicalName())
 			assert.Equal("mypage3.md", p.Pages[1].LogicalName())
@@ -178,16 +178,16 @@ PAG|{{ .Title }}|{{ $sect.InSection . }}
 			assert.True(active)
 		}},
 		{"l1", func(p *Page) {
-			assert.Equal("L1s", p.Title)
+			assert.Equal("L1s", p.title)
 			assert.Len(p.Pages, 2)
 			assert.True(p.Parent().IsHome())
 			assert.Len(p.Sections(), 2)
 		}},
 		{"l1,l2", func(p *Page) {
-			assert.Equal("T2_-1", p.Title)
+			assert.Equal("T2_-1", p.title)
 			assert.Len(p.Pages, 3)
 			assert.Equal(p, p.Pages[0].Parent())
-			assert.Equal("L1s", p.Parent().Title)
+			assert.Equal("L1s", p.Parent().title)
 			assert.Equal("/l1/l2/", p.URLPath.URL)
 			assert.Equal("/l1/l2/", p.RelPermalink())
 			assert.Len(p.Sections(), 1)
@@ -223,16 +223,16 @@ PAG|{{ .Title }}|{{ $sect.InSection . }}
 
 		}},
 		{"l1,l2_2", func(p *Page) {
-			assert.Equal("T22_-1", p.Title)
+			assert.Equal("T22_-1", p.title)
 			assert.Len(p.Pages, 2)
 			assert.Equal(filepath.FromSlash("l1/l2_2/page_2_2_1.md"), p.Pages[0].Path())
-			assert.Equal("L1s", p.Parent().Title)
+			assert.Equal("L1s", p.Parent().title)
 			assert.Len(p.Sections(), 0)
 		}},
 		{"l1,l2,l3", func(p *Page) {
-			assert.Equal("T3_-1", p.Title)
+			assert.Equal("T3_-1", p.title)
 			assert.Len(p.Pages, 2)
-			assert.Equal("T2_-1", p.Parent().Title)
+			assert.Equal("T2_-1", p.Parent().title)
 			assert.Len(p.Sections(), 0)
 
 			l1 := p.s.getPage(KindSection, "l1")
@@ -252,7 +252,7 @@ PAG|{{ .Title }}|{{ $sect.InSection . }}
 
 		}},
 		{"perm a,link", func(p *Page) {
-			assert.Equal("T9_-1", p.Title)
+			assert.Equal("T9_-1", p.title)
 			assert.Equal("/perm-a/link/", p.RelPermalink())
 			assert.Len(p.Pages, 4)
 			first := p.Pages[0]

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -160,7 +160,7 @@ func TestFutureExpirationRender(t *testing.T) {
 		}
 	}
 
-	if s.AllPages[0].Title == "doc2" {
+	if s.AllPages[0].title == "doc2" {
 		t.Fatal("Expired content published unexpectedly")
 	}
 }
@@ -642,40 +642,40 @@ func TestOrderedPages(t *testing.T) {
 
 	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{SkipRender: true})
 
-	if s.getPage(KindSection, "sect").Pages[1].Title != "Three" || s.getPage(KindSection, "sect").Pages[2].Title != "Four" {
+	if s.getPage(KindSection, "sect").Pages[1].title != "Three" || s.getPage(KindSection, "sect").Pages[2].title != "Four" {
 		t.Error("Pages in unexpected order.")
 	}
 
 	bydate := s.RegularPages.ByDate()
 
-	if bydate[0].Title != "One" {
-		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "One", bydate[0].Title)
+	if bydate[0].title != "One" {
+		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "One", bydate[0].title)
 	}
 
 	rev := bydate.Reverse()
-	if rev[0].Title != "Three" {
-		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "Three", rev[0].Title)
+	if rev[0].title != "Three" {
+		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "Three", rev[0].title)
 	}
 
 	bypubdate := s.RegularPages.ByPublishDate()
 
-	if bypubdate[0].Title != "One" {
-		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "One", bypubdate[0].Title)
+	if bypubdate[0].title != "One" {
+		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "One", bypubdate[0].title)
 	}
 
 	rbypubdate := bypubdate.Reverse()
-	if rbypubdate[0].Title != "Three" {
-		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "Three", rbypubdate[0].Title)
+	if rbypubdate[0].title != "Three" {
+		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "Three", rbypubdate[0].title)
 	}
 
 	bylength := s.RegularPages.ByLength()
-	if bylength[0].Title != "One" {
-		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "One", bylength[0].Title)
+	if bylength[0].title != "One" {
+		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "One", bylength[0].title)
 	}
 
 	rbylength := bylength.Reverse()
-	if rbylength[0].Title != "Four" {
-		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "Four", rbylength[0].Title)
+	if rbylength[0].title != "Four" {
+		t.Errorf("Pages in unexpected order. First should be '%s', got '%s'", "Four", rbylength[0].title)
 	}
 }
 
@@ -714,8 +714,8 @@ func TestGroupedPages(t *testing.T) {
 	if rbysection[2].Key != "sect1" {
 		t.Errorf("PageGroup array in unexpected order. Third group key should be '%s', got '%s'", "sect1", rbysection[2].Key)
 	}
-	if rbysection[0].Pages[0].Title != "Four" {
-		t.Errorf("PageGroup has an unexpected page. First group's pages should have '%s', got '%s'", "Four", rbysection[0].Pages[0].Title)
+	if rbysection[0].Pages[0].title != "Four" {
+		t.Errorf("PageGroup has an unexpected page. First group's pages should have '%s', got '%s'", "Four", rbysection[0].Pages[0].title)
 	}
 	if len(rbysection[2].Pages) != 2 {
 		t.Errorf("PageGroup has unexpected number of pages. Third group should have '%d' pages, got '%d' pages", 2, len(rbysection[2].Pages))
@@ -734,8 +734,8 @@ func TestGroupedPages(t *testing.T) {
 	if bytype[2].Key != "sect3" {
 		t.Errorf("PageGroup array in unexpected order. Third group key should be '%s', got '%s'", "sect3", bytype[2].Key)
 	}
-	if bytype[2].Pages[0].Title != "Four" {
-		t.Errorf("PageGroup has an unexpected page. Third group's data should have '%s', got '%s'", "Four", bytype[0].Pages[0].Title)
+	if bytype[2].Pages[0].title != "Four" {
+		t.Errorf("PageGroup has an unexpected page. Third group's data should have '%s', got '%s'", "Four", bytype[0].Pages[0].title)
 	}
 	if len(bytype[0].Pages) != 2 {
 		t.Errorf("PageGroup has unexpected number of pages. First group should have '%d' pages, got '%d' pages", 2, len(bytype[2].Pages))
@@ -762,8 +762,8 @@ func TestGroupedPages(t *testing.T) {
 	if bypubdate[1].Key != "0001" {
 		t.Errorf("PageGroup array in unexpected order. Second group key should be '%s', got '%s'", "0001", bypubdate[1].Key)
 	}
-	if bypubdate[0].Pages[0].Title != "Three" {
-		t.Errorf("PageGroup has an unexpected page. Third group's pages should have '%s', got '%s'", "Three", bypubdate[0].Pages[0].Title)
+	if bypubdate[0].Pages[0].title != "Three" {
+		t.Errorf("PageGroup has an unexpected page. Third group's pages should have '%s', got '%s'", "Three", bypubdate[0].Pages[0].title)
 	}
 	if len(bypubdate[0].Pages) != 3 {
 		t.Errorf("PageGroup has unexpected number of pages. First group should have '%d' pages, got '%d' pages", 3, len(bypubdate[0].Pages))
@@ -782,8 +782,8 @@ func TestGroupedPages(t *testing.T) {
 	if byparam[2].Key != "bar" {
 		t.Errorf("PageGroup array in unexpected order. Third group key should be '%s', got '%s'", "bar", byparam[2].Key)
 	}
-	if byparam[2].Pages[0].Title != "Three" {
-		t.Errorf("PageGroup has an unexpected page. Third group's pages should have '%s', got '%s'", "Three", byparam[2].Pages[0].Title)
+	if byparam[2].Pages[0].title != "Three" {
+		t.Errorf("PageGroup has an unexpected page. Third group's pages should have '%s', got '%s'", "Three", byparam[2].Pages[0].title)
 	}
 	if len(byparam[0].Pages) != 2 {
 		t.Errorf("PageGroup has unexpected number of pages. First group should have '%d' pages, got '%d' pages", 2, len(byparam[0].Pages))
@@ -815,8 +815,8 @@ func TestGroupedPages(t *testing.T) {
 	if byParamDate[1].Key != "1979-05" {
 		t.Errorf("PageGroup array in unexpected order. Second group key should be '%s', got '%s'", "1979-05", byParamDate[1].Key)
 	}
-	if byParamDate[1].Pages[0].Title != "One" {
-		t.Errorf("PageGroup has an unexpected page. Second group's pages should have '%s', got '%s'", "One", byParamDate[1].Pages[0].Title)
+	if byParamDate[1].Pages[0].title != "One" {
+		t.Errorf("PageGroup has an unexpected page. Second group's pages should have '%s', got '%s'", "One", byParamDate[1].Pages[0].title)
 	}
 	if len(byParamDate[0].Pages) != 2 {
 		t.Errorf("PageGroup has unexpected number of pages. First group should have '%d' pages, got '%d' pages", 2, len(byParamDate[2].Pages))
@@ -872,16 +872,16 @@ func TestWeightedTaxonomies(t *testing.T) {
 	writeSourcesToSource(t, "content", fs, sources...)
 	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{})
 
-	if s.Taxonomies["tags"]["a"][0].Page.Title != "foo" {
-		t.Errorf("Pages in unexpected order, 'foo' expected first, got '%v'", s.Taxonomies["tags"]["a"][0].Page.Title)
+	if s.Taxonomies["tags"]["a"][0].Page.title != "foo" {
+		t.Errorf("Pages in unexpected order, 'foo' expected first, got '%v'", s.Taxonomies["tags"]["a"][0].Page.title)
 	}
 
-	if s.Taxonomies["categories"]["d"][0].Page.Title != "bar" {
-		t.Errorf("Pages in unexpected order, 'bar' expected first, got '%v'", s.Taxonomies["categories"]["d"][0].Page.Title)
+	if s.Taxonomies["categories"]["d"][0].Page.title != "bar" {
+		t.Errorf("Pages in unexpected order, 'bar' expected first, got '%v'", s.Taxonomies["categories"]["d"][0].Page.title)
 	}
 
-	if s.Taxonomies["categories"]["e"][0].Page.Title != "bza" {
-		t.Errorf("Pages in unexpected order, 'bza' expected first, got '%v'", s.Taxonomies["categories"]["e"][0].Page.Title)
+	if s.Taxonomies["categories"]["e"][0].Page.title != "bza" {
+		t.Errorf("Pages in unexpected order, 'bza' expected first, got '%v'", s.Taxonomies["categories"]["e"][0].Page.title)
 	}
 }
 

--- a/hugolib/taxonomy.go
+++ b/hugolib/taxonomy.go
@@ -43,7 +43,7 @@ type WeightedPage struct {
 }
 
 func (w WeightedPage) String() string {
-	return fmt.Sprintf("WeightedPage(%d,%q)", w.Weight, w.Page.Title)
+	return fmt.Sprintf("WeightedPage(%d,%q)", w.Weight, w.Page.title)
 }
 
 // OrderedTaxonomy is another representation of an Taxonomy using an array rather than a map.
@@ -214,7 +214,7 @@ func (wp WeightedPages) Count() int { return len(wp) }
 func (wp WeightedPages) Less(i, j int) bool {
 	if wp[i].Weight == wp[j].Weight {
 		if wp[i].Page.Date.Equal(wp[j].Page.Date) {
-			return wp[i].Page.Title < wp[j].Page.Title
+			return wp[i].Page.title < wp[j].Page.title
 		}
 		return wp[i].Page.Date.After(wp[i].Page.Date)
 	}

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -200,11 +200,11 @@ permalinkeds:
 	if preserveTaxonomyNames {
 		helloWorld := s.getPage(KindTaxonomy, "others", "Hello Hugo world")
 		require.NotNil(t, helloWorld)
-		require.Equal(t, "Hello Hugo world", helloWorld.Title)
+		require.Equal(t, "Hello Hugo world", helloWorld.title)
 	} else {
 		helloWorld := s.getPage(KindTaxonomy, "others", "hello-hugo-world")
 		require.NotNil(t, helloWorld)
-		require.Equal(t, "Hello Hugo World", helloWorld.Title)
+		require.Equal(t, "Hello Hugo World", helloWorld.title)
 	}
 
 	// Issue #2977

--- a/hugolib/testhelpers_test.go
+++ b/hugolib/testhelpers_test.go
@@ -217,7 +217,7 @@ func dumpPages(pages ...*Page) {
 	for i, p := range pages {
 		fmt.Printf("%d: Kind: %s Title: %-10s RelPermalink: %-10s Path: %-10s sections: %s Len Sections(): %d\n",
 			i+1,
-			p.Kind, p.Title, p.RelPermalink(), p.Path(), p.sections, len(p.Sections()))
+			p.Kind, p.title, p.RelPermalink(), p.Path(), p.sections, len(p.Sections()))
 	}
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -231,6 +231,9 @@ func TestCoverHTML() error {
 		}
 		b, err := ioutil.ReadFile(cover)
 		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
 			return err
 		}
 		idx := bytes.Index(b, []byte{'\n'})

--- a/resource/image.go
+++ b/resource/image.go
@@ -208,7 +208,7 @@ func (i *Image) doWithImageConfig(action, spec string, f func(src image.Image, c
 
 	key := i.relTargetPathForRel(i.filenameFromConfig(conf), false)
 
-	return i.spec.imageCache.getOrCreate(i.spec, key, func(resourceCacheFilename string) (*Image, error) {
+	return i.spec.imageCache.getOrCreate(i, key, func(resourceCacheFilename string) (*Image, error) {
 		ci := i.clone()
 
 		ci.setBasePath(conf)

--- a/resource/image_test.go
+++ b/resource/image_test.go
@@ -147,3 +147,25 @@ func TestDecodeImaging(t *testing.T) {
 	assert.Equal(42, imaging.Quality)
 	assert.Equal("nearestneighbor", imaging.ResampleFilter)
 }
+
+func TestImageWithMetadata(t *testing.T) {
+	assert := require.New(t)
+
+	image := fetchSunset(assert)
+
+	var meta = []map[string]interface{}{
+		map[string]interface{}{
+			"title": "My Sunset",
+			"name":  "Sunset #:counter",
+			"src":   "*.jpg",
+		},
+	}
+
+	assert.NoError(AssignMetadata(meta, image))
+	assert.Equal("Sunset #1", image.Name())
+
+	resized, err := image.Resize("200x")
+	assert.NoError(err)
+	assert.Equal("Sunset #1", resized.Name())
+
+}


### PR DESCRIPTION
This commit expands the Resource interface with 3 new methods:

* Name
* Title
* Params

All of these can be set in the Page front matter. `Name` will get its default value from the base filename, and is the value used in the ByPrefix and GetByPrefix lookup methods.

Fixes #4244