### PR TITLE
Tighten page kind logic, introduce tests

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -759,7 +759,7 @@ func (s *Site) newPage(filename string) *Page {
 func (s *Site) newPageFromFile(fi *fileInfo) *Page {
 	return &Page{
 		pageInit:    &pageInit{},
-		Kind:        kindFromFilename(fi.Path()),
+		Kind:        kindFromFileInfo(fi),
 		contentType: "",
 		Source:      Source{File: fi},
 		Keywords:    []string{}, Sitemap: Sitemap{Priority: -1},
@@ -2010,24 +2010,16 @@ func sectionsFromDir(dirname string) []string {
 	return strings.Split(dirname, helpers.FilePathSeparator)
 }
 
-const (
-	regularPageFileNameDoesNotStartWith = "_index"
-
-	// There can be "my_regular_index_page.md but not /_index_file.md
-	regularPageFileNameDoesNotContain = helpers.FilePathSeparator + regularPageFileNameDoesNotStartWith
-)
-
-func kindFromFilename(filename string) string {
-	if !strings.HasPrefix(filename, regularPageFileNameDoesNotStartWith) && !strings.Contains(filename, regularPageFileNameDoesNotContain) {
-		return KindPage
+func kindFromFileInfo(fi *fileInfo) string {
+	if fi.TranslationBaseName() == "_index" {
+		if fi.Dir() == "" {
+			return KindHome
+		}
+		// Could be index for section, taxonomy, taxonomy term
+		// We don't know enough yet to determine which
+		return kindUnknown
 	}
-
-	if strings.HasPrefix(filename, "_index") {
-		return KindHome
-	}
-
-	// We don't know enough yet to determine the type.
-	return kindUnknown
+	return KindPage
 }
 
 func (p *Page) setValuesForKind(s *Site) {

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1010,6 +1010,60 @@ func TestCreatePage(t *testing.T) {
 	}
 }
 
+func TestPageKind(t *testing.T) {
+	t.Parallel()
+	const sep = helpers.FilePathSeparator
+	var tests = []struct {
+		file string
+		kind string
+	}{
+		{"_index.md", KindHome},
+		{"about.md", KindPage},
+		{"sectionA" + sep + "_index.md", KindSection},
+		{"sectionA" + sep + "about.md", KindPage},
+		{"categories" + sep + "_index.md", KindTaxonomyTerm},
+		{"categories" + sep + "categoryA" + sep + "_index.md", KindTaxonomy},
+		{"tags" + sep + "_index.md", KindTaxonomyTerm},
+		{"tags" + sep + "tagA" + sep + "_index.md", KindTaxonomy},
+
+		// nn is configured as a language
+		{"_index.nn.md", KindHome},
+		{"about.nn.md", KindPage},
+		{"sectionA" + sep + "_index.nn.md", KindSection},
+		{"sectionA" + sep + "about.nn.md", KindPage},
+
+		// should NOT be categorized as KindHome
+		{"_indexNOT.md", KindPage},
+
+		// To be consistent with FileInfo.TranslationBaseName(),
+		// language codes not explicitly configured for the site
+		// are not treated as such. "fr" is not configured as
+		// a language in the test site, so ALL of the
+		// following should be KindPage
+		{"_index.fr.md", KindPage}, //not KindHome
+		{"about.fr.md", KindPage},
+		{"sectionA" + sep + "_index.fr.md", KindPage}, // KindSection
+		{"sectionA" + sep + "about.fr.md", KindPage},
+	}
+
+	for _, test := range tests {
+		s := newTestSite(t, "languages.nn.languageName", "Nynorsk")
+		taxonomies := make(map[string]string)
+		taxonomies["tag"] = "tags"
+		taxonomies["category"] = "categories"
+		s.Taxonomies = make(TaxonomyList)
+		for _, plural := range taxonomies {
+			s.Taxonomies[plural] = make(Taxonomy)
+		}
+
+		p, _ := s.NewPage(test.file)
+		p.setValuesForKind(s)
+		if p.Kind != test.kind {
+			t.Errorf("for %s expected p.Kind == %s, got %s", test.file, test.kind, p.Kind)
+		}
+	}
+}
+
 func TestDegenerateInvalidFrontMatterShortDelim(t *testing.T) {
 	t.Parallel()
 	var tests = []struct {


### PR DESCRIPTION
`Site.kindFromFilename()` was a bit loose in its logic and inconsistent with `FileInfo.TranslationBaseName()`, which only recognizes language codes explicitly configured for the site. This is illustrated by running the tests I added with the original `page.go` and looking at the failures. It was also a bit inefficient, reparsing file path that had already been parsed before by `FileInfo`. 

I replaced `Site.kindFromFilename(filename string)` with `Site.kindFromFileInfo(fi *fileInfo)` with tighter logic and introduced tests (there was no testing of this logic before).