### PR TITLE
hugolib: Fix .Site.GetPage regression

### DIFF
--- a/hugolib/page_collections.go
+++ b/hugolib/page_collections.go
@@ -176,7 +176,14 @@ func (c *PageCollections) getPageOldVersion(ref ...string) (*Page, error) {
 	if len(refs) == 0 || refs[0] == KindHome {
 		key = "/"
 	} else if len(refs) == 1 {
-		key = refs[0]
+		if len(ref) == 2 && refs[0] == KindSection {
+			// This is an old style reference to the "Home Page section".
+			// Typically fetched via {{ .Site.GetPage "section" .Section }}
+			// See https://github.com/gohugoio/hugo/issues/4989
+			key = "/"
+		} else {
+			key = refs[0]
+		}
 	} else {
 		key = refs[1]
 	}

--- a/hugolib/site_sections_test.go
+++ b/hugolib/site_sections_test.go
@@ -109,6 +109,8 @@ Content
 {{ range .Paginator.Pages }}
 PAG|{{ .Title }}|{{ $sect.InSection . }}
 {{ end }}
+{{/* https://github.com/gohugoio/hugo/issues/4989 */}}
+{{ $sections := (.Site.GetPage "section" .Section).Sections.ByWeight }}
 </html>`)
 
 	cfg.Set("paginate", 2)


### PR DESCRIPTION
In Hugo 0.44 we simplified the `.Site.GetPage` API and added code to handle the old-style syntax in most cases.

This logic did not handle the lookup of the home page via `.Site.GetPage "section" ""` and similar. This commit fixes that.

Fixes #4989