### PR TITLE
resource: Fix multi-threaded image processing issue

### DIFF
--- a/resource/image.go
+++ b/resource/image.go
@@ -112,6 +112,9 @@ type Image struct {
 
 	copyToDestinationInit sync.Once
 
+	// Lock used when creating alternate versions of this image.
+	createMu sync.Mutex
+
 	imaging *Imaging
 
 	hash string


### PR DESCRIPTION
When doing something like this with the same image from a partial used in, say, both the home page and the single page:

```bash
{{ with $img }}
{{ $big := .Fill "1024x512 top" }}
{{ $small := $big.Resize "512x" }}
{{ end }}
```

There would be timing issues making Hugo in some cases try to process the same image with the same instructions in parallel.

You would experience errors of type:

```bash
png: invalid format: not enough pixel data
```

This commit works around that by adding a mutex per image. This should also improve the performance, sligthly, as it avoids duplicate work.

The current workaround before this fix is to always operate on the original:

```bash
{{ with $img }}
{{ $big := .Fill "1024x512 top" }}
{{ $small := .Fill "512x256 top" }}
{{ end }}
```

Fixes #4404

This PR works, but I will try to create a failing test for it.