### PR TITLE
Update Go modules to include new mmark library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/markbates/inflect v0.0.0-20171215194931-a12c3aec81a6
 	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/mattn/go-runewidth v0.0.2 // indirect
-	github.com/miekg/mmark v1.3.6
+	github.com/mmarkdown/mmark v1.9.980
 	github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452
 	github.com/mitchellh/mapstructure v0.0.0-20180715050151-f15292f7a699
 	github.com/muesli/smartcrop v0.0.0-20180228075044-f6ebaa786a12

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -30,8 +30,8 @@ import (
 	"github.com/chaseadamsio/goorgeous"
 	bp "github.com/gohugoio/hugo/bufferpool"
 	"github.com/gohugoio/hugo/config"
-	"github.com/miekg/mmark"
 	"github.com/mitchellh/mapstructure"
+	"github.com/mmarkdown/mmark"
 	"github.com/russross/blackfriday"
 	jww "github.com/spf13/jwalterweatherman"
 

--- a/helpers/content_renderer.go
+++ b/helpers/content_renderer.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"github.com/gohugoio/hugo/config"
-	"github.com/miekg/mmark"
+	"github.com/mmarkdown/mmark"
 	"github.com/russross/blackfriday"
 )
 

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/miekg/mmark"
+	"github.com/mmarkdown/mmark"
 	"github.com/russross/blackfriday"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
The Mmark project has been moved into a different GitHub org/repository. This commit updates the Go modules in `go.mod` to reflect this.