### PR TITLE
WIP: Bibliography with Pandoc

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -455,14 +455,15 @@ func ExtractTOC(content []byte) (newcontent []byte, toc []byte) {
 // for a given content rendering.
 // By creating you must set the Config, otherwise it will panic.
 type RenderingContext struct {
-	Frontmatter  map[string]interface{}
-	Content      []byte
-	PageFmt      string
-	DocumentID   string
-	DocumentName string
-	Config       *BlackFriday
-	RenderTOC    bool
-	Cfg          config.Provider
+	Frontmatter    map[string]interface{}
+	FrontmatterRaw []byte
+	Content        []byte
+	PageFmt        string
+	DocumentID     string
+	DocumentName   string
+	Config         *BlackFriday
+	RenderTOC      bool
+	Cfg            config.Provider
 }
 
 // RenderBytes renders a []byte.
@@ -723,8 +724,8 @@ func getPandocContent(ctx *RenderingContext) []byte {
 	pathCiteproc, errCiteproc := exec.LookPath("pandoc-citeproc")
 	if errCiteproc == nil {
 		if bib, ok := ctx.Frontmatter["bibliography"].(string); ok {
-			args = append(args, "--bibliography", "content/"+bib)
-			jww.INFO.Println("Rendering bibliography ", bib, "with", pathCiteproc, "...")
+			args = append(args, "--filter", "pandoc-citeproc")
+			jww.INFO.Println("Rendering bibliography", bib, "with", pathCiteproc, "...")
 		}
 	}
 
@@ -739,7 +740,8 @@ func orgRender(ctx *RenderingContext, c ContentSpec) []byte {
 }
 
 func externallyRenderContent(ctx *RenderingContext, path string, args []string) []byte {
-	content := ctx.Content
+	content := ctx.FrontmatterRaw
+	content = append(content, ctx.Content...)
 	cleanContent := bytes.Replace(content, SummaryDivider, []byte(""), 1)
 
 	cmd := exec.Command(path, args...)

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -455,6 +455,7 @@ func ExtractTOC(content []byte) (newcontent []byte, toc []byte) {
 // for a given content rendering.
 // By creating you must set the Config, otherwise it will panic.
 type RenderingContext struct {
+	Frontmatter  map[string]interface{}
 	Content      []byte
 	PageFmt      string
 	DocumentID   string
@@ -715,7 +716,18 @@ func getPandocContent(ctx *RenderingContext) []byte {
 			"                 Leaving pandoc content unrendered.")
 		return ctx.Content
 	}
+
+	jww.INFO.Println("Rendering", ctx.DocumentName, "with", path, "...")
 	args := []string{"--mathjax"}
+
+	pathCiteproc, errCiteproc := exec.LookPath("pandoc-citeproc")
+	if errCiteproc == nil {
+		if bib, ok := ctx.Frontmatter["bibliography"].(string); ok {
+			args = append(args, "--bibliography", "content/"+bib)
+			jww.INFO.Println("Rendering bibliography ", bib, "with", pathCiteproc, "...")
+		}
+	}
+
 	return externallyRenderContent(ctx, path, args)
 }
 

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -877,7 +877,8 @@ func (p *Page) setAutoSummary() error {
 
 func (p *Page) renderContent(content []byte) []byte {
 	return p.s.ContentSpec.RenderBytes(&helpers.RenderingContext{
-		Content: content, RenderTOC: true, PageFmt: p.Markup,
+		Frontmatter: p.params,
+		Content:     content, RenderTOC: true, PageFmt: p.Markup,
 		Cfg:        p.Language(),
 		DocumentID: p.UniqueID(), DocumentName: p.Path(),
 		Config: p.getRenderingConfig()})

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -877,8 +877,9 @@ func (p *Page) setAutoSummary() error {
 
 func (p *Page) renderContent(content []byte) []byte {
 	return p.s.ContentSpec.RenderBytes(&helpers.RenderingContext{
-		Frontmatter: p.params,
-		Content:     content, RenderTOC: true, PageFmt: p.Markup,
+		Frontmatter:    p.params,
+		FrontmatterRaw: p.frontmatter,
+		Content:        content, RenderTOC: true, PageFmt: p.Markup,
 		Cfg:        p.Language(),
 		DocumentID: p.UniqueID(), DocumentName: p.Path(),
 		Config: p.getRenderingConfig()})


### PR DESCRIPTION
It would be very handy to generate bibliographies with Hugo, see #4060.

This PR adds two possible implementations (see each commit):

1. Pass frontmatter into the external helper and check for the `bibliography`-key and pass its value to Pandoc, passes CI ✅ 
2. Simply add the frontmatter into the processing of the content on the external helper. This allows for even more functionality such as creating full bibliographies without citing every entry (in frontmatter add: `nocite: '@*'`) but is obviously more intrusive; another option would be to create a dedicated frontmatter entry (e.g. `external-frontmatter`) and to pass just this. Does not pass CI at the moment 🔴 

What do you think?