### PR TITLE
Adds abort error handling

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -476,6 +476,7 @@ func (c *commandeer) build() error {
 		fmt.Println()
 	}
 
+	var builderr error
 	if buildWatch {
 		watchDirs, err := c.getDirList()
 		if err != nil {
@@ -483,6 +484,10 @@ func (c *commandeer) build() error {
 		}
 		c.Logger.FEEDBACK.Println("Watching for changes in", c.PathSpec().AbsPathify(c.Cfg.GetString("contentDir")))
 		c.Logger.FEEDBACK.Println("Press Ctrl+C to stop")
+
+		c.enableAbort()
+		Hugo.Abort = c.abort
+
 		watcher, err := c.newWatcher(watchDirs...)
 		utils.CheckErr(c.Logger, err)
 		defer watcher.Close()
@@ -490,10 +495,14 @@ func (c *commandeer) build() error {
 		var sigs = make(chan os.Signal)
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-		<-sigs
+		// Wait for either ctrl-C, process terminate, or stop request
+		select {
+		case <-sigs:
+		case builderr = <-c.stop:
+		}
 	}
 
-	return nil
+	return builderr
 }
 
 func (c *commandeer) serverBuild() error {
@@ -1016,7 +1025,12 @@ func (c *commandeer) newWatcher(dirList ...string) (*watcher.Batcher, error) {
 						c.Logger.FEEDBACK.Printf("Syncing all static files\n")
 						_, err := c.copyStatic()
 						if err != nil {
-							utils.StopOnErr(c.Logger, err, "Error copying static files to publish dir")
+							c.Logger.CRITICAL.Println("Error copying static files to publish dir", err.Error())
+							// the original call to StopOnErr didn't print the error value - why?
+
+							// Signal to the top level that we want to stop
+							c.abort <- fmt.Errorf("copyStatic failed: %s\n", err.Error())
+							return
 						}
 					} else {
 						if err := staticSyncer.syncsStaticEvents(staticEvents); err != nil {

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -50,6 +50,9 @@ type HugoSites struct {
 
 	// If enabled, keeps a revision map for all content.
 	gitInfo *gitInfo
+
+	// If non-nil, can send on it to request program abort
+	Abort chan error
 }
 
 func (h *HugoSites) IsMultihost() bool {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -14,8 +14,6 @@
 package utils
 
 import (
-	"os"
-
 	jww "github.com/spf13/jwalterweatherman"
 )
 
@@ -33,27 +31,4 @@ func CheckErr(logger *jww.Notepad, err error, s ...string) {
 		logger.ERROR.Println(message)
 	}
 	logger.ERROR.Println(err)
-}
-
-// StopOnErr exits on any error after logging it.
-func StopOnErr(logger *jww.Notepad, err error, s ...string) {
-	if err == nil {
-		return
-	}
-
-	defer os.Exit(-1)
-
-	if len(s) == 0 {
-		newMessage := err.Error()
-		// Printing an empty string results in a error with
-		// no message, no bueno.
-		if newMessage != "" {
-			logger.CRITICAL.Println(newMessage)
-		}
-	}
-	for _, message := range s {
-		if message != "" {
-			logger.CRITICAL.Println(message)
-		}
-	}
 }


### PR DESCRIPTION
Removes internal os.Exit calls in favor of an abort channel;
sending an error on the abort channel tells top-level code that
it should exit. At the moment, this does not unwind all that
quickly, it just means that a failed build operation will result
in the outer "hugo server" or "hugo --watch" exiting.

This also removes utils.StopOnErr - it was only used in one
place and it had an os.Exit call in it.

There are remaining os.Exit calls but they are being used to
return non-zero status from main. Ideal future code would return
exit status to main and it would use os.Exit if the exit status
is non-zero.