### PR TITLE
hugolib: Allow nil to be unwrapped as *Page

### DIFF
--- a/hugolib/site_sections.go
+++ b/hugolib/site_sections.go
@@ -152,6 +152,8 @@ func unwrapPage(in interface{}) (*Page, error) {
 		return v.Page, nil
 	case *PageWithoutContent:
 		return v.Page, nil
+	case nil:
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("%T not supported", in)
 	}

--- a/hugolib/site_sections_test.go
+++ b/hugolib/site_sections_test.go
@@ -166,6 +166,11 @@ PAG|{{ .Title }}|{{ $sect.InSection . }}
 			assert.Equal("empty3.md", b.Pages[0].File.LogicalName())
 
 		}},
+		{"empty3", func(p *Page) {
+			xxx := p.s.getPage(KindPage, "empty3", "nil")
+			assert.Nil(xxx)
+			assert.Equal(xxx.Eq(nil), true)
+		}},
 		{"top", func(p *Page) {
 			assert.Equal("Tops", p.title)
 			assert.Len(p.Pages, 2)


### PR DESCRIPTION
Previously, calls to *Page.Eq(nil) would always return false because the
unwrapPage func didn't support the nil case.  Add support for unwrapping
nil to a *Page.

Fixes #5043