### PR TITLE
Use more canonical "twitter:image" property, not "twitter:image:src"

### DIFF
--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -233,18 +233,18 @@ func (t *templateHandler) embedTemplates() {
 
 	t.addInternalTemplate("", "twitter_cards.html", `{{- with $.Params.images -}}
 <meta name="twitter:card" content="summary_large_image"/>
-<meta name="twitter:image:src" content="{{ index . 0 | absURL }}"/>
+<meta name="twitter:image" content="{{ index . 0 | absURL }}"/>
 {{ else -}}
 {{- $images := $.Resources.ByType "image" -}}
 {{- $featured := $images.GetMatch "*feature*" -}}
 {{- $featured := cond (ne $featured nil) $featured ($images.GetMatch "{*cover*,*thumbnail*}") -}}
 {{- with $featured -}}
 <meta name="twitter:card" content="summary_large_image"/>
-<meta name="twitter:image:src" content="{{ $featured.Permalink }}"/>
+<meta name="twitter:image" content="{{ $featured.Permalink }}"/>
 {{- else -}}
 {{- with $.Site.Params.images -}}
 <meta name="twitter:card" content="summary_large_image"/>
-<meta name="twitter:image:src" content="{{ index . 0 | absURL }}"/>
+<meta name="twitter:image" content="{{ index . 0 | absURL }}"/>
 {{ else -}}
 <meta name="twitter:card" content="summary"/>
 {{- end -}}


### PR DESCRIPTION
This change is made in the "twitter_cards" internal template.

References:

- https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image
- https://twittercommunity.com/t/twitter-image-src-or-twitter-image/16085/7