### PR TITLE
Add .Site.Info.IsServer flag when using built-in Hugo server.

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -343,11 +343,9 @@ func (c *commandeer) serve() error {
 		for _, s := range Hugo.Sites {
 			baseURLs = append(baseURLs, s.BaseURL.String())
 			roots = append(roots, s.Language.Lang)
-			s.Info.IsServer = true
 		}
 	} else {
 		s := Hugo.Sites[0]
-		s.Info.IsServer = true
 		baseURLs = []string{s.BaseURL.String()}
 		roots = []string{""}
 	}

--- a/commands/server.go
+++ b/commands/server.go
@@ -343,9 +343,11 @@ func (c *commandeer) serve() error {
 		for _, s := range Hugo.Sites {
 			baseURLs = append(baseURLs, s.BaseURL.String())
 			roots = append(roots, s.Language.Lang)
+			s.Info.IsServer = true
 		}
 	} else {
 		s := Hugo.Sites[0]
+		s.Info.IsServer = true
 		baseURLs = []string{s.BaseURL.String()}
 		roots = []string{""}
 	}

--- a/docs/content/variables/site.md
+++ b/docs/content/variables/site.md
@@ -52,6 +52,9 @@ The following is a list of site-level (aka "global") variables. Many of these va
 .Site.IsMultiLingual
 : whether there are more than one language in this site. See [Multilingual](/content-management/multilingual/) for more information.
 
+.Site.IsServer
+: a boolean to indicate if the site is being served with Hugo's built-in server. See [`hugo server`](/commands/hugo_server/) for more information.
+
 .Site.Language.Lang
 : the language code of the current locale (e.g., `en`).
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -380,7 +380,6 @@ type SiteInfo struct {
 	BuildDrafts           bool
 	canonifyURLs          bool
 	relativeURLs          bool
-	IsServer              bool
 	uglyURLs              func(p *Page) bool
 	preserveTaxonomyNames bool
 	Data                  *map[string]interface{}
@@ -466,6 +465,10 @@ func (s *SiteInfo) Param(key interface{}) (interface{}, error) {
 
 func (s *SiteInfo) IsMultiLingual() bool {
 	return len(s.Languages) > 1
+}
+
+func (s *SiteInfo) IsServer() bool {
+	return s.owner.running
 }
 
 func (s *SiteInfo) refLink(ref string, page *Page, relative bool, outputFormat string) (string, error) {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -380,6 +380,7 @@ type SiteInfo struct {
 	BuildDrafts           bool
 	canonifyURLs          bool
 	relativeURLs          bool
+	IsServer              bool
 	uglyURLs              func(p *Page) bool
 	preserveTaxonomyNames bool
 	Data                  *map[string]interface{}


### PR DESCRIPTION
Fixes #4478.

Docs PR coming shortly.

Update:

Docs PR: gohugoio/hugoDocs#430