### PR TITLE
Date and slug from filename for leaf bundles

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1318,7 +1318,7 @@ func (p *Page) update(frontmatter map[string]interface{}) error {
 		Params:        p.params,
 		Dates:         &p.PageDates,
 		PageURLs:      &p.URLPath,
-		BaseFilename:  p.BaseFileName(),
+		BaseFilename:  p.ContentBaseName(),
 		ModTime:       mtime,
 		GitAuthorDate: gitAuthorDate,
 	}

--- a/hugolib/pagemeta/page_frontmatter.go
+++ b/hugolib/pagemeta/page_frontmatter.go
@@ -50,7 +50,8 @@ type FrontMatterDescriptor struct {
 	// This the Page's front matter.
 	Frontmatter map[string]interface{}
 
-	// This is the Page's base filename, e.g. page.md.
+	// This is the Page's base filename (BaseFilename), e.g. page.md., or
+	// if page is a leaf bundle, the bundle folder name (ContentBaseName).
 	BaseFilename string
 
 	// The content file's mod time.

--- a/source/fileInfo.go
+++ b/source/fileInfo.go
@@ -191,11 +191,11 @@ func (fi *FileInfo) init() {
 		}
 		fi.section = section
 
-		var contentBaseName = fi.translationBaseName
 		if fi.isLeafBundle && len(parts) > 0 {
-			contentBaseName = parts[len(parts)-1]
+			fi.contentBaseName = parts[len(parts)-1]
+		} else {
+			fi.contentBaseName = fi.translationBaseName
 		}
-		fi.contentBaseName = contentBaseName
 
 		fi.uniqueID = helpers.MD5String(filepath.ToSlash(fi.relPath))
 	})

--- a/source/fileInfo.go
+++ b/source/fileInfo.go
@@ -70,6 +70,10 @@ type File interface {
 	// not even the optional language extension part.
 	TranslationBaseName() string
 
+	// ContentBaseName is a either TranslationBaseName or name of containing folder
+	// if file is a leaf bundle.
+	ContentBaseName() string
+
 	// UniqueID is the MD5 hash of the file's path and is for most practical applications,
 	// Hugo content files being one of them, considered to be unique.
 	UniqueID() string
@@ -106,6 +110,7 @@ type FileInfo struct {
 	relPath             string
 	baseName            string
 	translationBaseName string
+	contentBaseName     string
 	section             string
 	isLeafBundle        bool
 
@@ -144,6 +149,13 @@ func (fi *FileInfo) BaseFileName() string { return fi.baseName }
 // language segement (ie. "page").
 func (fi *FileInfo) TranslationBaseName() string { return fi.translationBaseName }
 
+// ContentBaseName is a either TranslationBaseName or name of containing folder
+// if file is a leaf bundle.
+func (fi *FileInfo) ContentBaseName() string {
+	fi.init()
+	return fi.contentBaseName
+}
+
 // Section returns a file's section.
 func (fi *FileInfo) Section() string {
 	fi.init()
@@ -177,11 +189,15 @@ func (fi *FileInfo) init() {
 		if (!fi.isLeafBundle && len(parts) == 1) || len(parts) > 1 {
 			section = parts[0]
 		}
-
 		fi.section = section
 
-		fi.uniqueID = helpers.MD5String(filepath.ToSlash(fi.relPath))
+		var contentBaseName = fi.translationBaseName
+		if fi.isLeafBundle && len(parts) > 0 {
+			contentBaseName = parts[len(parts)-1]
+		}
+		fi.contentBaseName = contentBaseName
 
+		fi.uniqueID = helpers.MD5String(filepath.ToSlash(fi.relPath))
 	})
 }
 

--- a/source/fileInfo_test.go
+++ b/source/fileInfo_test.go
@@ -96,12 +96,15 @@ func TestFileInfoLanguage(t *testing.T) {
 	assert.Equal("en", fiEn.Lang())
 
 	// test contentBaseName implementation
-	fi1 := s.NewFileInfo("", "2018-10-01-contentbasename.md", false, nil)
-	fi2 := s.NewFileInfo("", "2018-10-01-contentbasename.en.md", false, nil)
-	fi3 := s.NewFileInfo("", "2018-10-01-contentbasename"+helpers.FilePathSeparator+"index.en.md",
-		true, nil)
+	fi := s.NewFileInfo("", "2018-10-01-contentbasename.md", false, nil)
+	assert.Equal("2018-10-01-contentbasename", fi.ContentBaseName())
 
-	assert.Equal("2018-10-01-contentbasename", fi1.ContentBaseName())
-	assert.Equal("2018-10-01-contentbasename", fi2.ContentBaseName())
-	assert.Equal("2018-10-01-contentbasename", fi3.ContentBaseName())
+	fi = s.NewFileInfo("", "2018-10-01-contentbasename.en.md", false, nil)
+	assert.Equal("2018-10-01-contentbasename", fi.ContentBaseName())
+
+	fi = s.NewFileInfo("", filepath.Join("2018-10-01-contentbasename", "index.en.md"), true, nil)
+	assert.Equal("2018-10-01-contentbasename", fi.ContentBaseName())
+
+	fi = s.NewFileInfo("", filepath.Join("2018-10-01-contentbasename", "_index.en.md"), false, nil)
+	assert.Equal("_index", fi.ContentBaseName())
 }

--- a/source/fileInfo_test.go
+++ b/source/fileInfo_test.go
@@ -94,4 +94,14 @@ func TestFileInfoLanguage(t *testing.T) {
 
 	assert.Equal("sv", fiSv.Lang())
 	assert.Equal("en", fiEn.Lang())
+
+	// test contentBaseName implementation
+	fi1 := s.NewFileInfo("", "2018-10-01-contentbasename.md", false, nil)
+	fi2 := s.NewFileInfo("", "2018-10-01-contentbasename.en.md", false, nil)
+	fi3 := s.NewFileInfo("", "2018-10-01-contentbasename"+helpers.FilePathSeparator+"index.en.md",
+		true, nil)
+
+	assert.Equal("2018-10-01-contentbasename", fi1.ContentBaseName())
+	assert.Equal("2018-10-01-contentbasename", fi2.ContentBaseName())
+	assert.Equal("2018-10-01-contentbasename", fi3.ContentBaseName())
 }


### PR DESCRIPTION
The definition of the `BaseFilename` field in the `FrontMatterDescriptor` structure provided to the frontmatter handlers has been changed, so that in the case of a leaf bundle `index.`-file, the name provided is that of the containing bundle folder.
Since the use of the `FrontMatterDescriptor` is localized to the frontmatter handler, this should not have external effects.

To compute the new value of `BaseFilename`, I have added a `ContentBaseName` method to the `File` interface. The `FileInfo` implementation of this interface has been modified to compute the value as part of `lazyinit`. 

This is my first ever `go`-code, so feel free to rewrite as you wish, or let me know if I should implement in another way.  