### PR TITLE
Improve minifier MIME type resolution

### DIFF
--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -97,7 +97,7 @@ top = "top"
 
 [mediaTypes]
 [mediaTypes."text/m1"]
-suffix = "m1main"
+suffixes = ["m1main"]
 
 [outputFormats.o1]
 mediaType = "text/m1"
@@ -135,9 +135,9 @@ p3 = "p3 theme"
 
 [mediaTypes]
 [mediaTypes."text/m1"]
-suffix = "m1theme"
+suffixes = ["m1theme"]
 [mediaTypes."text/m2"]
-suffix = "m2theme"
+suffixes = ["m2theme"]
 
 [outputFormats.o1]
 mediaType = "text/m1"
@@ -207,10 +207,14 @@ map[string]interface {}{
 	b.AssertObject(`
 map[string]interface {}{
   "text/m1": map[string]interface {}{
-    "suffix": "m1main",
+    "suffixes": []interface {}{
+      "m1main",
+    },
   },
   "text/m2": map[string]interface {}{
-    "suffix": "m2theme",
+    "suffixes": []interface {}{
+      "m2theme",
+    },
   },
 }`, got["mediatypes"])
 
@@ -221,7 +225,6 @@ map[string]interface {}{
     "mediatype": Type{
       MainType: "text",
       SubType: "m1",
-      OldSuffix: "m1main",
       Delimiter: ".",
       Suffixes: []string{
         "m1main",
@@ -233,7 +236,6 @@ map[string]interface {}{
     "mediatype": Type{
       MainType: "text",
       SubType: "m2",
-      OldSuffix: "m2theme",
       Delimiter: ".",
       Suffixes: []string{
         "m2theme",

--- a/hugolib/page_bundler_test.go
+++ b/hugolib/page_bundler_test.go
@@ -435,7 +435,7 @@ func newTestBundleSources(t *testing.T) (*hugofs.Fs, *viper.Viper) {
 	cfg.Set("baseURL", "https://example.com")
 	cfg.Set("mediaTypes", map[string]interface{}{
 		"text/bepsays": map[string]interface{}{
-			"suffix": "bep",
+			"suffixes": []string{"bep"},
 		},
 	})
 

--- a/hugolib/site_output_test.go
+++ b/hugolib/site_output_test.go
@@ -276,14 +276,12 @@ disableKinds = ["page", "section", "taxonomy", "taxonomyTerm", "sitemap", "robot
 
 [mediaTypes]
 [mediaTypes."text/nodot"]
-suffix = ""
 delimiter = ""
 [mediaTypes."text/defaultdelim"]
-suffix = "defd"
+suffixes = ["defd"]
 [mediaTypes."text/nosuffix"]
-suffix = ""
 [mediaTypes."text/customdelim"]
-suffix = "del"
+suffixes = ["del"]
 delimiter = "_"
 
 [outputs]
@@ -321,7 +319,7 @@ baseName = "customdelimbase"
 	th.assertFileContent("public/_redirects", "a dotless")
 	th.assertFileContent("public/defaultdelimbase.defd", "default delimim")
 	// This looks weird, but the user has chosen this definition.
-	th.assertFileContent("public/nosuffixbase.", "no suffix")
+	th.assertFileContent("public/nosuffixbase", "no suffix")
 	th.assertFileContent("public/customdelimbase_del", "custom delim")
 
 	s := h.Sites[0]
@@ -332,7 +330,7 @@ baseName = "customdelimbase"
 
 	require.Equal(t, "/blog/_redirects", outputs.Get("DOTLESS").RelPermalink())
 	require.Equal(t, "/blog/defaultdelimbase.defd", outputs.Get("DEF").RelPermalink())
-	require.Equal(t, "/blog/nosuffixbase.", outputs.Get("NOS").RelPermalink())
+	require.Equal(t, "/blog/nosuffixbase", outputs.Get("NOS").RelPermalink())
 	require.Equal(t, "/blog/customdelimbase_del", outputs.Get("CUS").RelPermalink())
 
 }

--- a/minifiers/minifiers_test.go
+++ b/minifiers/minifiers_test.go
@@ -32,4 +32,10 @@ func TestNew(t *testing.T) {
 
 	assert.NoError(m.Minify(media.CSSType, &b, strings.NewReader("body { color: blue; }")))
 	assert.Equal("body{color:blue}", b.String())
+
+	b.Reset()
+
+	// RSS should be handled as XML
+	assert.NoError(m.Minify(media.RSSType, &b, strings.NewReader("<hello>  Hugo!   </hello>  ")))
+	assert.Equal("<hello>Hugo!</hello>", b.String())
 }

--- a/output/outputFormat_test.go
+++ b/output/outputFormat_test.go
@@ -93,11 +93,9 @@ func TestGetFormatByExt(t *testing.T) {
 
 func TestGetFormatByFilename(t *testing.T) {
 	noExtNoDelimMediaType := media.TextType
-	noExtNoDelimMediaType.OldSuffix = ""
 	noExtNoDelimMediaType.Delimiter = ""
 
 	noExtMediaType := media.TextType
-	noExtMediaType.OldSuffix = ""
 
 	var (
 		noExtDelimFormat = Format{


### PR DESCRIPTION
This commit also removes the deprecated `Suffix` from MediaType. Now use `Suffixes` and put the MIME type suffix in the type, e.g. `application/svg+xml`.

Fixes #5093