### PR TITLE
tpl/collections: Add collections.Append

### DIFF
--- a/common/collections/collections.go
+++ b/common/collections/collections.go
@@ -24,5 +24,5 @@ type Grouper interface {
 // in collections.Slice template func to get types such as Pages, PageGroups etc.
 // instead of the less useful []interface{}.
 type Slicer interface {
-	Slice(items []interface{}) (interface{}, error)
+	Slice(items interface{}) (interface{}, error)
 }

--- a/docs/content/en/functions/append.md
+++ b/docs/content/en/functions/append.md
@@ -1,0 +1,38 @@
+---
+title: append
+description: "`append` appends one or more values to a slice and returns the resulting slice."
+date: 2018-09-14
+categories: [functions]
+menu:
+  docs:
+    parent: "functions"
+keywords: [collections]
+signature: ["COLLECTION | append VALUE [VALUE]...", "COLLECTION | append COLLECTION"]
+workson: []
+hugoversion: "0.49"
+relatedfuncs: [last,first,where,slice]
+aliases: []
+---
+
+An example appending single values:
+
+```go-html-template
+{{ $s := slice "a" "b" "c" }}
+{{ $s = $s | append "d" "e" }}
+{{/* $s now contains a []string with elements "a", "b", "c", "d", and "e" */}}
+
+```
+
+The same example appending a slice to a slice:
+
+
+```go-html-template
+{{ $s := slice "a" "b" "c" }}
+{{ $s = $s | append (slice "d" "e") }}
+```
+
+The `append` function works for all types, including `Pages`.
+
+
+
+

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,7 @@ github.com/magefile/mage v1.4.0 h1:RI7B1CgnPAuu2O9lWszwya61RLmfL0KCdo+QyyI/Bhk=
 github.com/magefile/mage v1.4.0/go.mod h1:IUDi13rsHje59lecXokTfGX0QIzO45uVPlXnJYsXepA=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/markbates/inflect v0.0.0-20171215194931-a12c3aec81a6 h1:LZhVjIISSbj8qLf2qDPP0D8z0uvOWAW5C85ly5mJW6c=
 github.com/markbates/inflect v0.0.0-20171215194931-a12c3aec81a6/go.mod h1:oTeZL2KHA7CUX6X+fovmK9OvIOFuqu0TwdQrZjLTh88=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=

--- a/resource/transform.go
+++ b/resource/transform.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gohugoio/hugo/common/collections"
 	"github.com/gohugoio/hugo/common/errors"
 	"github.com/gohugoio/hugo/common/hugio"
 	"github.com/gohugoio/hugo/helpers"
@@ -37,6 +38,7 @@ import (
 var (
 	_ ContentResource        = (*transformedResource)(nil)
 	_ ReadSeekCloserResource = (*transformedResource)(nil)
+	_ collections.Slicer     = (*transformedResource)(nil)
 )
 
 func (s *Spec) Transform(r Resource, t ResourceTransformation) (Resource, error) {
@@ -166,6 +168,8 @@ type transformedResourceMetadata struct {
 }
 
 type transformedResource struct {
+	commonResource
+
 	cache *ResourceCache
 
 	// This is the filename inside resources/_gen/assets

--- a/tpl/collections/append.go
+++ b/tpl/collections/append.go
@@ -1,0 +1,74 @@
+// Copyright 2018 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// Append appends the arguments up to the last one to the slice in the last argument.
+// This construct allows template constructs like this:
+//     {{ $pages = $pages | append $p2 $p1 }}
+// Note that with 2 arguments where both are slices of the same type,
+// the first slice will be appended to the second:
+//     {{ $pages = $pages | append .Site.RegularPages }}
+func (ns *Namespace) Append(args ...interface{}) (interface{}, error) {
+	if len(args) < 2 {
+		return nil, errors.New("need at least 2 arguments to append")
+	}
+
+	to := args[len(args)-1]
+	from := args[:len(args)-1]
+
+	tov, toIsNil := indirect(reflect.ValueOf(to))
+
+	toIsNil = toIsNil || to == nil
+	var tot reflect.Type
+
+	if !toIsNil {
+		if tov.Kind() != reflect.Slice {
+			return nil, fmt.Errorf("expected a slice, got %T", to)
+		}
+
+		tot = tov.Type().Elem()
+		toIsNil = tov.Len() == 0
+
+		if len(from) == 1 {
+			// If we get []string []string, we append the from slice to to
+			fromv := reflect.ValueOf(from[0])
+			if fromv.Kind() == reflect.Slice {
+				fromt := reflect.TypeOf(from[0]).Elem()
+				if tot == fromt {
+					return reflect.AppendSlice(tov, fromv).Interface(), nil
+				}
+			}
+		}
+	}
+
+	if toIsNil {
+		return ns.Slice(from...), nil
+	}
+
+	for _, f := range from {
+		fv := reflect.ValueOf(f)
+		if tot != fv.Type() {
+			return nil, fmt.Errorf("append element type mismatch: expected %v, got %v", tot, fv.Type())
+		}
+		tov = reflect.Append(tov, fv)
+	}
+
+	return tov.Interface(), nil
+}

--- a/tpl/collections/append_test.go
+++ b/tpl/collections/append_test.go
@@ -1,0 +1,77 @@
+// Copyright 2018 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collections
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/gohugoio/hugo/deps"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppend(t *testing.T) {
+	t.Parallel()
+
+	ns := New(&deps.Deps{})
+
+	for i, test := range []struct {
+		start    interface{}
+		addend   []interface{}
+		expected interface{}
+	}{
+		{[]string{"a", "b"}, []interface{}{"c"}, []string{"a", "b", "c"}},
+		{[]string{"a", "b"}, []interface{}{"c", "d", "e"}, []string{"a", "b", "c", "d", "e"}},
+		{[]string{"a", "b"}, []interface{}{[]string{"c", "d", "e"}}, []string{"a", "b", "c", "d", "e"}},
+		{nil, []interface{}{"a", "b"}, []string{"a", "b"}},
+		{nil, []interface{}{nil}, []interface{}{nil}},
+		{tstSlicers{&tstSlicer{"a"}, &tstSlicer{"b"}},
+			[]interface{}{&tstSlicer{"c"}},
+			tstSlicers{&tstSlicer{"a"}, &tstSlicer{"b"}, &tstSlicer{"c"}}},
+		{&tstSlicers{&tstSlicer{"a"}, &tstSlicer{"b"}},
+			[]interface{}{&tstSlicer{"c"}},
+			tstSlicers{&tstSlicer{"a"},
+				&tstSlicer{"b"},
+				&tstSlicer{"c"}}},
+		// Errors
+		{"", []interface{}{[]string{"a", "b"}}, false},
+		{[]string{"a", "b"}, []interface{}{}, false},
+		// No string concatenation.
+		{"ab",
+			[]interface{}{"c"},
+			false},
+	} {
+
+		errMsg := fmt.Sprintf("[%d]", i)
+
+		args := append(test.addend, test.start)
+
+		result, err := ns.Append(args...)
+
+		if b, ok := test.expected.(bool); ok && !b {
+			require.Error(t, err, errMsg)
+			continue
+		}
+
+		require.NoError(t, err, errMsg)
+
+		if !reflect.DeepEqual(test.expected, result) {
+			t.Fatalf("%s got\n%T: %v\nexpected\n%T: %v", errMsg, result, result, test.expected, test.expected)
+		}
+	}
+
+	assert.Len(t, ns.Slice(), 0)
+}

--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Hugo Authors. All rights reserved.
+// Copyright 2018 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -520,10 +520,11 @@ func (ns *Namespace) Slice(args ...interface{}) interface{} {
 	}
 
 	first := args[0]
-	allTheSame := true
-	if len(args) > 1 {
+	firstType := reflect.TypeOf(first)
+
+	allTheSame := firstType != nil
+	if allTheSame && len(args) > 1 {
 		// This can be a mix of types.
-		firstType := reflect.TypeOf(first)
 		for i := 1; i < len(args); i++ {
 			if firstType != reflect.TypeOf(args[i]) {
 				allTheSame = false
@@ -538,6 +539,12 @@ func (ns *Namespace) Slice(args ...interface{}) interface{} {
 			if err == nil {
 				return v
 			}
+		} else {
+			slice := reflect.MakeSlice(reflect.SliceOf(firstType), len(args), len(args))
+			for i, arg := range args {
+				slice.Index(i).Set(reflect.ValueOf(arg))
+			}
+			return slice.Interface()
 		}
 	}
 

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Hugo Authors. All rights reserved.
+// Copyright 2018 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -647,7 +647,8 @@ type tstSlicer struct {
 	name string
 }
 
-func (p *tstSlicer) Slice(items []interface{}) (interface{}, error) {
+func (p *tstSlicer) Slice(in interface{}) (interface{}, error) {
+	items := in.([]interface{})
 	result := make(tstSlicers, len(items))
 	for i, v := range items {
 		result[i] = v.(*tstSlicer)
@@ -666,13 +667,13 @@ func TestSlice(t *testing.T) {
 		args     []interface{}
 		expected interface{}
 	}{
-		{[]interface{}{"a", "b"}, []interface{}{"a", "b"}},
+		{[]interface{}{"a", "b"}, []string{"a", "b"}},
 		{[]interface{}{&tstSlicer{"a"}, &tstSlicer{"b"}}, tstSlicers{&tstSlicer{"a"}, &tstSlicer{"b"}}},
 		{[]interface{}{&tstSlicer{"a"}, "b"}, []interface{}{&tstSlicer{"a"}, "b"}},
 		{[]interface{}{}, []interface{}{}},
 		{[]interface{}{nil}, []interface{}{nil}},
 		{[]interface{}{5, "b"}, []interface{}{5, "b"}},
-		{[]interface{}{tstNoStringer{}}, []interface{}{tstNoStringer{}}},
+		{[]interface{}{tstNoStringer{}}, []tstNoStringer{tstNoStringer{}}},
 	} {
 		errMsg := fmt.Sprintf("[%d] %v", i, test.args)
 

--- a/tpl/collections/init.go
+++ b/tpl/collections/init.go
@@ -138,6 +138,11 @@ func init() {
 			[][2]string{},
 		)
 
+		ns.AddMethodMapping(ctx.Append,
+			[]string{"append"},
+			[][2]string{},
+		)
+
 		ns.AddMethodMapping(ctx.Group,
 			[]string{"group"},
 			[][2]string{},

--- a/tpl/path/path.go
+++ b/tpl/path/path.go
@@ -121,6 +121,10 @@ func (ns *Namespace) Join(elements ...interface{}) (string, error) {
 	var pathElements []string
 	for _, elem := range elements {
 		switch v := elem.(type) {
+		case []string:
+			for _, e := range v {
+				pathElements = append(pathElements, filepath.ToSlash(e))
+			}
 		case []interface{}:
 			for _, e := range v {
 				elemStr, err := cast.ToStringE(e)

--- a/tpl/resources/resources.go
+++ b/tpl/resources/resources.go
@@ -88,22 +88,11 @@ func (ns *Namespace) Concat(targetPathIn interface{}, r interface{}) (resource.R
 	var rr resource.Resources
 
 	switch v := r.(type) {
-	// This is what we get from the slice func.
-	case []interface{}:
-		rr = make([]resource.Resource, len(v))
-		for i := 0; i < len(v); i++ {
-			rv, ok := v[i].(resource.Resource)
-			if !ok {
-				return nil, fmt.Errorf("cannot concat type %T", v[i])
-			}
-			rr[i] = rv
-		}
-	// This is what we get from .Resources.Match etc.
 	case resource.Resources:
 		rr = v
+	case resource.ResourcesConverter:
+		rr = v.ToResources()
 	default:
-		// We may support Page collections at one point, but we need to think about ...
-		// what to acutually concatenate.
 		return nil, fmt.Errorf("slice %T not supported in concat", r)
 	}
 


### PR DESCRIPTION
Before this commit you would typically use `.Scratch.Add` to manually create slices in a loop.

With variable overwrite in Go 1.11, we can do better. This commit adds the `append` template func.

A made-up example:

```bash
{{ $p1 := index .Site.RegularPages 0 }}{{ $p2 := index .Site.RegularPages 1 }}
{{ $pages := slice }}
{{ if true }}
  {{ $pages = $pages | append $p2 $p1 }}
{{ end }}
```

Note that with 2 slices as arguments, the two examples below will give the same result:

```bash
{{ $s1 := slice "a" "b" | append (slice "c" "d") }}
{{ $s2 := slice "a" "b" | append "c" "d" }}
```

Both of the above will give `[]string{a, b, c, d}`.

This commit also improves the type handling in the `slice` template function. Now `slice "a" "b"` will give a `[]string` slice. The old behaviour was to return a `[]interface{}`.

Fixes #5190