### PR TITLE
Lowercase default lang when checking if it exists

### DIFF
--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -146,9 +146,10 @@ func loadLanguageSettings(cfg config.Provider, oldLangs helpers.Languages) error
 
 	// The defaultContentLanguage is something the user has to decide, but it needs
 	// to match a language in the language definition list.
+	lowerDefaultLang := strings.ToLower(defaultLang)
 	langExists := false
 	for _, lang := range langs {
-		if lang.Lang == defaultLang {
+		if lang.Lang == lowerDefaultLang {
 			langExists = true
 			break
 		}


### PR DESCRIPTION
Fix a regression from #4298. `lang.Lang` here is lowercased so the matching doesn’t work when the `defaultContentLanguage` config is written in the `ab-CD` style.

---

This is my first contribution to Hugo and first Go lang coding so I might be wrong. My site can't be built with the current version 0.34 due to the `en-CA` language code ([config](https://github.com/fxsitecompat/www.fxsitecompat.com/blob/master/config.yaml)). Actually Hugo has more issues on handing of the `ab-CD` style language code (see [hacks in my templates](https://github.com/fxsitecompat/www.fxsitecompat.com/search?q=replace+en-ca)) but those are separate issues. I'd like to see this regression fixed first. Thanks!