### PR TITLE
Add headless bundle support

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -508,7 +508,11 @@ func (h *HugoSites) setupTranslations() {
 			shouldBuild := p.shouldBuild()
 			s.updateBuildStats(p)
 			if shouldBuild {
-				s.Pages = append(s.Pages, p)
+				if p.headless {
+					s.headlessPages = append(s.headlessPages, p)
+				} else {
+					s.Pages = append(s.Pages, p)
+				}
 			}
 		}
 	}
@@ -557,6 +561,10 @@ func (s *Site) preparePagesForRender(cfg *BuildCfg) {
 	}
 
 	for _, p := range s.Pages {
+		pageChan <- p
+	}
+
+	for _, p := range s.headlessPages {
 		pageChan <- p
 	}
 

--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -179,19 +179,26 @@ func (h *HugoSites) assemble(config *BuildCfg) error {
 	}
 
 	for _, s := range h.Sites {
-		for _, p := range s.Pages {
-			// May have been set in front matter
-			if len(p.outputFormats) == 0 {
-				p.outputFormats = s.outputFormats[p.Kind]
-			}
-			for _, r := range p.Resources.ByType(pageResourceType) {
-				r.(*Page).outputFormats = p.outputFormats
-			}
+		for _, pages := range []Pages{s.Pages, s.headlessPages} {
+			for _, p := range pages {
+				// May have been set in front matter
+				if len(p.outputFormats) == 0 {
+					p.outputFormats = s.outputFormats[p.Kind]
+				}
 
-			if err := p.initPaths(); err != nil {
-				return err
-			}
+				if p.headless {
+					// headless = 1 output format only
+					p.outputFormats = p.outputFormats[:1]
+				}
+				for _, r := range p.Resources.ByType(pageResourceType) {
+					r.(*Page).outputFormats = p.outputFormats
+				}
 
+				if err := p.initPaths(); err != nil {
+					return err
+				}
+
+			}
 		}
 		s.assembleMenus()
 		s.refreshPageCaches()

--- a/hugolib/page_collections.go
+++ b/hugolib/page_collections.go
@@ -43,6 +43,9 @@ type PageCollections struct {
 	// Includes absolute all pages (of all types), including drafts etc.
 	rawAllPages Pages
 
+	// Includes headless bundles, i.e. bundles that produce no output for its content page.
+	headlessPages Pages
+
 	pageCache *cache.PartitionedLazyCache
 }
 
@@ -66,15 +69,17 @@ func (c *PageCollections) refreshPageCaches() {
 				// in this cache, as we intend to use this in the ref and relref
 				// shortcodes. If the user says "sect/doc1.en.md", he/she knows
 				// what he/she is looking for.
-				for _, p := range c.AllRegularPages {
-					cache[filepath.ToSlash(p.Source.Path())] = p
-					// Ref/Relref supports this potentially ambiguous lookup.
-					cache[p.Source.LogicalName()] = p
+				for _, pageCollection := range []Pages{c.AllRegularPages, c.headlessPages} {
+					for _, p := range pageCollection {
+						cache[filepath.ToSlash(p.Source.Path())] = p
+						// Ref/Relref supports this potentially ambiguous lookup.
+						cache[p.Source.LogicalName()] = p
 
-					if s != nil && p.s == s {
-						// We need a way to get to the current language version.
-						pathWithNoExtensions := path.Join(filepath.ToSlash(p.Source.Dir()), p.Source.TranslationBaseName())
-						cache[pathWithNoExtensions] = p
+						if s != nil && p.s == s {
+							// We need a way to get to the current language version.
+							pathWithNoExtensions := path.Join(filepath.ToSlash(p.Source.Dir()), p.Source.TranslationBaseName())
+							cache[pathWithNoExtensions] = p
+						}
 					}
 
 				}


### PR DESCRIPTION
This commit adds  support for `headless bundles` for the `index` bundle type.

So:

```toml
headless = true
```

In front matter means that

* It will have no `Permalink` and no rendered HTML in /public
* It will not be part of `.Site.RegularPages` etc.

But you can get it by:

* `.Site.GetPage ...`

The use cases are many:

* Shared media galleries
* Reusable page content "snippets"
* ...

Fixes #4311