### PR TITLE
Use stdlib context package

### DIFF
--- a/hugolib/page_bundler.go
+++ b/hugolib/page_bundler.go
@@ -14,13 +14,11 @@
 package hugolib
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"runtime"
 
-	// Use this until errgroup gets ported to context
-	// See https://github.com/golang/go/issues/19781
-	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -14,6 +14,7 @@
 package hugolib
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"html/template"
@@ -43,7 +44,6 @@ import (
 	"github.com/gohugoio/hugo/media"
 
 	"github.com/markbates/inflect"
-	"golang.org/x/net/context"
 
 	"github.com/fsnotify/fsnotify"
 	bp "github.com/gohugoio/hugo/bufferpool"


### PR DESCRIPTION
Hugo now depends on go 1.11
With that bump we no longer need to use `golang.org/x/net/context` and can instead use the one found in stdlib