### PR TITLE
Add page metadata dates tests

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1343,11 +1343,8 @@ func (p *Page) update(f interface{}) error {
 	}
 
 	if p.Date.IsZero() && p.s.Cfg.GetBool("useModTimeAsFallback") {
-		fi, err := p.s.Fs.Source.Stat(filepath.Join(p.s.PathSpec.AbsPathify(p.s.Cfg.GetString("contentDir")), p.File.Path()))
-		if err == nil {
-			p.Date = fi.ModTime()
-			p.params["date"] = p.Date
-		}
+		p.Date = p.Source.FileInfo().ModTime()
+		p.params["date"] = p.Date
 	}
 
 	if p.Lastmod.IsZero() {


### PR DESCRIPTION
Adds combinatorial tests for the various kinds of dates in Page metadata. Provide:

- needed coverage
- a way to visually review the logic (or illogic) of the current logic
- a way to expose an existing bug #4320
- a framework to easily add tests to cover proposed new
   metadata date sources, and to do so combinatorially with 
   existing sources

Page.go was updated to use a different method to access a file's modification timestamp. This was necessary for the tests to work, but is a better way to access the value anyway.