### PR TITLE
Update "Contributors" link in site-footer.html

### DIFF
--- a/docs/themes/gohugoioTheme/layouts/partials/site-footer.html
+++ b/docs/themes/gohugoioTheme/layouts/partials/site-footer.html
@@ -3,7 +3,7 @@
       <div class="pb3 pt4 w-100 w-50-ns">
       
          <div class="b f3  light-gray mb3 nested-links tc">
-           By the <a href="https://github.com/gohugoio/hugo/contributors" class="link">Hugo Authors</a><br />
+           By the <a href="https://github.com/gohugoio/hugo/graphs/contributors" class="link">Hugo Authors</a><br />
           </div>
 
           <div class="center w4">


### PR DESCRIPTION
The "Contributors" link is correct in the Release Notes documents, for example, but is incorrect in the site footer.