### PR TITLE
media: Allow multiple file suffixes per media type

### DIFF
--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -219,8 +219,11 @@ map[string]interface {}{
     "mediatype": Type{
       MainType: "text",
       SubType: "m1",
-      Suffix: "m1main",
+      OldSuffix: "m1main",
       Delimiter: ".",
+      Suffixes: []string{
+        "m1main",
+      },
     },
   },
   "o2": map[string]interface {}{
@@ -228,8 +231,11 @@ map[string]interface {}{
     "mediatype": Type{
       MainType: "text",
       SubType: "m2",
-      Suffix: "m2theme",
+      OldSuffix: "m2theme",
       Delimiter: ".",
+      Suffixes: []string{
+        "m2theme",
+      },
     },
   },
 }`, got["outputformats"])

--- a/hugolib/page_output.go
+++ b/hugolib/page_output.go
@@ -218,7 +218,7 @@ func newOutputFormat(p *Page, f output.Format) *OutputFormat {
 func (p *PageOutput) AlternativeOutputFormats() (OutputFormats, error) {
 	var o OutputFormats
 	for _, of := range p.OutputFormats() {
-		if of.f.NotAlternative || of.f == p.outputFormat {
+		if of.f.NotAlternative || of.f.Name == p.outputFormat.Name {
 			continue
 		}
 		o = append(o, of)

--- a/hugolib/page_paths.go
+++ b/hugolib/page_paths.go
@@ -239,7 +239,7 @@ func createTargetPath(d targetPathDescriptor) string {
 		}
 
 		if isUgly {
-			pagePath += d.Type.MediaType.Delimiter + d.Type.MediaType.Suffix
+			pagePath += d.Type.MediaType.FullSuffix()
 		} else {
 			pagePath = filepath.Join(pagePath, d.Type.BaseName+d.Type.MediaType.FullSuffix())
 		}

--- a/hugolib/page_paths_test.go
+++ b/hugolib/page_paths_test.go
@@ -30,7 +30,7 @@ func TestPageTargetPath(t *testing.T) {
 	pathSpec := newTestDefaultPathSpec(t)
 
 	noExtNoDelimMediaType := media.TextType
-	noExtNoDelimMediaType.Suffix = ""
+	noExtNoDelimMediaType.Suffixes = []string{}
 	noExtNoDelimMediaType.Delimiter = ""
 
 	// Netlify style _redirects
@@ -169,8 +169,8 @@ func TestPageTargetPath(t *testing.T) {
 							} else if test.d.Kind == KindHome && test.d.Type.Path != "" {
 							} else if (!strings.HasPrefix(expected, "/index") || test.d.Addends != "") && test.d.URL == "" && isUgly {
 								expected = strings.Replace(expected,
-									"/"+test.d.Type.BaseName+"."+test.d.Type.MediaType.Suffix,
-									"."+test.d.Type.MediaType.Suffix, -1)
+									"/"+test.d.Type.BaseName+"."+test.d.Type.MediaType.Suffix(),
+									"."+test.d.Type.MediaType.Suffix(), -1)
 							}
 
 							if test.d.LangPrefix != "" && !(test.d.Kind == KindPage && test.d.URL != "") {

--- a/hugolib/pagination_test.go
+++ b/hugolib/pagination_test.go
@@ -239,7 +239,7 @@ func TestPaginationURLFactory(t *testing.T) {
 					}
 
 					if uglyURLs {
-						expected = expected[:len(expected)-1] + "." + test.d.Type.MediaType.Suffix
+						expected = expected[:len(expected)-1] + "." + test.d.Type.MediaType.Suffix()
 					}
 
 					pathSpec := newTestPathSpec(fs, cfg)

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -173,11 +173,11 @@ type scKey struct {
 }
 
 func newScKey(m media.Type, shortcodeplaceholder string) scKey {
-	return scKey{Suffix: m.Suffix, ShortcodePlaceholder: shortcodeplaceholder}
+	return scKey{Suffix: m.Suffix(), ShortcodePlaceholder: shortcodeplaceholder}
 }
 
 func newScKeyFromLangAndOutputFormat(lang string, o output.Format, shortcodeplaceholder string) scKey {
-	return scKey{Lang: lang, Suffix: o.MediaType.Suffix, OutputFormat: o.Name, ShortcodePlaceholder: shortcodeplaceholder}
+	return scKey{Lang: lang, Suffix: o.MediaType.Suffix(), OutputFormat: o.Name, ShortcodePlaceholder: shortcodeplaceholder}
 }
 
 func newDefaultScKey(shortcodeplaceholder string) scKey {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -586,8 +586,9 @@ type whatChanged struct {
 // package, so it will behave correctly with Hugo's built-in server.
 func (s *Site) RegisterMediaTypes() {
 	for _, mt := range s.mediaTypesConfig {
-		// The last one will win if there are any duplicates.
-		_ = mime.AddExtensionType("."+mt.Suffix, mt.Type()+"; charset=utf-8")
+		for _, suffix := range mt.Suffixes {
+			_ = mime.AddExtensionType(mt.Delimiter+suffix, mt.Type()+"; charset=utf-8")
+		}
 	}
 }
 

--- a/hugolib/site_output_test.go
+++ b/hugolib/site_output_test.go
@@ -179,7 +179,7 @@ Len Pages: {{ .Kind }} {{ len .Site.RegularPages }} Page Number: {{ .Paginator.P
 		th.assertFileContent("public/index.html",
 			// The HTML entity is a deliberate part of this test: The HTML templates are
 			// parsed with html/template.
-			`List HTML|JSON Home|<atom:link href=http://example.com/blog/ rel="self" type="text/html&#43;html" />`,
+			`List HTML|JSON Home|<atom:link href=http://example.com/blog/ rel="self" type="text/html" />`,
 			"en: Elbow",
 			"ShortHTML",
 			"OtherShort: <h1>Hi!</h1>",
@@ -195,7 +195,7 @@ Len Pages: {{ .Kind }} {{ len .Site.RegularPages }} Page Number: {{ .Paginator.P
 		th.assertFileContent("public/index.json",
 			"Output/Rel: JSON/canonical|",
 			// JSON is plain text, so no need to safeHTML this and that
-			`<atom:link href=http://example.com/blog/index.json rel="self" type="application/json+json" />`,
+			`<atom:link href=http://example.com/blog/index.json rel="self" type="application/json" />`,
 			"ShortJSON",
 			"OtherShort: <h1>Hi!</h1>",
 		)

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -69,7 +69,7 @@ func headlessPagesPublisher(s *Site, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for _, page := range s.headlessPages {
 		outFormat := page.outputFormats[0] // There is only one
-		if outFormat != s.rc.Format {
+		if outFormat.Name != s.rc.Format.Name {
 			// Avoid double work.
 			continue
 		}
@@ -92,7 +92,7 @@ func pageRenderer(s *Site, pages <-chan *Page, results chan<- error, wg *sync.Wa
 
 		for i, outFormat := range page.outputFormats {
 
-			if outFormat != page.s.rc.Format {
+			if outFormat.Name != page.s.rc.Format.Name {
 				// Will be rendered  ... later.
 				continue
 			}

--- a/output/docshelper.go
+++ b/output/docshelper.go
@@ -72,7 +72,7 @@ func createLayoutExamples() interface{} {
 			Example:      example.name,
 			Kind:         example.d.Kind,
 			OutputFormat: example.f.Name,
-			Suffix:       example.f.MediaType.Suffix,
+			Suffix:       example.f.MediaType.Suffix(),
 			Layouts:      makeLayoutsPresentable(layouts)})
 	}
 

--- a/output/layout.go
+++ b/output/layout.go
@@ -47,7 +47,7 @@ type LayoutHandler struct {
 
 type layoutCacheKey struct {
 	d LayoutDescriptor
-	f Format
+	f string
 }
 
 // NewLayoutHandler creates a new LayoutHandler.
@@ -60,7 +60,7 @@ func NewLayoutHandler() *LayoutHandler {
 func (l *LayoutHandler) For(d LayoutDescriptor, f Format) ([]string, error) {
 
 	// We will get lots of requests for the same layouts, so avoid recalculations.
-	key := layoutCacheKey{d, f}
+	key := layoutCacheKey{d, f.Name}
 	l.mu.RLock()
 	if cacheVal, found := l.cache[key]; found {
 		l.mu.RUnlock()
@@ -209,7 +209,7 @@ func (l *layoutBuilder) resolveVariations() []string {
 					"TYPE", typeVar,
 					"LAYOUT", layoutVar,
 					"VARIATIONS", variation,
-					"EXTENSION", l.f.MediaType.Suffix,
+					"EXTENSION", l.f.MediaType.Suffix(),
 				))
 			}
 		}

--- a/output/layout_test.go
+++ b/output/layout_test.go
@@ -27,11 +27,11 @@ import (
 func TestLayout(t *testing.T) {
 
 	noExtNoDelimMediaType := media.TextType
-	noExtNoDelimMediaType.Suffix = ""
+	noExtNoDelimMediaType.Suffixes = nil
 	noExtNoDelimMediaType.Delimiter = ""
 
 	noExtMediaType := media.TextType
-	noExtMediaType.Suffix = ""
+	noExtMediaType.Suffixes = nil
 
 	var (
 		ampType = Format{
@@ -47,6 +47,7 @@ func TestLayout(t *testing.T) {
 			MediaType: noExtNoDelimMediaType,
 			BaseName:  "_redirects",
 		}
+
 		noExt = Format{
 			Name:      "NEX",
 			MediaType: noExtMediaType,

--- a/output/outputFormat.go
+++ b/output/outputFormat.go
@@ -178,7 +178,7 @@ func (formats Formats) Less(i, j int) bool { return formats[i].Name < formats[j]
 // The lookup is case insensitive.
 func (formats Formats) GetBySuffix(suffix string) (f Format, found bool) {
 	for _, ff := range formats {
-		if strings.EqualFold(suffix, ff.MediaType.Suffix) {
+		if strings.EqualFold(suffix, ff.MediaType.Suffix()) {
 			if found {
 				// ambiguous
 				found = false
@@ -331,7 +331,7 @@ func decode(mediaTypes media.Types, input, output interface{}) error {
 }
 
 func (formats Format) BaseFilename() string {
-	return formats.BaseName + "." + formats.MediaType.Suffix
+	return formats.BaseName + formats.MediaType.FullSuffix()
 }
 
 func (formats Format) MarshalJSON() ([]byte, error) {

--- a/output/outputFormat_test.go
+++ b/output/outputFormat_test.go
@@ -93,11 +93,11 @@ func TestGetFormatByExt(t *testing.T) {
 
 func TestGetFormatByFilename(t *testing.T) {
 	noExtNoDelimMediaType := media.TextType
-	noExtNoDelimMediaType.Suffix = ""
+	noExtNoDelimMediaType.OldSuffix = ""
 	noExtNoDelimMediaType.Delimiter = ""
 
 	noExtMediaType := media.TextType
-	noExtMediaType.Suffix = ""
+	noExtMediaType.OldSuffix = ""
 
 	var (
 		noExtDelimFormat = Format{

--- a/resource/bundler/bundler.go
+++ b/resource/bundler/bundler.go
@@ -70,7 +70,7 @@ func (c *Client) Concat(targetPath string, resources []resource.Resource) (resou
 		// The given set of resources must be of the same Media Type.
 		// We may improve on that in the future, but then we need to know more.
 		for i, r := range resources {
-			if i > 0 && r.MediaType() != resolvedm {
+			if i > 0 && r.MediaType().Type() != resolvedm.Type() {
 				return nil, errors.New("resources in Concat must be of the same Media Type")
 			}
 			resolvedm = r.MediaType()

--- a/resource/minifiers/minify.go
+++ b/resource/minifiers/minify.go
@@ -45,7 +45,7 @@ func New(rs *resource.Spec) *Client {
 	addMinifierFunc(m, mt, "text/html", "html", html.Minify)
 	addMinifierFunc(m, mt, "application/javascript", "js", js.Minify)
 	addMinifierFunc(m, mt, "application/json", "json", json.Minify)
-	addMinifierFunc(m, mt, "image/svg", "xml", svg.Minify)
+	addMinifierFunc(m, mt, "image/svg+xml", "svg", svg.Minify)
 	addMinifierFunc(m, mt, "application/xml", "xml", xml.Minify)
 	addMinifierFunc(m, mt, "application/rss", "xml", xml.Minify)
 

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -416,16 +416,15 @@ func (r *Spec) newResource(sourceFs afero.Fs, fd ResourceSourceDescriptor) (Reso
 	mimeType, found := r.MediaTypes.GetFirstBySuffix(strings.TrimPrefix(ext, "."))
 	// TODO(bep) we need to handle these ambigous types better, but in this context
 	// we most likely want the application/xml type.
-	if mimeType.Suffix == "xml" && mimeType.SubType == "rss" {
+	if mimeType.Suffix() == "xml" && mimeType.SubType == "rss" {
 		mimeType, found = r.MediaTypes.GetByType("application/xml")
 	}
 
 	if !found {
 		mimeStr := mime.TypeByExtension(ext)
 		if mimeStr != "" {
-			mimeType, _ = media.FromString(mimeStr)
+			mimeType, _ = media.FromStringAndExt(mimeStr, ext)
 		}
-
 	}
 
 	gr := r.newGenericResourceWithBase(

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -97,7 +97,7 @@ func TestNewResourceFromFilenameSubPathInBaseURL(t *testing.T) {
 
 }
 
-var pngType, _ = media.FromString("image/png")
+var pngType, _ = media.FromStringAndExt("image/png", "png")
 
 func TestResourcesByType(t *testing.T) {
 	assert := require.New(t)


### PR DESCRIPTION
Before this commit, `Suffix` on `MediaType` was used both to set a custom file suffix and as a way to augment the mediatype definition (what you see after the "+", e.g. "image/svg+xml").

This had its limitations. For one, it was only possible with one file extension per MIME type.

Now you can specify multiple file suffixes using "suffixes", but you need to specify the full MIME type
identifier:

[mediaTypes]
[mediaTypes."image/svg+xml"]
suffixes = ["svg", "abc ]

In most cases, it will be enough to just change:

[mediaTypes]
[mediaTypes."my/custom-mediatype"]
suffix = "txt"

To:

[mediaTypes]
[mediaTypes."my/custom-mediatype"]
suffixes = ["txt"]

Hugo will still respect values set in "suffix" if no value for "suffixes" is provided, but this will be removed in a future release.

Note that you can still get the Media Type's suffix from a template: {{ $mediaType.Suffix }}. But this will now map to the MIME type filename.

Fixes #4920