### PR TITLE
hugolib: Use double quotes instead of back quotes in timeout warning

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -305,7 +305,7 @@ func (p *Page) initContent() {
 
 		select {
 		case <-ctx.Done():
-			p.s.Log.WARN.Printf(`WARNING: Timed out creating content for page %q (.Content will be empty). This is most likely a circular shortcode content loop that should be fixed. If this is just a shortcode calling a slow remote service, try to set "timeout=20000" (or higher, value is in milliseconds) in config.toml.\n`, p.pathOrTitle())
+			p.s.Log.WARN.Printf("WARNING: Timed out creating content for page %q (.Content will be empty). This is most likely a circular shortcode content loop that should be fixed. If this is just a shortcode calling a slow remote service, try to set \"timeout=20000\" (or higher, value is in milliseconds) in config.toml.\n", p.pathOrTitle())
 		case err := <-c:
 			if err != nil {
 				p.s.Log.ERROR.Println(err)


### PR DESCRIPTION
A very trivial pull request: I was seeing an extra `\n` at the end of the warning message after adding `Logger: newWarningLogger()` (an excellent suggestion, by the way, thanks @ bep!   See #4672)

```
=== RUN   TestPageBundlerSiteRegular/ugly=false
...
WARN 2018/04/26 20:10:29 WARNING: Timed out creating content for page
"b/my-bundle/index.md" (.Content will be empty). This is most likely a circular
shortcode content loop that should be fixed. If this is just a shortcode calling
a slow remote service, try to set "timeout=20000" (or higher, value is in milliseconds)
in config.toml.\n
...
```

Thanks!