### PR TITLE
Make resources fetched via resources.Get and similar language agnostic

### DIFF
--- a/deps/deps.go
+++ b/deps/deps.go
@@ -221,10 +221,14 @@ func (d Deps) ForLanguage(cfg DepsCfg) (*Deps, error) {
 		return nil, err
 	}
 
+	// The resource cache is global so reuse.
+	// TODO(bep) clean up these inits.
+	resourceCache := d.ResourceSpec.ResourceCache
 	d.ResourceSpec, err = resource.NewSpec(d.PathSpec, d.Log, cfg.MediaTypes)
 	if err != nil {
 		return nil, err
 	}
+	d.ResourceSpec.ResourceCache = resourceCache
 
 	d.Cfg = l
 	d.Language = l

--- a/langs/language.go
+++ b/langs/language.go
@@ -33,6 +33,8 @@ var globalOnlySettings = map[string]bool{
 	strings.ToLower("defaultContentLanguageInSubdir"): true,
 	strings.ToLower("defaultContentLanguage"):         true,
 	strings.ToLower("multilingual"):                   true,
+	strings.ToLower("assetDir"):                       true,
+	strings.ToLower("resourceDir"):                    true,
 }
 
 // Language manages specific-language configuration.

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -366,14 +366,6 @@ func (r *Spec) newResourceForFs(sourceFs afero.Fs, fd ResourceSourceDescriptor) 
 		}
 	}
 
-	if fd.URLBase == "" {
-		fd.URLBase = r.GetURLLanguageBasePath()
-	}
-
-	if fd.TargetPathBase == "" {
-		fd.TargetPathBase = r.GetTargetLanguageBasePath()
-	}
-
 	if fd.RelTargetFilename == "" {
 		fd.RelTargetFilename = fd.Filename()
 	}


### PR DESCRIPTION
With the newly released Hugo Pipes, resources fetched and processed via `resources.Get` and similar was published to the relevant language sub folder when in multilingual mode.

The thought behind that was maximum flexibility with support for `assetDir` per language.

In practice this was a bad idea:

* You get duplication of identical content, with added processing time
* You end up with path issues that seem to be hard to find a way around (`@fa-font-path` is one example)

This commit changes that. Now there is only one `assetDir` and if you, as one example, need to generate a CSS per langugage, you need to set the paths yourself.

Fixes #5017