### PR TITLE
Generate .gitignore when creating a new site

### DIFF
--- a/commands/new_site.go
+++ b/commands/new_site.go
@@ -97,6 +97,7 @@ func (n *newSiteCmd) doNewSite(fs *hugofs.Fs, basepath string, force bool) error
 	}
 
 	createConfig(fs, basepath, n.configFormat)
+	createGitignore(fs, basepath)
 
 	// Create a default archetype file.
 	helpers.SafeWriteToDisk(filepath.Join(archeTypePath, "default.md"),
@@ -139,6 +140,14 @@ func createConfig(fs *hugofs.Fs, inpath string, kind string) (err error) {
 	}
 
 	return helpers.WriteToDisk(filepath.Join(inpath, "config."+kind), &buf, fs.Source)
+}
+
+func createGitignore(fs *hugofs.Fs, inpath string) (err error) {
+	var gitignore bytes.Buffer
+
+	gitignore.WriteString("public/")
+
+	return helpers.WriteToDisk(filepath.Join(inpath, ".gitignore"), &gitignore, fs.Source)
 }
 
 func nextStepsText() string {


### PR DESCRIPTION
I thought it would be a useful addition to add a `.gitignore` file when the site is first generated using `hugo new site [dir]`.

At present the file contains a single listing for the `public/` directory. This doesn't necessarily need to be committed every time there's a change as most people I've seen add a gitignore file anyway for that directory.

I'm not sure about any other directories/files that should be added to this file. Perhaps the `resources/` directory also as it's generated by a `hugo` command also.

Let me know what you think.