### PR TITLE
Fix Resource output in multihost setups

### DIFF
--- a/common/hugio/readers.go
+++ b/common/hugio/readers.go
@@ -1,0 +1,53 @@
+// Copyright 2018 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hugio
+
+import (
+	"io"
+	"strings"
+)
+
+// ReadSeeker wraps io.Reader and io.Seeker.
+type ReadSeeker interface {
+	io.Reader
+	io.Seeker
+}
+
+// ReadSeekCloser is implemented by afero.File. We use this as the common type for
+// content in Resource objects, even for strings.
+type ReadSeekCloser interface {
+	ReadSeeker
+	io.Closer
+}
+
+// ReadSeekerNoOpCloser implements ReadSeekCloser by doing nothing in Close.
+type ReadSeekerNoOpCloser struct {
+	ReadSeeker
+}
+
+// Close does nothing.
+func (r ReadSeekerNoOpCloser) Close() error {
+	return nil
+}
+
+// NewReadSeekerNoOpCloser creates a new ReadSeekerNoOpCloser with the given ReadSeeker.
+func NewReadSeekerNoOpCloser(r ReadSeeker) ReadSeekerNoOpCloser {
+	return ReadSeekerNoOpCloser{r}
+}
+
+// NewReadSeekerNoOpCloserFromString uses strings.NewReader to create a new ReadSeekerNoOpCloser
+// from the given string.
+func NewReadSeekerNoOpCloserFromString(content string) ReadSeekerNoOpCloser {
+	return ReadSeekerNoOpCloser{strings.NewReader(content)}
+}

--- a/common/hugio/writers.go
+++ b/common/hugio/writers.go
@@ -1,0 +1,43 @@
+// Copyright 2018 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hugio
+
+import (
+	"io"
+)
+
+type multiWriteCloser struct {
+	io.Writer
+	closers []io.WriteCloser
+}
+
+func (m multiWriteCloser) Close() error {
+	var err error
+	for _, c := range m.closers {
+		if closeErr := c.Close(); err != nil {
+			err = closeErr
+		}
+	}
+	return err
+}
+
+// NewMultiWriteCloser creates a new io.WriteCloser that duplicates its writes to all the
+// provided writers.
+func NewMultiWriteCloser(writeClosers ...io.WriteCloser) io.WriteCloser {
+	writers := make([]io.Writer, len(writeClosers))
+	for i, w := range writeClosers {
+		writers[i] = w
+	}
+	return multiWriteCloser{Writer: io.MultiWriter(writers...), closers: writeClosers}
+}

--- a/hugolib/hugo_sites_multihost_test.go
+++ b/hugolib/hugo_sites_multihost_test.go
@@ -81,8 +81,10 @@ languageName = "Nynorsk"
 	s2h := s2.getPage(KindHome)
 	assert.Equal("https://example.fr/", s2h.Permalink())
 
-	b.AssertFileContent("public/fr/index.html", "French Home Page")
-	b.AssertFileContent("public/en/index.html", "Default Home Page")
+	b.AssertFileContent("public/fr/index.html", "French Home Page", "String Resource: /docs/text/pipes.txt")
+	b.AssertFileContent("public/fr/text/pipes.txt", "Hugo Pipes")
+	b.AssertFileContent("public/en/index.html", "Default Home Page", "String Resource: /docs/text/pipes.txt")
+	b.AssertFileContent("public/en/text/pipes.txt", "Hugo Pipes")
 
 	// Check paginators
 	b.AssertFileContent("public/en/page/1/index.html", `refresh" content="0; url=https://example.com/docs/"`)

--- a/hugolib/page_bundler_handlers.go
+++ b/hugolib/page_bundler_handlers.go
@@ -332,7 +332,7 @@ func (c *contentHandlers) createResource() contentHandler {
 				SourceFile:        ctx.source,
 				RelTargetFilename: ctx.target,
 				URLBase:           c.s.GetURLLanguageBasePath(),
-				TargetPathBase:    c.s.GetTargetLanguageBasePath(),
+				TargetBasePaths:   []string{c.s.GetTargetLanguageBasePath()},
 			})
 
 		return handlerResult{err: err, handled: true, resource: resource}

--- a/hugolib/paths/paths.go
+++ b/hugolib/paths/paths.go
@@ -53,6 +53,10 @@ type Paths struct {
 
 	PublishDir string
 
+	// When in multihost mode, this returns a list of base paths below PublishDir
+	// for each language.
+	MultihostTargetBasePaths []string
+
 	DisablePathToLower bool
 	RemovePathAccents  bool
 	UglyURLs           bool
@@ -135,6 +139,15 @@ func New(fs *hugofs.Fs, cfg config.Provider) (*Paths, error) {
 		absResourcesDir = FilePathSeparator
 	}
 
+	multilingual := cfg.GetBool("multilingual")
+
+	var multihostTargetBasePaths []string
+	if multilingual {
+		for _, l := range languages {
+			multihostTargetBasePaths = append(multihostTargetBasePaths, l.Lang)
+		}
+	}
+
 	p := &Paths{
 		Fs:      fs,
 		Cfg:     cfg,
@@ -154,12 +167,13 @@ func New(fs *hugofs.Fs, cfg config.Provider) (*Paths, error) {
 
 		themes: config.GetStringSlicePreserveString(cfg, "theme"),
 
-		multilingual:                   cfg.GetBool("multilingual"),
+		multilingual:                   multilingual,
 		defaultContentLanguageInSubdir: cfg.GetBool("defaultContentLanguageInSubdir"),
 		DefaultContentLanguage:         defaultContentLanguage,
 
-		Language:  language,
-		Languages: languages,
+		Language:                 language,
+		Languages:                languages,
+		MultihostTargetBasePaths: multihostTargetBasePaths,
 
 		PaginatePath: cfg.GetString("paginatePath"),
 	}

--- a/hugolib/testhelpers_test.go
+++ b/hugolib/testhelpers_test.go
@@ -403,8 +403,8 @@ date: "2018-02-28"
 		defaultTemplates = []string{
 			"_default/single.html", "Single: {{ .Title }}|{{ i18n \"hello\" }}|{{.Lang}}|{{ .Content }}",
 			"_default/list.html", "{{ $p := .Paginator }}List Page {{ $p.PageNumber }}: {{ .Title }}|{{ i18n \"hello\" }}|{{ .Permalink }}|Pager: {{ template \"_internal/pagination.html\" . }}",
-			"index.html", "{{ $p := .Paginator }}Default Home Page {{ $p.PageNumber }}: {{ .Title }}|{{ .IsHome }}|{{ i18n \"hello\" }}|{{ .Permalink }}|{{  .Site.Data.hugo.slogan }}",
-			"index.fr.html", "{{ $p := .Paginator }}French Home Page {{ $p.PageNumber }}: {{ .Title }}|{{ .IsHome }}|{{ i18n \"hello\" }}|{{ .Permalink }}|{{  .Site.Data.hugo.slogan }}",
+			"index.html", "{{ $p := .Paginator }}Default Home Page {{ $p.PageNumber }}: {{ .Title }}|{{ .IsHome }}|{{ i18n \"hello\" }}|{{ .Permalink }}|{{  .Site.Data.hugo.slogan }}|String Resource: {{ ( \"Hugo Pipes\" | resources.FromString \"text/pipes.txt\").RelPermalink  }}",
+			"index.fr.html", "{{ $p := .Paginator }}French Home Page {{ $p.PageNumber }}: {{ .Title }}|{{ .IsHome }}|{{ i18n \"hello\" }}|{{ .Permalink }}|{{  .Site.Data.hugo.slogan }}|String Resource: {{ ( \"Hugo Pipes\" | resources.FromString \"text/pipes.txt\").RelPermalink  }}",
 
 			// Shortcodes
 			"shortcodes/shortcode.html", "Shortcode: {{ i18n \"hello\" }}",

--- a/resource/image_cache.go
+++ b/resource/image_cache.go
@@ -69,7 +69,7 @@ func (c *imageCache) getOrCreate(
 	parent *Image, conf imageConfig, create func(resourceCacheFilename string) (*Image, error)) (*Image, error) {
 
 	relTarget := parent.relTargetPathFromConfig(conf)
-	key := parent.relTargetPathForRel(relTarget.path(), false)
+	key := parent.relTargetPathForRel(relTarget.path(), false, false)
 
 	// First check the in-memory store, then the disk.
 	c.mu.RLock()

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -93,7 +93,7 @@ func TestNewResourceFromFilenameSubPathInBaseURL(t *testing.T) {
 	assert.Equal("/docs/a/b/logo.png", r.RelPermalink())
 	assert.Equal("https://example.com/docs/a/b/logo.png", r.Permalink())
 	img := r.(*Image)
-	assert.Equal(filepath.FromSlash("/a/b/logo.png"), img.targetFilename())
+	assert.Equal(filepath.FromSlash("/a/b/logo.png"), img.targetFilenames()[0])
 
 }
 

--- a/resource/transform.go
+++ b/resource/transform.go
@@ -267,7 +267,7 @@ func (r *transformedResource) initContent() error {
 func (r *transformedResource) transform(setContent bool) (err error) {
 
 	openPublishFileForWriting := func(relTargetPath string) (io.WriteCloser, error) {
-		return helpers.OpenFileForWriting(r.cache.rs.PublishFs, r.linker.relTargetPathFor(relTargetPath))
+		return helpers.OpenFilesForWriting(r.cache.rs.PublishFs, r.linker.relTargetPathsFor(relTargetPath)...)
 	}
 
 	// This can be the last resource in a chain.
@@ -299,7 +299,7 @@ func (r *transformedResource) transform(setContent bool) (err error) {
 			key = key + "_" + v.transformation.Key().key()
 		case permalinker:
 			r.linker = v
-			p := v.relTargetPath()
+			p := v.targetPath()
 			if p == "" {
 				panic("target path needed for key creation")
 			}


### PR DESCRIPTION
In Hugo 0.46 we made the output of what you get from resources.Get and similar static, i.e. language agnostic. This makes total sense, as it is wasteful and time-consuming to do SASS/SCSS/PostCSS processing for lots of languages when the output is lots of duplicates with different filenames.

But since we now output the result once only, this had a negative side effect for multihost setups: We publish the resource once only to the root folder (i.e. not to the language "domain folder").

Fixes #5058