### PR TITLE
Make JSON minification more generic

### DIFF
--- a/minifiers/minifiers.go
+++ b/minifiers/minifiers.go
@@ -74,6 +74,7 @@ func New(mediaTypes media.Types, outputFormats output.Formats) Client {
 	addMinifierFunc(m, mediaTypes, "css", css.Minify)
 	addMinifierFunc(m, mediaTypes, "js", js.Minify)
 	m.AddFuncRegexp(regexp.MustCompile("^(application|text)/(x-)?(java|ecma)script$"), js.Minify)
+	m.AddFuncRegexp(regexp.MustCompile("^(application|text)/(x-|ld\\+)?json$"), json.Minify)
 	addMinifierFunc(m, mediaTypes, "json", json.Minify)
 	addMinifierFunc(m, mediaTypes, "svg", svg.Minify)
 	addMinifierFunc(m, mediaTypes, "xml", xml.Minify)


### PR DESCRIPTION
[JSON-LD](https://json-ld.org/) is is a standardized format for providing information about a page and classifying the page content. In my use case I am using it for [Google SEO](https://developers.google.com/search/docs/guides/intro-structured-data).

In this pull request I've changed the minifier `mediaTypes` regex to allow for `application/ld+json`.

I wasn't able to find any tests for this section of code and I'm still pretty new to go so I'm unsure of how to add one.