### PR TITLE
Add twitter_simple

### DIFF
--- a/config/privacy/privacyConfig.go
+++ b/config/privacy/privacyConfig.go
@@ -77,6 +77,9 @@ type Twitter struct {
 	// When set to true, the Tweet and its embedded page on your site are not used
 	// for purposes that include personalized suggestions and personalized ads.
 	EnableDNT bool
+
+	// If simple mode is enabled, a static and no-JS version of the Tweet will be built.
+	Simple bool
 }
 
 // Vimeo holds the privacy configuration settingsrelated to the Vimeo shortcode.

--- a/config/privacy/privacyConfig_test.go
+++ b/config/privacy/privacyConfig_test.go
@@ -44,6 +44,7 @@ disable = true
 [privacy.twitter]
 disable = true
 enableDNT = true
+simple = true
 [privacy.vimeo]
 disable = true
 simple = true
@@ -69,6 +70,7 @@ simple = true
 	assert.True(pc.SpeakerDeck.Disable)
 	assert.True(pc.Twitter.Disable)
 	assert.True(pc.Twitter.EnableDNT)
+	assert.True(pc.Twitter.Simple)
 	assert.True(pc.Vimeo.Disable)
 	assert.True(pc.Vimeo.Simple)
 	assert.True(pc.YouTube.PrivacyEnhanced)

--- a/config/services/servicesConfig.go
+++ b/config/services/servicesConfig.go
@@ -30,6 +30,7 @@ type Config struct {
 	Disqus          Disqus
 	GoogleAnalytics GoogleAnalytics
 	Instagram       Instagram
+	Twitter         Twitter
 }
 
 // Disqus holds the functional configuration settings related to the Disqus template.
@@ -48,6 +49,14 @@ type GoogleAnalytics struct {
 type Instagram struct {
 	// The Simple variant of the Instagram is decorated with Bootstrap 4 card classes.
 	// This means that if you use Bootstrap 4 or want to provide your own CSS, you want
+	// to disable the inline CSS provided by Hugo.
+	DisableInlineCSS bool
+}
+
+// Twitter holds the functional configuration settings related to the Twitter shortcodes.
+type Twitter struct {
+	// The Simple variant of Twitter is decorated with a basic set of inline styles.
+	// This means that if you want to provide your own CSS, you want
 	// to disable the inline CSS provided by Hugo.
 	DisableInlineCSS bool
 }

--- a/config/services/servicesConfig_test.go
+++ b/config/services/servicesConfig_test.go
@@ -35,6 +35,8 @@ shortname = "DS"
 id = "ga_id"
 [services.instagram]
 disableInlineCSS = true
+[services.twitter]
+disableInlineCSS = true
 `
 	cfg, err := config.FromConfigString(tomlConfig, "toml")
 	assert.NoError(err)

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -390,10 +390,47 @@ if (!doNotTrack) {
 {{- end -}}`},
 	{`shortcodes/twitter.html`, `{{- $pc := .Page.Site.Config.Privacy.Twitter -}}
 {{- if not $pc.Disable -}}
+{{- if $pc.Simple -}}
+{{ template "_internal/shortcodes/twitter_simple.html" . }}
+{{- else -}}
 {{- $url := printf "https://api.twitter.com/1/statuses/oembed.json?id=%s&dnt=%t" (index .Params 0) $pc.EnableDNT -}}
 {{- $json := getJSON $url -}}
 {{ $json.html | safeHTML }}
+{{- end -}}
 {{- end -}}`},
+	{`shortcodes/twitter_simple.html`, `{{- $pc := .Page.Site.Config.Privacy.Twitter -}}
+{{- $sc := .Page.Site.Config.Services.Twitter -}}
+{{- if not $pc.Disable -}}
+{{- $id := .Get 0 -}}
+{{- $json := getJSON "https://api.twitter.com/1/statuses/oembed.json?id=" $id "&omit_script=true" -}}
+{{- if not $sc.DisableInlineCSS -}}
+{{ template "__h_simple_twitter_css" $ }}
+{{- end -}}
+{{ $json.html | safeHTML }}
+{{- end -}}
+
+{{ define "__h_simple_twitter_css" }}
+{{ if not (.Page.Scratch.Get "__h_simple_twitter_css") }}
+{{/* Only include once */}}
+{{  .Page.Scratch.Set "__h_simple_twitter_css" true }}
+<style type="text/css">
+  .twitter-tweet {
+  font: 14px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+  border-left: 4px solid #2b7bb9;
+  padding-left: 1.5em;
+  color: #555;
+}
+  .twitter-tweet a {
+  color: #2b7bb9;
+  text-decoration: none;
+}
+  blockquote.twitter-tweet a:hover,
+  blockquote.twitter-tweet a:focus {
+  text-decoration: underline;
+}
+</style>
+{{ end }}
+{{ end }}`},
 	{`shortcodes/vimeo.html`, `{{- $pc := .Page.Site.Config.Privacy.Vimeo -}}
 {{- if not $pc.Disable -}}
 {{- if $pc.Simple -}}

--- a/tpl/tplimpl/embedded/templates/shortcodes/twitter.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/twitter.html
@@ -1,6 +1,10 @@
 {{- $pc := .Page.Site.Config.Privacy.Twitter -}}
 {{- if not $pc.Disable -}}
+{{- if $pc.Simple -}}
+{{ template "_internal/shortcodes/twitter_simple.html" . }}
+{{- else -}}
 {{- $url := printf "https://api.twitter.com/1/statuses/oembed.json?id=%s&dnt=%t" (index .Params 0) $pc.EnableDNT -}}
 {{- $json := getJSON $url -}}
 {{ $json.html | safeHTML }}
+{{- end -}}
 {{- end -}}

--- a/tpl/tplimpl/embedded/templates/shortcodes/twitter_simple.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/twitter_simple.html
@@ -1,0 +1,33 @@
+{{- $pc := .Page.Site.Config.Privacy.Twitter -}}
+{{- $sc := .Page.Site.Config.Services.Twitter -}}
+{{- if not $pc.Disable -}}
+{{- $id := .Get 0 -}}
+{{- $json := getJSON "https://api.twitter.com/1/statuses/oembed.json?id=" $id "&omit_script=true" -}}
+{{- if not $sc.DisableInlineCSS -}}
+{{ template "__h_simple_twitter_css" $ }}
+{{- end -}}
+{{ $json.html | safeHTML }}
+{{- end -}}
+
+{{ define "__h_simple_twitter_css" }}
+{{ if not (.Page.Scratch.Get "__h_simple_twitter_css") }}
+{{/* Only include once */}}
+{{  .Page.Scratch.Set "__h_simple_twitter_css" true }}
+<style type="text/css">
+  .twitter-tweet {
+  font: 14px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+  border-left: 4px solid #2b7bb9;
+  padding-left: 1.5em;
+  color: #555;
+}
+  .twitter-tweet a {
+  color: #2b7bb9;
+  text-decoration: none;
+}
+  blockquote.twitter-tweet a:hover,
+  blockquote.twitter-tweet a:focus {
+  text-decoration: underline;
+}
+</style>
+{{ end }}
+{{ end }}


### PR DESCRIPTION
This PR contains the following:
- Simple variant for the internal Twitter shortcode with a basic set of inline styles (see attached screenshot of proposed display below)

- The CSS classes of the `blockquote` and its contents are provided by the Twitter oEmbed API.

- If the user wishes to disable the inline styles, it is possible to do so with the following configuration:
```
[services]
[services.twitter]
disableInlineCSS = true
```
![twitter_simple](https://user-images.githubusercontent.com/7918298/40746836-2824f948-6464-11e8-9d5d-37e645976a54.png)
