### PR TITLE
Allow first function to return an empty array.

### DIFF
--- a/docs/content/en/functions/first.md
+++ b/docs/content/en/functions/first.md
@@ -25,3 +25,5 @@ aliases: []
     {{ .Render "summary" }}
 {{ end }}
 ```
+
+*Note: Exclusive to `first`, LIMIT can be '0' to return an empty array.*

--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -215,8 +215,8 @@ func (ns *Namespace) First(limit interface{}, seq interface{}) (interface{}, err
 		return nil, err
 	}
 
-	if limitv < 1 {
-		return nil, errors.New("can't return negative/empty count of items from sequence")
+	if limitv < 0 {
+		return nil, errors.New("can't return negative count of items from sequence")
 	}
 
 	seqv := reflect.ValueOf(seq)

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -256,6 +256,7 @@ func TestFirst(t *testing.T) {
 		{int64(2), []int{100, 200, 300}, []int{100, 200}},
 		{100, []int{100, 200}, []int{100, 200}},
 		{"1", []int{100, 200, 300}, []int{100}},
+		{0, []string{"h", "u", "g", "o"}, []string{}},
 		{int64(-1), []int{100, 200, 300}, false},
 		{"noint", []int{100, 200, 300}, false},
 		{1, nil, false},


### PR DESCRIPTION
Fixes #5235.