### PR TITLE
hugolib: Do not FirstUpper taxonomy titles

### DIFF
--- a/docs/content/en/content-management/taxonomies.md
+++ b/docs/content/en/content-management/taxonomies.md
@@ -139,7 +139,7 @@ If you want to disable all taxonomies altogether, see the use of `disableKinds` 
 
 By default, taxonomy names are normalized.
 
-Therefore, if you want to have a taxonomy term with special characters such as `Gérard Depardieu` instead of `Gerard Depardieu`, set the value for `preserveTaxonomyNames` to `true` in your [site config][config]. Hugo will then preserve special characters in taxonomy values but will still title-ize the values for titles and normalize them in URLs.
+Therefore, if you want to have a taxonomy term with special characters such as `Gérard Depardieu` instead of `Gerard Depardieu`, set the value for `preserveTaxonomyNames` to `true` in your [site config][config]. Hugo will then preserve special characters in taxonomy values but will still normalize them in URLs.
 
 Note that if you use `preserveTaxonomyNames` and intend to manually construct URLs to the archive pages, you will need to pass the taxonomy values through the [`urlize` template function][].
 
@@ -148,6 +148,12 @@ You can add content and front matter to your taxonomy list and taxonomy terms pa
 
 Much like regular pages, taxonomy list [permalinks](/content-management/urls/) are configurable, but taxonomy term page permalinks are not.
 {{% /note %}}
+
+{{% warning "`preserveTaxonomyNames` behaviour change" %}}
+Before 0.49, Hugo would title-ize the taxonomy values for titles even if `preserveTaxonomyNames` was active. This no longer the case, which (for instance) makes it possible to have fully lower-case values.
+
+If you actually need to title-ize these values, you can do so using the [`title` template function][].
+{{% /warning %}}
 
 ## Add Taxonomies to Content
 
@@ -205,6 +211,7 @@ If you need to add custom metadata to your taxonomy terms, you will need to crea
 
 You can later use your custom metadata as shown in the [Taxonomy Terms Templates documentation](/templates/taxonomy-templates/#displaying-custom-metadata-in-taxonomy-terms-templates).
 
+[`title` template function]: /functions/title/
 [`urlize` template function]: /functions/urlize/
 [content section]: /content-management/sections/
 [content type]: /content-management/types/

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1830,10 +1830,7 @@ func (s *Site) newTaxonomyPage(plural, key string) *Page {
 	p := s.newNodePage(KindTaxonomy, plural, key)
 
 	if s.Info.preserveTaxonomyNames {
-		// Keep (mostly) as is in the title
-		// We make the first character upper case, mostly because
-		// it is easier to reason about in the tests.
-		p.title = helpers.FirstUpper(key)
+		p.title = key
 	} else {
 		p.title = strings.Replace(s.titleFunc(key), "-", " ", -1)
 	}

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -129,27 +129,38 @@ permalinkeds:
 	}
 
 	// 1.
-	th.assertFileContent(pathFunc("public/categories/cat1/index.html"), "List", "Cat1")
 	if preserveTaxonomyNames {
-		// As of this writing, term titles are given a first upper.
-		// See hugolib.Site.newTaxonomyPage().
-		th.assertFileContent(pathFunc("public/categories/cat-dog/index.html"), "List", "CAt/dOg")
+		th.assertFileContent(pathFunc("public/categories/cat1/index.html"), "List", "cat1")
+		th.assertFileContent(pathFunc("public/categories/cat-dog/index.html"), "List", "cAt/dOg")
 	} else {
+		th.assertFileContent(pathFunc("public/categories/cat1/index.html"), "List", "Cat1")
 		th.assertFileContent(pathFunc("public/categories/cat-dog/index.html"), "List", "Cat/Dog")
 	}
 	th.assertFileContent(pathFunc("public/categories/index.html"), "Terms List", "Category Terms")
 
 	// 2.
-	th.assertFileContent(pathFunc("public/tags/tag2/index.html"), "List", "Tag2")
+	if preserveTaxonomyNames {
+		th.assertFileContent(pathFunc("public/tags/tag2/index.html"), "List", "tag2")
+	} else {
+		th.assertFileContent(pathFunc("public/tags/tag2/index.html"), "List", "Tag2")
+	}
 	th.assertFileContent(pathFunc("public/tags/tag1/index.html"), "List", "Tag1")
 	th.assertFileContent(pathFunc("public/tags/index.html"), "Terms List", "Tags")
 
 	// 3.
-	th.assertFileContent(pathFunc("public/others/o1/index.html"), "List", "O1")
+	if preserveTaxonomyNames {
+		th.assertFileContent(pathFunc("public/others/o1/index.html"), "List", "o1")
+	} else {
+		th.assertFileContent(pathFunc("public/others/o1/index.html"), "List", "O1")
+	}
 	th.assertFileContent(pathFunc("public/others/index.html"), "Terms List", "Others")
 
 	// 4.
-	th.assertFileContent(pathFunc("public/perma/pl1/index.html"), "List", "Pl1")
+	if preserveTaxonomyNames {
+		th.assertFileContent(pathFunc("public/perma/pl1/index.html"), "List", "pl1")
+	} else {
+		th.assertFileContent(pathFunc("public/perma/pl1/index.html"), "List", "Pl1")
+	}
 	// This looks kind of funky, but the taxonomy terms do not have a permalinks definition,
 	// for good reasons.
 	th.assertFileContent(pathFunc("public/permalinkeds/index.html"), "Terms List", "Permalinkeds")


### PR DESCRIPTION
Doing so was probably a mistake. This may be a breaking change for some people, but it's easy to restore the previous behaviour in the layouts.

Fixes #5172