### PR TITLE
Increase refLinker test coverage

### DIFF
--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -874,6 +874,8 @@ func TestWeightedTaxonomies(t *testing.T) {
 func setupLinkingMockSite(t *testing.T) *Site {
 	sources := [][2]string{
 		{filepath.FromSlash("level2/unique.md"), ""},
+		{filepath.FromSlash("_index.md"), ""},
+		{filepath.FromSlash("common.md"), ""},
 		{filepath.FromSlash("rootfile.md"), ""},
 		{filepath.FromSlash("root-image.png"), ""},
 
@@ -884,10 +886,13 @@ func setupLinkingMockSite(t *testing.T) *Site {
 		{filepath.FromSlash("level2/common.png"), ""},
 
 		{filepath.FromSlash("level2/level3/start.md"), ""},
+		{filepath.FromSlash("level2/level3/_index.md"), ""},
 		{filepath.FromSlash("level2/level3/3-root.md"), ""},
 		{filepath.FromSlash("level2/level3/common.md"), ""},
 		{filepath.FromSlash("level2/level3/3-image.png"), ""},
 		{filepath.FromSlash("level2/level3/common.png"), ""},
+
+		{filepath.FromSlash("level2/level3/embedded.dot.md"), ""},
 	}
 
 	cfg, fs := newTestCfg()
@@ -921,14 +926,52 @@ func TestRefLinking(t *testing.T) {
 		relative     bool
 		expected     string
 	}{
+		// different refs resolving to the same unique filename:
+		{"/level2/unique.md", "", true, "/level2/unique/"},
+		{"../unique.md", "", true, "/level2/unique/"},
 		{"unique.md", "", true, "/level2/unique/"},
+
 		{"level2/common.md", "", true, "/level2/common/"},
 		{"3-root.md", "", true, "/level2/level3/3-root/"},
+		{"../..", "", true, "/"},
+
+		// different refs resolving to the same ambiguous top-level filename:
+		{"../../common.md", "", true, "/common/"},
+		{"/common.md", "", true, "/common/"},
+
+		// different refs resolving to the same ambiguous level-2 filename:
+		{"/level2/common.md", "", true, "/level2/common/"},
+		{"../common.md", "", true, "/level2/common/"},
+		{"common.md", "", true, "/level2/level3/common/"},
+
+		// different refs resolving to the same section:
+		{"/level2", "", true, "/level2/"},
+		{"..", "", true, "/level2/"},
+		{"../", "", true, "/level2/"},
+
+		// different refs resolving to the same subsection:
+		{"/level2/level3", "", true, "/level2/level3/"},
+		{"/level2/level3/_index.md", "", true, "/level2/level3/"},
+		{".", "", true, "/level2/level3/"},
+		{"./", "", true, "/level2/level3/"},
+
+		// try to confuse parsing
+		{"embedded.dot.md", "", true, "/level2/level3/embedded.dot/"},
+
+		//test empty link, as well as fragment only link
+		{"", "", true, ""},
 	} {
-		if out, err := site.refLink(test.link, currentPage, test.relative, test.outputFormat); err != nil || out != test.expected {
-			t.Errorf("[%d] Expected %s to resolve to (%s), got (%s) - error: %s", i, test.link, test.expected, out, err)
-		}
+		checkLinkCase(site, test.link, currentPage, test.relative, test.outputFormat, test.expected, t, i)
+
+		//make sure fragment links are also handled
+		checkLinkCase(site, test.link+"#intro", currentPage, test.relative, test.outputFormat, test.expected+"#intro", t, i)
 	}
 
 	// TODO: and then the failure cases.
+}
+
+func checkLinkCase(site *Site, link string, currentPage *Page, relative bool, outputFormat string, expected string, t *testing.T, i int) {
+	if out, err := site.refLink(link, currentPage, relative, outputFormat); err != nil || out != expected {
+		t.Errorf("[%d] Expected %q from %q to resolve to %q, got %q - error: %s", i, link, currentPage.absoluteSourceRef(), expected, out, err)
+	}
 }


### PR DESCRIPTION
@bep These are tests from my fork that I missed including in my PR for the ref logic changes. It may seem a little redundant with the tests for GetPage, but refLinker does more than simply look up a page based on a ref: 
- It first parses the ref to separate the file path from the fragment identifier (either one, both or neither can be supplied). The current implementation uses a URL parser to parse a file path, so we cannot assume it is correct.
- Instead of returning the Page, it returns its permalink or relative permalink 
- It appends the fragment identifier onto that (tested), possible making sure it is unique (not tested yet)

So I think these tests are worth having. Your call of course.
