### PR TITLE
Add new menu parameter "Target", See #3600

### DIFF
--- a/docs/content/content-management/menus.md
+++ b/docs/content/content-management/menus.md
@@ -65,6 +65,9 @@ A menu entry has the following properties (i.e., variables) available to it:
 `.Children`
 : Menu
 
+`.Target`
+: string
+
 Note that menus also have the following functions available as well:
 
 `.HasChildren`

--- a/docs/content/readfiles/menuvars.md
+++ b/docs/content/readfiles/menuvars.md
@@ -25,6 +25,9 @@
 `.Children`
 : Menu
 
+`.Target`
+: string
+
 Note that menus also have the following functions available as well:
 
 [`.HasChildren`](/functions/haschildren/)

--- a/docs/content/templates/menu-templates.md
+++ b/docs/content/templates/menu-templates.md
@@ -45,7 +45,7 @@ The following is an example:
           </ul>
       {{else}}
         <li>
-          <a href="{{.URL}}">
+          <a href="{{.URL}}" {{ if .Target }} target="{{ .Target }}" {{ end }} >
             {{ .Pre }}
             <span>{{ .Name }}</span>
           </a>

--- a/docs/content/variables/menus.md
+++ b/docs/content/variables/menus.md
@@ -64,4 +64,7 @@ not when it's created from the site config.
 .Children
 : Menu
 
+.Target
+: Menu
+
 [menu template]: /templates/menu-templates/

--- a/hugolib/menu.go
+++ b/hugolib/menu.go
@@ -35,6 +35,7 @@ type MenuEntry struct {
 	Weight     int
 	Parent     string
 	Children   Menu
+	Target     string
 }
 
 // Menu is a collection of menu entries.
@@ -100,6 +101,8 @@ func (m *MenuEntry) marshallMap(ime map[string]interface{}) {
 			m.Identifier = cast.ToString(v)
 		case "parent":
 			m.Parent = cast.ToString(v)
+		case "target":
+			m.Target = cast.ToString(v)
 		}
 	}
 }


### PR DESCRIPTION
Add new menu parameter "Target to allow themes creators to open menus using specific targets.
This is extremely useful when menu items are linking to external sites where theme user would like to open in new tab (hence Target = "_blank", Still it should allow more flexability to more complex use cases.

See #3600