### PR TITLE
hugolib: Fix static filesystem for themed multihost sites

### DIFF
--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -499,7 +499,6 @@ func (b *sourceFilesystemsBuilder) createRootMappingFs(dirKey, themeFolder strin
 	s.Fs = afero.NewReadOnlyFs(fs)
 
 	return s, nil
-
 }
 
 func (b *sourceFilesystemsBuilder) existsInSource(abspath string) bool {
@@ -534,6 +533,14 @@ func (b *sourceFilesystemsBuilder) createStaticFs() error {
 			fs, err := createOverlayFs(b.p.Fs.Source, s.Dirnames)
 			if err != nil {
 				return err
+			}
+
+			if b.hasTheme {
+				themeFolder := "static"
+				fs = afero.NewCopyOnWriteFs(newRealBase(afero.NewBasePathFs(b.themeFs, themeFolder)), fs)
+				for _, absThemeDir := range b.absThemeDirs {
+					s.Dirnames = append(s.Dirnames, filepath.Join(absThemeDir, themeFolder))
+				}
 			}
 
 			s.Fs = fs


### PR DESCRIPTION
Multihost is where each language has its own `baseURL`. In this configuration, static files from the theme was not picked up.

This was a regression in Hugo `0.42`. This commit also adds proper tests for this, so that does not happen again.

Fixes #4929