### PR TITLE
Render Markdown in figure sc generated figcaption caption and attr

### DIFF
--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -298,6 +298,11 @@ func TestFigureOnlySrc(t *testing.T) {
 	CheckShortCodeMatch(t, `{{< figure src="/found/here" >}}`, "\n<figure>\n    \n        <img src=\"/found/here\" />\n    \n    \n</figure>\n", nil)
 }
 
+func TestFigureCaptionWithMarkdown(t *testing.T) {
+	t.Parallel()
+	CheckShortCodeMatch(t, `{{< figure src="/found/here" caption="Something **bold** _italic_" >}}`, "<figure>\n    \n        <img src=\"/found/here\" alt=\"Something bold italic\" />\n    \n    \n    <figcaption>\n        <p>\n        Something <strong>bold</strong> <em>italic</em>\n        \n            \n        \n        </p> \n    </figcaption>\n    \n</figure>", nil)
+}
+
 func TestFigureImgWidth(t *testing.T) {
 	t.Parallel()
 	CheckShortCodeMatch(t, `{{% figure src="/found/here" class="bananas orange" alt="apple" width="100px" %}}`, "\n<figure class=\"bananas orange\">\n    \n        <img src=\"/found/here\" alt=\"apple\" width=\"100px\" />\n    \n    \n</figure>\n", nil)

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -21,15 +21,15 @@ func (t *templateHandler) embedShortcodes() {
 	t.addInternalShortcode("figure.html", `<!-- image -->
 <figure{{ with .Get "class" }} class="{{.}}"{{ end }}>
     {{ if .Get "link"}}<a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>{{ end }}
-        <img src="{{ .Get "src" }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}" {{ end }}{{ with .Get "width" }}width="{{.}}" {{ end }}{{ with .Get "height" }}height="{{.}}" {{ end }}/>
+        <img src="{{ .Get "src" }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" | markdownify | plainify }}{{ end }}" {{ end }}{{ with .Get "width" }}width="{{.}}" {{ end }}{{ with .Get "height" }}height="{{.}}" {{ end }}/>
     {{ if .Get "link"}}</a>{{ end }}
     {{ if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
     <figcaption>{{ if isset .Params "title" }}
         <h4>{{ .Get "title" }}</h4>{{ end }}
         {{ if or (.Get "caption") (.Get "attr")}}<p>
-        {{ .Get "caption" }}
+        {{ .Get "caption" | markdownify }}
         {{ with .Get "attrlink"}}<a href="{{.}}"> {{ end }}
-            {{ .Get "attr" }}
+            {{ .Get "attr" | markdownify }}
         {{ if .Get "attrlink"}}</a> {{ end }}
         </p> {{ end }}
     </figcaption>


### PR DESCRIPTION
- The Markdown emphasis characters if present in the "caption" and "attr"
  parameters for the figure shortcode will be rendered into HTML, and used in
  the shortcode-generated figcaption tag.
- The "caption" parameter is reused in the "alt" attribute in the <img>
  tag. Though, the alt text should contain only plain text. So emphasis tags are
  removed when "caption" is reused in the "alt" attribute.
- Add test for this.