### PR TITLE
hugolib: Normalize permalink path segments

### DIFF
--- a/hugolib/permalinks.go
+++ b/hugolib/permalinks.go
@@ -154,7 +154,7 @@ func pageToPermalinkDate(p *Page, dateField string) (string, error) {
 func pageToPermalinkTitle(p *Page, _ string) (string, error) {
 	// Page contains Node which has Title
 	// (also contains URLPath which has Slug, sometimes)
-	return p.s.PathSpec.URLize(p.title), nil
+	return p.s.PathSpec.MakeSegment(p.title), nil
 }
 
 // pageToPermalinkFilename returns the URL-safe form of the filename
@@ -166,7 +166,7 @@ func pageToPermalinkFilename(p *Page, _ string) (string, error) {
 		_, name = filepath.Split(dir)
 	}
 
-	return p.s.PathSpec.URLize(name), nil
+	return p.s.PathSpec.MakeSegment(name), nil
 }
 
 // if the page has a slug, return the slug, else return the title
@@ -181,20 +181,30 @@ func pageToPermalinkSlugElseTitle(p *Page, a string) (string, error) {
 		if strings.HasSuffix(p.Slug, "-") {
 			p.Slug = p.Slug[0 : len(p.Slug)-1]
 		}
-		return p.s.PathSpec.URLize(p.Slug), nil
+		return p.s.PathSpec.MakeSegment(p.Slug), nil
 	}
 	return pageToPermalinkTitle(p, a)
 }
 
 func pageToPermalinkSection(p *Page, _ string) (string, error) {
 	// Page contains Node contains URLPath which has Section
-	return p.Section(), nil
+	return p.s.PathSpec.MakeSegment(p.Section()), nil
 }
 
 func pageToPermalinkSections(p *Page, _ string) (string, error) {
 	// TODO(bep) we have some superflous URLize in this file, but let's
 	// deal with that later.
-	return path.Join(p.CurrentSection().sections...), nil
+
+	cs := p.CurrentSection()
+	if cs == nil {
+		return "", errors.New("\":sections\" attribute requires parent page but is nil")
+	}
+
+	sections := make([]string, len(cs.sections))
+	for i := range cs.sections {
+		sections[i] = p.s.PathSpec.MakeSegment(cs.sections[i])
+	}
+	return path.Join(sections...), nil
 }
 
 func init() {

--- a/hugolib/permalinks_test.go
+++ b/hugolib/permalinks_test.go
@@ -19,36 +19,26 @@ import (
 )
 
 // testdataPermalinks is used by a couple of tests; the expandsTo content is
-// subject to the data in SIMPLE_PAGE_JSON.
+// subject to the data in simplePageJSON.
 var testdataPermalinks = []struct {
 	spec      string
 	valid     bool
 	expandsTo string
 }{
-	//{"/:year/:month/:title/", true, "/2012/04/spf13-vim-3.0-release-and-new-website/"},
-	//{"/:title", true, "/spf13-vim-3.0-release-and-new-website"},
-	//{":title", true, "spf13-vim-3.0-release-and-new-website"},
-	//{"/blog/:year/:yearday/:title", true, "/blog/2012/97/spf13-vim-3.0-release-and-new-website"},
+	{":title", true, "spf13-vim-3.0-release-and-new-website"},
 	{"/:year-:month-:title", true, "/2012-04-spf13-vim-3.0-release-and-new-website"},
-	{"/blog/:year-:month-:title", true, "/blog/2012-04-spf13-vim-3.0-release-and-new-website"},
-	{"/blog-:year-:month-:title", true, "/blog-2012-04-spf13-vim-3.0-release-and-new-website"},
-	//{"/blog/:fred", false, ""},
-	//{"/:year//:title", false, ""},
-	//{
-	//"/:section/:year/:month/:day/:weekdayname/:yearday/:title",
-	//true,
-	//"/blue/2012/04/06/Friday/97/spf13-vim-3.0-release-and-new-website",
-	//},
-	//{
-	//"/:weekday/:weekdayname/:month/:monthname",
-	//true,
-	//"/5/Friday/04/April",
-	//},
-	//{
-	//"/:slug/:title",
-	//true,
-	//"/spf13-vim-3-0-release-and-new-website/spf13-vim-3.0-release-and-new-website",
-	//},
+
+	{"/:year/:yearday/:month/:monthname/:day/:weekday/:weekdayname/", true, "/2012/97/04/April/06/5/Friday/"}, // Dates
+	{"/:section/", true, "/blue/"},                                                                            // Section
+	{"/:title/", true, "/spf13-vim-3.0-release-and-new-website/"},                                             // Title
+	{"/:slug/", true, "/spf13-vim-3-0-release-and-new-website/"},                                              // Slug
+	{"/:filename/", true, "/test-page/"},                                                                      // Filename
+	// TODO(moorereason): need test scaffolding for this.
+	//{"/:sections/", false, "/blue/"},                                                                          // Sections
+
+	// Failures
+	{"/blog/:fred", false, ""},
+	{"/:year//:title", false, ""},
 }
 
 func TestPermalinkValidation(t *testing.T) {
@@ -75,7 +65,7 @@ func TestPermalinkExpansion(t *testing.T) {
 	page, err := s.NewPageFrom(strings.NewReader(simplePageJSON), "blue/test-page.md")
 
 	if err != nil {
-		t.Fatalf("failed before we began, could not parse SIMPLE_PAGE_JSON: %s", err)
+		t.Fatalf("failed before we began, could not parse simplePageJSON: %s", err)
 	}
 	for _, item := range testdataPermalinks {
 		if !item.valid {

--- a/hugolib/permalinks_test.go
+++ b/hugolib/permalinks_test.go
@@ -29,12 +29,12 @@ var testdataPermalinks = []struct {
 	{"/:year-:month-:title", true, "/2012-04-spf13-vim-3.0-release-and-new-website"},
 
 	{"/:year/:yearday/:month/:monthname/:day/:weekday/:weekdayname/", true, "/2012/97/04/April/06/5/Friday/"}, // Dates
-	{"/:section/", true, "/blue/"},                                                                            // Section
-	{"/:title/", true, "/spf13-vim-3.0-release-and-new-website/"},                                             // Title
-	{"/:slug/", true, "/spf13-vim-3-0-release-and-new-website/"},                                              // Slug
-	{"/:filename/", true, "/test-page/"},                                                                      // Filename
+	{"/:section/", true, "/blue/"},                                // Section
+	{"/:title/", true, "/spf13-vim-3.0-release-and-new-website/"}, // Title
+	{"/:slug/", true, "/spf13-vim-3-0-release-and-new-website/"},  // Slug
+	{"/:filename/", true, "/test-page/"},                          // Filename
 	// TODO(moorereason): need test scaffolding for this.
-	//{"/:sections/", false, "/blue/"},                                                                          // Sections
+	//{"/:sections/", false, "/blue/"},                              // Sections
 
 	// Failures
 	{"/blog/:fred", false, ""},


### PR DESCRIPTION
When constructing permalinks, ensure that path segments are normalized
with PathSpec.MakeSegment instead of PathSpec.URLize.

Fixes #4926