### PR TITLE
Create SUPPORT.md

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,3 @@
+### Asking Support Questions
+
+We have an active [discussion forum](https://discourse.gohugo.io) where users and developers can ask questions. Please don't use the GitHub issue tracker to ask questions.


### PR DESCRIPTION
To help cut down on the number of general questions, it'd be good to add a `SUPPORT.md` to the `.github` folder.

A link to this would then be displayed automatically when a user opens a New Issue (https://github.com/gohugoio/hugo/issues/new).

To see an example of this take a look at: https://github.com/twbs/bootstrap/issues/new