### PR TITLE
WIP: Use top-level markdown heading as default page Title

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -445,6 +445,9 @@ type RenderingContext struct {
 	Config       *BlackFriday
 	RenderTOC    bool
 	Cfg          config.Provider
+	// handle the first level-one header,
+	// return whether or not to remove it from the page body
+	HandleTitle func(title string) bool
 }
 
 // RenderBytes renders a []byte.

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -724,7 +724,18 @@ func (p *Page) renderContent(content []byte) []byte {
 		Content: content, RenderTOC: true, PageFmt: p.determineMarkupType(),
 		Cfg:        p.Language(),
 		DocumentID: p.UniqueID(), DocumentName: p.Path(),
-		Config: p.getRenderingConfig()})
+		HandleTitle: p.getTitleHandler(),
+		Config:      p.getRenderingConfig()})
+}
+
+//The title handler sets the default Page title to the content of the first level 1 Markdown header
+func (p *Page) getTitleHandler() func(title string) bool {
+	return func(title string) bool {
+		if p.title == "" {
+			p.title = title
+		}
+		return false
+	}
 }
 
 func (p *Page) getRenderingConfig() *helpers.BlackFriday {


### PR DESCRIPTION
Supports content where the title is declared as the top level heading within the markdown itself rather than in front matter. Sets the Page's title variable only if it was not set via front matter. See [this comment](https://github.com/gohugoio/hugo/issues/4341#issuecomment-361804082) under #4341.

This is a POC/WIP. It is fully functional. It is implemented not by a regex scan of the content, but via a hook into the BlackFriday renderer. As I am still new to the Hugo codebase, I'm not sure if I picked the right place to code the hook and pass it into BlackFriday. 

Since the hook is intercepting all BlackFriday heading render calls, it can also form the basis of a better TOC solution, with a proper data structure (I know @bep wants this!)

There are not yet config settings or tests, but need confirmation that this is indeed desired functionality first. 