### PR TITLE
Detect which thumb is loaded in youtube_simple

### DIFF
--- a/tpl/tplimpl/embedded/templates/shortcodes/__h_simple_assets.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/__h_simple_assets.html
@@ -3,19 +3,19 @@
 {{/* Only include once */}}
 {{  .Page.Scratch.Set "__h_simple_css" true }}
 <style>
-.__h_youtube, .s_youtube_simple {
+.__h_youtube {
    position: relative;padding-bottom: 56.23%;height: 0;
    overflow: hidden;
    max-width: 100%;
    background: #000;
    margin: 5px;
 }
-.__h_youtube img, .s_youtube_simple img {
+.__h_youtube img {
    min-width:100%;
    height:auto;
    color: #000;
 }
-.__h_youtube .play, .s_youtube_simple .play {
+.__h_youtube .play {
    height: 72px;
    width: 72px;
    left: 50%;

--- a/tpl/tplimpl/embedded/templates/shortcodes/__h_simple_assets.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/__h_simple_assets.html
@@ -3,19 +3,19 @@
 {{/* Only include once */}}
 {{  .Page.Scratch.Set "__h_simple_css" true }}
 <style>
-.__h_youtube {
+.__h_youtube, .s_youtube_simple {
    position: relative;padding-bottom: 56.23%;height: 0;
    overflow: hidden;
    max-width: 100%;
    background: #000;
    margin: 5px;
 }
-.__h_youtube img {
+.__h_youtube img, .s_youtube_simple img {
    min-width:100%;
    height:auto;
    color: #000;
 }
-.__h_youtube .play {
+.__h_youtube .play, .s_youtube_simple .play {
    height: 72px;
    width: 72px;
    left: 50%;

--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube_simple.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube_simple.html
@@ -8,8 +8,12 @@
 {{ end }}
 {{ $secondClass := "s_youtube_simple" }}
 {{ $divID := printf "%s_%d" $secondClass (add $.Ordinal 1) }}
+{{ $tb := printf "//i.ytimg.com/vi/%s/" $id }}
+{{ $mx := printf "%smaxresdefault.jpg" $tb }}
+{{ $hq := printf "%shqdefault.jpg" $tb }}
+{{ $dt := $mx | base64Encode }}
 <div class="{{ $secondClass }} {{ $class }}" id="{{ $divID }}">
 {{ $tb := printf "//i.ytimg.com/vi/%s/" $id }}
 <a href="//youtube.com/watch?v={{ $id | safeHTMLAttr }}" target="_blank">
-     <img src="{{ printf "%smaxresdefault.jpg" $tb }}" srcset="{{ printf "%shqdefault.jpg" $tb }} 1x {{ printf "%smaxresdefault.jpg" $tb }} 2x" alt="Video">
+     <img src="{{ if ne $dt "Ly9pLnl0aW1nLmNvbS92aS85TXpuSmR5T2xfRS9tYXhyZXNkZWZhdWx0LmpwZw=="}}{{ $mx }}{{ else }}{{ $hq }}{{ end }}" alt="Video">
 <div class="play"><svg height="100%" version="1.1" viewBox="0 0 68 48" width="100%"><path class="ytp-large-play-button-bg" d="{{ template "__h_simple_icon_play" $ }}" fill="#212121" fill-opacity="0.8"></path><path d="M 45,24 27,14 27,34" fill="#fff"></path></svg></div></a></div>


### PR DESCRIPTION
Added the `base64Encode` func to detect the contents of `maxresdefault.jpg` because of the way YouTube handles thumbnails for low res videos.

If the base64 value is `Ly9pLnl0aW1nLmNvbS92aS85TXpuSmR5T2xfRS9tYXhyZXNkZWZhdWx0LmpwZw==` load the low res `hqdefault.jpg` thumb instead. 

~~~Also edited the CSS to include the styles for the low res videos.~~~

Fixes https://github.com/gohugoio/hugo/issues/4755