### PR TITLE
Add instagram_simple shortcode

### DIFF
--- a/config/privacy/privacyConfig.go
+++ b/config/privacy/privacyConfig.go
@@ -53,6 +53,10 @@ type GoogleAnalytics struct {
 // Instagram holds the privacy configuration settings related to the Instagram shortcode.
 type Instagram struct {
 	Service `mapstructure:",squash"`
+
+	// If simple mode is enabled, a static and no-JS version of the Instagram
+	// image card will be built.
+	Simple bool
 }
 
 // SpeakerDeck holds the privacy configuration settings related to the SpeakerDeck shortcode.

--- a/config/privacy/privacyConfig_test.go
+++ b/config/privacy/privacyConfig_test.go
@@ -36,6 +36,7 @@ disable = true
 respectDoNotTrack = true
 [privacy.instagram]
 disable = true
+simple = true
 [privacy.speakerDeck]
 disable = true
 [privacy.tweet]
@@ -45,6 +46,7 @@ disable = true
 [privacy.youtube]
 disable = true
 privacyEnhanced = true
+simple = true
 `
 	cfg, err := config.FromConfigString(tomlConfig, "toml")
 	assert.NoError(err)
@@ -57,12 +59,14 @@ privacyEnhanced = true
 	assert.True(pc.GoogleAnalytics.Disable)
 	assert.True(pc.GoogleAnalytics.RespectDoNotTrack)
 	assert.True(pc.Instagram.Disable)
+	assert.True(pc.Instagram.Simple)
 	assert.True(pc.SpeakerDeck.Disable)
 	assert.True(pc.Tweet.Disable)
 	assert.True(pc.Vimeo.Disable)
 
 	assert.True(pc.YouTube.PrivacyEnhanced)
 	assert.True(pc.YouTube.Disable)
+	assert.True(pc.YouTube.Simple)
 }
 
 func TestDecodeConfigFromTOMLCaseInsensitive(t *testing.T) {

--- a/config/services/servicesConfig.go
+++ b/config/services/servicesConfig.go
@@ -29,6 +29,7 @@ const (
 type Config struct {
 	Disqus          Disqus
 	GoogleAnalytics GoogleAnalytics
+	Instagram       Instagram
 }
 
 // Disqus holds the functional configuration settings related to the Disqus template.
@@ -41,6 +42,14 @@ type Disqus struct {
 type GoogleAnalytics struct {
 	// The GA tracking ID.
 	ID string
+}
+
+// Instagram holds the functional configuration settings related to the Instagram shortcodes.
+type Instagram struct {
+	// The Simple variant of the Instagram is decorated with Bootstrap 4 card classes.
+	// This means that if you use Bootstrap 4 or want to provide your own CSS, you want
+	// to disable the inline CSS provided by Hugo.
+	DisableInlineCSS bool
 }
 
 func DecodeConfig(cfg config.Provider) (c Config, err error) {

--- a/config/services/servicesConfig_test.go
+++ b/config/services/servicesConfig_test.go
@@ -33,6 +33,8 @@ someOtherValue = "foo"
 shortname = "DS"
 [services.googleAnalytics]
 id = "ga_id"
+[services.instagram]
+disableInlineCSS = true
 `
 	cfg, err := config.FromConfigString(tomlConfig, "toml")
 	assert.NoError(err)
@@ -44,6 +46,7 @@ id = "ga_id"
 	assert.Equal("DS", config.Disqus.Shortname)
 	assert.Equal("ga_id", config.GoogleAnalytics.ID)
 
+	assert.True(config.Instagram.DisableInlineCSS)
 }
 
 // Support old root-level GA settings etc.

--- a/tpl/tplimpl/embedded/templates/shortcodes/__h_simple_assets.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/__h_simple_assets.html
@@ -1,4 +1,5 @@
-{{ define "__h_simple_css" }}{{/* This is also used in other "simple" variants. These template definitions are global. */}}
+{{ define "__h_simple_css" }}{{/* These template definitions are global. */}}
+{{/* TODO(bep) rename this to Youtube something. We need to add these per service. */}}
 {{ if not (.Page.Scratch.Get "__h_simple_css") }}
 {{/* Only include once */}}
 {{  .Page.Scratch.Set "__h_simple_css" true }}

--- a/tpl/tplimpl/embedded/templates/shortcodes/instagram.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/instagram.html
@@ -1,4 +1,10 @@
 {{- $pc := .Page.Site.Config.Privacy.Instagram -}}
 {{- if not $pc.Disable -}}
-{{ if len .Params | eq 2 }}{{ if eq (.Get 1) "hidecaption" }}{{ with getJSON "https://api.instagram.com/oembed/?url=https://instagram.com/p/" (index .Params 0) "/&hidecaption=1" }}{{ .html | safeHTML }}{{ end }}{{ end }}{{ else }}{{ with getJSON "https://api.instagram.com/oembed/?url=https://instagram.com/p/" (index .Params 0) "/&hidecaption=0" }}{{ .html | safeHTML }}{{ end }}{{ end }}
+{{- if $pc.Simple -}}
+{{ template "_internal/shortcodes/instagram_simple.html" . }}
+{{- else -}}
+{{ $id := .Get 0 }}
+{{ $hideCaption := cond (eq (.Get 1) "hidecaption") "1" "0" }}
+{{ with getJSON "https://api.instagram.com/oembed/?url=https://instagram.com/p/" $id "/&hidecaption=" $hideCaption  }}{{ .html | safeHTML }}{{ end }}
+{{- end -}}
 {{- end -}}

--- a/tpl/tplimpl/embedded/templates/shortcodes/instagram_simple.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/instagram_simple.html
@@ -1,0 +1,48 @@
+{{- $pc := .Page.Site.Config.Privacy.Instagram -}}
+{{- $sc := .Page.Site.Config.Services.Instagram -}}
+{{- if not $pc.Disable -}}
+{{- $id := .Get 0 -}}
+{{- $item := getJSON "https://api.instagram.com/oembed/?url=https://www.instagram.com/p/" $id "/&amp;maxwidth=640&amp;omitscript=true" -}}
+{{- $class1 := "__h_instagram" -}}
+{{- $class2 := "s_instagram_simple" -}}
+{{- $hideCaption := (eq (.Get 1) "hidecaption") -}}
+{{ with $item }}
+{{- $mediaURL := printf "https://instagram.com/p/%s/" $id | safeURL -}}
+{{- if not $sc.DisableInlineCSS -}}
+{{ template "__h_simple_instagram_css" $ }}
+{{- end -}}
+<div class="{{ $class1 }} {{ $class2 }} card" style="max-width: {{ $item.thumbnail_width }}px">
+	<div class="card-header">
+    <a href="{{ $item.author_url | safeURL }}" class="card-link">{{ $item.author_name }}</a>
+  </div>
+	<a href="{{ $mediaURL }}" target="_blank"><img class="card-img-top img-fluid" src="{{ $item.thumbnail_url }}" width="{{ $item.thumbnail_width }}"  height="{{ $item.thumbnail_height }}" alt="Instagram Image"></a>
+	<div class="card-body">
+		{{ if not $hideCaption }}<p class="card-text"><a href="{{ $item.author_url | safeURL }}" class="card-link">{{ $item.author_name }}</a> {{ $item.title}}</p>{{ end }}
+		<a href="{{ $item.author_url | safeURL }}" class="card-link">Vew More on Instagram</a>
+	</div>
+</div>
+{{ end }}
+{{- end -}}
+
+{{ define "__h_simple_instagram_css" }}
+{{ if not (.Page.Scratch.Get "__h_simple_instagram_css") }}
+{{/* Only include once */}}
+{{  .Page.Scratch.Set "__h_simple_instagram_css" true }}
+<style type="text/css">
+   .__h_instagram.card {
+   	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+   	font-size: 14px;
+      border: 1px solid rgb(219, 219, 219);
+      padding: 0;
+      margin: 0;
+   }
+   .__h_instagram.card .card-header, .__h_instagram.card .card-body {
+      padding: 10px 10px 10px;
+   }
+   .__h_instagram.card img {
+      width: 100%;
+    	height: auto;
+   }
+</style>
+{{ end }}
+{{ end }}


### PR DESCRIPTION
See it in action:

http://hugotest.bep.is/scodes/embedded-unstyled/
http://hugotest.bep.is/scodes/embedded/

Source test repo:

https://github.com/bep/hugotest

Note that how it looks depends on the current site configuration.

I have added a flag to turn off inline styling, that I think we want to make a pattern.

* Use Bootstrap 4 markup where possible
* Provide inline styles that looks OK, but can be turned off

Fixes #4748