### PR TITLE
helpers: Add check for baseURL containing '/' suffix

### DIFF
--- a/helpers/baseURL.go
+++ b/helpers/baseURL.go
@@ -27,6 +27,9 @@ type BaseURL struct {
 }
 
 func (b BaseURL) String() string {
+	if !strings.HasSuffix(b.urlStr, "/") {
+		return b.urlStr + "/"
+	}
 	return b.urlStr
 }
 


### PR DESCRIPTION
If the base URL is not suffixed with a forward slash, the code snippet will add one to it and then return the URL string.