### PR TITLE
Improve .Site.GetPage for regular translated pages

### DIFF
--- a/hugolib/hugo_sites_build_test.go
+++ b/hugolib/hugo_sites_build_test.go
@@ -299,6 +299,20 @@ func doTestMultiSitesBuild(t *testing.T, configTemplate, configSuffix string) {
 		require.Equal(t, "fr", frenchPage.Lang())
 	}
 
+	// See https://github.com/gohugoio/hugo/issues/4285
+	// Before Hugo 0.33 you had to be explicit with the content path to get the correct Page, which
+	// isn't ideal in a multilingual setup. You want a way to get the current language version if available.
+	// Now you can do lookups with translation base name to get that behaviour.
+	// Let us test all the regular page variants:
+	getPageDoc1En := enSite.getPage(KindPage, filepath.ToSlash(doc1en.Path()))
+	getPageDoc1EnBase := enSite.getPage(KindPage, "sect/doc1")
+	getPageDoc1Fr := frSite.getPage(KindPage, filepath.ToSlash(doc1fr.Path()))
+	getPageDoc1FrBase := frSite.getPage(KindPage, "sect/doc1")
+	require.Equal(t, doc1en, getPageDoc1En)
+	require.Equal(t, doc1fr, getPageDoc1Fr)
+	require.Equal(t, doc1en, getPageDoc1EnBase)
+	require.Equal(t, doc1fr, getPageDoc1FrBase)
+
 	// Check redirect to main language, French
 	languageRedirect := readDestination(t, fs, "public/index.html")
 	require.True(t, strings.Contains(languageRedirect, "0; url=http://example.com/blog/fr"), languageRedirect)
@@ -683,6 +697,7 @@ title = "Svenska"
 	// Veriy Swedish site
 	require.Len(t, svSite.RegularPages, 1)
 	svPage := svSite.RegularPages[0]
+
 	require.Equal(t, "Swedish Contentfile", svPage.title)
 	require.Equal(t, "sv", svPage.Lang())
 	require.Len(t, svPage.Translations(), 2)

--- a/hugolib/page_collections.go
+++ b/hugolib/page_collections.go
@@ -51,6 +51,12 @@ func (c *PageCollections) refreshPageCaches() {
 	c.RegularPages = c.findPagesByKindIn(KindPage, c.Pages)
 	c.AllRegularPages = c.findPagesByKindIn(KindPage, c.AllPages)
 
+	var s *Site
+
+	if len(c.Pages) > 0 {
+		s = c.Pages[0].s
+	}
+
 	cacheLoader := func(kind string) func() (map[string]interface{}, error) {
 		return func() (map[string]interface{}, error) {
 			cache := make(map[string]interface{})
@@ -64,6 +70,13 @@ func (c *PageCollections) refreshPageCaches() {
 					cache[filepath.ToSlash(p.Source.Path())] = p
 					// Ref/Relref supports this potentially ambiguous lookup.
 					cache[p.Source.LogicalName()] = p
+
+					if s != nil && p.s == s {
+						// We need a way to get to the current language version.
+						pathWithNoExtensions := path.Join(filepath.ToSlash(p.Source.Dir()), p.Source.TranslationBaseName())
+						cache[pathWithNoExtensions] = p
+					}
+
 				}
 			default:
 				for _, p := range c.indexPages {


### PR DESCRIPTION
You can still use the full path with extensions, but to get the current language version:

* If the content file lives in `/content/blog/mypost.en.md`
* Use `.Site.GetPage "page" "blog/mypost"`

Fixes #4285