### PR TITLE
Remove unneeded 'chrome=1' X-UA-Compatible meta tag

### DIFF
--- a/docs/themes/gohugoioTheme/layouts/_default/baseof.html
+++ b/docs/themes/gohugoioTheme/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
     <link rel="preload" href="{{ "files/muli-latin-400.woff2" | absURL }}" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="{{ "files/muli-latin-800.woff2" | absURL }}" as="font" type="font/woff2" crossorigin>
 
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
      {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
     <title>{{ block "title" . }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
     <meta name="HandheldFriendly" content="True">

--- a/examples/blog/layouts/partials/meta.html
+++ b/examples/blog/layouts/partials/meta.html
@@ -1,6 +1,6 @@
 
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{{ .Description }}">
     <meta name="author" content="A Hugo User"> <!-- This should be modified to be your name, if you want to include this information -->


### PR DESCRIPTION
This was only ever needed for a really old Chromeframe plugin for old IE and was discontinued by Google long ago.