### PR TITLE
helpers/content.go: call rst2html directly to render content, fix #5167

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -664,21 +664,9 @@ func getRstExecPath() string {
 	return path
 }
 
-func getPythonExecPath() string {
-	path, err := exec.LookPath("python")
-	if err != nil {
-		path, err = exec.LookPath("python.exe")
-		if err != nil {
-			return ""
-		}
-	}
-	return path
-}
-
 // getRstContent calls the Python script rst2html as an external helper
 // to convert reStructuredText content to HTML.
 func getRstContent(ctx *RenderingContext) []byte {
-	python := getPythonExecPath()
 	path := getRstExecPath()
 
 	if path == "" {
@@ -688,8 +676,8 @@ func getRstContent(ctx *RenderingContext) []byte {
 
 	}
 	jww.INFO.Println("Rendering", ctx.DocumentName, "with", path, "...")
-	args := []string{path, "--leave-comments", "--initial-header-level=2"}
-	result := externallyRenderContent(ctx, python, args)
+	args := []string{"--leave-comments", "--initial-header-level=2"}
+	result := externallyRenderContent(ctx, path, args)
 	// TODO(bep) check if rst2html has a body only option.
 	bodyStart := bytes.Index(result, []byte("<body>\n"))
 	if bodyStart < 0 {


### PR DESCRIPTION
Hugo launches rst2html by calling Python interpreter and passing it the path of rst2html file.
This doesn't work on NixOS like OSs because the real rst2html is actually wrapped behind a bash script which is responsible for correctly setting the env and then exec-ing the real rst2html.

The problem is that on such systems, rst2html is actually a bash script and not a Python script. Hence, Python fails to launch it with SyntaxError.

Ideally, rst2html should be launched directly by Hugo.
This patch ensures that rst2html is called correctly by Hugo.