### PR TITLE
FuzzyWordCount test should use p.FuzzyWordCount when outputting error

### DIFF
--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1104,7 +1104,7 @@ func TestWordCount(t *testing.T) {
 		}
 
 		if p.FuzzyWordCount() != 500 {
-			t.Fatalf("[%s] incorrect word count. expected %v, got %v", ext, 500, p.WordCount())
+			t.Fatalf("[%s] incorrect word count. expected %v, got %v", ext, 500, p.FuzzyWordCount())
 		}
 
 		if p.ReadingTime() != 3 {


### PR DESCRIPTION
 TestWordCount incorrectly uses p.WordCount when outputting error for p.FuzzyWordCount()