### PR TITLE
Add Reset method to delete key from Scratch

### DIFF
--- a/docs/content/functions/scratch.md
+++ b/docs/content/functions/scratch.md
@@ -32,6 +32,7 @@ See [this Go issue](https://github.com/golang/go/issues/10608) for the main moti
 * `Get` returns the `value` for the `key` given.
 * `SetInMap` takes a `key`, `mapKey` and `value`
 * `GetSortedMapValues` returns array of values from `key` sorted by `mapKey`
+* `Delete` takes a `key` to remove
 
 `Set` and `SetInMap` can store values of any type.
 
@@ -69,6 +70,11 @@ The usage is best illustrated with some samples:
 {{ $.Scratch.SetInMap "a3" "c" "CC" }}
 {{ $.Scratch.SetInMap "a3" "b" "BB" }}
 {{ $.Scratch.GetSortedMapValues "a3" }} {{/* => []interface {}{"AA", "BB", "CC"} */}}
+
+{{ $.Scratch.Add "a" 1 }}
+{{ $.Scratch.Delete "a" }}
+{{ $.Scratch.Add "a" 2 }}
+{{ $.Scratch.Get "a" }} {{/* => 2 */}}
 ```
 
 {{% note %}}

--- a/hugolib/scratch.go
+++ b/hugolib/scratch.go
@@ -74,7 +74,7 @@ func (c *Scratch) Set(key string, value interface{}) string {
 }
 
 // Reset deletes the given key
-func (c *Scratch) Delete (key string) string {
+func (c *Scratch) Delete(key string) string {
 	c.mu.Lock()
 	delete(c.values, key)
 	c.mu.Unlock()

--- a/hugolib/scratch.go
+++ b/hugolib/scratch.go
@@ -74,7 +74,7 @@ func (c *Scratch) Set(key string, value interface{}) string {
 }
 
 // Reset deletes the given key
-func (c *Scratch) Reset (key string) string {
+func (c *Scratch) Delete (key string) string {
 	c.mu.Lock()
 	delete(c.values, key)
 	c.mu.Unlock()

--- a/hugolib/scratch.go
+++ b/hugolib/scratch.go
@@ -73,6 +73,14 @@ func (c *Scratch) Set(key string, value interface{}) string {
 	return ""
 }
 
+// Reset deletes the given key
+func (c *Scratch) Reset (key string) string {
+	c.mu.Lock()
+	delete(c.values, key)
+	c.mu.Unlock()
+	return ""
+}
+
 // Get returns a value previously set by Add or Set
 func (c *Scratch) Get(key string) interface{} {
 	c.mu.RLock()

--- a/hugolib/scratch_test.go
+++ b/hugolib/scratch_test.go
@@ -88,12 +88,12 @@ func TestScratchSet(t *testing.T) {
 }
 
 func TestScratchReset(t *testing.T) {
-    t.Parallel()
-    scratch := newScratch()
-    scratch.Set("key", "val")
-    scratch.Reset("key")
-    scratch.Add("key", "Lucy Parsons")
-    assert.Equal(t, "Lucy Parsons", scratch.Get("key"))
+	t.Parallel()
+	scratch := newScratch()
+	scratch.Set("key", "val")
+	scratch.Reset("key")
+	scratch.Add("key", "Lucy Parsons")
+	assert.Equal(t, "Lucy Parsons", scratch.Get("key"))
 }
 
 // Issue #2005

--- a/hugolib/scratch_test.go
+++ b/hugolib/scratch_test.go
@@ -87,6 +87,15 @@ func TestScratchSet(t *testing.T) {
 	assert.Equal(t, "val", scratch.Get("key"))
 }
 
+func TestScratchReset(t *testing.T) {
+    t.Parallel()
+    scratch := newScratch()
+    scratch.Set("key", "val")
+    scratch.Reset("key")
+    scratch.Add("key", "Lucy Parsons")
+    asset.Equal(t, "Lucy Parsons", scratch.Get("key"))
+}
+
 // Issue #2005
 func TestScratchInParallel(t *testing.T) {
 	var wg sync.WaitGroup

--- a/hugolib/scratch_test.go
+++ b/hugolib/scratch_test.go
@@ -87,11 +87,11 @@ func TestScratchSet(t *testing.T) {
 	assert.Equal(t, "val", scratch.Get("key"))
 }
 
-func TestScratchReset(t *testing.T) {
+func TestScratchDelete(t *testing.T) {
 	t.Parallel()
 	scratch := newScratch()
 	scratch.Set("key", "val")
-	scratch.Reset("key")
+	scratch.Delete("key")
 	scratch.Add("key", "Lucy Parsons")
 	assert.Equal(t, "Lucy Parsons", scratch.Get("key"))
 }

--- a/hugolib/scratch_test.go
+++ b/hugolib/scratch_test.go
@@ -93,7 +93,7 @@ func TestScratchReset(t *testing.T) {
     scratch.Set("key", "val")
     scratch.Reset("key")
     scratch.Add("key", "Lucy Parsons")
-    asset.Equal(t, "Lucy Parsons", scratch.Get("key"))
+    assert.Equal(t, "Lucy Parsons", scratch.Get("key"))
 }
 
 // Issue #2005


### PR DESCRIPTION
Following a [discussion](https://discourse.gohugo.io/t/delimit-and-create-array/11065/11?u=cmal) in the forums, I'm proposing a `Reset` method for Scratch, to remove a Scratch entry. It could be renamed Delete if you prefer.

This is my first time writing some golang so sorry if I'm doing some things wrong. Unfortunately, I'm running golang 1.8.1 from Debian stable so I cannot run the tests. I tried it with the following snippet and it appears to work like a charm:

```
{{ $.Scratch.Set "test" "lol" }}
{{ $.Scratch.Reset "test" }}
{{ $.Scratch.Reset "anothertest" }}
{{ $.Scratch.Add "test" "Bonjour" }}
{{ $.Scratch.Get "test" }}
```

It printed "Bonjour" like expected and did not raise an error when attempting to delete a key that did not exist (I believe this is the desired behaviour).

I read the contribution guidelines and tried to give meaning to my commit message. Don't hesitate to amend my commit :)