### PR TITLE
Add flag to allow modifying task list checkboxes

### DIFF
--- a/docs/content/en/readfiles/bfconfig.md
+++ b/docs/content/en/readfiles/bfconfig.md
@@ -5,6 +5,11 @@
     Blackfriday flag: <br>
     Purpose: `false` turns off GitHub-style automatic task/TODO list generation.
 
+`TaskListsEditable`
+: default: **`false`**<br>
+    Blackfriday flag: <br>
+    Purpose: `true` turns on the ability to modify checkboxes in task lists.
+
 `smartypants`
 : default: **`true`** <br>
     Blackfriday flag: **`HTML_USE_SMARTYPANTS`** <br>

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -115,6 +115,7 @@ type BlackFriday struct {
 	SmartDashes           bool
 	LatexDashes           bool
 	TaskLists             bool
+	TaskListsEditable     bool
 	PlainIDAnchors        bool
 	Extensions            []string
 	ExtensionsMask        []string

--- a/helpers/content_renderer.go
+++ b/helpers/content_renderer.go
@@ -50,13 +50,24 @@ func (r *HugoHTMLRenderer) ListItem(out *bytes.Buffer, text []byte, flags int) {
 		return
 	}
 
+	var checked []byte
+	var unchecked []byte
+
+	if r.Config.TaskListsEditable {
+		checked = []byte(`<label><input type="checkbox" checked class="task-list-item">`)
+		unchecked = []byte(`<label><input type="checkbox" class="task-list-item">`)
+	} else {
+		checked = []byte(`<label><input type="checkbox" checked disabled class="task-list-item">`)
+		unchecked = []byte(`<label><input type="checkbox" disabled class="task-list-item">`)
+	}
+
 	switch {
 	case bytes.HasPrefix(text, []byte("[ ] ")):
-		text = append([]byte(`<label><input type="checkbox" disabled class="task-list-item">`), text[3:]...)
+		text = append(unchecked, text[3:]...)
 		text = append(text, []byte(`</label>`)...)
 
 	case bytes.HasPrefix(text, []byte("[x] ")) || bytes.HasPrefix(text, []byte("[X] ")):
-		text = append([]byte(`<label><input type="checkbox" checked disabled class="task-list-item">`), text[3:]...)
+		text = append(checked, text[3:]...)
 		text = append(text, []byte(`</label>`)...)
 	}
 


### PR DESCRIPTION
Adds a new Blackfriday flag "TaskListsEditable", which creates task list
checkboxes without the "disabled" flag, allowing those viewing the task
list to check and uncheck boxes in their view.

Fixes #4899