### PR TITLE
fix: goreleaser config

### DIFF
--- a/goreleaser-extended.yml
+++ b/goreleaser-extended.yml
@@ -47,6 +47,7 @@ nfpm:
   maintainer: "Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>"
   description: "A Fast and Flexible Static Site Generator built with love in GoLang."
   license: "Apache 2.0"
+  name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
   replacements:
     amd64: 64bit
     386: 32bit

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -21,15 +21,15 @@ build:
     - goos: openbsd
       goarch: arm
       goarm: 6
-
-fpm:
+nfpm:
   formats:
-      - deb
+    - deb
   vendor: "gohugo.io"
   homepage: "https://gohugo.io/"
   maintainer: "Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>"
   description: "A Fast and Flexible Static Site Generator built with love in GoLang."
   license: "Apache 2.0"
+  name_template: "{{.Binary}}_{{.Version}}_{{.Os}}-{{.Arch}}"
 archive:
   format: tar.gz
   format_overrides:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -30,6 +30,18 @@ nfpm:
   description: "A Fast and Flexible Static Site Generator built with love in GoLang."
   license: "Apache 2.0"
   name_template: "{{.Binary}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+  replacements:
+    amd64: 64bit
+    386: 32bit
+    arm: ARM
+    arm64: ARM64
+    darwin: macOS
+    linux: Linux
+    windows: Windows
+    openbsd: OpenBSD
+    netbsd: NetBSD
+    freebsd: FreeBSD
+    dragonfly: DragonFlyBSD
 archive:
   format: tar.gz
   format_overrides:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,3 +1,4 @@
+project_name: hugo
 build:
   main: main.go
   binary: hugo
@@ -29,7 +30,7 @@ nfpm:
   maintainer: "Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>"
   description: "A Fast and Flexible Static Site Generator built with love in GoLang."
   license: "Apache 2.0"
-  name_template: "{{.Binary}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+  name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
   replacements:
     amd64: 64bit
     386: 32bit
@@ -47,7 +48,7 @@ archive:
   format_overrides:
     - goos: windows
       format: zip
-  name_template: "{{.Binary}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+  name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
   replacements:
     amd64: 64bit
     386: 32bit


### PR DESCRIPTION
closes #5022

nfpm has its own name template now.

It seems that the "normal" (not extended) release is using an older version of goreleaser than the extended? Not sure how I can check the logs for that...

Anyway, I've make both files equal, except for the the `build` and `project_name` parts, so it should be easier to compare them in the future...
