### PR TITLE
resource/scss: Add IncludePaths config option

### DIFF
--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -244,8 +244,7 @@ func (d *SourceFilesystem) RealDirs(from string) []string {
 	var dirnames []string
 	for _, dir := range d.Dirnames {
 		dirname := filepath.Join(dir, from)
-
-		if _, err := hugofs.Os.Stat(dirname); err == nil {
+		if _, err := d.SourceFs.Stat(dirname); err == nil {
 			dirnames = append(dirnames, dirname)
 		}
 	}

--- a/hugolib/page_bundler_capture_test.go
+++ b/hugolib/page_bundler_capture_test.go
@@ -90,8 +90,9 @@ func TestPageBundlerCaptureSymlinks(t *testing.T) {
 	}
 
 	assert := require.New(t)
-	ps, workDir := newTestBundleSymbolicSources(t)
+	ps, clean, workDir := newTestBundleSymbolicSources(t)
 	sourceSpec := source.NewSourceSpec(ps, ps.BaseFs.Content.Fs)
+	defer clean()
 
 	fileStore := &storeFilenames{}
 	logger := loggers.NewErrorLogger()

--- a/hugolib/testhelpers_test.go
+++ b/hugolib/testhelpers_test.go
@@ -1,7 +1,9 @@
 package hugolib
 
 import (
+	"io/ioutil"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"bytes"
@@ -80,6 +82,20 @@ func newTestSitesBuilder(t testing.TB) *sitesBuilder {
 	}
 
 	return &sitesBuilder{T: t, Fs: fs, configFormat: "toml", dumper: litterOptions}
+}
+
+func createTempDir(prefix string) (string, func(), error) {
+	workDir, err := ioutil.TempDir("", prefix)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if runtime.GOOS == "darwin" && !strings.HasPrefix(workDir, "/private") {
+		// To get the entry folder in line with the rest. This its a little bit
+		// mysterious, but so be it.
+		workDir = "/private" + workDir
+	}
+	return workDir, func() { os.RemoveAll(workDir) }, nil
 }
 
 func (s *sitesBuilder) Running() *sitesBuilder {

--- a/resource/tocss/scss/client.go
+++ b/resource/tocss/scss/client.go
@@ -22,12 +22,13 @@ import (
 )
 
 type Client struct {
-	rs  *resource.Spec
-	sfs *filesystems.SourceFilesystem
+	rs     *resource.Spec
+	sfs    *filesystems.SourceFilesystem
+	workFs *filesystems.SourceFilesystem
 }
 
 func New(fs *filesystems.SourceFilesystem, rs *resource.Spec) (*Client, error) {
-	return &Client{sfs: fs, rs: rs}, nil
+	return &Client{sfs: fs, workFs: rs.BaseFs.Work, rs: rs}, nil
 }
 
 type Options struct {
@@ -37,6 +38,13 @@ type Options struct {
 	// control this by setting this, e.g. "styles/main.css" will create
 	// a Resource with that as a base for RelPermalink etc.
 	TargetPath string
+
+	// Hugo automatically adds the entry directories (where the main.scss lives)
+	// for project and themes to the list of include paths sent to LibSASS.
+	// Any paths set in this setting will be appended. Note that these will be
+	// treated as relative to the working dir, i.e. no include paths outside the
+	// project/themes.
+	IncludePaths []string
 
 	// Default is nested.
 	// One of nested, expanded, compact, compressed.

--- a/resource/tocss/scss/tocss.go
+++ b/resource/tocss/scss/tocss.go
@@ -49,9 +49,12 @@ func (t *toCSSTransformation) Transform(ctx *resource.ResourceTransformationCtx)
 
 	options := t.options
 
-	// We may allow the end user to add IncludePaths later, if we find a use
-	// case for that.
 	options.to.IncludePaths = t.c.sfs.RealDirs(path.Dir(ctx.SourcePath))
+
+	// Append any workDir relative include paths
+	for _, ip := range options.from.IncludePaths {
+		options.to.IncludePaths = append(options.to.IncludePaths, t.c.workFs.RealDirs(filepath.Clean(ip))...)
+	}
 
 	if ctx.InMediaType.SubType == media.SASSType.SubType {
 		options.to.SassSyntax = true


### PR DESCRIPTION
Takes paths relative to the current working dir.

Fixes #4921