### PR TITLE
[WIP] travis: Run "gem install" without sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-sudo: required
+sudo: false
 dist: trusty
 go:
   - 1.9.4
@@ -21,5 +21,7 @@ script:
   - ./hugo -s docs/
   - ./hugo --renderToMemory -s docs/
 before_install:
-  # gem install must be run with sudo on OSX
-  - sudo gem install asciidoctor | gem install asciidoctor
+  - which asciidoctor || true
+  - gem install asciidoctor
+  - which asciidoctor || true
+  - type asciidoctor || true


### PR DESCRIPTION
Probably related to commit 511d5d3 (moving to Ubuntu Trusty image on Travis CI), "sudo gem install" begins to have random errors like the following on Linux:

ERROR:  While executing gem ... (Errno::EACCES)
    Permission denied @ rb_sysopen - /home/travis/.rvm/gems/ruby-2.4.1/cache/asciidoctor-1.5.6.2.gem

Perhaps sudo is no longer necessary, even on OS X?  Let's experiment!  :-)