### PR TITLE
Add test coverage for recent ref overhaul

### DIFF
--- a/hugolib/page_collections_test.go
+++ b/hugolib/page_collections_test.go
@@ -96,6 +96,29 @@ func BenchmarkGetPageRegular(b *testing.B) {
 	}
 }
 
+type testCase struct {
+	kind          string
+	context       *Page
+	path          []string
+	expectedTitle string
+}
+
+func (t *testCase) check(p *Page, err error, errorMsg string, assert *require.Assertions) {
+	switch t.kind {
+	case "Ambiguous":
+		assert.Error(err)
+		assert.Nil(p, errorMsg)
+	case "NoPage":
+		assert.NoError(err)
+		assert.Nil(p, errorMsg)
+	default:
+		assert.NoError(err, errorMsg)
+		assert.NotNil(p, errorMsg)
+		assert.Equal(t.kind, p.Kind, errorMsg)
+		assert.Equal(t.expectedTitle, p.title, errorMsg)
+	}
+}
+
 func TestGetPage(t *testing.T) {
 
 	var (
@@ -110,51 +133,110 @@ func TestGetPage(t *testing.T) {
 		}
 	}
 
-	content := fmt.Sprintf(pageCollectionsPageTemplate, "UniqueBase")
+	content := fmt.Sprintf(pageCollectionsPageTemplate, "home page")
+	writeSource(t, fs, filepath.Join("content", "_index.md"), content)
+
+	content = fmt.Sprintf(pageCollectionsPageTemplate, "about page")
+	writeSource(t, fs, filepath.Join("content", "about.md"), content)
+
+	content = fmt.Sprintf(pageCollectionsPageTemplate, "section 3")
+	writeSource(t, fs, filepath.Join("content", "sect3", "_index.md"), content)
+
+	content = fmt.Sprintf(pageCollectionsPageTemplate, "UniqueBase")
 	writeSource(t, fs, filepath.Join("content", "sect3", "unique.md"), content)
+
+	content = fmt.Sprintf(pageCollectionsPageTemplate, "another sect7")
+	writeSource(t, fs, filepath.Join("content", "sect3", "sect7", "_index.md"), content)
+
+	content = fmt.Sprintf(pageCollectionsPageTemplate, "deep page")
+	writeSource(t, fs, filepath.Join("content", "sect3", "subsect", "deep.md"), content)
 
 	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{SkipRender: true})
 
-	tests := []struct {
-		kind          string
-		path          []string
-		expectedTitle string
-	}{
-		{KindHome, []string{}, ""},
-		{KindSection, []string{"sect3"}, "Sect3s"},
-		{KindPage, []string{"sect3/page1.md"}, "Title3_1"},
-		{KindPage, []string{"sect4/page2.md"}, "Title4_2"},
-		{KindPage, []string{filepath.FromSlash("sect5/page3.md")}, "Title5_3"},
-		// Ref/Relref supports this potentially ambiguous lookup.
-		{KindPage, []string{"unique.md"}, "UniqueBase"},
+	sec3, err := s.getPageNew(nil, "/sect3")
+	assert.NoError(err, "error getting Page for /sec3")
+	assert.NotNil(sec3, "failed to get Page for /sec3")
+
+	tests := []testCase{
+		// legacy content root relative paths
+		{KindHome, nil, []string{}, "home page"},
+		{KindPage, nil, []string{"about.md"}, "about page"},
+		{KindSection, nil, []string{"sect3"}, "section 3"},
+		{KindPage, nil, []string{"sect3/page1.md"}, "Title3_1"},
+		{KindPage, nil, []string{"sect4/page2.md"}, "Title4_2"},
+		{KindSection, nil, []string{"sect3/sect7"}, "another sect7"},
+		{KindPage, nil, []string{"sect3/subsect/deep.md"}, "deep page"},
+		{KindPage, nil, []string{filepath.FromSlash("sect5/page3.md")}, "Title5_3"}, //test OS-specific path
+
+		// shorthand refs (potentially ambiguous)
+		{KindPage, nil, []string{"unique.md"}, "UniqueBase"},
+		{"Ambiguous", nil, []string{"page1.md"}, ""},
+
+		// ISSUE: This is an ambiguous ref, but because we have to support the legacy
+		// content root relative paths without a leading slash, the lookup
+		// returns /sect7. This undermines ambiguity detection, but we have no choice.
+		//{"Ambiguous", nil, []string{"sect7"}, ""},
+		{KindSection, nil, []string{"sect7"}, "Sect7s"},
+
+		// absolute paths
+		{KindHome, nil, []string{"/"}, "home page"},
+		{KindPage, nil, []string{"/about.md"}, "about page"},
+		{KindSection, nil, []string{"/sect3"}, "section 3"},
+		{KindPage, nil, []string{"/sect3/page1.md"}, "Title3_1"},
+		{KindPage, nil, []string{"/sect4/page2.md"}, "Title4_2"},
+		{KindSection, nil, []string{"/sect3/sect7"}, "another sect7"},
+		{KindPage, nil, []string{"/sect3/subsect/deep.md"}, "deep page"},
+		{KindPage, nil, []string{filepath.FromSlash("/sect5/page3.md")}, "Title5_3"}, //test OS-specific path
+		{KindPage, nil, []string{"/sect3/unique.md"}, "UniqueBase"},                  //next test depends on this page existing
+		// {"NoPage", nil, []string{"/unique.md"}, ""},  // ISSUE #4969: this is resolving to /sect3/unique.md
+		{"NoPage", nil, []string{"/missing-page.md"}, ""},
+		{"NoPage", nil, []string{"/missing-section"}, ""},
+
+		// relative paths
+		{KindHome, sec3, []string{".."}, "home page"},
+		{KindHome, sec3, []string{"../"}, "home page"},
+		{KindPage, sec3, []string{"../about.md"}, "about page"},
+		{KindSection, sec3, []string{"."}, "section 3"},
+		{KindSection, sec3, []string{"./"}, "section 3"},
+		{KindPage, sec3, []string{"page1.md"}, "Title3_1"},
+		{KindPage, sec3, []string{"./page1.md"}, "Title3_1"},
+		{KindPage, sec3, []string{"../sect4/page2.md"}, "Title4_2"},
+		{KindSection, sec3, []string{"sect7"}, "another sect7"},
+		{KindSection, sec3, []string{"./sect7"}, "another sect7"},
+		{KindPage, sec3, []string{"./subsect/deep.md"}, "deep page"},
+		{KindPage, sec3, []string{"./subsect/../../sect7/page9.md"}, "Title7_9"},
+		{KindPage, sec3, []string{filepath.FromSlash("../sect5/page3.md")}, "Title5_3"}, //test OS-specific path
+		{KindPage, sec3, []string{"./unique.md"}, "UniqueBase"},
+		{"NoPage", sec3, []string{"./sect2"}, ""},
+		//{"NoPage", sec3, []string{"sect2"}, ""}, // ISSUE: /sect3 page relative query is resolving to /sect2
+
+		// absolute paths ignore context
+		{KindHome, sec3, []string{"/"}, "home page"},
+		{KindPage, sec3, []string{"/about.md"}, "about page"},
+		{KindPage, sec3, []string{"/sect4/page2.md"}, "Title4_2"},
+		{KindPage, sec3, []string{"/sect3/subsect/deep.md"}, "deep page"}, //next test depends on this page existing
+		//{"NoPage", sec3, []string{"/subsect/deep.md"}, ""}, // ISSUE #4969: this absolute ref is resolving to /sect3/subsect/deep.md
 	}
 
-	for i, test := range tests {
-		errorMsg := fmt.Sprintf("Test %d", i)
+	for _, test := range tests {
+		errorMsg := fmt.Sprintf("Test case %s %v -> %s", test.context, test.path, test.expectedTitle)
 
-		// test legacy public Site.GetPage
-		args := append([]string{test.kind}, test.path...)
-		page, err := s.Info.GetPage(args...)
-		assert.NoError(err)
-		assert.NotNil(page, errorMsg)
-		assert.Equal(test.kind, page.Kind, errorMsg)
-		assert.Equal(test.expectedTitle, page.title)
+		// test legacy public Site.GetPage (which does not support page context relative queries)
+		if test.context == nil {
+			args := append([]string{test.kind}, test.path...)
+			page, err := s.Info.GetPage(args...)
+			test.check(page, err, errorMsg, assert)
+		}
 
-		// test new internal Site.getPage
+		// test new internal Site.getPageNew
 		var ref string
 		if len(test.path) == 1 {
 			ref = filepath.ToSlash(test.path[0])
 		} else {
 			ref = path.Join(test.path...)
 		}
-		page2, err := s.getPageNew(nil, ref)
-		assert.NoError(err)
-		assert.NotNil(page2, errorMsg)
-		assert.Equal(test.kind, page2.Kind, errorMsg)
-		assert.Equal(test.expectedTitle, page2.title)
-
+		page2, err := s.getPageNew(test.context, ref)
+		test.check(page2, err, errorMsg, assert)
 	}
-
-	// vas(todo) add ambiguity detection tests
 
 }


### PR DESCRIPTION
These are the tests I intended to write to include in and give thorough coverage to #4796 once I got word that the work I had done was approved (I didn't want to waste my time writing tests for a PR that wasn't going anywhere). But my commits from that PR suddenly got merged via #4955.

A logic change made in the latter PR, in commit 3eb313fe, introduced a flaw in the handling of absolute refs. These tests demonstrate that flaw. 

They also show some corner-case issues resulting from the co-existance of unix-path semantics and "ambiguous ref" semantics (They will necessarily conflict!). Whether or not the issues are addressed, it is good they are known. 

All the above issues are flagged in the tests with the text "ISSUE:".