### PR TITLE
Adds abort error handling

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -56,6 +56,12 @@ type commandeer struct {
 	// Used in cases where we get flooded with events in server mode.
 	debounce func(f func())
 
+	// Routines send to abort to say "stop operation"
+	// A top-level watcher monitors stop to check for early termination
+	abort   chan error
+	stop    chan error
+	stoperr error
+
 	serverPorts []int
 	languages   helpers.Languages
 
@@ -91,6 +97,29 @@ func (c *commandeer) initFs(fs *hugofs.Fs) error {
 	c.staticDirsConfig = dirsConfig
 
 	return nil
+}
+
+// enableAbort allows deep calls to abort program execution.
+// If we have a command that is persistant (e.g. "hugo --watch" or "hugo server"),
+// we set up a channel that callers can use to request that execution be
+// aborted. A deep caller does "c.abort <- err" to send an abort request;
+// the error is received by the high-level caller by either polling c.stoperr
+// or selecting on c.stop (only one receiver can do that, of course).
+func (c *commandeer) enableAbort() {
+	c.abort = make(chan error)
+	c.stop = make(chan error)
+
+	// Gather any async errors - the first one results in a stop-operation
+	go func(c *commandeer) {
+		var didstop bool
+		for err := range c.abort {
+			if !didstop {
+				c.stoperr = err // Maybe we should save all the errors together?
+				c.stop <- err
+				didstop = true
+			}
+		}
+	}(c)
 }
 
 func newCommandeer(running bool, doWithCommandeer func(c *commandeer) error, subCmdVs ...*cobra.Command) (*commandeer, error) {

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -50,6 +50,9 @@ type HugoSites struct {
 
 	// If enabled, keeps a revision map for all content.
 	gitInfo *gitInfo
+
+	// If non-nil, can send on it to request program abort
+	Abort chan error
 }
 
 func (h *HugoSites) IsMultihost() bool {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -14,8 +14,6 @@
 package utils
 
 import (
-	"os"
-
 	jww "github.com/spf13/jwalterweatherman"
 )
 
@@ -33,27 +31,4 @@ func CheckErr(logger *jww.Notepad, err error, s ...string) {
 		logger.ERROR.Println(message)
 	}
 	logger.ERROR.Println(err)
-}
-
-// StopOnErr exits on any error after logging it.
-func StopOnErr(logger *jww.Notepad, err error, s ...string) {
-	if err == nil {
-		return
-	}
-
-	defer os.Exit(-1)
-
-	if len(s) == 0 {
-		newMessage := err.Error()
-		// Printing an empty string results in a error with
-		// no message, no bueno.
-		if newMessage != "" {
-			logger.CRITICAL.Println(newMessage)
-		}
-	}
-	for _, message := range s {
-		if message != "" {
-			logger.CRITICAL.Println(message)
-		}
-	}
 }


### PR DESCRIPTION
Removes internal os.Exit calls in favor of an abort channel;
sending an error on the abort channel tells top-level code that
it should exit. At the moment, this does not unwind all that
quickly, it just means that a failed build operation will result
in the outer "hugo server" or "hugo --watch" exiting.

This also removes utils.StopOnErr - it was only used in one
place and it had an os.Exit call in it.

There are remaining os.Exit calls but they are being used to
return non-zero status from main. Ideal future code would return
exit status to main and it would use os.Exit if the exit status
is non-zero.