### PR TITLE
hugolib: Fix "borrow content from another language" issue

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1249,10 +1249,10 @@ func (p *Page) prepareForRender() error {
 	// or a template or similar has changed so wee need to do a rerendering
 	// of the shortcodes etc.
 
-	// If in watch mode or if we have multiple output formats,
+	// If in watch mode or if we have multiple sites or output formats,
 	// we need to keep the original so we can
 	// potentially repeat this process on rebuild.
-	needsACopy := s.running() || len(p.outputFormats) > 1
+	needsACopy := s.running() || len(s.owner.Sites) > 1 || len(p.outputFormats) > 1
 	var workContentCopy []byte
 	if needsACopy {
 		workContentCopy = make([]byte, len(p.workContent))


### PR DESCRIPTION
If a content file contains shortcode(s), we have logic in place to re-render it per output format.

We also have logic in place that avoids making a copy of the content used for this process if we don't need it.

This was before this commit limited to server mode and if the page should be output to multiple formats.

But there is a third case: If a site (language) borrows and renders `.Content` from another language. This would, before this commit, behave oddly for content with shortcodes.

Fixes #4986