### PR TITLE
Add no-cookie variants of the Google Analytics templates

### DIFF
--- a/config/privacy/privacyConfig.go
+++ b/config/privacy/privacyConfig.go
@@ -45,6 +45,9 @@ type Disqus struct {
 type GoogleAnalytics struct {
 	Service `mapstructure:",squash"`
 
+	// Enabling this will disable the use of Cookies and use Session Storage to Store the GA Client ID.
+	UseSessionStorage bool
+
 	// Enabling this will make the GA templates respect the
 	// "Do Not Track" HTTP header. See  https://www.paulfurley.com/google-analytics-dnt/.
 	RespectDoNotTrack bool

--- a/config/privacy/privacyConfig_test.go
+++ b/config/privacy/privacyConfig_test.go
@@ -35,6 +35,7 @@ disable = true
 disable = true
 respectDoNotTrack = true
 anonymizeIP = true
+useSessionStorage = true
 [privacy.instagram]
 disable = true
 simple = true
@@ -61,6 +62,7 @@ simple = true
 	assert.True(pc.GoogleAnalytics.Disable)
 	assert.True(pc.GoogleAnalytics.RespectDoNotTrack)
 	assert.True(pc.GoogleAnalytics.AnonymizeIP)
+	assert.True(pc.GoogleAnalytics.UseSessionStorage)
 	assert.True(pc.Instagram.Disable)
 	assert.True(pc.Instagram.Simple)
 	assert.True(pc.SpeakerDeck.Disable)

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -109,7 +109,20 @@ if (!doNotTrack) {
 	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	{{- if $pc.UseSessionStorage }}
+	if (window.sessionStorage) {
+		var GA_SESSION_STORAGE_KEY = 'ga:clientId';
+		ga('create', '{{ . }}', {
+	    'storage': 'none',
+	    'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+	   });
+	   ga(function(tracker) {
+	    sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
+	   });
+   }
+	{{ else }}
 	ga('create', '{{ . }}', 'auto');
+	{{ end -}}
 	ga('send', 'pageview');
 	{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end -}}
 }
@@ -132,7 +145,20 @@ var doNotTrack = (dnt == "1" || dnt == "yes");
 {{ template "__ga_js_set_doNotTrack" $ }}
 if (!doNotTrack) {
 	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	{{- if $pc.UseSessionStorage }}
+	if (window.sessionStorage) {
+		var GA_SESSION_STORAGE_KEY = 'ga:clientId';
+		ga('create', '{{ . }}', {
+	    'storage': 'none',
+	    'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+	   });
+	   ga(function(tracker) {
+	    sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
+	   });
+   }
+	{{ else }}
 	ga('create', '{{ . }}', 'auto');
+	{{ end -}}
 	ga('send', 'pageview');
 	{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end -}}
 }

--- a/tpl/tplimpl/embedded/templates/google_analytics.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics.html
@@ -8,7 +8,20 @@ if (!doNotTrack) {
 	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	{{- if $pc.UseSessionStorage }}
+	if (window.sessionStorage) {
+		var GA_SESSION_STORAGE_KEY = 'ga:clientId';
+		ga('create', '{{ . }}', {
+	    'storage': 'none',
+	    'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+	   });
+	   ga(function(tracker) {
+	    sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
+	   });
+   }
+	{{ else }}
 	ga('create', '{{ . }}', 'auto');
+	{{ end -}}
 	ga('send', 'pageview');
 	{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end -}}
 }

--- a/tpl/tplimpl/embedded/templates/google_analytics_async.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics_async.html
@@ -5,7 +5,20 @@
 {{ template "__ga_js_set_doNotTrack" $ }}
 if (!doNotTrack) {
 	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	{{- if $pc.UseSessionStorage }}
+	if (window.sessionStorage) {
+		var GA_SESSION_STORAGE_KEY = 'ga:clientId';
+		ga('create', '{{ . }}', {
+	    'storage': 'none',
+	    'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+	   });
+	   ga(function(tracker) {
+	    sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
+	   });
+   }
+	{{ else }}
 	ga('create', '{{ . }}', 'auto');
+	{{ end -}}
 	ga('send', 'pageview');
 	{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end -}}
 }


### PR DESCRIPTION
The current full set of options for GA is now:

```toml
[privacy]
[privacy.googleAnalytics]
disable = false
respectDoNotTrack = true
anonymizeIP = true
useSessionStorage = true
```

Fixes #4775