### PR TITLE
Adds .gitattributes to force Go files to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Text files have auto line endings
+* text=auto
+
+# Go source files always have LF line endings
+*.go text eol=lf


### PR DESCRIPTION
Even on Windows machines, we want *.go files to have LF line
endings (go fmt insists). This leaves other files as auto, but
makes *.go files always be LF on Windows machines. With this
change, running go fmt will be a pleasant operation, not a
painful one.

Note that changing .gitattributes only affects files at initial
checkout. To update an entire working directory after making a
change like this, do this (but only after committing all work in
progress, this will destroy uncommitted changes):

$ git rm --cached -r .
$ git reset --hard

Again - do not do this to a working directory with uncommitted
work in it.