### PR TITLE
shuffle random seed

### DIFF
--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -29,6 +29,10 @@ import (
 	"github.com/spf13/cast"
 )
 
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
 // New returns a new instance of the collections-namespaced template functions.
 func New(deps *deps.Deps) *Namespace {
 	return &Namespace{
@@ -474,7 +478,6 @@ func (ns *Namespace) Shuffle(seq interface{}) (interface{}, error) {
 
 	shuffled := reflect.MakeSlice(reflect.TypeOf(seq), seqv.Len(), seqv.Len())
 
-	rand.Seed(time.Now().UTC().UnixNano())
 	randomIndices := rand.Perm(seqv.Len())
 
 	for index, value := range randomIndices {


### PR DESCRIPTION
https://github.com/gohugoio/hugo/blob/ed4a00e46f2344320a22f07febe5aec4075cb3fb/tpl/collections/collections.go#L477-L482

in the Line 477,we set the random seed.But there is a situation that the seed will be the same.So the `randomIndices ` we get in the Line 478 will be the same.

eg.
![snipaste20180127_232629](https://user-images.githubusercontent.com/2113954/35473465-04220ab2-03bc-11e8-8e12-e8b6bd264508.png)

I need to random a background picture for each article.But sometimes the picture will be the same.
So I changed.Set the random seed in the function `init`.