### PR TITLE
Fix language params handling

### DIFF
--- a/helpers/language_test.go
+++ b/helpers/language_test.go
@@ -23,11 +23,24 @@ import (
 func TestGetGlobalOnlySetting(t *testing.T) {
 	v := viper.New()
 	lang := NewDefaultLanguage(v)
-	lang.SetParam("defaultContentLanguageInSubdir", false)
-	lang.SetParam("paginatePath", "side")
+	lang.Set("defaultContentLanguageInSubdir", false)
+	lang.Set("paginatePath", "side")
 	v.Set("defaultContentLanguageInSubdir", true)
 	v.Set("paginatePath", "page")
 
 	require.True(t, lang.GetBool("defaultContentLanguageInSubdir"))
 	require.Equal(t, "side", lang.GetString("paginatePath"))
+}
+
+func TestLanguageParams(t *testing.T) {
+	assert := require.New(t)
+
+	v := viper.New()
+	v.Set("p1", "p1cfg")
+
+	lang := NewDefaultLanguage(v)
+	lang.SetParam("p1", "p1p")
+
+	assert.Equal("p1p", lang.Params()["p1"])
+	assert.Equal("p1cfg", lang.Get("p1"))
 }

--- a/hugolib/multilingual.go
+++ b/hugolib/multilingual.go
@@ -111,10 +111,20 @@ func toSortedLanguages(cfg config.Provider, l map[string]interface{}) (helpers.L
 				language.LanguageName = cast.ToString(v)
 			case "weight":
 				language.Weight = cast.ToInt(v)
+			case "params":
+				m := cast.ToStringMap(v)
+				// Needed for case insensitive fetching of params values
+				helpers.ToLowerMap(m)
+				for k, vv := range m {
+					language.SetParam(k, vv)
+				}
 			}
 
 			// Put all into the Params map
 			language.SetParam(loki, v)
+
+			// Also set it in the configuration map (for baseURL etc.)
+			language.Set(loki, v)
 		}
 
 		langs[i] = language


### PR DESCRIPTION
This fixes some issues with language params handling by separating params from configuration values per language.

This means that you can now do this:

```toml
[languages]
[languages.en]
languageName = "English"
weight = 1
title = "My Cool Site"
[languages.en.params]
myParam = "Hi!"
```

This is not a breaking change, but the above is a less suprising way of configuring custom params.

It also fixes some hard-to-debug corner-cases in multilingual sites.

Fixes #4356
Fixes #4352