### PR TITLE
Add a BlackFriday option for rel="noreferrer" on external links

### DIFF
--- a/docs/content/en/readfiles/bfconfig.md
+++ b/docs/content/en/readfiles/bfconfig.md
@@ -43,6 +43,11 @@
     Blackfriday flag: **`HTML_HREF_TARGET_BLANK`** <br>
     Purpose: `true` opens <s>external links</s> **absolute** links in a new window or tab. While the `target="_blank"` attribute is typically used for external links, Blackfriday does that for _all_ absolute links ([ref](https://discourse.gohugo.io/t/internal-links-in-same-tab-external-links-in-new-tab/11048/8)). One needs to make note of this if they use absolute links throughout, for internal links too (for example, by setting `canonifyURLs` to `true` or via `absURL`).
 
+`noreferrerLinks`
+: default: **`false`** <br>
+    Blackfriday flag: **`HTML_NOREFERRER_LINKS`** <br>
+    Purpose: `true` creates <s>external links</s> **absolute** links with `noreferrer` being added to their `rel` attribute. Thus when following the link no referrer information will be leaked. While the `rel="noreferrer"` attribute is typically used for external links, Blackfriday does that for _all_ absolute links. One needs to make note of this if they use absolute links throughout, for internal links too (for example, by setting `canonifyURLs` to `true` or via `absURL`).
+
 `plainIDAnchors`
 : default **`true`** <br>
     Blackfriday flag: **`FootnoteAnchorPrefix` and `HeaderIDSuffix`** <br>

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -108,6 +108,7 @@ type BlackFriday struct {
 	AngledQuotes          bool
 	Fractions             bool
 	HrefTargetBlank       bool
+	NoreferrerLinks       bool
 	SmartDashes           bool
 	LatexDashes           bool
 	TaskLists             bool
@@ -124,6 +125,7 @@ func newBlackfriday(config map[string]interface{}) *BlackFriday {
 		"smartypantsQuotesNBSP": false,
 		"fractions":             true,
 		"hrefTargetBlank":       false,
+		"noreferrerLinks":       false,
 		"smartDashes":           true,
 		"latexDashes":           true,
 		"plainIDAnchors":        true,
@@ -275,6 +277,10 @@ func (c *ContentSpec) getHTMLRenderer(defaultFlags int, ctx *RenderingContext) b
 
 	if ctx.Config.HrefTargetBlank {
 		htmlFlags |= blackfriday.HTML_HREF_TARGET_BLANK
+	}
+
+	if ctx.Config.NoreferrerLinks {
+		htmlFlags |= blackfriday.HTML_NOREFERRER_LINKS
 	}
 
 	if ctx.Config.SmartDashes {

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -204,6 +204,7 @@ func TestGetHTMLRendererAllFlags(t *testing.T) {
 		{blackfriday.HTML_SMARTYPANTS_ANGLED_QUOTES},
 		{blackfriday.HTML_SMARTYPANTS_FRACTIONS},
 		{blackfriday.HTML_HREF_TARGET_BLANK},
+		{blackfriday.HTML_NOREFERRER_LINKS},
 		{blackfriday.HTML_SMARTYPANTS_DASHES},
 		{blackfriday.HTML_SMARTYPANTS_LATEX_DASHES},
 	}
@@ -212,6 +213,7 @@ func TestGetHTMLRendererAllFlags(t *testing.T) {
 	ctx.Config.AngledQuotes = true
 	ctx.Config.Fractions = true
 	ctx.Config.HrefTargetBlank = true
+	ctx.Config.NoreferrerLinks = true
 	ctx.Config.LatexDashes = true
 	ctx.Config.PlainIDAnchors = true
 	ctx.Config.SmartDashes = true


### PR DESCRIPTION
Add a configuration option "noreferrerLinks". When set to "true" the "HTML_NOREFERRER_LINKS" flag is being passed to Blackfriday. Thereby all *absolute* links will get a "noreferrer" value for their "rel" attribute.

See #4722