### PR TITLE
Fix file paths for uncached transformed images

### DIFF
--- a/resource/image_cache.go
+++ b/resource/image_cache.go
@@ -100,16 +100,16 @@ func (c *imageCache) getOrCreate(
 
 	if exists {
 		img = parent.clone()
-		img.relTargetDirFile.file = relTarget.file
-		img.sourceFilename = cacheFilename
-		// We have to look in the resources file system for this.
-		img.overriddenSourceFs = img.spec.BaseFs.Resources.Fs
 	} else {
 		img, err = create(cacheFilename)
 		if err != nil {
 			return nil, err
 		}
 	}
+	img.relTargetDirFile.file = relTarget.file
+	img.sourceFilename = cacheFilename
+	// We have to look in the resources file system for this.
+	img.overriddenSourceFs = img.spec.BaseFs.Resources.Fs
 
 	c.mu.Lock()
 	if img2, found := c.store[key]; found {

--- a/resource/image_test.go
+++ b/resource/image_test.go
@@ -73,6 +73,7 @@ func TestImageTransformBasic(t *testing.T) {
 	assert.NoError(err)
 	assert.True(image != resized)
 	assert.True(image.genericResource != resized.genericResource)
+	assert.True(image.sourceFilename != resized.sourceFilename)
 
 	resized0x, err := image.Resize("x200")
 	assert.NoError(err)
@@ -128,6 +129,7 @@ func TestImageTransformBasic(t *testing.T) {
 	filledAgain, err := image.Fill("200x100 bottomLeft")
 	assert.NoError(err)
 	assert.True(filled == filledAgain)
+	assert.True(filled.sourceFilename == filledAgain.sourceFilename)
 	assertFileCache(assert, image.spec.BaseFs.Resources.Fs, filledAgain.RelPermalink(), 200, 100)
 
 }

--- a/resource/image_test.go
+++ b/resource/image_test.go
@@ -101,7 +101,7 @@ func TestImageTransformBasic(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal("/a/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_625708021e2bb281c9f1002f88e4753f.jpg", fitted.RelPermalink())
 	assert.Equal(50, fitted.Width())
-	assert.Equal(31, fitted.Height())
+	assert.Equal(33, fitted.Height())
 
 	// Check the MD5 key threshold
 	fittedAgain, _ := fitted.Fit("10x20")


### PR DESCRIPTION
When resizing an image the `sourceFilename` (and thus its `.Contents`) represented the original file _if_ the resized image was not already within Hugo's resource cache. If the resized file was already in the resource cache, `sourceFilename` (and `.Contents`) were set as expected.

This PR defers setting `sourceFilename` until we already have an image, whether it was loaded from cache or created anew.

Fixes #5012