### PR TITLE
JSON, YAML and TOML data equivalency, Better array data support

### DIFF
--- a/hugolib/datafiles_test.go
+++ b/hugolib/datafiles_test.go
@@ -261,8 +261,7 @@ func TestDataDirMultipleSourcesCommingled(t *testing.T) {
 	doTestDataDir(t, dd, expected, "theme", "mytheme")
 }
 
-// TODO Issue #4366 unresolved
-func _TestDataDirMultipleSourcesCollidingChildArrays(t *testing.T) {
+func TestDataDirCollidingChildArrays(t *testing.T) {
 	t.Parallel()
 
 	var dd dataDir
@@ -284,8 +283,7 @@ func _TestDataDirMultipleSourcesCollidingChildArrays(t *testing.T) {
 	doTestDataDir(t, dd, expected, "theme", "mytheme")
 }
 
-// TODO Issue #4366 unresolved
-func _TestDataDirMultipleSourcesCollidingTopLevelArrays(t *testing.T) {
+func TestDataDirCollidingTopLevelArrays(t *testing.T) {
 	t.Parallel()
 
 	var dd dataDir
@@ -297,6 +295,27 @@ func _TestDataDirMultipleSourcesCollidingTopLevelArrays(t *testing.T) {
 			"a": map[string]interface{}{
 				"b1": []interface{}{"1", "2", "3"},
 			},
+		}
+
+	doTestDataDir(t, dd, expected, "theme", "mytheme")
+}
+
+func TestDataDirCollidingMapsAndArrays(t *testing.T) {
+	t.Parallel()
+
+	var dd dataDir
+	// on
+	dd.addSource("themes/mytheme/data/a.json", `["1", "2", "3"]`)
+	dd.addSource("themes/mytheme/data/b.json", `{ "film" : "Logan Lucky" }`)
+	dd.addSource("data/a.json", `{ "music" : "Queen's Rebuke" }`)
+	dd.addSource("data/b.json", `["x", "y", "z"]`)
+
+	expected :=
+		map[string]interface{}{
+			"a": map[string]interface{}{
+				"music": "Queen's Rebuke",
+			},
+			"b": []interface{}{"x", "y", "z"},
 		}
 
 	doTestDataDir(t, dd, expected, "theme", "mytheme")

--- a/hugolib/datafiles_test.go
+++ b/hugolib/datafiles_test.go
@@ -36,6 +36,69 @@ func TestDataDirJSON(t *testing.T) {
 	t.Parallel()
 
 	sources := [][2]string{
+		{filepath.FromSlash("data/test/a.json"), `{ "b" : { "c1": "red" , "c2": "blue" } }`},
+	}
+
+	expected := map[string]interface{}{
+		"test": map[string]interface{}{
+			"a": map[string]interface{}{
+				"b": map[string]interface{}{
+					"c1": "red",
+					"c2": "blue",
+				},
+			},
+		},
+	}
+
+	doTestDataDir(t, expected, sources)
+}
+
+func TestDataDirYAML(t *testing.T) {
+	t.Parallel()
+
+	sources := [][2]string{
+		{"data/test/a.yaml", "b:\n  c1: red\n  c2: blue"},
+	}
+
+	expected := map[string]interface{}{
+		"test": map[string]interface{}{
+			"a": map[string]interface{}{
+				"b": map[string]interface{}{
+					"c1": "red",
+					"c2": "blue",
+				},
+			},
+		},
+	}
+
+	doTestDataDir(t, expected, sources)
+}
+
+func TestDataDirToml(t *testing.T) {
+	t.Parallel()
+
+	sources := [][2]string{
+		{"data/test/a.toml", "[b]\nc1 = \"red\"\nc2 = \"blue\"\n"},
+	}
+
+	expected := map[string]interface{}{
+		"test": map[string]interface{}{
+			"a": map[string]interface{}{
+				"b": map[string]interface{}{
+					"c1": "red",
+					"c2": "blue",
+				},
+			},
+		},
+	}
+
+	doTestDataDir(t, expected, sources)
+}
+
+func TestDataDirJSON2(t *testing.T) {
+	t.Parallel()
+
+	sources := [][2]string{
 		{filepath.FromSlash("data/test/foo.json"), `{ "bar": "foofoo"  }`},
 		{filepath.FromSlash("data/test.json"), `{ "hello": [ { "world": "foo" } ] }`},
 	}
@@ -55,52 +118,7 @@ func TestDataDirJSON(t *testing.T) {
 	doTestDataDir(t, expected, sources)
 }
 
-// Enable / adjust in https://github.com/gohugoio/hugo/issues/4393
-func _TestDataDirYAML(t *testing.T) {
-	t.Parallel()
-
-	sources := [][2]string{
-		{"data/test/a.yaml", "b:\n  c1: 1\n  c2: 2"},
-	}
-
-	expected :=
-		map[string]interface{}{
-			"test": map[string]interface{}{
-				"a": map[string]interface{}{
-					"b": map[interface{}]interface{}{
-						"c1": 1,
-						"c2": 2,
-					},
-				},
-			},
-		}
-
-	doTestDataDir(t, expected, sources)
-}
-
-func TestDataDirToml(t *testing.T) {
-	t.Parallel()
-
-	sources := [][2]string{
-		{"data/test/kung.toml", "[foo]\nbar = 1"},
-	}
-
-	expected :=
-		map[string]interface{}{
-			"test": map[string]interface{}{
-				"kung": map[string]interface{}{
-					"foo": map[string]interface{}{
-						"bar": 1,
-					},
-				},
-			},
-		}
-
-	doTestDataDir(t, expected, sources)
-}
-
-// Enable / adjust in https://github.com/gohugoio/hugo/issues/4393
-func _TestDataDirYAML2(t *testing.T) {
+func TestDataDirYAML2(t *testing.T) {
 	t.Parallel()
 
 	sources := [][2]string{
@@ -122,21 +140,7 @@ func _TestDataDirYAML2(t *testing.T) {
 			},
 		}
 
-	// what we are actually getting as of v0.34
-	expectedV0_34 :=
-		map[string]interface{}{
-			"test": map[string]interface{}{
-				"hello": []interface{}{
-					map[interface{}]interface{}{"world": "foo"},
-				},
-				"foo": map[string]interface{}{
-					"bar": "foofoo",
-				},
-			},
-		}
-	_ = expected
-
-	doTestDataDir(t, expectedV0_34, sources)
+	doTestDataDir(t, expected, sources)
 }
 
 func TestDataDirToml2(t *testing.T) {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -870,7 +870,7 @@ func (s *Site) readData(f source.ReadableFile) (interface{}, error) {
 
 	switch f.Extension() {
 	case "yaml", "yml":
-		return parser.HandleYAMLMetaData(content)
+		return parser.HandleYAMLData(content)
 	case "json":
 		return parser.HandleJSONData(content)
 	case "toml":

--- a/parser/frontmatter.go
+++ b/parser/frontmatter.go
@@ -216,6 +216,23 @@ func HandleYAMLMetaData(datum []byte) (map[string]interface{}, error) {
 	return m, err
 }
 
+// HandleYAMLData unmarshals YAML-encoded datum and returns a Go interface
+// representing the encoded data structure.
+func HandleYAMLData(datum []byte) (interface{}, error) {
+	var m interface{}
+	err := yaml.Unmarshal(datum, &m)
+
+	// To support boolean keys, the `yaml` package unmarshals maps to
+	// map[interface{}]interface{}. Here we recurse through the result
+	// and change all maps to map[string]interface{} like we would've
+	// gotten from `json`.
+	if err == nil {
+		m = stringifyYAMLMapKeys(m)
+	}
+
+	return m, err
+}
+
 // stringifyKeysMapValue recurses into in and changes all instances of
 // map[interface{}]interface{} to map[string]interface{}. This is useful to
 // work around the impedence mismatch between JSON and YAML unmarshaling that's


### PR DESCRIPTION
Proposed resolution of #4393, per @bep's comment under that issue:

> And my thoughts are this:
>
> - Front matter and /data are meant to be portable across formats (which was the reason why I closed my eyes and merged the related PR)
> - We even have commands to do conversion between them that kind of does not work because of this
> - People should be able to mix-and-match YAML and TOML etc. content
> - Theme author should be able to write portable templates
> - Having YAML keys as `interface{}` makes sorting random. The lexicographically sort you get with string keys have its own problems, but it is better than random.
>
> So, here is how I **suggest** we do this:
>
> - Keep the implementation as is now (adjust tests)
> - Add a check for non-string keys and print a WARNING to the console.

Four commits with isolated pushes to isolate changes for easier diff review and isolated CI tests results:  

1. The Re-enable YAML data tests disabled in f554503f in isolated committed to prove production code passes tests as-is. Resolves test breakage by #4138.
2. Refactoring of test code also made in isolated commit and push for same reason.
3. #4366 fixed with test coverage. 
4. #3890 fixed with test coverage. 

See commit comments for details.

If this PR is accepted, I can reduce the scope of #4379. 