### PR TITLE
add a check in IsSet function which panics if array is passed and key is not int

### DIFF
--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -318,6 +318,9 @@ func (ns *Namespace) IsSet(a interface{}, key interface{}) (bool, error) {
 
 	switch av.Kind() {
 	case reflect.Array, reflect.Chan, reflect.Slice:
+		if kv.Kind() != reflect.Int {
+			return false, nil
+		}
 		if int64(av.Len()) > kv.Int() {
 			return true, nil
 		}


### PR DESCRIPTION
add a check in IsSet function which panics if array is passed and key is not int
fixes #4522