### PR TITLE
Extend youtube shortcode to support playlists

### DIFF
--- a/docs/content/en/content-management/shortcodes.md
+++ b/docs/content/en/content-management/shortcodes.md
@@ -338,7 +338,7 @@ Using the preceding `vimeo` example, the following simulates the displayed exper
 
 ### `youtube`
 
-The `youtube` shortcode embeds a responsive video player for [YouTube videos][]. Only the ID of the video is required, e.g.:
+The `youtube` shortcode embeds a responsive video player for [YouTube videos][] and playlists. Only the ID of the video or playlist is required, e.g.:
 
 ```
 https://www.youtube.com/watch?v=w7Ft2ymGmfc
@@ -373,6 +373,12 @@ Using the preceding `youtube` example, the following HTML will be added to your 
 Using the preceding `youtube` example (without `autoplay="true"`), the following simulates the displayed experience for visitors to your website. Naturally, the final display will be contingent on your stylesheets and surrounding markup. The video is also include in the [Quick Start of the Hugo documentation][quickstart].
 
 {{< youtube w7Ft2ymGmfc >}}
+
+#### Example `youtube` playlist
+
+For playlists use the playlist ID from the URL, which begins with "PL".
+
+{{< youtube PLLAZ4kZ9dFpOnyRlyS-liKL5ReHDcj4G3 >}}
 
 ## Privacy Config
 

--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
@@ -2,8 +2,16 @@
 {{- if not $pc.Disable -}}
 {{- $ytHost := cond $pc.PrivacyEnhanced  "www.youtube-nocookie.com" "www.youtube.com" -}}
 {{- $id := .Get "id" | default (.Get 0) -}}
+{{- $path := "" -}}
+{{- if hasPrefix $id "PL" -}}
+{{- $path = printf "?listType=playlist&list=%s" $id -}}
+{{ if eq (.Get "autoplay") "true" }}{{- $path = printf "%s%s" $path "&autoplay=1" -}}{{ end }}
+{{- else -}}
+{{- $path = $id -}}
+{{ if eq (.Get "autoplay") "true" }}{{- $path = printf "%s%s" $path "?autoplay=1" -}}{{ end }}
+{{- end -}}
 {{- $class := .Get "class" | default (.Get 1) }}
 <div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
-  <iframe src="//{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="YouTube Video"></iframe>
+  <iframe src="//{{ $ytHost }}/embed/{{ $path }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="YouTube Video"></iframe>
 </div>
 {{ end -}}


### PR DESCRIPTION
The player will load the first video of the playlist by default.
The playlist is available in the YouTube player menu (top left).

I’m not sure if this is the best way to code the template.
I declare `$path`, and then determine the subpath in an if else block, and append the adequate autoplay query parameter if necessary.