### PR TITLE
Make figure SC insert absolute links in the src attribute

### DIFF
--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -123,22 +123,22 @@ func TestShortcodeFigure(t *testing.T) {
 	}{
 		{
 			`{{< figure src="/img/hugo-logo.png" >}}`,
-			"(?s)\n<figure>.*?<img src=\"/img/hugo-logo.png\" />.*?</figure>\n",
+			"(?s)\n<figure>.*?<img src=\"/img/hugo-logo.png\"/>.*?</figure>\n",
 		},
 		{
 			// set alt
 			`{{< figure src="/img/hugo-logo.png" alt="Hugo logo" >}}`,
-			"(?s)\n<figure>.*?<img src=\"/img/hugo-logo.png\" alt=\"Hugo logo\" />.*?</figure>\n",
+			"(?s)\n<figure>.*?<img src=\"/img/hugo-logo.png\" alt=\"Hugo logo\"/>.*?</figure>\n",
 		},
 		// set title
 		{
 			`{{< figure src="/img/hugo-logo.png" title="Hugo logo" >}}`,
-			"(?s)\n<figure>.*?<img src=\"/img/hugo-logo.png\" />.*?<figcaption>.*?<h4>Hugo logo</h4>.*?</figcaption>.*?</figure>\n",
+			"(?s)\n<figure>.*?<img src=\"/img/hugo-logo.png\"/>.*?<figcaption>.*?<h4>Hugo logo</h4>.*?</figcaption>.*?</figure>\n",
 		},
 		// set attr and attrlink
 		{
 			`{{< figure src="/img/hugo-logo.png" attr="Hugo logo" attrlink="/img/hugo-logo.png" >}}`,
-			"(?s)\n<figure>.*?<img src=\"/img/hugo-logo.png\" />.*?<figcaption>.*?<p>.*?<a href=\"/img/hugo-logo.png\">.*?Hugo logo.*?</a>.*?</p>.*?</figcaption>.*?</figure>\n",
+			"(?s)\n<figure>.*?<img src=\"/img/hugo-logo.png\"/>.*?<figcaption>.*?<p>.*?<a href=\"/img/hugo-logo.png\">.*?Hugo logo.*?</a>.*?</p>.*?</figcaption>.*?</figure>\n",
 		},
 	} {
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -794,7 +794,7 @@ func TestPageWithShortCodeInSummary(t *testing.T) {
 	assertFunc := func(t *testing.T, ext string, pages Pages) {
 		p := pages[0]
 		checkPageTitle(t, p, "Simple")
-		checkPageContent(t, p, normalizeExpected(ext, "<p>Summary Next Line. \n<figure>\n    \n        <img src=\"/not/real\" />\n    \n    \n</figure>\n.\nMore text here.</p>\n\n<p>Some more text</p>\n"))
+		checkPageContent(t, p, normalizeExpected(ext, "<p>Summary Next Line. \n<figure>\n    \n        <img src=\"/not/real\"/>\n    \n    \n</figure>\n.\nMore text here.</p>\n\n<p>Some more text</p>\n"))
 		checkPageSummary(t, p, "Summary Next Line.  . More text here. Some more text")
 		checkPageType(t, p, "page")
 	}

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -305,23 +305,42 @@ if (!doNotTrack) {
 {{- end -}}
 `},
 	{`shortcodes/figure.html`, `<!-- image -->
-<figure{{ with .Get "class" }} class="{{.}}"{{ end }}>
+{{ $image := .Get "src" }}
+<figure{{ with .Get "class" }} class="{{ . }}"{{ end }}>
     {{ if .Get "link"}}<a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>{{ end }}
-        <img src="{{ .Get "src" }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}" {{ end }}{{ with .Get "width" }}width="{{.}}" {{ end }}{{ with .Get "height" }}height="{{.}}" {{ end }}/>
-    {{ if .Get "link"}}</a>{{ end }}
-    {{ if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
-    <figcaption>{{ if isset .Params "title" }}
-        <h4>{{ .Get "title" }}</h4>{{ end }}
-        {{ if or (.Get "caption") (.Get "attr")}}<p>
-        {{ .Get "caption" }}
-        {{ with .Get "attrlink"}}<a href="{{.}}"> {{ end }}
-            {{ .Get "attr" }}
-        {{ if .Get "attrlink"}}</a> {{ end }}
-        </p> {{ end }}
-    </figcaption>
-    {{ end }}
+        {{ if (findRE "(^|:)//" $image) -}} <!-- If image link is a URL with protocol or two leading slashes, use just that unmodified. -->
+            <img src="{{ $image }}"
+        {{- else if (findRE "^/" $image) -}} <!-- If image link has one leading slash -->
+            {{- /* Cannot use absURL below because it doesn't work as expected if baseURL has a subdir. */ -}}
+            {{- $baseurl_no_trailing_slash := $.Site.BaseURL | replaceRE "/$" "" -}}
+            <img src="{{ (printf "%s%s" $baseurl_no_trailing_slash $image) }}"
+        {{- else -}}
+            {{- /* Below variable will always have a trailing slash, even with uglyURLs enabled. */ -}}
+            {{- $permalink_pretty := $.Page.Permalink | replaceRE "\\.html$" "/" -}}
+            <img src="{{ (printf "%s%s" $permalink_pretty $image) }}"
+        {{- end -}}
+            {{- with (or (.Get "alt") (.Get "caption")) -}}
+                {{- printf " alt=\"%s\"" . | safeHTMLAttr -}}
+            {{- end -}}
+            {{- with .Get "width" }} width="{{ . }}"{{ end -}}
+            {{- with .Get "height" }} height="{{ . }}"{{ end -}}/> <!-- Closing img tag -->
+        {{- if .Get "link" }}</a>{{ end -}}
+        {{- if or (or (.Get "title") (.Get "caption")) (.Get "attr") -}}
+            <figcaption>
+                {{ if isset .Params "title" }}
+                    <h4>{{ .Get "title" }}</h4>
+                {{ end }}
+                {{ if or (.Get "caption") (.Get "attr") }}<p>
+                    {{ .Get "caption" }}
+                    {{ with .Get "attrlink" }}<a href="{{ . }}"> {{ end }}
+                        {{ .Get "attr" }}
+                        {{ if .Get "attrlink" }}</a>{{ end }}</p>
+                {{ end }}
+            </figcaption>
+        {{- end -}}
 </figure>
-<!-- image -->`},
+<!-- image -->
+`},
 	{`shortcodes/gist.html`, `<script src="//gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }}?file={{ index .Params 2 }}{{end}}"></script>`},
 	{`shortcodes/highlight.html`, `{{ if len .Params | eq 2 }}{{ highlight (trim .Inner "\n\r") (.Get 0) (.Get 1) }}{{ else }}{{ highlight (trim .Inner "\n\r") (.Get 0) "" }}{{ end }}`},
 	{`shortcodes/instagram.html`, `{{- $pc := .Page.Site.Config.Privacy.Instagram -}}

--- a/tpl/tplimpl/embedded/templates/shortcodes/figure.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/figure.html
@@ -1,18 +1,36 @@
 <!-- image -->
-<figure{{ with .Get "class" }} class="{{.}}"{{ end }}>
+{{ $image := .Get "src" }}
+<figure{{ with .Get "class" }} class="{{ . }}"{{ end }}>
     {{ if .Get "link"}}<a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>{{ end }}
-        <img src="{{ .Get "src" }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}" {{ end }}{{ with .Get "width" }}width="{{.}}" {{ end }}{{ with .Get "height" }}height="{{.}}" {{ end }}/>
-    {{ if .Get "link"}}</a>{{ end }}
-    {{ if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
-    <figcaption>{{ if isset .Params "title" }}
-        <h4>{{ .Get "title" }}</h4>{{ end }}
-        {{ if or (.Get "caption") (.Get "attr")}}<p>
-        {{ .Get "caption" }}
-        {{ with .Get "attrlink"}}<a href="{{.}}"> {{ end }}
-            {{ .Get "attr" }}
-        {{ if .Get "attrlink"}}</a> {{ end }}
-        </p> {{ end }}
-    </figcaption>
-    {{ end }}
+        {{ if (findRE "(^|:)//" $image) -}} <!-- If image link is a URL with protocol or two leading slashes, use just that unmodified. -->
+            <img src="{{ $image }}"
+        {{- else if (findRE "^/" $image) -}} <!-- If image link has one leading slash -->
+            {{- /* Cannot use absURL below because it doesn't work as expected if baseURL has a subdir. */ -}}
+            {{- $baseurl_no_trailing_slash := $.Site.BaseURL | replaceRE "/$" "" -}}
+            <img src="{{ (printf "%s%s" $baseurl_no_trailing_slash $image) }}"
+        {{- else -}}
+            {{- /* Below variable will always have a trailing slash, even with uglyURLs enabled. */ -}}
+            {{- $permalink_pretty := $.Page.Permalink | replaceRE "\\.html$" "/" -}}
+            <img src="{{ (printf "%s%s" $permalink_pretty $image) }}"
+        {{- end -}}
+            {{- with (or (.Get "alt") (.Get "caption")) -}}
+                {{- printf " alt=\"%s\"" . | safeHTMLAttr -}}
+            {{- end -}}
+            {{- with .Get "width" }} width="{{ . }}"{{ end -}}
+            {{- with .Get "height" }} height="{{ . }}"{{ end -}}/> <!-- Closing img tag -->
+        {{- if .Get "link" }}</a>{{ end -}}
+        {{- if or (or (.Get "title") (.Get "caption")) (.Get "attr") -}}
+            <figcaption>
+                {{ if isset .Params "title" }}
+                    <h4>{{ .Get "title" }}</h4>
+                {{ end }}
+                {{ if or (.Get "caption") (.Get "attr") }}<p>
+                    {{ .Get "caption" }}
+                    {{ with .Get "attrlink" }}<a href="{{ . }}"> {{ end }}
+                        {{ .Get "attr" }}
+                        {{ if .Get "attrlink" }}</a>{{ end }}</p>
+                {{ end }}
+            </figcaption>
+        {{- end -}}
 </figure>
 <!-- image -->


### PR DESCRIPTION
- Fixes https://github.com/gohugoio/hugo/issues/4562
  - So now the figure shortcode inserted images work fine on list pages and on
    sites with baseURL containing subdir too.
- Support figure SC src attribute with protocol or two leading slashes
- Update the figure shortcode + src attr tests to use BaseURL
- Add tests for all of the above.

Other:

- White-space change syncup between figure SC and tests
- Consistency edits: {{.}} -> {{ . }}, {{else}} -> {{ else }}, and similar