### PR TITLE
Add runelen function

### DIFF
--- a/docs/content/en/functions/runelen.md
+++ b/docs/content/en/functions/runelen.md
@@ -1,0 +1,28 @@
+---
+title: runelen
+description: Determines the number of runes in a string.
+godocref:
+date: 2018-06-01
+publishdate: 2018-06-01
+lastmod: 2018-06-01
+categories: [functions]
+menu:
+  docs:
+    parent: "functions"
+keywords: [counting, character count, length, rune length, rune count]
+signature: ["runelen INPUT"]
+workson: []
+hugoversion:
+relatedfuncs: []
+deprecated: false
+aliases: [/functions/runelen/]
+---
+
+In contrast with `countrunes` function, which strips HTML and whitespace before counting runes, `runelen` simply counts all the runes in a string. It relies on the Go [`utf8.RuneCount`](https://golang.org/pkg/unicode/utf8/#RuneCount) function.
+
+```
+{{ "Hello, 世界" | runelen }}
+<!-- outputs a content length of 9 runes. -->
+```
+
+[pagevars]: /variables/page/

--- a/docs/content/en/functions/runelen.md
+++ b/docs/content/en/functions/runelen.md
@@ -18,11 +18,11 @@ deprecated: false
 aliases: [/functions/runelen/]
 ---
 
-In contrast with `countrunes` function, which strips HTML and whitespace before counting runes, `runelen` simply counts all the runes in a string. It relies on the Go [`utf8.RuneCount`](https://golang.org/pkg/unicode/utf8/#RuneCount) function.
+In contrast with `countrunes` function, which strips HTML and whitespace before counting runes, `runelen` simply counts all the runes in a string. It relies on the Go [`utf8.RuneCount`] function.
 
 ```
 {{ "Hello, 世界" | runelen }}
 <!-- outputs a content length of 9 runes. -->
 ```
 
-[pagevars]: /variables/page/
+[`utf8.RuneCount`]: https://golang.org/pkg/unicode/utf8/#RuneCount

--- a/docs/content/en/functions/strings.RuneCount.md
+++ b/docs/content/en/functions/strings.RuneCount.md
@@ -1,5 +1,5 @@
 ---
-title: runelen
+title: strings.RuneCount
 description: Determines the number of runes in a string.
 godocref:
 date: 2018-06-01
@@ -10,18 +10,18 @@ menu:
   docs:
     parent: "functions"
 keywords: [counting, character count, length, rune length, rune count]
-signature: ["runelen INPUT"]
+signature: ["strings.CountRunes INPUT"]
 workson: []
 hugoversion:
-relatedfuncs: []
+relatedfuncs: ["len", "countrunes"]
 deprecated: false
-aliases: [/functions/runelen/]
+aliases: []
 ---
 
-In contrast with `countrunes` function, which strips HTML and whitespace before counting runes, `runelen` simply counts all the runes in a string. It relies on the Go [`utf8.RuneCount`] function.
+In contrast with `countrunes` function, which strips HTML and whitespace before counting runes, `RuneCount` simply counts all the runes in a string. It relies on the Go [`utf8.RuneCount`] function.
 
 ```
-{{ "Hello, 世界" | runelen }}
+{{ "Hello, 世界" | strings.RuneCount }}
 <!-- outputs a content length of 9 runes. -->
 ```
 

--- a/docs/content/en/functions/strings.RuneCount.md
+++ b/docs/content/en/functions/strings.RuneCount.md
@@ -10,7 +10,7 @@ menu:
   docs:
     parent: "functions"
 keywords: [counting, character count, length, rune length, rune count]
-signature: ["strings.CountRunes INPUT"]
+signature: ["strings.RuneCount INPUT"]
 workson: []
 hugoversion:
 relatedfuncs: ["len", "countrunes"]
@@ -18,7 +18,7 @@ deprecated: false
 aliases: []
 ---
 
-In contrast with `countrunes` function, which strips HTML and whitespace before counting runes, `RuneCount` simply counts all the runes in a string. It relies on the Go [`utf8.RuneCount`] function.
+In contrast with `strings.CountRunes` function, which strips HTML and whitespace before counting runes, `strings.RuneCount` simply counts all the runes in a string. It relies on the Go [`utf8.RuneCountInString`] function.
 
 ```
 {{ "Hello, 世界" | strings.RuneCount }}

--- a/docs/data/docs.json
+++ b/docs/data/docs.json
@@ -3148,6 +3148,16 @@
           ],
           "Examples": []
         },
+        "RuneLength": {
+          "Description": "RuneLength returns the number of runes in s",
+          "Args": [
+            "s"
+          ],
+          "Aliases": [
+            "runelen"
+          ],
+          "Examples": []
+        },
         "CountWords": {
           "Description": "CountWords returns the approximate word count in s.",
           "Args": [

--- a/docs/data/docs.json
+++ b/docs/data/docs.json
@@ -3146,17 +3146,25 @@
           "Aliases": [
             "countrunes"
           ],
-          "Examples": []
+          "Examples": [
+            [
+              "{{ \"Hello, 世界\" | countrunes }}",
+              "8"
+            ]
+          ]
         },
-        "RuneLength": {
-          "Description": "RuneLength returns the number of runes in s",
+        "RuneCount": {
+          "Description": "RuneCount returns the number of runes in s",
           "Args": [
             "s"
           ],
-          "Aliases": [
-            "runelen"
-          ],
-          "Examples": []
+          "Aliases": [],
+          "Examples": [
+            [
+              "{{ \"Hello, 世界\" | strings.RuneCount }}",
+              "9"
+            ]
+          ]
         },
         "CountWords": {
           "Description": "CountWords returns the approximate word count in s.",

--- a/tpl/strings/init.go
+++ b/tpl/strings/init.go
@@ -41,6 +41,11 @@ func init() {
 			[][2]string{},
 		)
 
+		ns.AddMethodMapping(ctx.RuneLength,
+			[]string{"runelen"},
+			[][2]string{},
+		)
+
 		ns.AddMethodMapping(ctx.CountWords,
 			[]string{"countwords"},
 			[][2]string{},

--- a/tpl/strings/init.go
+++ b/tpl/strings/init.go
@@ -41,8 +41,8 @@ func init() {
 			[][2]string{},
 		)
 
-		ns.AddMethodMapping(ctx.RuneLength,
-			[]string{"runelen"},
+		ns.AddMethodMapping(ctx.RuneCount,
+			nil,
 			[][2]string{},
 		)
 

--- a/tpl/strings/strings.go
+++ b/tpl/strings/strings.go
@@ -57,8 +57,8 @@ func (ns *Namespace) CountRunes(s interface{}) (int, error) {
 	return counter, nil
 }
 
-// RuneLength returns the number of runes in s.
-func (ns *Namespace) RuneLength(s interface{}) (int, error) {
+// RuneCount returns the number of runes in s.
+func (ns *Namespace) RuneCount(s interface{}) (int, error) {
 	ss, err := cast.ToStringE(s)
 	if err != nil {
 		return 0, fmt.Errorf("Failed to convert content to string: %s", err)

--- a/tpl/strings/strings.go
+++ b/tpl/strings/strings.go
@@ -57,6 +57,15 @@ func (ns *Namespace) CountRunes(s interface{}) (int, error) {
 	return counter, nil
 }
 
+// RuneLength returns the number of runes in s.
+func (ns *Namespace) RuneLength(s interface{}) (int, error) {
+	ss, err := cast.ToStringE(s)
+	if err != nil {
+		return 0, fmt.Errorf("Failed to convert content to string: %s", err)
+	}
+	return utf8.RuneCountInString(ss), nil
+}
+
 // CountWords returns the approximate word count in s.
 func (ns *Namespace) CountWords(s interface{}) (int, error) {
 	ss, err := cast.ToStringE(s)

--- a/tpl/strings/strings_test.go
+++ b/tpl/strings/strings_test.go
@@ -173,6 +173,33 @@ func TestCountRunes(t *testing.T) {
 	}
 }
 
+func TestRuneLength(t *testing.T) {
+	t.Parallel()
+
+	for i, test := range []struct {
+		s      interface{}
+		expect interface{}
+	}{
+		{"foo bar", 7},
+		{"旁边", 2},
+		{`<div class="test">旁边</div>`, 26},
+		// errors
+		{tstNoStringer{}, false},
+	} {
+		errMsg := fmt.Sprintf("[%d] %v", i, test.s)
+
+		result, err := ns.RuneLength(test.s)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			require.Error(t, err, errMsg)
+			continue
+		}
+
+		require.NoError(t, err, errMsg)
+		assert.Equal(t, test.expect, result, errMsg)
+	}
+}
+
 func TestCountWords(t *testing.T) {
 	t.Parallel()
 

--- a/tpl/strings/strings_test.go
+++ b/tpl/strings/strings_test.go
@@ -173,7 +173,7 @@ func TestCountRunes(t *testing.T) {
 	}
 }
 
-func TestRuneLength(t *testing.T) {
+func TestRuneCount(t *testing.T) {
 	t.Parallel()
 
 	for i, test := range []struct {
@@ -188,7 +188,7 @@ func TestRuneLength(t *testing.T) {
 	} {
 		errMsg := fmt.Sprintf("[%d] %v", i, test.s)
 
-		result, err := ns.RuneLength(test.s)
+		result, err := ns.RuneCount(test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
 			require.Error(t, err, errMsg)


### PR DESCRIPTION
Unlike RuneCount, it does not strip HTML or whitespace before counting runes. Useful
for formatting plain text.