### PR TITLE
Fix rendering of resource pages in leaf bundles

### DIFF
--- a/hugolib/page_bundler_test.go
+++ b/hugolib/page_bundler_test.go
@@ -345,6 +345,34 @@ func TestPageBundlerSiteWitSymbolicLinksInContent(t *testing.T) {
 
 }
 
+func TestPageBundlerRenderResource(t *testing.T) {
+	cfg, fs := newTestCfg()
+
+	assert := require.New(t)
+
+	workDir := "/work"
+	cfg.Set("workingDir", workDir)
+	cfg.Set("contentDir", "base")
+	cfg.Set("baseURL", "https://example.com")
+
+	writeSource(t, fs, filepath.Join(workDir, "layouts", "_default", "single.html"), `
+single
+{{ range .Resources }}{{ .Render "resourcerender" }}{{ end }}`)
+	writeSource(t, fs, filepath.Join(workDir, "layouts", "_default", "resourcerender.html"), "resourcerender {{ .Title }}")
+	writeSource(t, fs, filepath.Join(workDir, "base", "a", "index.md"), `---
+title: "This is the page"
+---`)
+	writeSource(t, fs, filepath.Join(workDir, "base", "a", "resource.md"), `---
+title: "This is the resource"
+---`)
+
+	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{})
+	assert.Equal(1, len(s.RegularPages))
+	fmt.Print()
+	th := testHelper{s.Cfg, s.Fs, t}
+	th.assertFileContent(filepath.FromSlash(workDir+"/public/a/index.html"), "resourcerender This is the resource")
+}
+
 func TestPageBundlerHeadless(t *testing.T) {
 	t.Parallel()
 

--- a/hugolib/page_output.go
+++ b/hugolib/page_output.go
@@ -156,7 +156,15 @@ func executeToString(templ tpl.Template, data interface{}) (string, error) {
 
 func (p *Page) Render(layout ...string) template.HTML {
 	if p.mainPageOutput == nil {
-		panic(fmt.Sprintf("programming error: no mainPageOutput for %q", p.Path()))
+		pageOutput, err := newPageOutput(p, false, false, p.OutputFormats().Get("html").f)
+		if err == nil {
+			p.mainPageOutput = pageOutput
+			err = pageOutput.renderResources()
+		}
+
+		if err != nil {
+			panic(fmt.Sprintf("Failed to render resources for page %q: %s", p.Path(), err))
+		}
 	}
 	return p.mainPageOutput.Render(layout...)
 }


### PR DESCRIPTION
When having a leave bundle with nested pages calling `.Render` currently results in an error message. I do not think this is supposed to happen. This PR provides a very simple fix. See the test for an example.

Also fixes https://github.com/gohugoio/hugo/issues/4861 and hence the referenced example repository https://github.com/jrisch/hugo-test can be taken as an example use case. (without this PR rendering hugo-test breaks with `Failed to render "_default/page.html": programming error: no mainPageOutput for "products/myproduct/codeexample.md"`)