### PR TITLE
Allow "jsonify" to pretty print JSON

### DIFF
--- a/docs/content/en/functions/jsonify.md
+++ b/docs/content/en/functions/jsonify.md
@@ -1,7 +1,7 @@
 ---
 title: jsonify
 linktitle: jsonify
-description: Encodes a given object to JSON.
+description: Encodes a given object to JSON, returning pretty printed output.
 godocref:
 date: 2017-02-01
 publishdate: 2017-02-01

--- a/tpl/encoding/encoding.go
+++ b/tpl/encoding/encoding.go
@@ -50,9 +50,9 @@ func (ns *Namespace) Base64Encode(content interface{}) (string, error) {
 	return base64.StdEncoding.EncodeToString([]byte(conv)), nil
 }
 
-// Jsonify encodes a given object to JSON.
+// Jsonify encodes a given object to JSON, returning pretty printed output.
 func (ns *Namespace) Jsonify(v interface{}) (template.HTML, error) {
-	b, err := json.Marshal(v)
+	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		return "", err
 	}

--- a/tpl/encoding/encoding_test.go
+++ b/tpl/encoding/encoding_test.go
@@ -88,7 +88,7 @@ func TestJsonify(t *testing.T) {
 		v      interface{}
 		expect interface{}
 	}{
-		{[]string{"a", "b"}, template.HTML(`["a","b"]`)},
+		{[]string{"a", "b"}, template.HTML("[\n  \"a\",\n  \"b\"\n]")},
 		{tstNoStringer{}, template.HTML("{}")},
 		{nil, template.HTML("null")},
 		// errors

--- a/tpl/encoding/init.go
+++ b/tpl/encoding/init.go
@@ -47,7 +47,7 @@ func init() {
 		ns.AddMethodMapping(ctx.Jsonify,
 			[]string{"jsonify"},
 			[][2]string{
-				{`{{ (slice "A" "B" "C") | jsonify }}`, `["A","B","C"]`},
+				{`{{ (slice "A" "B" "C") | jsonify }}`, "[\n  \"A\",\n  \"B\",\n  \"C\"\n]"},
 			},
 		)
 


### PR DESCRIPTION
Fixes #5040: Allow "jsonify" to pretty print JSON

This PR replaces `json.Marshal` with `json.MarshalIndent`, to return pretty-printed output instead of compact. A sensible spacing of two spaces has chosen for the indentation.