### PR TITLE
Enhance Page and Resource String() methods

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -2013,7 +2013,11 @@ func (p *Page) RelRef(refs ...string) (string, error) {
 }
 
 func (p *Page) String() string {
+	if p.Path() != "" {
+		return fmt.Sprintf("Page(%s)", p.Path())
+	}
 	return fmt.Sprintf("Page(%q)", p.title)
+
 }
 
 // Scratch returns the writable context associated with this Page.

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -419,8 +419,6 @@ type genericResource struct {
 	// The relative path to this resource.
 	relTargetPath dirFile
 
-	file string
-
 	// Base is set when the output format's path has a offset, e.g. for AMP.
 	base string
 
@@ -552,6 +550,10 @@ func (l *genericResource) ResourceType() string {
 
 func (l *genericResource) AbsSourceFilename() string {
 	return l.sourceFilename
+}
+
+func (l *genericResource) String() string {
+	return fmt.Sprintf("Resource(%s: %s)", l.resourceType, l.name)
 }
 
 func (l *genericResource) Publish() error {


### PR DESCRIPTION
Updated `Page.String()`: There are many cases where a Page has no title. Also it's path is a better identifier since it is unique. 

Added `Resource.String()`: facilitates debugging

Removed unused `genericResource.file` field.
