### PR TITLE
hugolib: Mark shortcode changes as content changes in server mode

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -817,7 +817,7 @@ func (s *Site) processPartial(events []fsnotify.Event) (whatChanged, error) {
 	}
 
 	changed := whatChanged{
-		source: len(sourceChanged) > 0,
+		source: len(sourceChanged) > 0 || len(shortcodesChanged) > 0,
 		other:  len(tmplChanged) > 0 || len(i18nChanged) > 0 || len(dataChanged) > 0,
 		files:  sourceFilesChanged,
 	}


### PR DESCRIPTION
This is unfortunate, but is needed to re-create the taxonomies collections etc. that may be referenced from them.

Fixes #4965