### PR TITLE
hugolib: Remove empty resources/ dir after TestNewSiteDefaultLang

### DIFF
--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -15,6 +15,7 @@ package hugolib
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -359,6 +360,7 @@ func doTestShouldAlwaysHaveUglyURLs(t *testing.T, uglyURLs bool) {
 
 func TestNewSiteDefaultLang(t *testing.T) {
 	t.Parallel()
+	defer os.Remove("resources")
 	s, err := NewSiteDefaultLang()
 	require.NoError(t, err)
 	require.Equal(t, hugofs.Os, s.Fs.Source)


### PR DESCRIPTION
While packaging Hugo v0.43 for Debian, the Lintian tool informed me of the following:

    I: golang-github-gohugoio-hugo-dev: package-contains-empty-directory usr/share/gocode/src/github.com/gohugoio/hugo/hugolib/resources/

This is something new to v0.43.  I wonder what changed.  Hmm...

After some testing, it was found that the hugolib/resources/ directory was created during `go test` run, reproducible by running:

    go test -v ./hugolib/... -run TestNewSiteDefaultLang

It is a very trivial issue, and this PR of adding `defer os.Remove("resources")` is likely not the proper fix either, but I thought I should report it nevertheless.