### PR TITLE
Simplify travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,14 @@ go:
 os:
   - linux
   - osx
+env:
+- GO111MODULE=on
 matrix:
   allow_failures:
     - go: tip
   fast_finish: true
 install:
-  - mkdir -p $HOME/src
-  - mv $HOME/gopath/src/github.com/gohugoio/hugo $HOME/src
-  - export TRAVIS_BUILD_DIR=$HOME/src/hugo
-  - cd $HOME/src/hugo
+  - go mod download
   - go get github.com/magefile/mage
 script:
 - mage -v test


### PR DESCRIPTION
This change avoids the need to copy the source out of the GOPATH by
applying GO111MODULE=on as an environment variable. Additionally, avoids
issues with parallel module downloads (see golang/go#26794 and
golang/go#27372) by running 'go mod download' during the install step.