### PR TITLE
Fix handling of content files with "." in them

### DIFF
--- a/hugofs/language_fs.go
+++ b/hugofs/language_fs.go
@@ -292,9 +292,8 @@ func (fs *LanguageFs) newLanguageFileInfo(filename string, fi os.FileInfo) (*Lan
 
 		if fs.languages[fileLang] {
 			lang = fileLang
+			baseNameNoExt = strings.TrimSuffix(baseNameNoExt, fileLangExt)
 		}
-
-		baseNameNoExt = strings.TrimSuffix(baseNameNoExt, fileLangExt)
 
 		// This connects the filename to the filesystem, not the language.
 		virtualName = baseNameNoExt + "." + lang + ext

--- a/hugofs/language_fs_test.go
+++ b/hugofs/language_fs_test.go
@@ -52,3 +52,47 @@ func TestLanguagFs(t *testing.T) {
 	assert.Equal("page.md", lfi.RealName())
 
 }
+
+// Issue 4559
+func TestFilenamesHandling(t *testing.T) {
+	languages := map[string]bool{
+		"sv": true,
+	}
+	base := filepath.FromSlash("/my/base")
+	assert := require.New(t)
+	m := afero.NewMemMapFs()
+	bfs := afero.NewBasePathFs(m, base)
+	lfs := NewLanguageFs("sv", languages, bfs)
+	assert.NotNil(lfs)
+	assert.Equal("sv", lfs.Lang())
+
+	for _, test := range []struct {
+		filename string
+		check    func(fi *LanguageFileInfo)
+	}{
+		{"tc-lib-color/class-Com.Tecnick.Color.Css", func(fi *LanguageFileInfo) {
+			assert.Equal("class-Com.Tecnick.Color", fi.TranslationBaseName())
+			assert.Equal(filepath.FromSlash("/my/base"), fi.BaseDir())
+			assert.Equal(filepath.FromSlash("tc-lib-color/class-Com.Tecnick.Color.Css"), fi.Path())
+			assert.Equal("class-Com.Tecnick.Color.Css", fi.RealName())
+			assert.Equal(filepath.FromSlash("/my/base/tc-lib-color/class-Com.Tecnick.Color.Css"), fi.Filename())
+		}},
+		{"tc-lib-color/class-Com.Tecnick.Color.sv.Css", func(fi *LanguageFileInfo) {
+			assert.Equal("class-Com.Tecnick.Color", fi.TranslationBaseName())
+			assert.Equal("class-Com.Tecnick.Color.sv.Css", fi.RealName())
+			assert.Equal(filepath.FromSlash("/my/base/tc-lib-color/class-Com.Tecnick.Color.sv.Css"), fi.Filename())
+		}},
+	} {
+		err := afero.WriteFile(lfs, filepath.FromSlash(test.filename), []byte("abc"), 0777)
+		assert.NoError(err)
+		fi, err := lfs.Stat(filepath.FromSlash(test.filename))
+		assert.NoError(err)
+
+		lfi, ok := fi.(*LanguageFileInfo)
+		assert.True(ok)
+		assert.Equal("sv", lfi.Lang())
+		test.check(lfi)
+
+	}
+
+}

--- a/source/fileInfo.go
+++ b/source/fileInfo.go
@@ -204,9 +204,8 @@ func (sp *SourceSpec) NewFileInfo(baseDir, filename string, isLeafBundle bool, f
 		// This is usyally provided by the filesystem. But this FileInfo is also
 		// created in a standalone context when doing "hugo new". This is
 		// an approximate implementation, which is "good enough" in that case.
-		translationBaseName = strings.TrimSuffix(baseName, ext)
-		fileLangExt := filepath.Ext(translationBaseName)
-		translationBaseName = strings.TrimSuffix(translationBaseName, fileLangExt)
+		fileLangExt := filepath.Ext(baseName)
+		translationBaseName = strings.TrimSuffix(baseName, fileLangExt)
 	}
 
 	f := &FileInfo{

--- a/source/fileInfo_test.go
+++ b/source/fileInfo_test.go
@@ -49,6 +49,13 @@ func TestFileInfo(t *testing.T) {
 			assert.Equal("b", f.Section())
 
 		}},
+		{filepath.FromSlash("/a/"), filepath.FromSlash("/a/b/page.en.MD"), func(f *FileInfo) {
+			assert.Equal("b", f.Section())
+			assert.Equal(filepath.FromSlash("b/page.en.MD"), f.Path())
+			assert.Equal(filepath.FromSlash("page"), f.TranslationBaseName())
+			assert.Equal(filepath.FromSlash("page.en"), f.BaseFileName())
+
+		}},
 	} {
 		f := s.NewFileInfo(this.base, this.filename, false, nil)
 		this.assert(f)


### PR DESCRIPTION
As in, more dots than just to separate the extension and any language indicator.

Fixes #4559