### PR TITLE
[Work in progress] Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 sudo: false
 dist: trusty
+git:
+  depth: false
 go:
   - 1.9.4
   - "1.10"

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"html/template"
 	"os"
-	"runtime"
 
 	"path/filepath"
 	"reflect"
@@ -912,9 +911,6 @@ func TestPageWithDate(t *testing.T) {
 }
 
 func TestPageWithLastmodFromGitInfo(t *testing.T) {
-	if runtime.GOOS != "windows" && os.Getenv("CI") != "" {
-		t.Skip()
-	}
 	assrt := require.New(t)
 
 	// We need to use the OS fs for this.


### PR DESCRIPTION
I came across https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth, and suddenly, a light bulb lighted up.  Travis, by default, uses `--depth 50` for git clone, but over 50 commits have happened since commit ce6e4310, so inst

    git log --name-only --no-merges --format="format:%ai" hugolib/testsite/content/first-post.md

returns the date of a grafted commit, which currently is "2018-03-15 09:37:30 +0100", instead of 2018-03-11.

Disabling shallow clone should hopefully fix #4584.

(Please don't merge yet; I am making it a PR to trigger a Travis CI test build.)