### PR TITLE
hugolib: Do not create paginator pages for the other output formats

### DIFF
--- a/hugolib/site_output_test.go
+++ b/hugolib/site_output_test.go
@@ -47,13 +47,14 @@ baseURL = "http://example.com/blog"
 paginate = 1
 defaultContentLanguage = "en"
 
-disableKinds = ["page", "section", "taxonomy", "taxonomyTerm", "RSS", "sitemap", "robotsTXT", "404"]
+disableKinds = ["section", "taxonomy", "taxonomyTerm", "RSS", "sitemap", "robotsTXT", "404"]
 
 [Taxonomies]
 tag = "tags"
 category = "categories"
 
 defaultContentLanguage = "en"
+
 
 [languages]
 
@@ -125,8 +126,10 @@ List HTML|{{.Title }}|
 Partial Hugo 1: {{ partial "GoHugo.html" . }}
 Partial Hugo 2: {{ partial "GoHugo" . -}}
 Content: {{ .Content }}
+Len Pages: {{ .Kind }} {{ len .Site.RegularPages }} Page Number: {{ .Paginator.PageNumber }}
 {{ end }}
 `,
+		"layouts/_default/single.html", `{{ define "main" }}{{ .Content }}{{ end }}`,
 	)
 	require.Len(t, h.Sites, 2)
 
@@ -134,6 +137,11 @@ Content: {{ .Content }}
 
 	writeSource(t, fs, "content/_index.md", fmt.Sprintf(pageTemplate, "JSON Home", outputsStr))
 	writeSource(t, fs, "content/_index.nn.md", fmt.Sprintf(pageTemplate, "JSON Nynorsk Heim", outputsStr))
+
+	for i := 1; i <= 10; i++ {
+		writeSource(t, fs, fmt.Sprintf("content/p%d.md", i), fmt.Sprintf(pageTemplate, fmt.Sprintf("Page %d", i), outputsStr))
+
+	}
 
 	err := h.Build(BuildCfg{})
 
@@ -175,7 +183,11 @@ Content: {{ .Content }}
 			"en: Elbow",
 			"ShortHTML",
 			"OtherShort: <h1>Hi!</h1>",
+			"Len Pages: home 10",
 		)
+		th.assertFileContent("public/page/2/index.html", "Page Number: 2")
+		th.assertFileNotExist("public/page/2/index.json")
+
 		th.assertFileContent("public/nn/index.html",
 			"List HTML|JSON Nynorsk Heim|",
 			"nn: Olboge")

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -168,7 +168,8 @@ func pageRenderer(s *Site, pages <-chan *Page, results chan<- error, wg *sync.Wa
 					results <- err
 				}
 
-				if pageOutput.IsNode() {
+				// Only render paginators for the main output format
+				if i == 0 && pageOutput.IsNode() {
 					if err := s.renderPaginator(pageOutput); err != nil {
 						results <- err
 					}


### PR DESCRIPTION
This is a recent regression in Hugo, where we have started to produce `/page/30/index.json` when the main output format (usually `HTML`) is set up with pagination.

For JSON this is potentially lot of superflous work and hurts performance.

This commit reinstates the earlier behaviour: We only create paginators if in use in the main output format.

And add a test for it to prevent this from happening again.

Fixes #4890