### PR TITLE
Add a way to disable one or more languages

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -173,20 +173,23 @@ func server(cmd *cobra.Command, args []string) error {
 			c.Set("liveReloadPort", serverPorts[0])
 		}
 
-		if c.languages.IsMultihost() {
-			for i, language := range c.languages {
-				baseURL, err := fixURL(language, baseURL, serverPorts[i])
-				if err != nil {
-					return err
-				}
-				language.Set("baseURL", baseURL)
+		isMultiHost := c.languages.IsMultihost()
+		for i, language := range c.languages {
+			var serverPort int
+			if isMultiHost {
+				serverPort = serverPorts[i]
+			} else {
+				serverPort = serverPorts[0]
 			}
-		} else {
-			baseURL, err := fixURL(c.Cfg, baseURL, serverPorts[0])
+
+			baseURL, err := fixURL(language, baseURL, serverPort)
 			if err != nil {
 				return err
 			}
-			c.Set("baseURL", baseURL)
+			language.Set("baseURL", baseURL)
+			if i == 0 {
+				c.Set("baseURL", baseURL)
+			}
 		}
 
 		return nil

--- a/config/configProvider.go
+++ b/config/configProvider.go
@@ -20,6 +20,7 @@ type Provider interface {
 	GetBool(key string) bool
 	GetStringMap(key string) map[string]interface{}
 	GetStringMapString(key string) map[string]string
+	GetStringSlice(key string) []string
 	Get(key string) interface{}
 	Set(key string, value interface{})
 	IsSet(key string) bool

--- a/helpers/language.go
+++ b/helpers/language.go
@@ -140,6 +140,11 @@ func (l *Language) GetStringMapString(key string) map[string]string {
 	return cast.ToStringMapString(l.Get(key))
 }
 
+//  returns the value associated with the key as a slice of strings.
+func (l *Language) GetStringSlice(key string) []string {
+	return cast.ToStringSlice(l.Get(key))
+}
+
 // Get returns a value associated with the key relying on specified language.
 // Get is case-insensitive for a key.
 //

--- a/hugolib/fileInfo.go
+++ b/hugolib/fileInfo.go
@@ -31,6 +31,9 @@ type fileInfo struct {
 	bundleTp bundleDirType
 	source.ReadableFile
 	overriddenLang string
+
+	// Set if the content language for this file is disabled.
+	disabled bool
 }
 
 func (fi *fileInfo) Lang() string {
@@ -59,6 +62,9 @@ func newFileInfo(sp *source.SourceSpec, baseDir, filename string, fi os.FileInfo
 		bundleTp:     tp,
 		ReadableFile: baseFi,
 	}
+
+	lang := f.Lang()
+	f.disabled = lang != "" && sp.DisabledLanguages[lang]
 
 	return f
 

--- a/hugolib/page_bundler_capture_test.go
+++ b/hugolib/page_bundler_capture_test.go
@@ -174,6 +174,7 @@ func TestPageBundlerCaptureMultilingual(t *testing.T) {
 	expected := `
 F:
 /work/base/1s/mypage.md
+/work/base/1s/mypage.nn.md
 /work/base/bb/_1.md
 /work/base/bb/_1.nn.md
 /work/base/bb/en.md

--- a/source/sourceSpec.go
+++ b/source/sourceSpec.go
@@ -35,12 +35,19 @@ type SourceSpec struct {
 
 	Languages              map[string]interface{}
 	DefaultContentLanguage string
+	DisabledLanguages      map[string]bool
 }
 
 // NewSourceSpec initializes SourceSpec using languages from a given configuration.
 func NewSourceSpec(cfg config.Provider, fs *hugofs.Fs) *SourceSpec {
 	defaultLang := cfg.GetString("defaultContentLanguage")
 	languages := cfg.GetStringMap("languages")
+
+	disabledLangsSet := make(map[string]bool)
+
+	for _, disabledLang := range cfg.GetStringSlice("disableLanguages") {
+		disabledLangsSet[disabledLang] = true
+	}
 
 	if len(languages) == 0 {
 		l := helpers.NewDefaultLanguage(cfg)
@@ -62,7 +69,7 @@ func NewSourceSpec(cfg config.Provider, fs *hugofs.Fs) *SourceSpec {
 		}
 	}
 
-	return &SourceSpec{ignoreFilesRe: regexps, Cfg: cfg, Fs: fs, Languages: languages, DefaultContentLanguage: defaultLang}
+	return &SourceSpec{ignoreFilesRe: regexps, Cfg: cfg, Fs: fs, Languages: languages, DefaultContentLanguage: defaultLang, DisabledLanguages: disabledLangsSet}
 }
 
 func (s *SourceSpec) IgnoreFile(filename string) bool {


### PR DESCRIPTION
This commit adds a new config setting:

```toml
disableLanguages = ["fr"]
```

If this is a multilingual site:

* No site for the French language will be created
* French content pages will be ignored/not read
* The French language configuration (menus etc.) will also be ignored

This makes it possible to start translating new languages and turn it on when you're happy etc.

Fixes #4297
Fixed #4329