### PR TITLE
docs: Fix typo in quick-start.md

### DIFF
--- a/docs/content/en/getting-started/quick-start.md
+++ b/docs/content/en/getting-started/quick-start.md
@@ -77,7 +77,7 @@ echo 'theme = "ananke"' >> config.toml
 ## Step 4: Add Some Content
 
 ```
-hugo new posts/my-first-post.md
+hugo new post/my-first-post.md
 ```
 
 


### PR DESCRIPTION
The original command put the article into `content/posts`, then there is nothing display on the home page.

It does give the First-time users like me a little trouble.