### PR TITLE
Fix .WordCount, .FuzzyWordCount, .ReadingTime when summary marker is set

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -493,7 +493,10 @@ func totalWordsOld(s string) int {
 }
 
 // TruncateWordsByRune truncates words by runes.
-func (c *ContentSpec) TruncateWordsByRune(words []string) (string, bool) {
+func (c *ContentSpec) TruncateWordsByRune(in []string) (string, bool) {
+	words := make([]string, len(in))
+	copy(words, in)
+
 	count := 0
 	for index, word := range words {
 		if count >= c.summaryLength {

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -982,22 +982,33 @@ func (p *Page) ReadFrom(buf io.Reader) (int64, error) {
 }
 
 func (p *Page) WordCount() int {
-	p.analyzePage()
+	p.initContentPlainAndMeta()
 	return p.wordCount
 }
 
 func (p *Page) ReadingTime() int {
-	p.analyzePage()
+	p.initContentPlainAndMeta()
 	return p.readingTime
 }
 
 func (p *Page) FuzzyWordCount() int {
-	p.analyzePage()
+	p.initContentPlainAndMeta()
 	return p.fuzzyWordCount
 }
 
-func (p *Page) analyzePage() {
+func (p *Page) initContentPlainAndMeta() {
 	p.initContent()
+	p.initPlain(true)
+	p.initPlainWords(true)
+	p.initMeta()
+}
+
+func (p *Page) initContentAndMeta() {
+	p.initContent()
+	p.initMeta()
+}
+
+func (p *Page) initMeta() {
 	p.pageMetaInit.Do(func() {
 		if p.isCJKLanguage {
 			p.wordCount = 0


### PR DESCRIPTION
This bug was introduced in Hugo 0.40. It is when you use the `<!--more-->` summary marker.

Note that this affects the word stats only. The related `PlainWords`, `Plain`, `Content` all return correct values.

Fixes #4675