### PR TITLE
Allow some  config from themes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -163,6 +163,7 @@
     ".",
     "hcl/ast",
     "hcl/parser",
+    "hcl/printer",
     "hcl/scanner",
     "hcl/strconv",
     "hcl/token",
@@ -275,6 +276,12 @@
   revision = "55d61fa8aa702f59229e6cff85793c22e580eaf5"
 
 [[projects]]
+  name = "github.com/sanity-io/litter"
+  packages = ["."]
+  revision = "ae543b7ba8fd6af63e4976198f146e1348ae53c1"
+  version = "v1.1.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/shurcooL/sanitized_anchor_name"
   packages = ["."]
@@ -331,8 +338,8 @@
 [[projects]]
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
-  version = "v1.0.0"
+  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
+  version = "v1.0.2"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -417,6 +424,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4657586103d844434bda6db23d03f30e2ae0db16dc48746b9559ce742902535a"
+  inputs-digest = "13ab39f8bfafadc12c05726e565ee3f3d94bf7d6c0e8adf04056de0691bf2dd6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -141,3 +141,7 @@
   name = "github.com/muesli/smartcrop"
   branch = "master"
 
+
+[[constraint]]
+  name = "github.com/sanity-io/litter"
+  version = "1.1.0"

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -306,7 +306,7 @@ func InitializeConfig(running bool, doWithCommandeer func(c *commandeer) error, 
 	// Init file systems. This may be changed at a later point.
 	osFs := hugofs.Os
 
-	config, err := hugolib.LoadConfig(osFs, source, cfgFile)
+	config, err := hugolib.LoadConfig(hugolib.ConfigSourceDescriptor{Fs: osFs, Src: source, Name: cfgFile})
 	if err != nil {
 		return nil, err
 	}

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -154,11 +154,16 @@ func ReplaceExtension(path string, newExt string) string {
 // AbsPathify creates an absolute path if given a relative path. If already
 // absolute, the path is just cleaned.
 func (p *PathSpec) AbsPathify(inPath string) string {
+	return AbsPathify(p.workingDir, inPath)
+}
+
+// AbsPathify creates an absolute path if given a working dir and arelative path.
+// If already absolute, the path is just cleaned.
+func AbsPathify(workingDir, inPath string) string {
 	if filepath.IsAbs(inPath) {
 		return filepath.Clean(inPath)
 	}
-
-	return filepath.Join(p.workingDir, inPath)
+	return filepath.Join(workingDir, inPath)
 }
 
 // GetLayoutDirPath returns the absolute path to the layout file dir

--- a/hugolib/case_insensitive_test.go
+++ b/hugolib/case_insensitive_test.go
@@ -149,7 +149,7 @@ func TestCaseInsensitiveConfigurationVariations(t *testing.T) {
 
 	caseMixingTestsWriteCommonSources(t, mm)
 
-	cfg, err := LoadConfig(ConfigSourceDescriptor{Fs: mm})
+	cfg, _, err := LoadConfig(ConfigSourceDescriptor{Fs: mm, Filename: "config.toml"})
 	require.NoError(t, err)
 
 	fs := hugofs.NewFrom(mm, cfg)

--- a/hugolib/case_insensitive_test.go
+++ b/hugolib/case_insensitive_test.go
@@ -149,7 +149,7 @@ func TestCaseInsensitiveConfigurationVariations(t *testing.T) {
 
 	caseMixingTestsWriteCommonSources(t, mm)
 
-	cfg, err := LoadConfig(mm, "", "config.toml")
+	cfg, err := LoadConfig(ConfigSourceDescriptor{Fs: mm})
 	require.NoError(t, err)
 
 	fs := hugofs.NewFrom(mm, cfg)
@@ -260,7 +260,7 @@ func doTestCaseInsensitiveConfigurationForTemplateEngine(t *testing.T, suffix st
 
 	caseMixingTestsWriteCommonSources(t, mm)
 
-	cfg, err := LoadConfig(mm, "", "config.toml")
+	cfg, err := LoadConfigDefault(mm)
 	require.NoError(t, err)
 
 	fs := hugofs.NewFrom(mm, cfg)

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -34,7 +34,7 @@ func TestLoadConfig(t *testing.T) {
 
 	writeToFs(t, mm, "hugo.toml", configContent)
 
-	cfg, err := LoadConfig(mm, "", "hugo.toml")
+	cfg, err := LoadConfig(ConfigSourceDescriptor{Fs: mm, Name: "hugo.toml"})
 	require.NoError(t, err)
 
 	assert.Equal(t, "side", cfg.GetString("paginatePath"))
@@ -59,7 +59,7 @@ func TestLoadMultiConfig(t *testing.T) {
 
 	writeToFs(t, mm, "override.toml", configContentSub)
 
-	cfg, err := LoadConfig(mm, "", "base.toml,override.toml")
+	cfg, err := LoadConfig(ConfigSourceDescriptor{Fs: mm, Name: "base.toml,override.toml"})
 	require.NoError(t, err)
 
 	assert.Equal(t, "top", cfg.GetString("paginatePath"))

--- a/hugolib/disableKinds_test.go
+++ b/hugolib/disableKinds_test.go
@@ -90,7 +90,7 @@ categories:
 	siteConfig := fmt.Sprintf(siteConfigTemplate, disabledStr)
 	writeToFs(t, mf, "config.toml", siteConfig)
 
-	cfg, err := LoadConfig(mf, "", "config.toml")
+	cfg, err := LoadConfigDefault(mf)
 	require.NoError(t, err)
 
 	fs := hugofs.NewFrom(mf, cfg)

--- a/hugolib/page_bundler_test.go
+++ b/hugolib/page_bundler_test.go
@@ -200,6 +200,7 @@ func TestPageBundlerSiteMultilingual(t *testing.T) {
 				cfg.Set("uglyURLs", ugly)
 
 				assert.NoError(loadDefaultSettingsFor(cfg))
+				assert.NoError(loadLanguageSettings(cfg, nil))
 				sites, err := NewHugoSites(deps.DepsCfg{Fs: fs, Cfg: cfg})
 				assert.NoError(err)
 				assert.Equal(2, len(sites.Sites))
@@ -264,6 +265,8 @@ func TestMultilingualDisableDefaultLanguage(t *testing.T) {
 	cfg.Set("disableLanguages", []string{"en"})
 
 	err := loadDefaultSettingsFor(cfg)
+	assert.NoError(err)
+	err = loadLanguageSettings(cfg, nil)
 	assert.Error(err)
 	assert.Contains(err.Error(), "cannot disable default language")
 }

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -296,6 +296,7 @@ func NewSite(cfg deps.DepsCfg) (*Site, error) {
 // NewSiteDefaultLang creates a new site in the default language.
 // The site will have a template system loaded and ready to use.
 // Note: This is mainly used in single site tests.
+// TODO(bep) test refactor -- remove
 func NewSiteDefaultLang(withTemplate ...func(templ tpl.TemplateHandler) error) (*Site, error) {
 	v := viper.New()
 	if err := loadDefaultSettingsFor(v); err != nil {
@@ -307,6 +308,7 @@ func NewSiteDefaultLang(withTemplate ...func(templ tpl.TemplateHandler) error) (
 // NewEnglishSite creates a new site in English language.
 // The site will have a template system loaded and ready to use.
 // Note: This is mainly used in single site tests.
+// TODO(bep) test refactor -- remove
 func NewEnglishSite(withTemplate ...func(templ tpl.TemplateHandler) error) (*Site, error) {
 	v := viper.New()
 	if err := loadDefaultSettingsFor(v); err != nil {

--- a/hugolib/testhelpers_test.go
+++ b/hugolib/testhelpers_test.go
@@ -229,7 +229,7 @@ func (s *sitesBuilder) CreateSites() *sitesBuilder {
 	s.writeFilePairs("i18n", s.i18nFilePairsAdded)
 
 	if s.Cfg == nil {
-		cfg, err := LoadConfig(s.Fs.Source, "", "config."+s.configFormat)
+		cfg, err := LoadConfig(ConfigSourceDescriptor{Fs: s.Fs.Source, Name: "config." + s.configFormat})
 		if err != nil {
 			s.Fatalf("Failed to load config: %s", err)
 		}
@@ -460,7 +460,7 @@ func newTestSitesFromConfig(t testing.TB, afs afero.Fs, tomlConfig string, layou
 
 	writeToFs(t, afs, "config.toml", tomlConfig)
 
-	cfg, err := LoadConfig(afs, "", "config.toml")
+	cfg, err := LoadConfigDefault(afs)
 	require.NoError(t, err)
 
 	fs := hugofs.NewFrom(afs, cfg)


### PR DESCRIPTION
See #4490 

This allows a config.toml in the theme to set

1) `params` (but cannot override params in project. Will also get its own "namespace", i.e. `{{ .Site.Params.mytheme.my_param }}` will be the same as `{{ .Site.Params.my_param }}` providing that the main project does not define a param with that key.
2) `menu` -- but cannot redefine/add menus in the project. Must create its own menus with its own identifiers.
3) `languages` -- only `params` and `menu`. Same rules as above.
4) **new** `outputFormats`
5) **new** `mediaTypes`
