### PR TITLE
Do not return error on .Get "class" and vice versa in shortcodes

### DIFF
--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -85,7 +85,10 @@ func (scp *ShortcodeWithPage) Get(key interface{}) interface{} {
 	switch key.(type) {
 	case int64, int32, int16, int8, int:
 		if reflect.TypeOf(scp.Params).Kind() == reflect.Map {
-			return "error: cannot access named params by position"
+			// We treat this as a non error, so people can do similar to
+			// {{ $myParam := .Get "myParam" | default .Get 0 }}
+			// Without having to do additional checks.
+			return nil
 		} else if reflect.TypeOf(scp.Params).Kind() == reflect.Slice {
 			idx := int(reflect.ValueOf(key).Int())
 			ln := reflect.ValueOf(scp.Params).Len()
@@ -101,10 +104,10 @@ func (scp *ShortcodeWithPage) Get(key interface{}) interface{} {
 				return ""
 			}
 		} else if reflect.TypeOf(scp.Params).Kind() == reflect.Slice {
-			if reflect.ValueOf(scp.Params).Len() == 1 && reflect.ValueOf(scp.Params).Index(0).String() == "" {
-				return nil
-			}
-			return "error: cannot access positional params by string name"
+			// We treat this as a non error, so people can do similar to
+			// {{ $myParam := .Get "myParam" | default .Get 0 }}
+			// Without having to do additional checks.
+			return nil
 		}
 	}
 

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -185,17 +185,14 @@ func TestNestedNamedMissingParam(t *testing.T) {
 func TestIsNamedParamsSC(t *testing.T) {
 	t.Parallel()
 	wt := func(tem tpl.TemplateHandler) error {
-		tem.AddTemplate("_internal/shortcodes/byposition.html", `<div id="{{ .Get 0 }}">`)
-		tem.AddTemplate("_internal/shortcodes/byname.html", `<div id="{{ .Get "id" }}">`)
+		tem.AddTemplate("_internal/shortcodes/bynameorposition.html", `{{ with .Get "id" }}Named: {{ . }}{{ else }}Pos: {{ .Get 0 }}{{ end }}`)
 		tem.AddTemplate("_internal/shortcodes/ifnamedparams.html", `<div id="{{ if .IsNamedParams }}{{ .Get "id" }}{{ else }}{{ .Get 0 }}{{end}}">`)
 		return nil
 	}
 	CheckShortCodeMatch(t, `{{< ifnamedparams id="name" >}}`, `<div id="name">`, wt)
 	CheckShortCodeMatch(t, `{{< ifnamedparams position >}}`, `<div id="position">`, wt)
-	CheckShortCodeMatch(t, `{{< byname id="name" >}}`, `<div id="name">`, wt)
-	CheckShortCodeMatch(t, `{{< byname position >}}`, `<div id="error: cannot access positional params by string name">`, wt)
-	CheckShortCodeMatch(t, `{{< byposition position >}}`, `<div id="position">`, wt)
-	CheckShortCodeMatch(t, `{{< byposition id="name" >}}`, `<div id="error: cannot access named params by position">`, wt)
+	CheckShortCodeMatch(t, `{{< bynameorposition id="name" >}}`, `Named: name`, wt)
+	CheckShortCodeMatch(t, `{{< bynameorposition position >}}`, `Pos: position`, wt)
 }
 
 func TestInnerSC(t *testing.T) {


### PR DESCRIPTION
The current error handling makes parameter checking in shortcodes too verbose for no good reason.

Fixes #4745