### PR TITLE
Merge matching resources params maps

### DIFF
--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -234,6 +234,7 @@ func TestAssignMetadata(t *testing.T) {
 				"src":   "*loGo*",
 				"params": map[string]interface{}{
 					"Param1": true,
+					"icon":   "logo",
 				},
 			},
 			map[string]interface{}{
@@ -241,6 +242,7 @@ func TestAssignMetadata(t *testing.T) {
 				"src":   "*",
 				"params": map[string]interface{}{
 					"Param2": true,
+					"icon":   "resource",
 				},
 			},
 		}, func(err error) {
@@ -249,8 +251,21 @@ func TestAssignMetadata(t *testing.T) {
 			assert.Equal("My Resource", foo3.Title())
 			_, p1 := logo2.Params()["param1"]
 			_, p2 := foo2.Params()["param2"]
+			_, p1_2 := foo2.Params()["param1"]
+			_, p2_2 := logo2.Params()["param2"]
+
+			icon1, _ := logo2.Params()["icon"]
+			icon2, _ := foo2.Params()["icon"]
+
 			assert.True(p1)
 			assert.True(p2)
+
+			// Check merge
+			assert.True(p2_2)
+			assert.False(p1_2)
+
+			assert.Equal("logo", icon1)
+			assert.Equal("resource", icon2)
 
 		}},
 		{[]map[string]interface{}{


### PR DESCRIPTION
```toml
[[resources]]
src = "documents/photo_specs.pdf"
title = "Photo Specifications"
[resources.params]
ref = 90564687
icon = "photo"
[[resources]]
src = "documents/guide.pdf"
title = "Instruction Guide"
[resources.params]
ref = 90564568
[[resources]]
src = "documents/checklist.pdf"
title = "Document Checklist"
[resources.params]
ref = 90564572
[[resources]]
src = "documents/payment.docx"
title = "Proof of Payment"
[[resources]]
src = "documents/*.pdf"
title = "PDF file"
[resources.params]
icon = "pdf"
[[resources]]
src = "documents/*.docx"
title = "Word document"
[resources.params]
icon = "word"
```


In the above `TOML` example, `photo_specs.pdf` will get the `photo` icon, the other pdf files will get the default `pdf` icon.

Note that in the example above, the order matters: It will take the first value for a given params key, title or name that it finds.

Fixes #4315