### PR TITLE
Fix typo-logic bug in GetPage

### DIFF
--- a/hugolib/page_collections.go
+++ b/hugolib/page_collections.go
@@ -221,7 +221,7 @@ func (c *PageCollections) getPageNew(context *Page, ref string) (*Page, error) {
 
 	// Last try.
 	ref = strings.TrimPrefix(ref, "/")
-	context, err := c.getFromCache(ref)
+	p, err := c.getFromCache(ref)
 
 	if err != nil {
 		if context != nil {
@@ -230,7 +230,7 @@ func (c *PageCollections) getPageNew(context *Page, ref string) (*Page, error) {
 		return nil, fmt.Errorf("failed to resolve page: %s", err)
 	}
 
-	return context, nil
+	return p, nil
 }
 
 func (*PageCollections) findPagesByKindIn(kind string, inPages Pages) Pages {


### PR DESCRIPTION
I'm not sure what it takes to invoke the "Last try" lookup, as none of the tests get it, but it is clearly a bug. 