### PR TITLE
Prevent stale content in Fast Render Mode

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -324,10 +324,7 @@ func (c *commandeer) loadConfig(mustHaveConfigFile, running bool) error {
 			fs.Destination = new(afero.MemMapFs)
 		}
 
-		doLiveReload := !c.h.buildWatch && !config.GetBool("disableLiveReload")
-		fastRenderMode := doLiveReload && !config.GetBool("disableFastRender")
-
-		if fastRenderMode {
+		if c.fastRenderMode {
 			// For now, fast render mode only. It should, however, be fast enough
 			// for the full variant, too.
 			changeDetector := &fileChangeDetector{

--- a/common/types/evictingqueue.go
+++ b/common/types/evictingqueue.go
@@ -52,6 +52,13 @@ func (q *EvictingStringQueue) Add(v string) {
 	q.mu.Unlock()
 }
 
+// Contains returns whether the queue contains v.
+func (q *EvictingStringQueue) Contains(v string) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.set[v]
+}
+
 // Peek looks at the last element added to the queue.
 func (q *EvictingStringQueue) Peek() string {
 	q.mu.Lock()

--- a/common/types/evictingqueue_test.go
+++ b/common/types/evictingqueue_test.go
@@ -36,6 +36,9 @@ func TestEvictingStringQueue(t *testing.T) {
 	queue.Add("a")
 	queue.Add("b")
 
+	assert.True(queue.Contains("a"))
+	assert.False(queue.Contains("foo"))
+
 	assert.Equal([]string{"b", "a"}, queue.PeekAll())
 	assert.Equal("b", queue.Peek())
 	queue.Add("c")

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -368,6 +368,11 @@ type BuildCfg struct {
 	SkipRender bool
 	// Use this to indicate what changed (for rebuilds).
 	whatChanged *whatChanged
+
+	// This is a partial re-render of some selected pages. This means
+	// we should skip most of the processing.
+	PartialReRender bool
+
 	// Recently visited URLs. This is used for partial re-rendering.
 	RecentlyVisited map[string]bool
 }

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -43,7 +43,7 @@ func (s *Site) renderPages(cfg *BuildCfg) error {
 		go pageRenderer(s, pages, results, wg)
 	}
 
-	if len(s.headlessPages) > 0 {
+	if !cfg.PartialReRender && len(s.headlessPages) > 0 {
 		wg.Add(1)
 		go headlessPagesPublisher(s, wg)
 	}


### PR DESCRIPTION
We do that by re-render visited pages that is not already in the stack. This may potentially do some double work, but that small penalty should be well worth it.

Fixes #5281