### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN apk add --no-cache --virtual git musl-dev
 RUN go get github.com/golang/dep/cmd/dep
 
 WORKDIR /go/src/github.com/gohugoio/hugo
-RUN dep ensure
 ADD . /go/src/github.com/gohugoio/hugo/
+RUN dep ensure
 RUN go install -ldflags '-s -w'
 
 FROM alpine:3.6


### PR DESCRIPTION
The present Dockerfile in master does not build a Hugo container. The
build container prematurely exits because `dep ensure` can not locate
`Gopkg.toml` due to the source files not being copied/added to the
container prior to running this command. The minimal change require
to resolve the issue is merely move the ADD source before the RUN dep.

Fixes #4076
Resolves #4077