### PR TITLE
resource: Clean up the in-memory Resource reader usage

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -143,12 +143,6 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/dsnet/golib"
-  packages = ["memfile"]
-  revision = "1ea1667757804fdcccc5a1810e09aba618885ac2"
-
-[[projects]]
-  branch = "master"
   name = "github.com/eknkc/amber"
   packages = [
     ".",
@@ -525,6 +519,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "993acf46c3937e5cebef4f39a2733150aad7cbf96913a017e56cd03c8241a56e"
+  inputs-digest = "9990a6372a365db28e5c7f5bf96aaa6ea72ed217790ff3380e7b6f3c1cd19009"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/resource/create/create.go
+++ b/resource/create/create.go
@@ -16,12 +16,10 @@
 package create
 
 import (
-	"io"
 	"path/filepath"
 
 	"github.com/spf13/afero"
 
-	"github.com/dsnet/golib/memfile"
 	"github.com/gohugoio/hugo/resource"
 )
 
@@ -36,15 +34,6 @@ func New(rs *resource.Spec) *Client {
 	return &Client{rs: rs}
 }
 
-type memFileCloser struct {
-	*memfile.File
-	io.Closer
-}
-
-func (m *memFileCloser) Close() error {
-	return nil
-}
-
 // Get creates a new Resource by opening the given filename in the given filesystem.
 func (c *Client) Get(fs afero.Fs, filename string) (resource.Resource, error) {
 	filename = filepath.Clean(filename)
@@ -53,7 +42,6 @@ func (c *Client) Get(fs afero.Fs, filename string) (resource.Resource, error) {
 			resource.ResourceSourceDescriptor{
 				LazyPublish:    true,
 				SourceFilename: filename})
-
 	})
 
 }
@@ -66,9 +54,7 @@ func (c *Client) FromString(targetPath, content string) (resource.Resource, erro
 			resource.ResourceSourceDescriptor{
 				LazyPublish: true,
 				OpenReadSeekCloser: func() (resource.ReadSeekCloser, error) {
-					return &memFileCloser{
-						File: memfile.New([]byte(content)),
-					}, nil
+					return resource.NewReadSeekerNoOpCloserFromString(content), nil
 				},
 				RelTargetFilename: filepath.Clean(targetPath)})
 

--- a/resource/readers.go
+++ b/resource/readers.go
@@ -1,0 +1,53 @@
+// Copyright 2018 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"io"
+	"strings"
+)
+
+// ReadSeeker wraps io.Reader and io.Seeker.
+type ReadSeeker interface {
+	io.Reader
+	io.Seeker
+}
+
+// ReadSeekCloser is implemented by afero.File. We use this as the common type for
+// content in Resource objects, even for strings.
+type ReadSeekCloser interface {
+	ReadSeeker
+	io.Closer
+}
+
+// ReadSeekerNoOpCloser implements ReadSeekCloser by doing nothing in Close.
+type ReadSeekerNoOpCloser struct {
+	ReadSeeker
+}
+
+// Close does nothing.
+func (r ReadSeekerNoOpCloser) Close() error {
+	return nil
+}
+
+// NewReadSeekerNoOpCloser creates a new ReadSeekerNoOpCloser with the given ReadSeeker.
+func NewReadSeekerNoOpCloser(r ReadSeeker) ReadSeekerNoOpCloser {
+	return ReadSeekerNoOpCloser{r}
+}
+
+// NewReadSeekerNoOpCloserFromString uses strings.NewReader to create a new ReadSeekerNoOpCloser
+// from the given string.
+func NewReadSeekerNoOpCloserFromString(content string) ReadSeekerNoOpCloser {
+	return ReadSeekerNoOpCloser{strings.NewReader(content)}
+}

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -16,7 +16,6 @@ package resource
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"mime"
 	"os"
@@ -132,14 +131,6 @@ type ContentResource interface {
 	// * JSON: String
 	// * Etc.
 	Content() (interface{}, error)
-}
-
-// ReadSeekCloser is implemented by afero.File. We use this as the common type for
-// content in Resource objects, even for strings.
-type ReadSeekCloser interface {
-	io.Reader
-	io.Seeker
-	io.Closer
 }
 
 // OpenReadSeekeCloser allows setting some other way (than reading from a filesystem)

--- a/resource/transform.go
+++ b/resource/transform.go
@@ -188,25 +188,11 @@ type transformedResource struct {
 	Resource
 }
 
-type readSeeker struct {
-	io.Reader
-	io.Seeker
-	io.Closer
-}
-
-func (r *readSeeker) Close() error {
-	return nil
-}
-
-func (r *readSeeker) Seek(offset int64, whence int) (int64, error) {
-	panic("Seek is not supported by this io.Reader")
-}
-
 func (r *transformedResource) ReadSeekCloser() (ReadSeekCloser, error) {
 	if err := r.initContent(); err != nil {
 		return nil, err
 	}
-	return &readSeeker{Reader: strings.NewReader(r.content)}, nil
+	return NewReadSeekerNoOpCloserFromString(r.content), nil
 }
 
 func (r *transformedResource) transferTransformedValues(another *transformedResource) {


### PR DESCRIPTION
Turns out `strings.Reader` implements both `io.Reader` and `io.Seeker`, so we don't need anything special.

Updates #4936