### PR TITLE
Small typo

### DIFF
--- a/config/privacy/privacyConfig_test.go
+++ b/config/privacy/privacyConfig_test.go
@@ -86,7 +86,7 @@ someOtherValue = "foo"
 
 [Privacy]
 [Privacy.YouTube]
-PrivacyENhanced = true
+PrivacyEnhanced = true
 `
 	cfg, err := config.FromConfigString(tomlConfig, "toml")
 	assert.NoError(err)


### PR DESCRIPTION
Fixed a small typo in the privacyConfig_test.go file