### PR TITLE
resource: Optimize integrity string generation

### DIFF
--- a/resource/integrity/integrity.go
+++ b/resource/integrity/integrity.go
@@ -96,7 +96,7 @@ func (c *Client) Fingerprint(res resource.Resource, algo string) (resource.Resou
 
 func integrity(algo string, sum []byte) template.HTMLAttr {
 	encoded := base64.StdEncoding.EncodeToString(sum)
-	return template.HTMLAttr(fmt.Sprintf("%s-%s", algo, encoded))
+	return template.HTMLAttr(algo + "-" + encoded)
 }
 
 func digest(h hash.Hash) ([]byte, error) {


### PR DESCRIPTION
Remove use of fmt.Sprintf for simple string concatenation.  A simple
change for a small perf boost.

```
name         old time/op    new time/op    delta
Integrity-4     525ns ± 2%     268ns ± 2%  -48.92%  (p=0.000 n=10+10)

name         old alloc/op   new alloc/op   delta
Integrity-4      144B ± 0%      112B ± 0%  -22.22%  (p=0.000 n=10+10)

name         old allocs/op  new allocs/op  delta
Integrity-4      5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
```