### PR TITLE
Adds --source, --theme, --themesDir to "hugo config"

### DIFF
--- a/commands/list_config.go
+++ b/commands/list_config.go
@@ -29,6 +29,10 @@ var configCmd = &cobra.Command{
 }
 
 func init() {
+	configCmd.Flags().StringVarP(&source, "source", "s", "", "filesystem path to read files relative from")
+	configCmd.Flags().StringVarP(&theme, "theme", "t", "", "theme to use (located in /themes/THEMENAME/)")
+	configCmd.Flags().StringVar(&themesDir, "themesDir", "", "filesystem path to themes directory")
+
 	configCmd.RunE = printConfig
 }
 


### PR DESCRIPTION
Add extra command-line flags so "hugo config" can work on site
dirs that have themes located elsewhere, or so that we can do
"hugo config" on a site that's not the current working directory.