### PR TITLE
Add external renderer configuration

### DIFF
--- a/config/configProvider.go
+++ b/config/configProvider.go
@@ -20,6 +20,7 @@ type Provider interface {
 	GetBool(key string) bool
 	GetStringMap(key string) map[string]interface{}
 	GetStringMapString(key string) map[string]string
+	GetStringSlice(key string) []string
 	Get(key string) interface{}
 	Set(key string, value interface{})
 	IsSet(key string) bool

--- a/docs/content/content-management/formats.md
+++ b/docs/content/content-management/formats.md
@@ -201,12 +201,26 @@ For example, for Asciidoc files, Hugo will try to call the `asciidoctor` or `asc
 
 To use these formats, just use the standard extension and the front matter exactly as you would do with natively supported `.md` files.
 
-Hugo passes reasonable default arguments to these external helpers by default:
+By default, Hugo searches external renderers on the `PATH` and passes reasonable default arguments to these external helpers by default:
 
 - `asciidoc`: `--no-header-footer --safe -`
 - `asciidoctor`: `--no-header-footer --safe --trace -`
 - `rst2html`: `--leave-comments --initial-header-level=2`
 - `pandoc`: `--mathjax`
+
+It is possible to adjust this default configuration. Path and arguments for the external helpers may be configured under `asciidoc`, `pandoc`, and `rst` as follows:
+
+{{< code file="config.yml">}}
+asciidoc:
+  path: /path/to/asciidoc(tor)
+  args:
+    - -r
+    - asciidoctor-diagram
+{{< /code >}}
+
+{{% note "Default Arguments" %}}
+Note, that the above-listed default arguments for each renderer type are always added if not configured.
+{{% /note %}}
 
 {{% warning "Performance of External Helpers" %}}
 Because additional formats are external commands generation performance will rely heavily on the performance of the external tool you are using. As this feature is still in its infancy, feedback is welcome.

--- a/helpers/general.go
+++ b/helpers/general.go
@@ -465,3 +465,13 @@ func DiffStringSlices(slice1 []string, slice2 []string) []string {
 
 	return diffStr
 }
+
+// StringContainedInValues checks whether the give string is contained in the trailing arguments
+func StringContainedInValues(k string, values ...string) bool {
+	for _, v := range values {
+		if k == v {
+			return true
+		}
+	}
+	return false
+}

--- a/helpers/language.go
+++ b/helpers/language.go
@@ -140,6 +140,11 @@ func (l *Language) GetStringMapString(key string) map[string]string {
 	return cast.ToStringMapString(l.Get(key))
 }
 
+// GetStringSlice returns the value associated with the key as a slice of strings.
+func (l *Language) GetStringSlice(key string) []string {
+	return cast.ToStringSlice(l.Get(key))
+}
+
 // Get returns a value associated with the key relying on specified language.
 // Get is case-insensitive for a key.
 //

--- a/hugolib/disableKinds_test.go
+++ b/hugolib/disableKinds_test.go
@@ -190,12 +190,12 @@ func assertDisabledKinds(th testHelper, s *Site, disabled ...string) {
 }
 
 func assertDisabledKind(th testHelper, kindAssert func(bool) bool, disabled []string, kind, path, matcher string) {
-	isDisabled := stringSliceContains(kind, disabled...)
+	isDisabled := helpers.StringContainedInValues(kind, disabled...)
 	require.True(th.T, kindAssert(isDisabled), fmt.Sprintf("%s: %t", kind, isDisabled))
 
 	if kind == kindRSS && !isDisabled {
 		// If the home page is also disabled, there is not RSS to look for.
-		if stringSliceContains(KindHome, disabled...) {
+		if helpers.StringContainedInValues(KindHome, disabled...) {
 			isDisabled = true
 		}
 	}
@@ -209,13 +209,4 @@ func assertDisabledKind(th testHelper, kindAssert func(bool) bool, disabled []st
 	} else {
 		th.assertFileContent(path, matcher)
 	}
-}
-
-func stringSliceContains(k string, values ...string) bool {
-	for _, v := range values {
-		if k == v {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
This introduces the option to configure path and arguments for external
renderers (asciidoc, pandoc, and rst). The code makes sure that the
default arguments are always added. 'config.Provider' needs to implements
the additional method 'GetStringSlice' to read the args list from the config.

Fixes #4082