### PR TITLE
tlp: Fix compiling amber templates that import other templates

### DIFF
--- a/tpl/tplimpl/amber_compiler.go
+++ b/tpl/tplimpl/amber_compiler.go
@@ -17,10 +17,12 @@ import (
 	"html/template"
 
 	"github.com/eknkc/amber"
+	"github.com/spf13/afero"
 )
 
 func (t *templateHandler) compileAmberWithTemplate(b []byte, path string, templ *template.Template) (*template.Template, error) {
 	c := amber.New()
+	c.Options.VirtualFilesystem = afero.NewHttpFs(t.layoutsFs)
 
 	if err := c.ParseData(b, path); err != nil {
 		return nil, err


### PR DESCRIPTION
Without this patch, amber would try to load templates from the filesystem instead of the layouts virtual filesystem.

For example:

* A file `layouts/partials/mixins.amber`
* A file `layouts/_defaults/single.amber` with the line `import ../partials/mixins`.

Would fail with:

> ERROR 2018/08/12 15:17:15 Failed to add template "_default/single.amber" in path "_default/single.amber": Amber Error in <_default/single.amber>: Unable to read partials/mixins.amber, Error: open partials/mixins.amber: no such file or directory - Line: 15, Column: 5, Length: 25

**Tests:**

As far as I can tell, there are no tests for amber templates. Is there a simple way to test this without implementing an integration testing framweork?