### PR TITLE
hugolib: Only set 'allThemes' if there are themes in the config file

### DIFF
--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -285,6 +285,11 @@ func loadThemeConfig(d ConfigSourceDescriptor, v1 *viper.Viper) ([]string, error
 	if err != nil {
 		return nil, err
 	}
+
+	if len(themeConfigs) == 0 {
+		return nil, nil
+	}
+
 	v1.Set("allThemes", themeConfigs)
 
 	var configFilenames []string

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -42,6 +42,8 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal("side", cfg.GetString("paginatePath"))
 	// default
 	assert.Equal("layouts", cfg.GetString("layoutDir"))
+	// no themes
+	assert.False(cfg.IsSet("allThemes"))
 }
 
 func TestLoadMultiConfig(t *testing.T) {


### PR DESCRIPTION
When the 'allThemes' configuration setting is read, it will panic if
there are no themes. This was a regression introduced in Hugo 0.42.

Also updated a unit test to check for this.

Fixes #4851