### PR TITLE
tpl: Prevent isBaseTemplate() from matching "baseof" in dir

### DIFF
--- a/tpl/tplimpl/template.go
+++ b/tpl/tplimpl/template.go
@@ -726,5 +726,5 @@ func isBackupFile(path string) bool {
 const baseFileBase = "baseof"
 
 func isBaseTemplate(path string) bool {
-	return strings.Contains(path, baseFileBase)
+	return strings.Contains(filepath.Base(path), baseFileBase)
 }


### PR DESCRIPTION
Fixes #4809