### PR TITLE
Improve resource paths

### DIFF
--- a/resource/image.go
+++ b/resource/image.go
@@ -237,7 +237,7 @@ func (i *Image) doWithImageConfig(action, spec string, f func(src image.Image, c
 		}
 	}
 
-	key := i.relTargetPathForRel(i.filenameFromConfig(conf), false)
+	key := i.filenameFromConfig(conf)
 
 	return i.spec.imageCache.getOrCreate(i, key, func(resourceCacheFilename string) (*Image, error) {
 		ci := i.clone()

--- a/resource/image.go
+++ b/resource/image.go
@@ -579,6 +579,7 @@ func (i *Image) setBasePath(conf imageConfig) {
 
 func (i *Image) filenameFromConfig(conf imageConfig) string {
 	p1, p2 := helpers.FileAndExt(i.relTargetPath)
+	path := i.relTargetPath[0:strings.LastIndex(i.relTargetPath, p1)]
 	idStr := fmt.Sprintf("_hu%s_%d", i.hash, i.osFileInfo.Size())
 
 	// Do not change for no good reason.
@@ -605,7 +606,7 @@ func (i *Image) filenameFromConfig(conf imageConfig) string {
 		idStr = ""
 	}
 
-	return fmt.Sprintf("%s%s_%s%s", p1, idStr, key, p2)
+	return fmt.Sprintf("%s%s%s_%s%s", path, p1, idStr, key, p2)
 }
 
 func decodeImaging(m map[string]interface{}) (Imaging, error) {

--- a/resource/testhelpers_test.go
+++ b/resource/testhelpers_test.go
@@ -117,7 +117,8 @@ func fetchResourceForSpec(spec *Spec, assert *require.Assertions, name string) R
 	return r
 }
 func assertFileCache(assert *require.Assertions, fs *hugofs.Fs, filename string, width, height int) {
-	f, err := fs.Source.Open(filepath.Join("/res/_gen/images", filename))
+	p := filepath.Join("/res/_gen/images", path.Base(filename))
+	f, err := fs.Source.Open(p)
 	assert.NoError(err)
 	defer f.Close()
 


### PR DESCRIPTION
These two small changes improve the generation of target paths for bundle resources that are transformed (i.e., which use the image transformation methods such as `Resize`).

## Issue description

### Duplicated relative path

When generating paths for transformed resources in page bundles (both headless or not), the relative path of the bundle is added twice to the final image path.
For instance, source resource:

```
/section/page/name/123/resource.png
```

once transformed, will end up as:

```
/public/section/page/name/123/section/page/name/123/resource_hu49c03114a…q50_box.png
```

This is not an issue _per se_, but generates unnecessarily deep directory hierarchies and very long URLs.
Very deep directories can lead to problems with tools on Windows that are affected by the operating system's old `MAX_PATH` limitations (e.g., Filezilla, when uploading the generated website, which is how I found the problem).

Commit `9fd19dc` fixes this by removing the duplicated call to `resource.relTargetPathForRel` when generating the transformed resource's cache key.
The transformed image in the example above will be correctly stored along the original resource:

```
/public/section/page/name/123/resource.png
/public/section/page/name/123/resource_hu49c03114a…q50_box.png
```

### Relative resource paths

Transformed bundle resources do not keep their relative path to the owning bundle. For instance, given a bundle with the following files:

```
/section/bundle/index.md
/section/bundle/resource1.jpg
/section/bundle/subdir/resource2.jpg
```

the destination directory will keep the bundle's structure for the source files, but transformed files will be _flattened_ to the bundle's root directory. That is, the final file structure will look like:

```
/public/section/bundle/index.html
/public/section/bundle/resource1.jpg
/public/section/bundle/resource1_hu123….jpg
/public/section/bundle/subdir/resource2.jpg
/public/section/bundle/resource2_hu234….jpg
```

Notice that the last file is _not_ stored inside the `subdir` directory.

This is due to how the image key is generated in `image.filenameFromConfig`, using the `FileAndExt` helper that strips relative path information from the resource file.
This is fixed in commit `5a1a0c8` by keeping track of the resource's path relative to the owning bundle and adding it to the generated image key.

## Note

This is my first contribution and I just recently started using both Go and Hugo, I hope there are no major mistakes. 😊