### PR TITLE
Add fileStat to tpl/os/os

### DIFF
--- a/tpl/os/init.go
+++ b/tpl/os/init.go
@@ -55,7 +55,7 @@ func init() {
 			},
 		)
 
-		ns.AddMethodMapping(ctx.FileStat,
+		ns.AddMethodMapping(ctx.Stat,
 			[]string{"fileStat"},
 			[][2]string{
 				{`{{ (fileStat "files/README.txt").Size }}`, `11`},

--- a/tpl/os/init.go
+++ b/tpl/os/init.go
@@ -58,7 +58,7 @@ func init() {
 		ns.AddMethodMapping(ctx.FileStat,
 			[]string{"fileStat"},
 			[][2]string{
-				{`{{ (fileExists "files/README.txt").Size }}`, `11`},
+				{`{{ (fileStat "files/README.txt").Size }}`, `11`},
 			},
 		)
 

--- a/tpl/os/init.go
+++ b/tpl/os/init.go
@@ -55,13 +55,6 @@ func init() {
 			},
 		)
 
-		ns.AddMethodMapping(ctx.Stat,
-			[]string{"fileStat"},
-			[][2]string{
-				{`{{ (fileStat "files/README.txt").Size }}`, `11`},
-			},
-		)
-
 		return ns
 
 	}

--- a/tpl/os/init.go
+++ b/tpl/os/init.go
@@ -55,6 +55,13 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.FileStat,
+			[]string{"fileStat"},
+			[][2]string{
+				{`{{ (fileExists "files/README.txt").Size }}`, `11`},
+			},
+		)
+
 		return ns
 
 	}

--- a/tpl/os/os.go
+++ b/tpl/os/os.go
@@ -131,8 +131,8 @@ func (ns *Namespace) FileExists(i interface{}) (bool, error) {
 	return status, nil
 }
 
-// FileStat Stat returns the os.FileInfo structure describing file.
-func (ns *Namespace) FileStat(i interface{}) (_os.FileInfo, error) {
+// Stat returns the os.FileInfo structure describing file.
+func (ns *Namespace) Stat(i interface{}) (_os.FileInfo, error) {
 	path, err := cast.ToStringE(i)
 	if err != nil {
 		return nil, err

--- a/tpl/os/os.go
+++ b/tpl/os/os.go
@@ -130,3 +130,22 @@ func (ns *Namespace) FileExists(i interface{}) (bool, error) {
 
 	return status, nil
 }
+
+// FileStat Stat returns the os.FileInfo structure describing file.
+func (ns *Namespace) FileStat(i interface{}) (_os.FileInfo, error) {
+	path, err := cast.ToStringE(i)
+	if err != nil {
+		return nil, err
+	}
+
+	if path == "" {
+		return nil, errors.New("fileStat needs a path to a file")
+	}
+
+	r, err := ns.readFileFs.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}

--- a/tpl/os/os_test.go
+++ b/tpl/os/os_test.go
@@ -100,7 +100,7 @@ func TestFileExists(t *testing.T) {
 	}
 }
 
-func TestFileStat(t *testing.T) {
+func TestStat(t *testing.T) {
 	t.Parallel()
 
 	workingDir := "/home/hugo"
@@ -122,7 +122,7 @@ func TestFileStat(t *testing.T) {
 		{"", nil},
 	} {
 		errMsg := fmt.Sprintf("[%d] %v", i, test)
-		result, err := ns.FileStat(test.filename)
+		result, err := ns.Stat(test.filename)
 
 		if test.expect == nil {
 			require.Error(t, err, errMsg)


### PR DESCRIPTION
#### Summary
Add `fileStat` method to `os`
`fileStat PATH` returns `os.FileInfo`

#### Use Case
Method `readFile` has the size limitation (1MB).
To avoid throwing the error and make a workaround, the size must be got before executing `readFile`.
Under the current condition, this can be done via `[]os.FileInfo` as a result of `readDir`.
However, it is a little complicated because you have to handle an array even though you need just a single `os.FileInfo`.
`fileStat` is useful in such situations.
