### PR TITLE
tpl/collections: Add collections.Append

### DIFF
--- a/create/content.go
+++ b/create/content.go
@@ -17,12 +17,14 @@ package create
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/hugolib"
+	"github.com/spf13/afero"
 	jww "github.com/spf13/jwalterweatherman"
 )
 
@@ -32,25 +34,35 @@ func NewContent(
 	ps *helpers.PathSpec,
 	siteFactory func(filename string, siteUsed bool) (*hugolib.Site, error), kind, targetPath string) error {
 	ext := helpers.Ext(targetPath)
-	fs := ps.BaseFs.SourceFilesystems.Archetypes.Fs
+	archetypeFs := ps.BaseFs.SourceFilesystems.Archetypes.Fs
 
 	jww.INFO.Printf("attempting to create %q of %q of ext %q", targetPath, kind, ext)
 
-	archetypeFilename := findArchetype(ps, kind, ext)
+	archetypeFilename, isDir := findArchetype(ps, kind, ext)
+
+	if isDir {
+		cm, err := mapArcheTypeDir(ps, archetypeFs, archetypeFilename)
+		if err != nil {
+			return err
+		}
+		s, err := siteFactory(targetPath, cm.siteUsed)
+		if err != nil {
+			return err
+		}
+		contentPath := resolveContentPath(s, s.Fs.Source, targetPath)
+		return newContentFromDir(kind, s, archetypeFs, s.Fs.Source, cm, contentPath)
+	}
 
 	// Building the sites can be expensive, so only do it if really needed.
 	siteUsed := false
 
 	if archetypeFilename != "" {
-		f, err := fs.Open(archetypeFilename)
+		var err error
+		siteUsed, err = usesSiteVar(archetypeFs, archetypeFilename)
 		if err != nil {
-			return fmt.Errorf("failed to open archetype file: %s", err)
+			return err
 		}
-		defer f.Close()
 
-		if helpers.ReaderContains(f, []byte(".Site")) {
-			siteUsed = true
-		}
 	}
 
 	s, err := siteFactory(targetPath, siteUsed)
@@ -58,28 +70,11 @@ func NewContent(
 		return err
 	}
 
-	var content []byte
+	contentPath := resolveContentPath(s, archetypeFs, targetPath)
 
-	content, err = executeArcheTypeAsTemplate(s, kind, targetPath, archetypeFilename)
+	content, err := executeArcheTypeAsTemplate(s, kind, targetPath, archetypeFilename)
 	if err != nil {
 		return err
-	}
-
-	// The site may have multiple content dirs, and we currently do not know which contentDir the
-	// user wants to create this content in. We should improve on this, but we start by testing if the
-	// provided path points to an existing dir. If so, use it as is.
-	var contentPath string
-	var exists bool
-	targetDir := filepath.Dir(targetPath)
-
-	if targetDir != "" && targetDir != "." {
-		exists, _ = helpers.Exists(targetDir, fs)
-	}
-
-	if exists {
-		contentPath = targetPath
-	} else {
-		contentPath = s.PathSpec.AbsPathify(filepath.Join(s.Cfg.GetString("contentDir"), targetPath))
 	}
 
 	if err := helpers.SafeWriteToDisk(contentPath, bytes.NewReader(content), s.Fs.Source); err != nil {
@@ -103,29 +98,150 @@ func NewContent(
 	return nil
 }
 
+func newContentFromDir(
+	kind string,
+	s *hugolib.Site,
+	sourceFs, targetFs afero.Fs,
+	cm archetypeMap, targetPath string) error {
+
+	for _, filename := range cm.otherFiles {
+		// Just copy the file to destination.
+		in, err := sourceFs.Open(filename)
+		if err != nil {
+			return err
+		}
+
+		targetFilename := filepath.Join(targetPath, filename)
+		targetDir := filepath.Dir(targetFilename)
+		if err := targetFs.MkdirAll(targetDir, 0777); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create target directory for %s: %s", targetDir, err)
+		}
+
+		out, err := targetFs.Create(targetFilename)
+
+		_, err = io.Copy(out, in)
+		if err != nil {
+			return err
+		}
+
+		in.Close()
+		out.Close()
+	}
+
+	for _, filename := range cm.contentFiles {
+		targetFilename := filepath.Join(targetPath, filename)
+		content, err := executeArcheTypeAsTemplate(s, kind, targetFilename, filename)
+		if err != nil {
+			return err
+		}
+
+		if err := helpers.SafeWriteToDisk(targetFilename, bytes.NewReader(content), targetFs); err != nil {
+			return err
+		}
+	}
+
+	jww.FEEDBACK.Println(targetPath, "created")
+
+	return nil
+}
+
+type archetypeMap struct {
+	// These needs to be parsed and executed as Go templates.
+	contentFiles []string
+	// These are just copied to destination.
+	otherFiles []string
+	// If the templates needs a fully built site. This can potentially be
+	// expensive, so only do when needed.
+	siteUsed bool
+}
+
+func mapArcheTypeDir(
+	ps *helpers.PathSpec,
+	fs afero.Fs,
+	archetypeDir string) (archetypeMap, error) {
+
+	var m archetypeMap
+
+	walkFn := func(filename string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if fi.IsDir() {
+			return nil
+		}
+
+		if hugolib.IsContentFile(filename) {
+			m.contentFiles = append(m.contentFiles, filename)
+			if !m.siteUsed {
+				m.siteUsed, err = usesSiteVar(fs, filename)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		m.otherFiles = append(m.otherFiles, filename)
+
+		return nil
+	}
+
+	if err := helpers.SymbolicWalk(fs, archetypeDir, walkFn); err != nil {
+		return m, err
+	}
+
+	return m, nil
+}
+
+func usesSiteVar(fs afero.Fs, filename string) (bool, error) {
+	f, err := fs.Open(filename)
+	if err != nil {
+		return false, fmt.Errorf("failed to open archetype file: %s", err)
+	}
+	defer f.Close()
+	return helpers.ReaderContains(f, []byte(".Site")), nil
+}
+
+func resolveContentPath(s *hugolib.Site, fs afero.Fs, targetPath string) string {
+	// The site may have multiple content dirs, and we currently do not know which contentDir the
+	// user wants to create this content in. We should improve on this, but we start by testing if the
+	// provided path points to an existing dir. If so, use it as is.
+	var contentPath string
+	var exists bool
+	targetDir := filepath.Dir(targetPath)
+
+	if targetDir != "" && targetDir != "." {
+		exists, _ = helpers.Exists(targetDir, fs)
+	}
+
+	if exists {
+		contentPath = targetPath
+	} else {
+		contentPath = s.PathSpec.AbsPathify(filepath.Join(s.Cfg.GetString("contentDir"), targetPath))
+	}
+
+	return contentPath
+}
+
 // FindArchetype takes a given kind/archetype of content and returns the path
 // to the archetype in the archetype filesystem, blank if none found.
-func findArchetype(ps *helpers.PathSpec, kind, ext string) (outpath string) {
+func findArchetype(ps *helpers.PathSpec, kind, ext string) (outpath string, isDir bool) {
 	fs := ps.BaseFs.Archetypes.Fs
 
-	// If the new content isn't in a subdirectory, kind == "".
-	// Therefore it should be excluded otherwise `is a directory`
-	// error will occur. github.com/gohugoio/hugo/issues/411
-	var pathsToCheck = []string{"default"}
+	var pathsToCheck []string
 
-	if ext != "" {
-		if kind != "" {
-			pathsToCheck = append([]string{kind + ext, "default" + ext}, pathsToCheck...)
-		} else {
-			pathsToCheck = append([]string{"default" + ext}, pathsToCheck...)
-		}
+	if kind != "" {
+		pathsToCheck = append(pathsToCheck, kind+ext)
 	}
+	pathsToCheck = append(pathsToCheck, "default"+ext)
 
 	for _, p := range pathsToCheck {
-		if exists, _ := helpers.Exists(p, fs); exists {
-			return p
+		fi, err := fs.Stat(p)
+		if err == nil {
+			return p, fi.IsDir()
 		}
 	}
 
-	return ""
+	return "", false
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/chaseadamsio/goorgeous v1.1.0
 	github.com/cpuguy83/go-md2man v1.0.8 // indirect
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
+	github.com/derekparker/delve v1.1.0 // indirect
 	github.com/disintegration/imaging v1.5.0
 	github.com/dlclark/regexp2 v1.1.6 // indirect
 	github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385
@@ -55,12 +56,15 @@ require (
 	github.com/tdewolff/minify v2.3.5+incompatible
 	github.com/tdewolff/parse v2.3.3+incompatible // indirect
 	github.com/tdewolff/test v0.0.0-20171106182207-265427085153 // indirect
+	github.com/visualfc/gocode v0.0.0-20180902020244-08a66b5525c8 // indirect
+	github.com/visualfc/gotools v0.0.0-20180902041808-77fd0f0b4437 // indirect
 	github.com/wellington/go-libsass v0.0.0-20180624165032-615eaa47ef79 // indirect
 	github.com/yosssi/ace v0.0.5
 	golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81
 	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
 	golang.org/x/text v0.3.0
+	golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5
 github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/derekparker/delve v1.1.0 h1:icd65nMp7s2HiLz6y/6RCVXBdoED3xxYLwX09EMaRCc=
+github.com/derekparker/delve v1.1.0/go.mod h1:pMSZMfp0Nhbm8qdZJkuE/yPGOkLpGXLS1I4poXQpuJU=
 github.com/disintegration/imaging v1.5.0 h1:uYqUhwNmLU4K1FN44vhqS4TZJRAA4RhBINgbQlKyGi0=
 github.com/disintegration/imaging v1.5.0/go.mod h1:9B/deIUIrliYkyMTuXJd6OUFLcrZ2tf+3Qlwnaf/CjU=
 github.com/dlclark/regexp2 v1.1.6 h1:CqB4MjHw0MFCDj+PHHjiESmHX+N7t0tJzKvC6M97BRg=
@@ -56,6 +58,7 @@ github.com/jdkato/prose v1.1.0 h1:LpvmDGwbKGTgdCH3a8VJL56sr7p/wOFPw/R4lM4PfFg=
 github.com/jdkato/prose v1.1.0/go.mod h1:jkF0lkxaX5PFSlk9l4Gh9Y+T57TqUZziWT7uZbW5ADg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -121,6 +124,10 @@ github.com/tdewolff/parse v2.3.3+incompatible h1:q6OSjvHtvBucLb34z24OH1xl5wGdw1m
 github.com/tdewolff/parse v2.3.3+incompatible/go.mod h1:8oBwCsVmUkgHO8M5iCzSIDtpzXOT0WXX9cWhz+bIzJQ=
 github.com/tdewolff/test v0.0.0-20171106182207-265427085153 h1:B1Z2txQ2QI9nsWELeEvGBAdNhMylGMSCCypjsLJh/Mw=
 github.com/tdewolff/test v0.0.0-20171106182207-265427085153/go.mod h1:DiQUlutnqlEvdvhSn2LPGy4TFwRauAaYDsL+683RNX4=
+github.com/visualfc/gocode v0.0.0-20180902020244-08a66b5525c8 h1:FgL0HKpzMGIYQAqSyMH+Y8jVGhehdldoI3eJGLAB9Gk=
+github.com/visualfc/gocode v0.0.0-20180902020244-08a66b5525c8/go.mod h1:jpZqxVZ6mC+EjvX9RrJnIKbM40y/DSWI8bisCpS8Tfw=
+github.com/visualfc/gotools v0.0.0-20180902041808-77fd0f0b4437 h1:vUPo8Vq+Zlpl2JHEKVExNdd4aizqiLZGDFgt6gFutPc=
+github.com/visualfc/gotools v0.0.0-20180902041808-77fd0f0b4437/go.mod h1:L4JCuK2/abY1jUXNDGB3gS9uWSQut22gKWkTe1R8b70=
 github.com/wellington/go-libsass v0.0.0-20180624165032-615eaa47ef79 h1:ivqgxj/zO3UZuzX7ZnlcyX8cAbNqLl1oes4zPddAO5Q=
 github.com/wellington/go-libsass v0.0.0-20180624165032-615eaa47ef79/go.mod h1:mxgxgam0N0E+NAUMHLcu20Ccfc3mVpDkyrLDayqfiTs=
 github.com/yosssi/ace v0.0.5 h1:tUkIP/BLdKqrlrPwcmH0shwEEhTRHoGnc1wFIWmaBUA=
@@ -135,6 +142,8 @@ golang.org/x/sys v0.0.0-20180906133057-8cf3aee42992 h1:BH3eQWeGbwRU2+wxxuuPOdFBm
 golang.org/x/sys v0.0.0-20180906133057-8cf3aee42992/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e h1:FDhOuMEY4JVRztM/gsbk+IKUQ8kj74bxZrgw87eMMVc=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/hugolib/fileInfo.go
+++ b/hugolib/fileInfo.go
@@ -61,7 +61,7 @@ func (fi *fileInfo) isOwner() bool {
 	return fi.bundleTp > bundleNot
 }
 
-func isContentFile(filename string) bool {
+func IsContentFile(filename string) bool {
 	return contentFileExtensionsSet[strings.TrimPrefix(helpers.Ext(filename), ".")]
 }
 
@@ -98,7 +98,7 @@ const (
 // Returns the given file's name's bundle type and whether it is a content
 // file or not.
 func classifyBundledFile(name string) (bundleDirType, bool) {
-	if !isContentFile(name) {
+	if !IsContentFile(name) {
 		return bundleNot, false
 	}
 	if strings.HasPrefix(name, "_index.") {

--- a/hugolib/page_bundler_capture.go
+++ b/hugolib/page_bundler_capture.go
@@ -76,7 +76,7 @@ func newCapturer(
 	isBundleHeader := func(filename string) bool {
 		base := filepath.Base(filename)
 		name := helpers.Filename(base)
-		return isContentFile(base) && (name == "index" || name == "_index")
+		return IsContentFile(base) && (name == "index" || name == "_index")
 	}
 
 	// Make sure that any bundle header files are processed before the others. This makes

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -795,7 +795,7 @@ func (s *Site) processPartial(events []fsnotify.Event) (whatChanged, error) {
 				removed = true
 			}
 		}
-		if removed && isContentFile(ev.Name) {
+		if removed && IsContentFile(ev.Name) {
 			h.removePageByFilename(ev.Name)
 		}
 


### PR DESCRIPTION
Before this commit you would typically use `.Scratch.Add´ to manually create slices in a loop.

With variable overwrite in Go 1.11, we can do better. This commit adds the `append` template func.

A made-up example:

```bash
{{ $p1 := index .Site.RegularPages 0 }}{{ $p2 := index .Site.RegularPages 1 }}
{{ $pages := slice }}
{{ if true }}
  {{ $pages = $pages | append $p2 $p1 }}
{{ end }}
```

Note that with 2 slices a arguments, the two examples below will give the same result:

```bash
{{ $s1 := slice "a" "b" | append (slice "c" "d") }}
{{ $s2 := slice "a" "b" | append "c" "d" }}
```

Both of the above will give `[]string{a, b, c, d}`.

This commit also improves the type handling in the `slice` template function. Now `slice "a" "b"` will give a `[]string` slice. The old behaviour was to return a `[]interface{}`.

Fixes #5190