### PR TITLE
helpers: Consolidate MakeSegment vs MakePathSanitized

### DIFF
--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -51,7 +51,8 @@ func TestMakeSegment(t *testing.T) {
 		{"Your #1 Fan", "your-1-fan"},
 		{"Red & Blue", "red-blue"},
 		{"double//slash", "double-slash"},
-		{"My // Taxonomy", "my-taxonomy"},
+		{"triple///slash", "triple-slash"},
+		{"-my/way-", "my-way"},
 	}
 
 	for _, test := range tests {

--- a/hugolib/permalinks.go
+++ b/hugolib/permalinks.go
@@ -152,10 +152,10 @@ func pageToPermalinkDate(p *Page, dateField string) (string, error) {
 
 // pageToPermalinkTitle returns the URL-safe form of the title
 func pageToPermalinkTitle(p *Page, _ string) (string, error) {
-	if p.Kind == "taxonomy" {
+	if p.Kind == KindTaxonomy {
 		// Taxonomies are allowed to have '/' characters, so don't normalize
 		// them with MakeSegment.
-		return p.s.PathSpec.URLize(p.title), nil
+		return p.s.PathSpec.MakePathSanitized(p.title), nil
 	}
 
 	return p.s.PathSpec.MakeSegment(p.title), nil


### PR DESCRIPTION
In short:

* Avoid double tolower in MakeSegment
* Use MakePathSanitized for taxonomies in pageToPermalinkTitle; this matches what MakeSegment does.
* Move the "double hyphen and space" logic into UnicodeSanitize

The last bullet may be slightly breaking for some that now does not get the "--" in some URLs, but we need to reduce the amount of URL logic.

See #4926