### PR TITLE
Add a BlackFriday option for rel="noreferrer" on external links

### DIFF
--- a/docs/content/en/readfiles/bfconfig.md
+++ b/docs/content/en/readfiles/bfconfig.md
@@ -48,6 +48,11 @@
     Blackfriday flag: **`HTML_NOFOLLOW_LINKS`** <br>
     Purpose: `true` creates <s>external links</s> **absolute** links with `nofollow` being added to their `rel` attribute. Thereby crawlers are advised to not follow the link. While the `rel="nofollow"` attribute is typically used for external links, Blackfriday does that for _all_ absolute links. One needs to make note of this if they use absolute links throughout, for internal links too (for example, by setting `canonifyURLs` to `true` or via `absURL`).
 
+`noreferrerLinks`
+: default: **`false`** <br>
+    Blackfriday flag: **`HTML_NOREFERRER_LINKS`** <br>
+    Purpose: `true` creates <s>external links</s> **absolute** links with `noreferrer` being added to their `rel` attribute. Thus when following the link no referrer information will be leaked. While the `rel="noreferrer"` attribute is typically used for external links, Blackfriday does that for _all_ absolute links. One needs to make note of this if they use absolute links throughout, for internal links too (for example, by setting `canonifyURLs` to `true` or via `absURL`).
+
 `plainIDAnchors`
 : default **`true`** <br>
     Blackfriday flag: **`FootnoteAnchorPrefix` and `HeaderIDSuffix`** <br>

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -109,6 +109,7 @@ type BlackFriday struct {
 	Fractions             bool
 	HrefTargetBlank       bool
 	NofollowLinks         bool
+	NoreferrerLinks       bool
 	SmartDashes           bool
 	LatexDashes           bool
 	TaskLists             bool
@@ -126,6 +127,7 @@ func newBlackfriday(config map[string]interface{}) *BlackFriday {
 		"fractions":             true,
 		"hrefTargetBlank":       false,
 		"nofollowLinks":         false,
+		"noreferrerLinks":       false,
 		"smartDashes":           true,
 		"latexDashes":           true,
 		"plainIDAnchors":        true,
@@ -281,6 +283,10 @@ func (c *ContentSpec) getHTMLRenderer(defaultFlags int, ctx *RenderingContext) b
 
 	if ctx.Config.NofollowLinks {
 		htmlFlags |= blackfriday.HTML_NOFOLLOW_LINKS
+	}
+
+	if ctx.Config.NoreferrerLinks {
+		htmlFlags |= blackfriday.HTML_NOREFERRER_LINKS
 	}
 
 	if ctx.Config.SmartDashes {

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -205,6 +205,7 @@ func TestGetHTMLRendererAllFlags(t *testing.T) {
 		{blackfriday.HTML_SMARTYPANTS_FRACTIONS},
 		{blackfriday.HTML_HREF_TARGET_BLANK},
 		{blackfriday.HTML_NOFOLLOW_LINKS},
+		{blackfriday.HTML_NOREFERRER_LINKS},
 		{blackfriday.HTML_SMARTYPANTS_DASHES},
 		{blackfriday.HTML_SMARTYPANTS_LATEX_DASHES},
 	}
@@ -214,6 +215,7 @@ func TestGetHTMLRendererAllFlags(t *testing.T) {
 	ctx.Config.Fractions = true
 	ctx.Config.HrefTargetBlank = true
 	ctx.Config.NofollowLinks = true
+	ctx.Config.NoreferrerLinks = true
 	ctx.Config.LatexDashes = true
 	ctx.Config.PlainIDAnchors = true
 	ctx.Config.SmartDashes = true


### PR DESCRIPTION
Add a configuration option "noreferrerLinks". When set to "true" the "HTML_NOREFERRER_LINKS" flag is being passed to Blackfriday. Thereby all *absolute* links will get a "noreferrer" value for their "rel" attribute.

See #4722