### PR TITLE
hugolib: Extract title from filename

### DIFF
--- a/docs/content/en/getting-started/configuration.md
+++ b/docs/content/en/getting-started/configuration.md
@@ -373,6 +373,23 @@ The above will try first to extract the value for `.Date` from the filename, the
 `:git`
 : This is the Git author date for the last revision of this content file. This will only be set if `--enableGitInfo` is set or `enableGitInfo = true` is set in site config.
 
+## Configure Title
+
+It is possible to enable deriving title from the filename/slug. 
+
+`:filename`
+
+: Fetches the title from the content file's filename. For example, `my_page.md` will extract the title `My Page`. 
+If you use `:filename` for date too then `2018-02-22-my_page.md` will extract both date and title from the filename.
+
+An example:
+
+```toml
+[frontmatter]
+date  = [":filename", ":default"]
+title = [":filename", ":default"]
+```
+
 ## Configure Blackfriday
 
 [Blackfriday](https://github.com/russross/blackfriday) is Hugo's built-in Markdown rendering engine.

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1321,15 +1321,21 @@ func (p *Page) update(frontmatter map[string]interface{}) error {
 		BaseFilename:  p.BaseFileName(),
 		ModTime:       mtime,
 		GitAuthorDate: gitAuthorDate,
+		TitleFunc:     p.s.titleFunc,
+		// Title not set as it will only be set if a title found in frontmatter.
 	}
 
 	// Handle the date separately
 	// TODO(bep) we need to "do more" in this area so this can be split up and
 	// more easily tested without the Page, but the coupling is strong.
-	err := p.s.frontmatterHandler.HandleDates(descriptor)
+	err := p.s.frontmatterHandler.HandleFrontMatter(descriptor)
 	if err != nil {
 		p.s.Log.ERROR.Printf("Failed to handle dates for page %q: %s", p.Path(), err)
 	}
+	if descriptor.Title != nil {
+		p.title = *descriptor.Title
+	}
+
 
 	var draft, published, isCJKLanguage *bool
 	for k, v := range frontmatter {
@@ -1349,9 +1355,6 @@ func (p *Page) update(frontmatter map[string]interface{}) error {
 		}
 
 		switch loki {
-		case "title":
-			p.title = cast.ToString(v)
-			p.params[loki] = p.title
 		case "linktitle":
 			p.linkTitle = cast.ToString(v)
 			p.params[loki] = p.linkTitle

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -88,6 +88,7 @@ Content of the file goes Here
 `
 
 	simplePageRFC3339Date  = "---\ntitle: RFC3339 Date\ndate: \"2013-05-17T16:59:30Z\"\n---\nrfc3339 content"
+	simplePageNoTitleNoFrontMatter = "No title nor frontmatter"
 	simplePageJSONMultiple = `
 {
 	"title": "foobar",
@@ -765,6 +766,46 @@ Simple Page With Some Date`
 
 	testAllMarkdownEnginesForPages(t, assertFunc, nil, pageContents...)
 }
+
+func TestTitleWhenNoTitle(t *testing.T) {
+	t.Parallel()
+	cfg, fs := newTestCfg()
+
+	cfg.Set("frontmatter", map[string]interface{}{
+		"title": []string{":filename"},
+	})
+
+	writeSource(t, fs, filepath.Join("content", "simple-is_sometimes-more.md"), simplePageNoTitleNoFrontMatter)
+
+	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{SkipRender: true})
+
+	require.Len(t, s.RegularPages, 1)
+
+	p := s.RegularPages[0]
+
+	checkPageTitle(t, p, "Simple Is Sometimes More")
+}
+
+func TestTitleWhenNoTitleFileDatestamp(t *testing.T) {
+	t.Parallel()
+	cfg, fs := newTestCfg()
+
+	cfg.Set("frontmatter", map[string]interface{}{
+		"title": []string{":filename"},
+		"date": []string{":filename"},
+	})
+
+	writeSource(t, fs, filepath.Join("content", "2017-01-31-simple.md"), simplePageNoTitleNoFrontMatter)
+
+	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{SkipRender: true})
+
+	require.Len(t, s.RegularPages, 1)
+
+	p := s.RegularPages[0]
+
+	checkPageTitle(t, p, "Simple")
+}
+
 
 // Issue #2601
 func TestPageRawContent(t *testing.T) {
@@ -1573,7 +1614,7 @@ func TestKind(t *testing.T) {
 	require.Equal(t, "home", KindHome)
 	require.Equal(t, "section", KindSection)
 	require.Equal(t, "taxonomy", KindTaxonomy)
-	require.Equal(t, "taxonomyTerm", KindTaxonomyTerm)
+	require.Equal(t, "taxonomyTerm", KindTaxonomyTerm)  
 
 }
 


### PR DESCRIPTION
Why:

 * Would be nice to just add content without a frontmatter.
   title is at the moment the only required field in frontmatter for
   hugo.
 * Like to migrate existing content more easily to frontmatter.
   Existing static generators can derive title from filename or content
   markup.

This change addreses the need by:

 * use the same mechanics added for handling date fields in
   commit: 68bf1511f2b to allow configure how title is configured.

   The default for doing title is simply:

   ```toml
   [frontmatter]
   title = [ "title" ]
   ```

   So, if you want to use a different field than `title` this works:

   ```toml
   [frontmatter]
   title = [ "mytitle", ":default" ]
   ```

   This commit adds support for deriving title from filename and possible
   to combine with filename suppor for dates.

   A good configuration for deriving date and titles from filenames while still
   honoring values found in frontmatter are:

   ```toml
   [frontmatter]
   date = [ ":default", "filename" ]
   title = [ ":default", "filename" ]
   ```

   Fixes #3805