### PR TITLE
.Get allows optional positional params (fixes #4619)

### DIFF
--- a/docs/content/functions/get.md
+++ b/docs/content/functions/get.md
@@ -10,7 +10,7 @@ menu:
   docs:
     parent: "functions"
 keywords: [shortcodes]
-signature: ["Get INDEX", "Get KEY"]
+signature: [".Get INDEX", ".Get KEY"]
 workson: []
 hugoversion:
 relatedfuncs: []

--- a/docs/content/functions/get.md
+++ b/docs/content/functions/get.md
@@ -20,10 +20,13 @@ needsexample: true
 ---
 
 
-`.Get` is specifically used when creating your own [shortcode template][sc].
+`.Get` is specifically used when creating your own [shortcode template][sc], to access the [positional and named](/templates/shortcode-templates/#positional-vs-named-parameters) parameters passed to it. When used with a numeric INDEX, it queries positional parameters (starting with 0). With a string KEY, it queries named parameters.
 
+When accessing a named parameter that does not exist, `.Get` returns an empty string instead of interrupting the build. The same goes with positional parameters in hugo version 0.40 and after. This allows you to chain `.Get` with `if`, `with`, `default` or `cond` to check for parameter existence. For example, you may now use:
 
-
+```
+{{ $quality := default "100" (.Get 1) }}
+```
 
 [sc]: /templates/shortcode-templates/
 

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -86,8 +86,7 @@ func (scp *ShortcodeWithPage) Get(key interface{}) interface{} {
 			idx := int(reflect.ValueOf(key).Int())
 			ln := reflect.ValueOf(scp.Params).Len()
 			if idx > ln-1 {
-				helpers.DistinctErrorLog.Printf("No shortcode param at .Get %d in page %s, have params: %v", idx, scp.Page.FullFilePath(), scp.Params)
-				return fmt.Sprintf("error: index out of range for positional param at position %d", idx)
+				return ""
 			}
 			x = reflect.ValueOf(scp.Params).Index(idx)
 		}

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -144,10 +144,10 @@ func TestPositionalParamSC(t *testing.T) {
 func TestPositionalParamIndexOutOfBounds(t *testing.T) {
 	t.Parallel()
 	wt := func(tem tpl.TemplateHandler) error {
-		tem.AddTemplate("_internal/shortcodes/video.html", `Playing Video {{ .Get 1 }}`)
+		tem.AddTemplate("_internal/shortcodes/video.html", `Playing Video {{ with .Get 1 }}{{ . }}{{ else }}Missing{{ end }}`)
 		return nil
 	}
-	CheckShortCodeMatch(t, "{{< video 47238zzb >}}", "Playing Video error: index out of range for positional param at position 1", wt)
+	CheckShortCodeMatch(t, "{{< video 47238zzb >}}", "Playing Video Missing", wt)
 }
 
 // some repro issues for panics in Go Fuzz testing


### PR DESCRIPTION
Return empty string instead of crashing when a positional parameter is missing. See discussions in #4619 and [on the forums](https://discourse.gohugo.io/t/optional-shortcode-parameters-conditional-variables-assignment/).

Also, the first commit in the PR is about fixing the function signature which was mentioning `Get` function instead of `.Get`.