### PR TITLE
commands: Remove accidental and breaking space in baseURL flag

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -101,6 +101,7 @@ func TestCommandsPersistentFlags(t *testing.T) {
 		assert.Equal("mylayouts", cfg.GetString("layoutDir"))
 		assert.Equal("mytheme", cfg.GetString("theme"))
 		assert.Equal("mythemes", cfg.GetString("themesDir"))
+		assert.Equal("https://example.com/b/", cfg.GetString("baseURL"))
 
 		assert.Equal([]string{"page", "home"}, cfg.Get("disableKinds"))
 

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -189,7 +189,7 @@ func initializeFlags(cmd *cobra.Command, cfg config.Provider) {
 		"templateMetricsHints",
 
 		// Moved from vars.
-		"baseURL ",
+		"baseURL",
 		"buildWatch",
 		"cacheDir",
 		"cfgFile",
@@ -231,6 +231,7 @@ var deprecatedFlags = map[string]bool{
 }
 
 func setValueFromFlag(flags *flag.FlagSet, key string, cfg config.Provider, targetKey string) {
+	key = strings.TrimSpace(key)
 	if flags.Changed(key) {
 		if _, deprecated := deprecatedFlags[strings.ToLower(key)]; deprecated {
 			msg := fmt.Sprintf(`Set "%s = true" in your config.toml.


### PR DESCRIPTION
And added key-trimming to prevent future mishaps.

See #4607