### PR TITLE
tpl/collections: Fix handling of different interface types in Slice

### DIFF
--- a/hugolib/resource_chain_test.go
+++ b/hugolib/resource_chain_test.go
@@ -238,6 +238,10 @@ T1: Content: {{ $combined.Content }}|RelPermalink: {{ $combined.RelPermalink }}|
 {{ $combinedText := . | resources.Concat "bundle/concattxt.txt" }}
 T2: Content: {{ $combinedText.Content }}|{{ $combinedText.RelPermalink }}
 {{ end }}
+{{/* https://github.com/gohugoio/hugo/issues/5269 */}}
+{{ $css := "body { color: blue; }" | resources.FromString "styles.css" }}
+{{ $minified := resources.Get "css/styles1.css" | minify }}
+{{ slice $css $minified | resources.Concat "bundle/mixed.css" }} 
 `)
 		}, func(b *sitesBuilder) {
 			b.AssertFileContent("public/index.html", `T1: Content: ABC|RelPermalink: /bundle/concat.txt|Permalink: http://example.com/bundle/concat.txt|MediaType: text/plain`)

--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -522,33 +522,36 @@ func (ns *Namespace) Slice(args ...interface{}) interface{} {
 	first := args[0]
 	firstType := reflect.TypeOf(first)
 
-	allTheSame := firstType != nil
-	if allTheSame && len(args) > 1 {
+	if firstType == nil {
+		return args
+	}
+
+	if g, ok := first.(collections.Slicer); ok {
+		v, err := g.Slice(args)
+		if err == nil {
+			return v
+		}
+
+		// If Slice fails, the items are not of the same type and
+		// []interface{} is the best we can do.
+		return args
+	}
+
+	if len(args) > 1 {
 		// This can be a mix of types.
 		for i := 1; i < len(args); i++ {
 			if firstType != reflect.TypeOf(args[i]) {
-				allTheSame = false
-				break
+				// []interface{} is the best we can do
+				return args
 			}
 		}
 	}
 
-	if allTheSame {
-		if g, ok := first.(collections.Slicer); ok {
-			v, err := g.Slice(args)
-			if err == nil {
-				return v
-			}
-		} else {
-			slice := reflect.MakeSlice(reflect.SliceOf(firstType), len(args), len(args))
-			for i, arg := range args {
-				slice.Index(i).Set(reflect.ValueOf(arg))
-			}
-			return slice.Interface()
-		}
+	slice := reflect.MakeSlice(reflect.SliceOf(firstType), len(args), len(args))
+	for i, arg := range args {
+		slice.Index(i).Set(reflect.ValueOf(arg))
 	}
-
-	return args
+	return slice.Interface()
 }
 
 type intersector struct {


### PR DESCRIPTION
In Hugo `0.49` we improved type support in `slice`. This has an unfortunate side effect in that `resources.Concat` now expects something that can resolve to `resource.Resources`.

This worked for most situations, but when you try to `slice` different `Resource` objects, you would be getting `[]interface {}` and not `resource.Resources`. And `concat` would fail:

```bash
error calling Concat: slice []interface {} not supported in concat.
```

This commit fixes that by simplifying the type checking logic in `Slice`:

* If the first item implements the `Slicer` interface, we try that
* If the above fails or the first item does not implement `Slicer`, we just return the `[]interface {}`

Fixes #5269