### PR TITLE
Enable page exclusion from sitemap.xml

### DIFF
--- a/docs/content/en/templates/sitemap-template.md
+++ b/docs/content/en/templates/sitemap-template.md
@@ -33,11 +33,14 @@ A sitemap is a `Page` and therefore has all the [page variables][pagevars] avail
 `.Sitemap.Filename`
 : The sitemap filename
 
+.Sitemap.Exclude
+: Whether or not to exclude the page from the sitemap. A boolean that defaults to false.
+
 If provided, Hugo will use `/layouts/sitemap.xml` instead of the internal `sitemap.xml` template that ships with Hugo.
 
 ## Sitemap Templates
 
-Hugo has built-on Sitemap templates, but you can provide your own if needed, in either `layouts/sitemap.xml` or `layouts/_default/sitemap.xml`.
+Hugo has built-in Sitemap templates, but you can provide your own if needed, in either `layouts/sitemap.xml` or `layouts/_default/sitemap.xml`.
 
 For multilingual sites, we also create a Sitemap index. You can provide a custom layout for that in either `layouts/sitemapindex.xml` or `layouts/_default/sitemapindex.xml`.
 
@@ -48,7 +51,7 @@ This template respects the version 0.9 of the [Sitemap Protocol](http://www.site
 ```xml
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range where .Pages ".Sitemap.Exclude" false }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -102,6 +105,7 @@ Defaults for `<changefreq>`, `<priority>` and `filename` values can be set in th
   changefreq = "monthly"
   priority = 0.5
   filename = "sitemap.xml"
+  exclude = true
 {{</ code-toggle >}}
 
 The same fields can be specified in an individual content file's front matter in order to override the value assigned to that piece of content at render time.

--- a/docs/content/en/variables/sitemap.md
+++ b/docs/content/en/variables/sitemap.md
@@ -29,4 +29,7 @@ A sitemap is a `Page` and therefore has all the [page variables][pagevars] avail
 .Sitemap.Filename
 : the sitemap filename
 
+.Sitemap.Exclude
+: whether or not to exclude the page from the sitemap, defaults to false
+
 [pagevars]: /variables/page/

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -326,6 +326,7 @@ func (s *Site) renderSitemap() error {
 	page.Sitemap.ChangeFreq = sitemapDefault.ChangeFreq
 	page.Sitemap.Priority = sitemapDefault.Priority
 	page.Sitemap.Filename = sitemapDefault.Filename
+	page.Sitemap.Exclude = sitemapDefault.Exclude
 
 	n.data["Pages"] = pages
 	n.Pages = pages
@@ -348,6 +349,7 @@ func (s *Site) renderSitemap() error {
 		if page.Sitemap.Filename == "" {
 			page.Sitemap.Filename = sitemapDefault.Filename
 		}
+		// Sitemap.Exclude isn't listed here because bools default to false, so it's done for us.
 	}
 
 	smLayouts := []string{"sitemap.xml", "_default/sitemap.xml", "_internal/_default/sitemap.xml"}

--- a/hugolib/sitemap.go
+++ b/hugolib/sitemap.go
@@ -23,6 +23,7 @@ type Sitemap struct {
 	ChangeFreq string
 	Priority   float64
 	Filename   string
+	Exclude    bool
 }
 
 func parseSitemap(input map[string]interface{}) Sitemap {
@@ -36,6 +37,8 @@ func parseSitemap(input map[string]interface{}) Sitemap {
 			sitemap.Priority = cast.ToFloat64(value)
 		case "filename":
 			sitemap.Filename = cast.ToString(value)
+		case "exclude":
+			sitemap.Exclude = cast.ToBool(value)
 		default:
 			jww.WARN.Printf("Unknown Sitemap field: %s\n", key)
 		}

--- a/hugolib/sitemap_test.go
+++ b/hugolib/sitemap_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const sitemapTemplate = `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {{ range .Data.Pages }}
+  {{ range where .Pages ".Sitemap.Exclude" false }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -86,11 +86,12 @@ func doTestSitemapOutput(t *testing.T, internal bool) {
 
 func TestParseSitemap(t *testing.T) {
 	t.Parallel()
-	expected := Sitemap{Priority: 3.0, Filename: "doo.xml", ChangeFreq: "3"}
+	expected := Sitemap{ChangeFreq: "3", Priority: 3.0, Filename: "doo.xml", Exclude: true}
 	input := map[string]interface{}{
 		"changefreq": "3",
 		"priority":   3.0,
 		"filename":   "doo.xml",
+		"exclude":    true,
 		"unknown":    "ignore",
 	}
 	result := parseSitemap(input)

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -47,7 +47,7 @@ var EmbeddedTemplates = [][2]string{
 </rss>`},
 	{`_default/sitemap.xml`, `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range where .Pages ".Sitemap.Exclude" false }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -65,7 +65,8 @@ var EmbeddedTemplates = [][2]string{
                 />{{ end }}
   </url>
   {{ end }}
-</urlset>`},
+</urlset>
+`},
 	{`_default/sitemapindex.xml`, `<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	{{ range . }}
 	<sitemap>

--- a/tpl/tplimpl/embedded/templates/_default/sitemap.xml
+++ b/tpl/tplimpl/embedded/templates/_default/sitemap.xml
@@ -1,6 +1,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range where .Pages ".Sitemap.Exclude" false }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}


### PR DESCRIPTION
This PR adds a new key to .Sitemap called `Exclude`. `Exclude` is a
boolean that is set to false by default meaning all available pages are
included. This is the behavior currently. When `Exclude` is set to true,
it will not appear in any `sitemap.xml` files that Hugo may generate.

`Exclude` can be set to true in the Hugo config turning `sitemap.xml`
into an opt-in rather than an opt-out.

Fixes #653