### PR TITLE
Render *.xml files as XML (with <?xml … ?> header)

### DIFF
--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -163,8 +163,14 @@ func pageRenderer(s *Site, pages <-chan *Page, results chan<- error, wg *sync.Wa
 
 				s.Log.DEBUG.Printf("Render %s to %q with layouts %q", pageOutput.Kind, targetPath, layouts)
 
-				if err := s.renderAndWritePage(&s.PathSpec.ProcessingStats.Pages, "page "+pageOutput.FullFilePath(), targetPath, pageOutput, layouts...); err != nil {
-					results <- err
+				if strings.HasSuffix(targetPath, ".xml") {
+					if err := s.renderAndWriteXML(&s.PathSpec.ProcessingStats.Pages, "page "+pageOutput.FullFilePath(), targetPath, pageOutput, layouts...); err != nil {
+						results <- err
+					}
+				} else {
+					if err := s.renderAndWritePage(&s.PathSpec.ProcessingStats.Pages, "page "+pageOutput.FullFilePath(), targetPath, pageOutput, layouts...); err != nil {
+						results <- err
+					}
 				}
 
 				if pageOutput.IsNode() {


### PR DESCRIPTION
This is required to generate XML files with proper UTF-8 encoding.