### PR TITLE
Tweak "new theme" and "new site" subcommands

### DIFF
--- a/commands/new.go
+++ b/commands/new.go
@@ -126,27 +126,6 @@ func (n *newCmd) newContent(cmd *cobra.Command, args []string) error {
 	return create.NewContent(ps, siteFactory, kind, createPath)
 }
 
-func nextStepsText() string {
-	var nextStepsText bytes.Buffer
-
-	nextStepsText.WriteString(`Just a few more steps and you're ready to go:
-
-1. Download a theme into the same-named folder.
-   Choose a theme from https://themes.gohugo.io/, or
-   create your own with the "hugo new theme <THEMENAME>" command.
-2. Perhaps you want to add some content. You can add single files
-   with "hugo new `)
-
-	nextStepsText.WriteString(filepath.Join("<SECTIONNAME>", "<FILENAME>.<FORMAT>"))
-
-	nextStepsText.WriteString(`".
-3. Start the built-in live server via "hugo server".
-
-Visit https://gohugo.io/ for quickstart guide and full documentation.`)
-
-	return nextStepsText.String()
-}
-
 func mkdir(x ...string) {
 	p := filepath.Join(x...)
 

--- a/commands/new_site.go
+++ b/commands/new_site.go
@@ -15,24 +15,18 @@ package commands
 
 import (
 	"bytes"
-	"path/filepath"
-
-	"github.com/spf13/viper"
-
 	"errors"
-
-	"github.com/gohugoio/hugo/create"
-
 	"fmt"
-
+	"path/filepath"
 	"strings"
 
-	"github.com/gohugoio/hugo/parser"
-
+	"github.com/gohugoio/hugo/create"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/hugofs"
+	"github.com/gohugoio/hugo/parser"
 	"github.com/spf13/cobra"
 	jww "github.com/spf13/jwalterweatherman"
+	"github.com/spf13/viper"
 )
 
 var _ cmder = (*newSiteCmd)(nil)
@@ -104,7 +98,7 @@ func (n *newSiteCmd) doNewSite(fs *hugofs.Fs, basepath string, force bool) error
 
 	createConfig(fs, basepath, n.configFormat)
 
-	// Create a defaul archetype file.
+	// Create a default archetype file.
 	helpers.SafeWriteToDisk(filepath.Join(archeTypePath, "default.md"),
 		strings.NewReader(create.ArchetypeTemplateTemplate), fs.Source)
 
@@ -145,4 +139,25 @@ func createConfig(fs *hugofs.Fs, inpath string, kind string) (err error) {
 	}
 
 	return helpers.WriteToDisk(filepath.Join(inpath, "config."+kind), &buf, fs.Source)
+}
+
+func nextStepsText() string {
+	var nextStepsText bytes.Buffer
+
+	nextStepsText.WriteString(`Just a few more steps and you're ready to go:
+
+1. Download a theme into the same-named folder.
+   Choose a theme from https://themes.gohugo.io/, or
+   create your own with the "hugo new theme <THEMENAME>" command.
+2. Perhaps you want to add some content. You can add single files
+   with "hugo new `)
+
+	nextStepsText.WriteString(filepath.Join("<SECTIONNAME>", "<FILENAME>.<FORMAT>"))
+
+	nextStepsText.WriteString(`".
+3. Start the built-in live server via "hugo server".
+
+Visit https://gohugo.io/ for quickstart guide and full documentation.`)
+
+	return nextStepsText.String()
 }

--- a/commands/new_theme.go
+++ b/commands/new_theme.go
@@ -80,6 +80,22 @@ func (n *newThemeCmd) newTheme(cmd *cobra.Command, args []string) error {
 	touchFile(cfg.Fs.Source, createpath, "layouts", "_default", "list.html")
 	touchFile(cfg.Fs.Source, createpath, "layouts", "_default", "single.html")
 
+	baseofDefault := []byte(`<html>
+    {{- partial "head.html" . -}}
+    <body>
+        {{- partial "header.html" . -}}
+        <div id="content">
+        {{- block "main" . }}{{- end }}
+        </div>
+        {{- partial "footer.html" . -}}
+    </body>
+</html>
+`)
+	err = helpers.WriteToDisk(filepath.Join(createpath, "layouts", "_default", "baseof.html"), bytes.NewReader(baseofDefault), cfg.Fs.Source)
+	if err != nil {
+		return err
+	}
+
 	touchFile(cfg.Fs.Source, createpath, "layouts", "partials", "header.html")
 	touchFile(cfg.Fs.Source, createpath, "layouts", "partials", "footer.html")
 

--- a/commands/new_theme.go
+++ b/commands/new_theme.go
@@ -133,7 +133,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 `)
 
-	err = helpers.WriteToDisk(filepath.Join(createpath, "LICENSE.md"), bytes.NewReader(by), cfg.Fs.Source)
+	err = helpers.WriteToDisk(filepath.Join(createpath, "LICENSE"), bytes.NewReader(by), cfg.Fs.Source)
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func (n *newThemeCmd) createThemeMD(fs *hugofs.Fs, inpath string) (err error) {
 
 name = "` + strings.Title(helpers.MakeTitle(filepath.Base(inpath))) + `"
 license = "MIT"
-licenselink = "https://github.com/yourname/yourtheme/blob/master/LICENSE.md"
+licenselink = "https://github.com/yourname/yourtheme/blob/master/LICENSE"
 description = ""
 homepage = "http://example.com/"
 tags = []

--- a/commands/new_theme.go
+++ b/commands/new_theme.go
@@ -14,16 +14,14 @@
 package commands
 
 import (
-	"path/filepath"
-
 	"bytes"
-
+	"errors"
+	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/gohugoio/hugo/hugofs"
-
 	"github.com/gohugoio/hugo/helpers"
+	"github.com/gohugoio/hugo/hugofs"
 	"github.com/spf13/cobra"
 	jww "github.com/spf13/jwalterweatherman"
 )
@@ -53,6 +51,7 @@ as you see fit.`,
 	return ccmd
 }
 
+// newTheme creates a new Hugo theme template
 func (n *newThemeCmd) newTheme(cmd *cobra.Command, args []string) error {
 	c, err := initializeConfig(false, false, &n.hugoBuilderCommon, n, nil)
 
@@ -65,12 +64,12 @@ func (n *newThemeCmd) newTheme(cmd *cobra.Command, args []string) error {
 	}
 
 	createpath := c.hugo.PathSpec.AbsPathify(filepath.Join(c.Cfg.GetString("themesDir"), args[0]))
-	jww.INFO.Println("creating theme at", createpath)
+	jww.FEEDBACK.Println("Creating theme at", createpath)
 
 	cfg := c.DepsCfg
 
 	if x, _ := helpers.Exists(createpath, cfg.Fs.Source); x {
-		return newUserError(createpath, "already exists")
+		return errors.New(createpath + " already exists")
 	}
 
 	mkdir(createpath, "layouts", "_default")


### PR DESCRIPTION
commit a7acd073ca9432d1275de05a521e5641c880461b:

>    commands: Move nextStepsText() to new_site.go

commit a036cc8efaada4c4fbf6f7edf392197691dc0775:

>    commands: Make "new theme" feedback more intuitive

commit bdaa62ad8df43e5895a322726873976c748d3ea4

>    commands: Create _default/baseof.html in "new theme"
>    
>    Thanks to @digitalcraftsman, @bep and @rdwatters for providing the
>    actual content of the default baseof.html file.
>    
>    Fixes #3576

commit 691a35756cb0bbebbbfb5d41185abe98022bb30f

>    commands: Create LICENSE rather than LICENSE.md in "new theme"
>    
>    See also #4623
