### PR TITLE
hugolib: Extract title from filename

### DIFF
--- a/docs/content/en/getting-started/configuration.md
+++ b/docs/content/en/getting-started/configuration.md
@@ -373,6 +373,25 @@ The above will try first to extract the value for `.Date` from the filename, the
 `:git`
 : This is the Git author date for the last revision of this content file. This will only be set if `--enableGitInfo` is set or `enableGitInfo = true` is set in site config.
 
+## Configure Title
+
+It is possible to enable deriving title from the filename/slug. 
+
+`:filename`
+
+: Fetches the title from the content file's filename. For example, `my_page.md` will extract the title `My Page`. 
+If you use `:filename` for date too then `2018-02-22-my_page.md` will extract both date and title from the filename.
+
+An example:
+
+```toml
+[frontmatter]
+date  = [":default", ":filename"]
+title = [":default", ":filename]
+```
+
+Note: putting `:filename` at the end ensures you can still use `title` in frontmatter and it will be used over the filename.
+
 ## Configure Blackfriday
 
 [Blackfriday](https://github.com/russross/blackfriday) is Hugo's built-in Markdown rendering engine.

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1321,14 +1321,19 @@ func (p *Page) update(frontmatter map[string]interface{}) error {
 		BaseFilename:  p.BaseFileName(),
 		ModTime:       mtime,
 		GitAuthorDate: gitAuthorDate,
+		TitleFunc:     p.s.titleFunc,
+		// Title not set as it will only be set if a title found in frontmatter.
 	}
 
 	// Handle the date separately
 	// TODO(bep) we need to "do more" in this area so this can be split up and
 	// more easily tested without the Page, but the coupling is strong.
-	err := p.s.frontmatterHandler.HandleDates(descriptor)
+	err := p.s.frontmatterHandler.HandleFrontMatter(descriptor)
 	if err != nil {
 		p.s.Log.ERROR.Printf("Failed to handle dates for page %q: %s", p.Path(), err)
+	}
+	if descriptor.Title != nil {
+		p.title = *descriptor.Title
 	}
 
 	var draft, published, isCJKLanguage *bool
@@ -1344,14 +1349,11 @@ func (p *Page) update(frontmatter map[string]interface{}) error {
 			continue
 		}
 
-		if p.s.frontmatterHandler.IsDateKey(loki) {
+		if p.s.frontmatterHandler.IsFrontMatterKey(loki) {
 			continue
 		}
 
 		switch loki {
-		case "title":
-			p.title = cast.ToString(v)
-			p.params[loki] = p.title
 		case "linktitle":
 			p.linkTitle = cast.ToString(v)
 			p.params[loki] = p.linkTitle

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -87,8 +87,9 @@ Leading
 Content of the file goes Here
 `
 
-	simplePageRFC3339Date  = "---\ntitle: RFC3339 Date\ndate: \"2013-05-17T16:59:30Z\"\n---\nrfc3339 content"
-	simplePageJSONMultiple = `
+	simplePageRFC3339Date          = "---\ntitle: RFC3339 Date\ndate: \"2013-05-17T16:59:30Z\"\n---\nrfc3339 content"
+	simplePageNoTitleNoFrontMatter = "No title nor frontmatter"
+	simplePageJSONMultiple         = `
 {
 	"title": "foobar",
 	"customData": { "foo": "bar" },
@@ -764,6 +765,45 @@ Simple Page With Some Date`
 	}
 
 	testAllMarkdownEnginesForPages(t, assertFunc, nil, pageContents...)
+}
+
+func TestTitleWhenNoTitle(t *testing.T) {
+	t.Parallel()
+	cfg, fs := newTestCfg()
+
+	cfg.Set("frontmatter", map[string]interface{}{
+		"title": []string{":filename"},
+	})
+
+	writeSource(t, fs, filepath.Join("content", "simple-is_sometimes-more.md"), simplePageNoTitleNoFrontMatter)
+
+	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{SkipRender: true})
+
+	require.Len(t, s.RegularPages, 1)
+
+	p := s.RegularPages[0]
+
+	checkPageTitle(t, p, "Simple Is Sometimes More")
+}
+
+func TestTitleWhenNoTitleFileDatestamp(t *testing.T) {
+	t.Parallel()
+	cfg, fs := newTestCfg()
+
+	cfg.Set("frontmatter", map[string]interface{}{
+		"title": []string{":filename"},
+		"date":  []string{":filename"},
+	})
+
+	writeSource(t, fs, filepath.Join("content", "2017-01-31-simple.md"), simplePageNoTitleNoFrontMatter)
+
+	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{SkipRender: true})
+
+	require.Len(t, s.RegularPages, 1)
+
+	p := s.RegularPages[0]
+
+	checkPageTitle(t, p, "Simple")
 }
 
 // Issue #2601

--- a/hugolib/pagemeta/page_frontmatter.go
+++ b/hugolib/pagemeta/page_frontmatter.go
@@ -28,7 +28,7 @@ import (
 )
 
 // FrontMatterHandler maps front matter into Page fields and .Params.
-// Note that we currently have only extracted the date logic.
+// Currently have extracted date and title logic.
 type FrontMatterHandler struct {
 	fmConfig frontmatterConfig
 
@@ -36,9 +36,10 @@ type FrontMatterHandler struct {
 	lastModHandler     frontMatterFieldHandler
 	publishDateHandler frontMatterFieldHandler
 	expiryDateHandler  frontMatterFieldHandler
+	titleHandler       frontMatterFieldHandler
 
-	// A map of all date keys configured, including any custom.
-	allDateKeys map[string]bool
+	// A map of all keys configured, including any custom.
+	allFrontMatterKeys map[string]bool
 
 	logger *jww.Notepad
 }
@@ -59,6 +60,15 @@ type FrontMatterDescriptor struct {
 	// May be set from the author date in Git.
 	GitAuthorDate time.Time
 
+	// This the titlefunc used by page site
+	// todo: would have preferred to point to Site to read other configuration
+	// but cannot use hugolib from nested package
+	TitleFunc func(s string) string
+
+	// Set if a title is found by handlers
+	// If have a value it will be set onto the Page title
+	Title *string
+
 	// The below are pointers to values on Page and will be modified.
 
 	// This is the Page's params.
@@ -77,19 +87,24 @@ var (
 		fmLastmod:    []string{"modified"},
 		fmPubDate:    []string{"pubdate", "published"},
 		fmExpiryDate: []string{"unpublishdate"},
+		fmTitle:      []string{"title"},
 	}
 )
 
-// HandleDates updates all the dates given the current configuration and the
+// HandleFrontMatter updates all the fields that have front matter handlers given the current configuration and the
 // supplied front matter params. Note that this requires all lower-case keys
 // in the params map.
-func (f FrontMatterHandler) HandleDates(d *FrontMatterDescriptor) error {
+func (f FrontMatterHandler) HandleFrontMatter(d *FrontMatterDescriptor) error {
 	if d.Dates == nil {
 		panic("missing dates")
 	}
 
 	if f.dateHandler == nil {
 		panic("missing date handler")
+	}
+
+	if f.titleHandler == nil {
+		panic("missing title handler")
 	}
 
 	if _, err := f.dateHandler(d); err != nil {
@@ -108,13 +123,17 @@ func (f FrontMatterHandler) HandleDates(d *FrontMatterDescriptor) error {
 		return err
 	}
 
+	if _, err := f.titleHandler(d); err != nil {
+		return err
+	}
+
 	return nil
 }
 
-// IsDateKey returns whether the given front matter key is considered a date by the current
+// IsFrontMatterKey returns whether the given front matter key is managed by frontmatter handlers by the current
 // configuration.
-func (f FrontMatterHandler) IsDateKey(key string) bool {
-	return f.allDateKeys[key]
+func (f FrontMatterHandler) IsFrontMatterKey(key string) bool {
+	return f.allFrontMatterKeys[key]
 }
 
 // A Zero date is a signal that the name can not be parsed.
@@ -163,17 +182,21 @@ type frontmatterConfig struct {
 	lastmod     []string
 	publishDate []string
 	expiryDate  []string
+	title       []string
 }
 
 const (
-	// These are all the date handler identifiers
+	// These are all the front matter config identifiers
 	// All identifiers not starting with a ":" maps to a front matter parameter.
 	fmDate       = "date"
 	fmPubDate    = "publishdate"
 	fmLastmod    = "lastmod"
 	fmExpiryDate = "expirydate"
+	fmTitle      = "title"
 
-	// Gets date from filename, e.g 218-02-22-mypage.md
+	// Gets date or title from filename, e.g 218-02-22-mypage.md
+	// in cas of date it will update slug to just have the non-date part
+	// in case of title it will take slug first if present, title second.
 	fmFilename = ":filename"
 
 	// Gets date from file OS mod time.
@@ -190,6 +213,7 @@ func newDefaultFrontmatterConfig() frontmatterConfig {
 		lastmod:     []string{fmGitAuthorDate, fmLastmod, fmDate, fmPubDate},
 		publishDate: []string{fmPubDate, fmDate},
 		expiryDate:  []string{fmExpiryDate},
+		title:       []string{fmTitle},
 	}
 }
 
@@ -210,6 +234,8 @@ func newFrontmatterConfig(cfg config.Provider) (frontmatterConfig, error) {
 				c.lastmod = toLowerSlice(v)
 			case fmExpiryDate:
 				c.expiryDate = toLowerSlice(v)
+			case fmTitle:
+				c.title = toLowerSlice(v)
 			}
 		}
 	}
@@ -224,6 +250,7 @@ func newFrontmatterConfig(cfg config.Provider) (frontmatterConfig, error) {
 	c.publishDate = expander(c.publishDate, defaultConfig.publishDate)
 	c.lastmod = expander(c.lastmod, defaultConfig.lastmod)
 	c.expiryDate = expander(c.expiryDate, defaultConfig.expiryDate)
+	c.title = expander(c.title, defaultConfig.title)
 
 	return c, nil
 }
@@ -274,11 +301,11 @@ func NewFrontmatterHandler(logger *jww.Notepad, cfg config.Provider) (FrontMatte
 		return FrontMatterHandler{}, err
 	}
 
-	allDateKeys := make(map[string]bool)
+	allFrontMatterKeys := make(map[string]bool)
 	addKeys := func(vals []string) {
 		for _, k := range vals {
 			if !strings.HasPrefix(k, ":") {
-				allDateKeys[k] = true
+				allFrontMatterKeys[k] = true
 			}
 		}
 	}
@@ -287,8 +314,9 @@ func NewFrontmatterHandler(logger *jww.Notepad, cfg config.Provider) (FrontMatte
 	addKeys(frontMatterConfig.expiryDate)
 	addKeys(frontMatterConfig.lastmod)
 	addKeys(frontMatterConfig.publishDate)
+	addKeys(frontMatterConfig.title)
 
-	f := FrontMatterHandler{logger: logger, fmConfig: frontMatterConfig, allDateKeys: allDateKeys}
+	f := FrontMatterHandler{logger: logger, fmConfig: frontMatterConfig, allFrontMatterKeys: allFrontMatterKeys}
 
 	if err := f.createHandlers(); err != nil {
 		return f, err
@@ -328,6 +356,14 @@ func (f *FrontMatterHandler) createHandlers() error {
 		func(d *FrontMatterDescriptor, t time.Time) {
 			setParamIfNotSet(fmExpiryDate, t, d)
 			d.Dates.ExpiryDate = t
+		}); err != nil {
+		return err
+	}
+
+	if f.titleHandler, err = f.createTitleHandler(f.fmConfig.title,
+		func(d *FrontMatterDescriptor, t string) {
+			setParamIfNotSet(fmTitle, t, d)
+			d.Title = &t
 		}); err != nil {
 		return err
 	}
@@ -423,6 +459,65 @@ func (f *frontmatterFieldHandlers) newDateGitAuthorDateHandler(setter func(d *Fr
 			return false, nil
 		}
 		setter(d, d.GitAuthorDate)
+		return true, nil
+	}
+}
+
+func (f FrontMatterHandler) createTitleHandler(identifiers []string, setter func(d *FrontMatterDescriptor, t string)) (frontMatterFieldHandler, error) {
+	var h *frontmatterFieldHandlers
+	var handlers []frontMatterFieldHandler
+
+	for _, identifier := range identifiers {
+		switch identifier {
+		case fmFilename:
+			handlers = append(handlers, h.newTitleFilenameHandler(setter))
+		default:
+			handlers = append(handlers, h.newStringFieldHandler(identifier, setter))
+		}
+	}
+
+	return f.newChainedFrontMatterFieldHandler(handlers...), nil
+
+}
+
+func (f *frontmatterFieldHandlers) newStringFieldHandler(key string, setter func(d *FrontMatterDescriptor, t string)) frontMatterFieldHandler {
+	return func(d *FrontMatterDescriptor) (bool, error) {
+		v, found := d.Frontmatter[key]
+
+		if !found {
+			return false, nil
+		}
+
+		str := cast.ToString(v)
+
+		setter(d, str)
+
+		// This is the params key as set in front matter.
+		d.Params[key] = str
+
+		return true, nil
+	}
+}
+
+func (f *frontmatterFieldHandlers) newTitleFilenameHandler(setter func(d *FrontMatterDescriptor, t string)) frontMatterFieldHandler {
+	return func(d *FrontMatterDescriptor) (bool, error) {
+
+		var rawpath string
+
+		// we look at slug first to make it work well with date = :filename to avoid date being in header.
+		if d.PageURLs.Slug != "" {
+			rawpath = d.PageURLs.Slug
+		} else {
+			rawpath = d.BaseFilename
+		}
+
+		// replace common separators with space
+		rawpath = strings.Replace(rawpath, "-", " ", -1)
+		rawpath = strings.Replace(rawpath, "_", " ", -1)
+		rawpath = strings.Replace(rawpath, ".", " ", -1)
+
+		var derivedTitle = d.TitleFunc(rawpath)
+		setter(d, derivedTitle)
 		return true, nil
 	}
 }

--- a/hugolib/pagemeta/page_frontmatter_test.go
+++ b/hugolib/pagemeta/page_frontmatter_test.go
@@ -142,13 +142,13 @@ func TestFrontMatterDatesHandlers(t *testing.T) {
 			d.GitAuthorDate = d1
 		}
 		d.Frontmatter["date"] = d2
-		assert.NoError(handler.HandleDates(d))
+		assert.NoError(handler.HandleFrontMatter(d))
 		assert.Equal(d1, d.Dates.Date)
 		assert.Equal(d2, d.Params["date"])
 
 		d = newTestFd()
 		d.Frontmatter["date"] = d2
-		assert.NoError(handler.HandleDates(d))
+		assert.NoError(handler.HandleFrontMatter(d))
 		assert.Equal(d2, d.Dates.Date)
 		assert.Equal(d2, d.Params["date"])
 
@@ -184,7 +184,7 @@ func TestFrontMatterDatesCustomConfig(t *testing.T) {
 	testDate = testDate.Add(24 * time.Hour)
 	d.Frontmatter["expirydate"] = testDate
 
-	assert.NoError(handler.HandleDates(d))
+	assert.NoError(handler.HandleFrontMatter(d))
 
 	assert.Equal(1, d.Dates.Date.Day())
 	assert.Equal(4, d.Dates.Lastmod.Day())
@@ -196,10 +196,10 @@ func TestFrontMatterDatesCustomConfig(t *testing.T) {
 	assert.Equal(d.Dates.PublishDate, d.Params["publishdate"])
 	assert.Equal(d.Dates.ExpiryDate, d.Params["expirydate"])
 
-	assert.False(handler.IsDateKey("date")) // This looks odd, but is configured like this.
-	assert.True(handler.IsDateKey("mydate"))
-	assert.True(handler.IsDateKey("publishdate"))
-	assert.True(handler.IsDateKey("pubdate"))
+	assert.False(handler.IsFrontMatterKey("date")) // This looks odd, but is configured like this.
+	assert.True(handler.IsFrontMatterKey("mydate"))
+	assert.True(handler.IsFrontMatterKey("publishdate"))
+	assert.True(handler.IsFrontMatterKey("pubdate"))
 
 }
 
@@ -225,7 +225,7 @@ func TestFrontMatterDatesDefaultKeyword(t *testing.T) {
 	d.Frontmatter["mypubdate"] = testDate.Add(2 * 24 * time.Hour)
 	d.Frontmatter["publishdate"] = testDate.Add(3 * 24 * time.Hour)
 
-	assert.NoError(handler.HandleDates(d))
+	assert.NoError(handler.HandleFrontMatter(d))
 
 	assert.Equal(1, d.Dates.Date.Day())
 	assert.Equal(2, d.Dates.Lastmod.Day())
@@ -258,4 +258,61 @@ func TestFrontMatterDateFieldHandler(t *testing.T) {
 	assert.True(handled)
 	assert.NoError(err)
 	assert.Equal(d, fd.Dates.Date)
+}
+
+func TestFrontMatterTitleCustomConfig(t *testing.T) {
+	t.Parallel()
+
+	assert := require.New(t)
+
+	cfg := viper.New()
+	cfg.Set("frontmatter", map[string]interface{}{
+		"title": []string{"mytitle"},
+	})
+
+	handler, err := NewFrontmatterHandler(nil, cfg)
+	assert.NoError(err)
+
+	testTitle := "Right Title"
+
+	d := newTestFd()
+	d.Frontmatter["mytitle"] = testTitle
+	d.Frontmatter["title"] = "Wrong title"
+
+	assert.NoError(handler.HandleFrontMatter(d))
+
+	assert.NotNil(d.Title)
+	assert.Equal(testTitle, *d.Title)
+	assert.Equal(testTitle, d.Params["title"])
+	assert.Equal(testTitle, d.Params["mytitle"])
+
+	assert.True(handler.IsFrontMatterKey("mytitle"))
+
+	assert.False(handler.IsFrontMatterKey("title"))
+
+}
+
+func TestFrontMatterTitleNoCustomConfig(t *testing.T) {
+	t.Parallel()
+
+	assert := require.New(t)
+
+	cfg := viper.New()
+
+	handler, err := NewFrontmatterHandler(nil, cfg)
+	assert.NoError(err)
+
+	testTitle := "Right Title"
+
+	d := newTestFd()
+	d.Frontmatter["title"] = testTitle
+
+	assert.NoError(handler.HandleFrontMatter(d))
+
+	assert.NotNil(d.Title)
+	assert.Equal(testTitle, *d.Title)
+	assert.Equal(testTitle, d.Params["title"])
+
+	assert.True(handler.IsFrontMatterKey("title"))
+
 }


### PR DESCRIPTION
Why:

 * Would be nice to just add content without a frontmatter.
   title is at the moment the only required field in frontmatter for
   hugo.
 * Like to migrate existing content more easily to frontmatter.
   Existing static generators can derive title from filename or content
   markup.

This change addreses the need by:

 * use the same mechanics added for handling date fields in
   commit: 68bf1511f2b to allow configure how title is configured.

   The default for doing title is simply:

   ```toml
   [frontmatter]
   title = [ "title" ]
   ```

   So, if you want to use a different field than `title` this works:

   ```toml
   [frontmatter]
   title = [ "mytitle", ":default" ]
   ```

   This commit adds support for deriving title from filename and possible
   to combine with filename suppor for dates.

   A good configuration for deriving date and titles from filenames while still
   honoring values found in frontmatter are:

   ```toml
   [frontmatter]
   date = [ ":default", "filename" ]
   title = [ ":default", "filename" ]
   ```

   Fixes #3805