### PR TITLE
Fix bug in Site.assembleSections method

### DIFF
--- a/hugolib/site_sections.go
+++ b/hugolib/site_sections.go
@@ -167,11 +167,15 @@ func (s *Site) assembleSections() Pages {
 		undecided  Pages
 	)
 
+	homes := s.findPagesByKind(KindHome)
+	if len(homes) == 1 {
+		home = homes[0]
+	} else if len(homes) > 1 {
+		panic("Too many homes")
+	}
+
 	for i, p := range s.Pages {
 		if p.Kind != KindPage {
-			if p.Kind == KindHome {
-				home = p
-			}
 			continue
 		}
 


### PR DESCRIPTION
Site.assembleSections logic assumes that the the home page would always be the first in the Site's list of pages. This is not in fact guaranteed to be true. When it is not, the method can fail to set the parent for some or all root-level pages.  

Fixes #4447