### PR TITLE
Improve markup determination logic

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -729,8 +729,7 @@ func replaceDivider(content, from, to []byte) ([]byte, bool) {
 // rendering engines.
 func (p *Page) replaceDivider(content []byte) []byte {
 	summaryDivider := helpers.SummaryDivider
-	// TODO(bep) handle better.
-	if p.Ext() == "org" || p.Markup == "org" {
+	if p.Markup == "org" {
 		summaryDivider = []byte("# more")
 	}
 
@@ -864,7 +863,7 @@ func (p *Page) setAutoSummary() error {
 
 func (p *Page) renderContent(content []byte) []byte {
 	return p.s.ContentSpec.RenderBytes(&helpers.RenderingContext{
-		Content: content, RenderTOC: true, PageFmt: p.determineMarkupType(),
+		Content: content, RenderTOC: true, PageFmt: p.Markup,
 		Cfg:        p.Language(),
 		DocumentID: p.UniqueID(), DocumentName: p.Path(),
 		Config: p.getRenderingConfig()})
@@ -1469,6 +1468,13 @@ func (p *Page) update(frontmatter map[string]interface{}) error {
 		}
 	}
 
+	// Try markup explicitly set in the frontmatter
+	p.Markup = helpers.GuessType(p.Markup)
+	if p.Markup == "unknown" {
+		// Fall back to file extension (might also return "unknown")
+		p.Markup = helpers.GuessType(p.Source.Ext())
+	}
+
 	if draft != nil && published != nil {
 		p.Draft = *draft
 		p.s.Log.ERROR.Printf("page %s has both draft and published settings in its frontmatter. Using draft.", p.File.Path())
@@ -1706,17 +1712,6 @@ func (p *Page) Menus() PageMenus {
 func (p *Page) shouldRenderTo(f output.Format) bool {
 	_, found := p.outputFormats.GetByName(f.Name)
 	return found
-}
-
-func (p *Page) determineMarkupType() string {
-	// Try markup explicitly set in the frontmatter
-	p.Markup = helpers.GuessType(p.Markup)
-	if p.Markup == "unknown" {
-		// Fall back to file extension (might also return "unknown")
-		p.Markup = helpers.GuessType(p.Source.Ext())
-	}
-
-	return p.Markup
 }
 
 func (p *Page) parse(reader io.Reader) error {

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -314,7 +314,8 @@ func renderShortcode(
 
 		if sc.doMarkup {
 			newInner := p.s.ContentSpec.RenderBytes(&helpers.RenderingContext{
-				Content: []byte(inner), PageFmt: p.determineMarkupType(),
+				Content:      []byte(inner),
+				PageFmt:      p.Markup,
 				Cfg:          p.Language(),
 				DocumentID:   p.UniqueID(),
 				DocumentName: p.Path(),
@@ -333,7 +334,7 @@ func renderShortcode(
 			//     substitutions in <div>HUGOSHORTCODE-1</div> which prevents the
 			//     generation, but means that you can’t use shortcodes inside of
 			//     markdown structures itself (e.g., `[foo]({{% ref foo.md %}})`).
-			switch p.determineMarkupType() {
+			switch p.Markup {
 			case "unknown", "markdown":
 				if match, _ := regexp.MatchString(innerNewlineRegexp, inner); !match {
 					cleaner, err := regexp.Compile(innerCleanupRegexp)


### PR DESCRIPTION
Sets Page.markup earlier (as early as possible, when the page is loaded). Sets it once and only once, removing many redundant calls to determineMarkupType().

This kills a sleeping bug that was avoided by the parts of the code depending on this value making those redundant calls. I encountered this bug in my fork, which I could have fixed either by adding another redundant call or making the enclosed change.