### PR TITLE
Updated GetCSV error message

### DIFF
--- a/tpl/data/data.go
+++ b/tpl/data/data.go
@@ -59,7 +59,7 @@ func (ns *Namespace) GetCSV(sep string, urlParts ...string) (d [][]string, err e
 		var req *http.Request
 		req, err = http.NewRequest("GET", url, nil)
 		if err != nil {
-			jww.ERROR.Printf("Failed to create request for getJSON: %s", err)
+			jww.ERROR.Printf("Failed to create request for getCSV: %s", err)
 			return nil, err
 		}
 


### PR DESCRIPTION
Previously the error message was:
 `jww.ERROR.Printf("Failed to create request for getJSON: %s", err) `. 
This has now been changed to the proper message of: 
`jww.ERROR.Printf("Failed to create request for getCSV: %s", err)`

This fixes #4567