### PR TITLE
hugolib: Simplify bundle lookup via .Site.GetPage, ref, relref

### DIFF
--- a/hugolib/page_bundler_capture_test.go
+++ b/hugolib/page_bundler_capture_test.go
@@ -186,9 +186,11 @@ D:
 __bundle/en/work/base/bb/_index.md/resources/en/work/base/bb/a.png|en/work/base/bb/b.png|nn/work/base/bb/c.nn.png
 __bundle/en/work/base/bc/_index.md/resources/en/work/base/bc/logo-bc.png
 __bundle/en/work/base/bd/index.md/resources/en/work/base/bd/page.md
+__bundle/en/work/base/bf/my-bf-bundle/index.md/resources/en/work/base/bf/my-bf-bundle/page.md
 __bundle/en/work/base/lb/index.md/resources/en/work/base/lb/1.md|en/work/base/lb/2.md|en/work/base/lb/c/d/deep.png|en/work/base/lb/c/logo.png|en/work/base/lb/c/one.png|en/work/base/lb/c/page.md
 __bundle/nn/work/base/bb/_index.nn.md/resources/en/work/base/bb/a.png|nn/work/base/bb/b.nn.png|nn/work/base/bb/c.nn.png
 __bundle/nn/work/base/bd/index.md/resources/nn/work/base/bd/page.nn.md
+__bundle/nn/work/base/bf/my-bf-bundle/index.nn.md/resources
 __bundle/nn/work/base/lb/index.nn.md/resources/en/work/base/lb/c/d/deep.png|en/work/base/lb/c/one.png|nn/work/base/lb/2.nn.md|nn/work/base/lb/c/logo.nn.png
 C:
 /work/base/1s/mylogo.png

--- a/hugolib/page_bundler_test.go
+++ b/hugolib/page_bundler_test.go
@@ -192,6 +192,32 @@ func TestPageBundlerSiteMultilingual(t *testing.T) {
 				bundleWithSubPath := s.getPage(KindPage, "lb/index")
 				assert.NotNil(bundleWithSubPath)
 
+				// See https://github.com/gohugoio/hugo/issues/4312
+				// Before that issue:
+				// A bundle in a/b/index.en.md
+				// a/b/index.en.md => OK
+				// a/b/index => OK
+				// index.en.md => ambigous, but OK.
+				// With bundles, the file name has little meaning, the folder it lives in does. So this should also work:
+				// a/b
+				// and probably also just b (aka "my-bundle")
+				// These may also be translated, so we also need to test that.
+				//  "bf", "my-bf-bundle", "index.md + nn
+				bfBundle := s.getPage(KindPage, "bf/my-bf-bundle/index")
+				assert.NotNil(bfBundle)
+				assert.Equal("en", bfBundle.Lang())
+				assert.Equal(bfBundle, s.getPage(KindPage, "bf/my-bf-bundle/index.md"))
+				assert.Equal(bfBundle, s.getPage(KindPage, "bf/my-bf-bundle"))
+				assert.Equal(bfBundle, s.getPage(KindPage, "my-bf-bundle"))
+
+				nnSite := sites.Sites[1]
+				bfBundleNN := nnSite.getPage(KindPage, "bf/my-bf-bundle/index")
+				assert.NotNil(bfBundleNN)
+				assert.Equal("nn", bfBundleNN.Lang())
+				assert.Equal(bfBundleNN, nnSite.getPage(KindPage, "bf/my-bf-bundle/index.nn.md"))
+				assert.Equal(bfBundleNN, nnSite.getPage(KindPage, "bf/my-bf-bundle"))
+				assert.Equal(bfBundleNN, nnSite.getPage(KindPage, "my-bf-bundle"))
+
 				// See https://github.com/gohugoio/hugo/issues/4295
 				// Every resource should have its Name prefixed with its base folder.
 				cBundleResources := bundleWithSubPath.Resources.ByPrefix("c/")
@@ -517,6 +543,11 @@ TheContent.
 	writeSource(t, fs, filepath.Join(workDir, "base", "lb", "c", "logo.nn.png"), "content")
 	writeSource(t, fs, filepath.Join(workDir, "base", "lb", "c", "one.png"), "content")
 	writeSource(t, fs, filepath.Join(workDir, "base", "lb", "c", "d", "deep.png"), "content")
+
+	//Translated bundle in some sensible sub path.
+	writeSource(t, fs, filepath.Join(workDir, "base", "bf", "my-bf-bundle", "index.md"), pageContent)
+	writeSource(t, fs, filepath.Join(workDir, "base", "bf", "my-bf-bundle", "index.nn.md"), pageContent)
+	writeSource(t, fs, filepath.Join(workDir, "base", "bf", "my-bf-bundle", "page.md"), pageContent)
 
 	return cfg, fs
 }


### PR DESCRIPTION
Given a bundle in `blog/my-bundle/index.en.md` all of these will now worK:

* `blog/my-bundle/index.en.md`
* `blog/my-bundle/index`
* `blog/my-bundle`
* `my-bundle`

The last one is potentially ambigous.

Fixes #4312