### PR TITLE
Support render .ipynb file as a new feature

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -464,6 +464,8 @@ func (c ContentSpec) RenderBytes(ctx *RenderingContext) []byte {
 		return orgRender(ctx, c)
 	case "pandoc":
 		return getPandocContent(ctx)
+	case "jupyter":
+		return jupyterRender(ctx, c)
 	}
 }
 
@@ -704,6 +706,23 @@ func orgRender(ctx *RenderingContext, c ContentSpec) []byte {
 	cleanContent := bytes.Replace(content, []byte("# more"), []byte(""), 1)
 	return goorgeous.Org(cleanContent,
 		c.getHTMLRenderer(blackfriday.HTML_TOC, ctx))
+}
+
+func jupyterRender(ctx *RenderingContext, c ContentSpec) []byte {
+	jupyter, err := exec.LookPath("jupyter")
+	if err != nil {
+		jww.ERROR.Println("jupyter not found in $PATH.\n",
+			"                 Leaving notebook content unrendered.")
+		return ctx.Content
+	}
+	// TODO not sure how to structure SummaryDivider yet, leave it for later
+	// cleanContent := bytes.Replace(ctx.Content, SummaryDivider, []byte(""), 1)
+	args := []string{"nbconvert", "--to", "markdown", "--stdin", "--stdout",
+		"--log-level=ERROR"}
+	markdownContent := externallyRenderContent(ctx, jupyter, args)
+	ctx.Content = markdownContent
+	ctx.RenderTOC = false
+	return c.markdownRender(ctx)
 }
 
 func externallyRenderContent(ctx *RenderingContext, path string, args []string) []byte {

--- a/helpers/general.go
+++ b/helpers/general.go
@@ -86,6 +86,8 @@ func GuessType(in string) string {
 		return "html"
 	case "org":
 		return "org"
+	case "ipynb":
+		return "jupyter"
 	}
 
 	return "unknown"

--- a/helpers/general_test.go
+++ b/helpers/general_test.go
@@ -43,6 +43,7 @@ func TestGuessType(t *testing.T) {
 		{"htm", "html"},
 		{"org", "org"},
 		{"excel", "unknown"},
+		{"ipynb", "jupyter"},
 	} {
 		result := GuessType(this.in)
 		if result != this.expect {

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -709,10 +709,13 @@ func (p *Page) setAutoSummary() error {
 
 func (p *Page) renderContent(content []byte) []byte {
 	return p.s.ContentSpec.RenderBytes(&helpers.RenderingContext{
-		Content: content, RenderTOC: true, PageFmt: p.determineMarkupType(),
-		Cfg:        p.Language(),
-		DocumentID: p.UniqueID(), DocumentName: p.Path(),
-		Config: p.getRenderingConfig()})
+		Content:      content,
+		RenderTOC:    true,
+		PageFmt:      p.determineMarkupType(),
+		Cfg:          p.Language(),
+		DocumentID:   p.UniqueID(),
+		DocumentName: p.Path(),
+		Config:       p.getRenderingConfig()})
 }
 
 func (p *Page) getRenderingConfig() *helpers.BlackFriday {
@@ -1534,7 +1537,14 @@ func (p *Page) determineMarkupType() string {
 }
 
 func (p *Page) parse(reader io.Reader) error {
-	psr, err := parser.ReadFrom(reader)
+	var psr parser.Page
+	var err error
+	if p.Source.Extension() == "ipynb" {
+		psr, err = parser.ReadFromNotebook(reader)
+	} else {
+		psr, err = parser.ReadFrom(reader)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/hugolib/page_bundler_handlers.go
+++ b/hugolib/page_bundler_handlers.go
@@ -33,7 +33,9 @@ var (
 		"rest", "rst",
 		"mmark",
 		"org",
-		"pandoc", "pdc"}
+		"pandoc", "pdc",
+		"ipynb",
+	}
 
 	contentFileExtensionsSet map[string]bool
 )

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -438,6 +438,45 @@ activity = "exam"
 Hi.
 `
 
+const contentJupyterNotebook = `
+{
+	"cells": [
+		{
+			"cell_type": "markdown",
+			"metadata": {},
+			"source": [
+				"Jupyter notebook\n"
+			]
+		}
+	],
+	"metadata": {
+		"frontmatter": {
+			"title": "Fixture for Hugo"
+		},
+		"kernelspec": {
+			"display_name": "Python 3",
+			"language": "python",
+			"name": "python3"
+		},
+		"language_info": {
+			"codemirror_mode": {
+				"name": "ipython",
+				"version": 3
+			},
+			"file_extension": ".py",
+			"mimetype": "text/x-python",
+			"name": "python",
+			"nbconvert_exporter": "python",
+			"pygments_lexer": "ipython3",
+			"version": "3.5.2"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+}
+
+`
+
 func checkError(t *testing.T, err error, expected string) {
 	if err == nil {
 		t.Fatalf("err is nil.  Expected: %s", expected)
@@ -1040,6 +1079,7 @@ func TestShouldRenderContent(t *testing.T) {
 		{contentWithCommentedTextFrontmatter, true},
 		{contentWithCommentedLongFrontmatter, false},
 		{contentWithCommentedLong2Frontmatter, true},
+		{contentJupyterNotebook, true},
 	}
 
 	for _, test := range tests {

--- a/parser/page.go
+++ b/parser/page.go
@@ -16,6 +16,7 @@ package parser
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
@@ -160,6 +161,27 @@ func ReadFrom(r io.Reader) (p Page, err error) {
 
 	newp.content = content
 
+	return newp, nil
+}
+
+// Construct a Page from a .ipynb notebook
+func ReadFromNotebook(r io.Reader) (p Page, err error) {
+	var notebookContent struct {
+		Metadata struct {
+			Frontmatter json.RawMessage
+		}
+	}
+	br := new(bytes.Buffer)
+	if _, err = br.ReadFrom(r); err != nil {
+		return nil, err
+	}
+	if err = json.Unmarshal(br.Bytes(), &notebookContent); err != nil {
+		return nil, err
+	}
+	newp := new(page)
+	newp.render = true
+	newp.frontmatter = notebookContent.Metadata.Frontmatter
+	newp.content = br.Bytes()
 	return newp, nil
 }
 

--- a/parser/page_test.go
+++ b/parser/page_test.go
@@ -127,4 +127,64 @@ social:
 	This is a sample comment.
 -->
 `
+	notebookJSONFile = `
+{
+	"cells":[],
+	"metadata":{
+		"frontmatter":{
+			"title": "Jupyter Test 1",
+			"social": [
+				["a", "#"],
+				["b", "#"]
+			]
+		}
+	}
+}`
+	notebookJSONFileNoFrontmatter = `{
+		"title": "Jupyter Test 1",
+		"social": [
+			["a", "#"],
+			["b", "#"]
+		]
+	}`
 )
+
+func TestNotebookPage(t *testing.T) {
+	cases := []struct {
+		raw string
+
+		content     string
+		frontmatter string
+		renderable  bool
+		metadata    map[string]interface{}
+	}{
+		{
+			notebookJSONFile,
+
+			notebookJSONFile,
+			notebookJSONFileNoFrontmatter,
+			true,
+			map[string]interface{}{
+				"title": "Jupyter Test 1",
+				"social": []interface{}{
+					[]interface{}{"a", "#"},
+					[]interface{}{"b", "#"},
+				},
+			},
+		},
+	}
+
+	for i, c := range cases {
+		p := pageMust(ReadFromNotebook(strings.NewReader(c.raw)))
+		meta, err := p.Metadata()
+
+		mesg := fmt.Sprintf("[%d]", i)
+
+		require.Nil(t, err, mesg)
+		assert.Equal(t, c.content, string(p.Content()), mesg+" content")
+		// skip this check due to whitespace in the JSON, rely on test of Metadata instead
+		// assert.Equal(t, c.frontmatter, string(p.FrontMatter()), mesg+" frontmatter")
+		assert.Equal(t, c.renderable, p.IsRenderable(), mesg+" renderable")
+		assert.Equal(t, c.metadata, meta, mesg+" metadata")
+	}
+}


### PR DESCRIPTION
This is done through 2 main steps:
- Adding new extension "ipynb" as external handler. This also requires
`jupyter` and its converter, but can gracefully fall back to raw content.
- Add an alternative parser, only for .ipynb type, because .ipynb file
is one whole JSON object. That will have different proccessing than parsing
JSON frontmatter.

The frontmatter for .ipynb is expected in the "metadata" of the notebook:
```
{
  "metadat":{
    "frontmatter": {
      "title": ""
    }
  }
}
```