### PR TITLE
Improve new theme generator

### DIFF
--- a/commands/new_theme.go
+++ b/commands/new_theme.go
@@ -97,6 +97,7 @@ func (n *newThemeCmd) newTheme(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	touchFile(cfg.Fs.Source, createpath, "layouts", "partials", "head.html")
 	touchFile(cfg.Fs.Source, createpath, "layouts", "partials", "header.html")
 	touchFile(cfg.Fs.Source, createpath, "layouts", "partials", "footer.html")
 

--- a/commands/new_theme.go
+++ b/commands/new_theme.go
@@ -80,7 +80,8 @@ func (n *newThemeCmd) newTheme(cmd *cobra.Command, args []string) error {
 	touchFile(cfg.Fs.Source, createpath, "layouts", "_default", "list.html")
 	touchFile(cfg.Fs.Source, createpath, "layouts", "_default", "single.html")
 
-	baseofDefault := []byte(`<html>
+	baseofDefault := []byte(`<!DOCTYPE html>
+<html>
     {{- partial "head.html" . -}}
     <body>
         {{- partial "header.html" . -}}


### PR DESCRIPTION
This pull request implements two little improvements to the theme generator. As discussed [here](https://discourse.gohugo.io/t/incomplete-generation-of-a-new-theme/12577/4) the generation of new themes seems to be incomplete to me.

After the generation of a new theme a `head.html` needs to be added, because the `baseof.html` which is generated references this partial. If the partial is missing an error is thrown. This might cause confusion for new users.

Also a doctype is useful in the `baseof.html` template, which was added with this pull request as well.