### PR TITLE
commands: Do not show empty BuildDate in version

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -45,7 +45,11 @@ func newVersionCmd() *versionCmd {
 
 func printHugoVersion() {
 	if hugolib.CommitHash == "" {
-		jww.FEEDBACK.Printf("Hugo Static Site Generator v%s %s/%s BuildDate: %s\n", helpers.CurrentHugoVersion, runtime.GOOS, runtime.GOARCH, hugolib.BuildDate)
+		if hugolib.BuildDate == "" {
+			jww.FEEDBACK.Printf("Hugo Static Site Generator v%s %s/%s\n", helpers.CurrentHugoVersion, runtime.GOOS, runtime.GOARCH)
+		} else {
+			jww.FEEDBACK.Printf("Hugo Static Site Generator v%s %s/%s BuildDate: %s\n", helpers.CurrentHugoVersion, runtime.GOOS, runtime.GOARCH, hugolib.BuildDate)
+		}
 	} else {
 		jww.FEEDBACK.Printf("Hugo Static Site Generator v%s-%s %s/%s BuildDate: %s\n", helpers.CurrentHugoVersion, strings.ToUpper(hugolib.CommitHash), runtime.GOOS, runtime.GOARCH, hugolib.BuildDate)
 	}


### PR DESCRIPTION
When hugo is not compiled with Mage, or when hugo is compiled without manually setting the appropriate `-ldflags`, `hugo version` returns a version string with an empty BuildDate.

For example, the current Hugo brew on macOS returns the following version:

    Hugo Static Site Generator v0.40.1 darwin/amd64 BuildDate:

where the empty `BuildDate:` is unsettling to me, and probably to others too.

That unsettling feeling finally motivated me to fix the problem in a "reproducible" way (honouring `SOURCE_DATE_EPOCH`) in the Debian/Ubuntu package a while ago:

* https://salsa.debian.org/go-team/packages/hugo/commit/8e6ef376510873e75e5e07b11b38b681447535b8

However, despite our best effort, some users or downstream packagers are just not going to use `mage` or to set the proper `-ldflags`, sometimes due to their packaging policy, see Homebrew/homebrew-core#27106 for example.  In cases like this, maybe it is better just to show:

    Hugo Static Site Generator v0.40.1 darwin/amd64

lest the end user may mistakenly think the empty `BuildDate: ` were a Hugo bug.