### PR TITLE
Always load script over HTTPS

### DIFF
--- a/hugolib/embedded_templates_test.go
+++ b/hugolib/embedded_templates_test.go
@@ -50,7 +50,7 @@ Disqus:
 	b.AssertFileContent("public/index.html",
 		"'anonymizeIp', true",
 		"'script','https://www.google-analytics.com/analytics.js','ga');\n\tga('create', 'ga_id', 'auto')",
-		"<script async src='//www.google-analytics.com/analytics.js'>")
+			    "<script async src='https://www.google-analytics.com/analytics.js'>")
 
 	// Disqus
 	b.AssertFileContent("public/index.html", "\"disqus_shortname\" + '.disqus.com/embed.js';")

--- a/hugolib/embedded_templates_test.go
+++ b/hugolib/embedded_templates_test.go
@@ -50,7 +50,7 @@ Disqus:
 	b.AssertFileContent("public/index.html",
 		"'anonymizeIp', true",
 		"'script','https://www.google-analytics.com/analytics.js','ga');\n\tga('create', 'ga_id', 'auto')",
-			    "<script async src='https://www.google-analytics.com/analytics.js'>")
+		"<script async src='https://www.google-analytics.com/analytics.js'>")
 
 	// Disqus
 	b.AssertFileContent("public/index.html", "\"disqus_shortname\" + '.disqus.com/embed.js';")

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -163,7 +163,7 @@ if (!doNotTrack) {
 	ga('send', 'pageview');
 }
 </script>
-<script async src='//www.google-analytics.com/analytics.js'></script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
 {{ end }}
 {{- end -}}`},
 	{`google_news.html`, `{{ if .IsPage }}{{ with .Params.news_keywords }}

--- a/tpl/tplimpl/embedded/templates/google_analytics_async.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics_async.html
@@ -23,6 +23,6 @@ if (!doNotTrack) {
 	ga('send', 'pageview');
 }
 </script>
-<script async src='//www.google-analytics.com/analytics.js'></script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
 {{ end }}
 {{- end -}}


### PR DESCRIPTION
This is potentially safer, faster and recommended by Google
REF: https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tracking_snippet