### PR TITLE
Avoid ANSI character output on Windows

### DIFF
--- a/commands/helpers.go
+++ b/commands/helpers.go
@@ -23,13 +23,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	ansiEsc    = "\u001B"
-	clearLine  = "\r\033[K"
-	hideCursor = ansiEsc + "[?25l"
-	showCursor = ansiEsc + "[?25h"
-)
-
 type flagsToConfigHandler interface {
 	flagsToConfig(cfg config.Provider)
 }

--- a/commands/helpers_others.go
+++ b/commands/helpers_others.go
@@ -1,0 +1,23 @@
+// Copyright 2018 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package commands
+
+const (
+	ansiEsc    = "\u001B"
+	clearLine  = "\r\033[K"
+	hideCursor = ansiEsc + "[?25l"
+	showCursor = ansiEsc + "[?25h"
+)

--- a/commands/helpers_windows.go
+++ b/commands/helpers_windows.go
@@ -1,0 +1,23 @@
+// Copyright 2018 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package commands
+
+const (
+	ansiEsc    = ""
+	clearLine  = ""
+	hideCursor = ""
+	showCursor = ""
+)


### PR DESCRIPTION
Disables ANSI character output on Windows, which displays unprintable characters (see #4462).