### PR TITLE
Add note regarding missing translation files

### DIFF
--- a/docs/content/en/content-management/multilingual.md
+++ b/docs/content/en/content-management/multilingual.md
@@ -438,6 +438,10 @@ Hugo will generate your website with these missing translation placeholders. It 
 
 For merging of content from other languages (i.e. missing content translations), see [lang.Merge](/functions/lang.merge/).
 
+{{% note %}}
+Hugo will create default variants of the home page and any root section, meaning that the translation of a subpage will lead to the generation of language variants for the root section page, even without providing a root section translation file.
+{{% /note %}}
+
 ## Multilingual Themes support
 
 To support Multilingual mode in your themes, some considerations must be taken for the URLs in the templates. If there is more than one language, URLs must meet the following criteria:


### PR DESCRIPTION
Based on [this discussion](https://github.com/gohugoio/hugo/issues/5195#issuecomment-419834325) I believe it is important to mention in the documentation that Hugo will generate root section page translation files in the case of existing subpage translation files.