### PR TITLE
Skip watcher event files if matched in ignoreFiles

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -825,6 +825,9 @@ func (c *commandeer) handleEvents(watcher *watcher.Batcher,
 		if istemp {
 			continue
 		}
+		if c.hugo.Deps.SourceSpec.IgnoreFile(ev.Name) {
+			continue
+		}
 		// Sometimes during rm -rf operations a '"": REMOVE' is triggered. Just ignore these
 		if ev.Name == "" {
 			continue


### PR DESCRIPTION
This is a naive attempt to fix the unexpected behavior with the ignoreFiles config option.

Known caveats:
If the setting exists, then is removed from config.toml, the formerly matching filenames will be sync'ed. If the ignoreFiles does not exist, then hugo server will have to be restarted for filenames to match.

For #4874 