### PR TITLE
Show site build warning in TestPageBundlerSiteRegular

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -45,7 +45,11 @@ func newVersionCmd() *versionCmd {
 
 func printHugoVersion() {
 	if hugolib.CommitHash == "" {
-		jww.FEEDBACK.Printf("Hugo Static Site Generator v%s %s/%s BuildDate: %s\n", helpers.CurrentHugoVersion, runtime.GOOS, runtime.GOARCH, hugolib.BuildDate)
+		if hugolib.BuildDate == "" {
+			jww.FEEDBACK.Printf("Hugo Static Site Generator v%s %s/%s\n", helpers.CurrentHugoVersion, runtime.GOOS, runtime.GOARCH)
+		} else {
+			jww.FEEDBACK.Printf("Hugo Static Site Generator v%s %s/%s BuildDate: %s\n", helpers.CurrentHugoVersion, runtime.GOOS, runtime.GOARCH, hugolib.BuildDate)
+		}
 	} else {
 		jww.FEEDBACK.Printf("Hugo Static Site Generator v%s-%s %s/%s BuildDate: %s\n", helpers.CurrentHugoVersion, strings.ToUpper(hugolib.CommitHash), runtime.GOOS, runtime.GOARCH, hugolib.BuildDate)
 	}

--- a/hugolib/page_bundler_test.go
+++ b/hugolib/page_bundler_test.go
@@ -75,7 +75,7 @@ func TestPageBundlerSiteRegular(t *testing.T) {
 
 				cfg.Set("uglyURLs", ugly)
 
-				s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{})
+				s := buildSingleSite(t, deps.DepsCfg{Logger: newWarningLogger(), Fs: fs, Cfg: cfg}, BuildCfg{})
 
 				th := testHelper{s.Cfg, s.Fs, t}
 


### PR DESCRIPTION
So that a timeout warning does appear if it does happen
especially on a slow machine with soft floating-point CPU.

Special thanks to @bep for the solution.

See #4672