### PR TITLE
Add PreprocessedContent

### DIFF
--- a/docs/content/en/templates/output-formats.md
+++ b/docs/content/en/templates/output-formats.md
@@ -68,7 +68,7 @@ Given a media type and some additional configuration, you get an **Output Format
 
 This is the full set of Hugo's built-in output formats:
 
-{{< datatable "output" "formats" "name" "mediaType" "path" "baseName" "rel" "protocol" "isPlainText" "isHTML" "noUgly">}}
+{{< datatable "output" "formats" "name" "mediaType" "path" "baseName" "rel" "protocol" "isPlainText" "isHTML" "noUgly" "noRender">}}
 
 * A page can be output in as many output formats as you want, and you can have an infinite amount of output formats defined **as long as they resolve to a unique path on the file system**. In the above table, the best example of this is `AMP` vs. `HTML`. `AMP` has the value `amp` for `Path` so it doesn't overwrite the `HTML` version; e.g. we can now have both `/index.html` and `/amp/index.html`.
 * The `MediaType` must match the `Type` of an already defined media type.
@@ -82,6 +82,7 @@ mediaType = "text/enriched"
 baseName = "myindex"
 isPlainText = true
 protocol = "bep://"
+parseMarkup = true
 {{</ code-toggle >}}
 
 The above example is fictional, but if used for the homepage on a site with `baseURL` `https://example.org`, it will produce a plain text homepage with the URL `bep://example.org/myindex.enr`.
@@ -119,6 +120,8 @@ The following is the full list of configuration options for output formats and t
 
 `notAlternative`
 : enable if it doesn't make sense to include this format in an `AlternativeOutputFormats` format listing on `Page` (e.g., with `CSS`). Note that we use the term *alternative* and not *alternate* here, as it does not necessarily replace the other format. **Default:** `false`.
+
+`noRender` : enable if the raw content  (Markdown, Emacs Org-Mode, Asciidoc, etc.) should not be rendered into HTML. 
 
 ## Output Formats for Pages
 

--- a/docs/data/docs.json
+++ b/docs/data/docs.json
@@ -1315,6 +1315,7 @@
         "isPlainText": false,
         "isHTML": true,
         "noUgly": false,
+        "noRender": false,
         "notAlternative": false
       },
       {
@@ -1335,6 +1336,7 @@
         "isPlainText": true,
         "isHTML": false,
         "noUgly": false,
+        "noRender": false,
         "notAlternative": true
       },
       {
@@ -1355,6 +1357,7 @@
         "isPlainText": true,
         "isHTML": false,
         "noUgly": false,
+        "noRender": false,
         "notAlternative": false
       },
       {
@@ -1375,6 +1378,7 @@
         "isPlainText": true,
         "isHTML": false,
         "noUgly": false,
+        "noRender": false,
         "notAlternative": false
       },
       {
@@ -1395,6 +1399,7 @@
         "isPlainText": false,
         "isHTML": true,
         "noUgly": false,
+        "noRender": false,
         "notAlternative": false
       },
       {
@@ -1415,6 +1420,7 @@
         "isPlainText": true,
         "isHTML": false,
         "noUgly": false,
+        "noRender": false,
         "notAlternative": false
       },
       {
@@ -1435,6 +1441,7 @@
         "isPlainText": true,
         "isHTML": false,
         "noUgly": false,
+        "noRender": false,
         "notAlternative": false
       },
       {
@@ -1455,6 +1462,7 @@
         "isPlainText": false,
         "isHTML": false,
         "noUgly": true,
+        "noRender": false,
         "notAlternative": false
       },
       {
@@ -1475,6 +1483,7 @@
         "isPlainText": false,
         "isHTML": false,
         "noUgly": true,
+        "noRender": false,
         "notAlternative": false
       }
     ],

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1259,7 +1259,7 @@ func (p *Page) prepareForRender() error {
 	s := p.s
 
 	// If we got this far it means that this is either a new Page pointer
-	// or a template or similar has changed so wee need to do a rerendering
+	// or a template or similar has changed so we need to do a rerendering
 	// of the shortcodes etc.
 
 	// If in watch mode or if we have multiple output formats,

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -577,6 +577,9 @@ func (p *Page) initPlain(lock bool) {
 	})
 }
 
+// PreprocessedContent returns the content after shortcodes have executed and
+// Emojification has been performed, but the content has not otherwise been
+// converted to HTML.
 func (p *Page) PreprocessedContent() []byte {
 	p.initContent()
 	p.initPreproc(true)

--- a/hugolib/page_bundler_handlers.go
+++ b/hugolib/page_bundler_handlers.go
@@ -284,6 +284,8 @@ func (c *contentHandlers) handlePageContent() contentHandler {
 		}
 
 		p.workContent = p.replaceDivider(p.workContent)
+		p.preproc = make([]byte, len(p.workContent))
+		copy(p.preproc, p.workContent)
 		p.workContent = p.renderContent(p.workContent)
 
 		tmpContent, tmpTableOfContents := helpers.ExtractTOC(p.workContent)

--- a/output/outputFormat.go
+++ b/output/outputFormat.go
@@ -64,6 +64,13 @@ type Format struct {
 	// Enable to ignore the global uglyURLs setting.
 	NoUgly bool `json:"noUgly"`
 
+	// NoRender determines whether the content for this format should be
+	// rendered into HTML. If true, the markup of the raw document (Markdown,
+	// Emacs Org-Mode, Asciidoc, etc.) will not be rendered, but passed through
+	// as the text document. Shortcodes and Emojification will still be applied.
+	// Defaults to false.
+	NoRender bool `json:noRender`
+
 	// Enable if it doesn't make sense to include this format in an alternative
 	// format listing, CSS being one good example.
 	// Note that we use the term "alternative" and not "alternate" here, as it

--- a/output/outputFormat.go
+++ b/output/outputFormat.go
@@ -69,7 +69,7 @@ type Format struct {
 	// Emacs Org-Mode, Asciidoc, etc.) will not be rendered, but passed through
 	// as the text document. Shortcodes and Emojification will still be applied.
 	// Defaults to false.
-	NoRender bool `json:noRender`
+	NoRender bool `json:"noRender"`
 
 	// Enable if it doesn't make sense to include this format in an alternative
 	// format listing, CSS being one good example.

--- a/output/outputFormat_test.go
+++ b/output/outputFormat_test.go
@@ -28,6 +28,7 @@ func TestDefaultTypes(t *testing.T) {
 	require.Empty(t, CalendarFormat.Path)
 	require.True(t, CalendarFormat.IsPlainText)
 	require.False(t, CalendarFormat.IsHTML)
+	require.False(t, CalendarFormat.NoRender)
 
 	require.Equal(t, "CSS", CSSFormat.Name)
 	require.Equal(t, media.CSSType, CSSFormat.MediaType)
@@ -35,6 +36,7 @@ func TestDefaultTypes(t *testing.T) {
 	require.Empty(t, CSSFormat.Protocol) // Will inherit the BaseURL protocol.
 	require.True(t, CSSFormat.IsPlainText)
 	require.False(t, CSSFormat.IsHTML)
+	require.False(t, CSSFormat.NoRender)
 
 	require.Equal(t, "CSV", CSVFormat.Name)
 	require.Equal(t, media.CSVType, CSVFormat.MediaType)
@@ -42,6 +44,7 @@ func TestDefaultTypes(t *testing.T) {
 	require.Empty(t, CSVFormat.Protocol)
 	require.True(t, CSVFormat.IsPlainText)
 	require.False(t, CSVFormat.IsHTML)
+	require.False(t, CSVFormat.NoRender)
 
 	require.Equal(t, "HTML", HTMLFormat.Name)
 	require.Equal(t, media.HTMLType, HTMLFormat.MediaType)
@@ -49,6 +52,7 @@ func TestDefaultTypes(t *testing.T) {
 	require.Empty(t, HTMLFormat.Protocol)
 	require.False(t, HTMLFormat.IsPlainText)
 	require.True(t, HTMLFormat.IsHTML)
+	require.False(t, HTMLFormat.NoRender)
 
 	require.Equal(t, "AMP", AMPFormat.Name)
 	require.Equal(t, media.HTMLType, AMPFormat.MediaType)
@@ -56,14 +60,15 @@ func TestDefaultTypes(t *testing.T) {
 	require.Empty(t, AMPFormat.Protocol)
 	require.False(t, AMPFormat.IsPlainText)
 	require.True(t, AMPFormat.IsHTML)
+	require.False(t, AMPFormat.NoRender)
 
 	require.Equal(t, "RSS", RSSFormat.Name)
 	require.Equal(t, media.RSSType, RSSFormat.MediaType)
 	require.Empty(t, RSSFormat.Path)
 	require.False(t, RSSFormat.IsPlainText)
 	require.True(t, RSSFormat.NoUgly)
-	require.False(t, CalendarFormat.IsHTML)
-
+	require.False(t, RSSFormat.IsHTML)
+	require.False(t, RSSFormat.NoRender)
 }
 
 func TestGetFormatByName(t *testing.T) {


### PR DESCRIPTION
I wanted a way to get out the raw markdown after it was preprocessed for shortcakes and Emoji and before it was converted to HTML. This will allow me to publish plain text content as the raw markdown, but with the shortcodes removed and replaced with content appropriate to a plain-text output. So I poked at the internals and figured out how to get it to do it, though I'm sure it's not as efficient or Hugo-ish as one might want. LMK if you'd like it done differently, and pointers for adding tests would also be appreciated.