### PR TITLE
hugolib: Reset the global pages cache on server rebuilds

### DIFF
--- a/hugolib/page_output.go
+++ b/hugolib/page_output.go
@@ -141,6 +141,9 @@ func (p *PageOutput) Render(layout ...string) template.HTML {
 }
 
 func (p *Page) Render(layout ...string) template.HTML {
+	if p.mainPageOutput == nil {
+		panic(fmt.Sprintf("programming error: no mainPageOutput for %q", p.Path()))
+	}
 	return p.mainPageOutput.Render(layout...)
 }
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1492,6 +1492,8 @@ func (s *Site) resetBuildState() {
 
 	s.expiredCount = 0
 
+	spc = newPageCache()
+
 	for _, p := range s.rawAllPages {
 		p.subSections = Pages{}
 		p.parent = nil


### PR DESCRIPTION
In Hugo 0.42, this could lead to errors of type `runtime error: invalid memory address or nil pointer dereference` in some rare situations.

Note that this was also an issue before 0.42, but the symptom was then potentially stale list content on rebuilds on content changes.

This commit also improves the above error message.

Fixes #4845