### PR TITLE
tpl: Handle truncated identifiers in Go template errors

### DIFF
--- a/hugolib/hugo_sites_build_errors_test.go
+++ b/hugolib/hugo_sites_build_errors_test.go
@@ -108,6 +108,21 @@ func TestSiteBuildErrors(t *testing.T) {
 			},
 		},
 		{
+			name:     "Single template execute failed, long keyword",
+			fileType: single,
+			fileFixer: func(content string) string {
+				return strings.Replace(content, ".Title", ".ThisIsAVeryLongTitle", 1)
+			},
+			assertBuildError: func(a testSiteBuildErrorAsserter, err error) {
+				fe := a.getFileError(err)
+				assert.Equal(5, fe.LineNumber)
+				assert.Equal(14, fe.ColumnNumber)
+				assert.Equal("go-html-template", fe.ChromaLexer)
+				a.assertErrorMessage("\"layouts/_default/single.html:5:14\": execute of template failed", fe.Error())
+
+			},
+		},
+		{
 			name:     "Shortcode parse failed",
 			fileType: shortcode,
 			fileFixer: func(content string) string {

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -133,7 +133,9 @@ func (t *TemplateAdapter) Execute(w io.Writer, data interface{}) (execErr error)
 	return
 }
 
-var identifiersRe = regexp.MustCompile("at \\<(.*?)\\>:")
+// The identifiers may be truncated in the log, e.g.
+// "executing "main" at <$scaled.SRelPermalin...>: can't evaluate field SRelPermalink in type *resource.Image"
+var identifiersRe = regexp.MustCompile("at \\<(.*?)(\\.{3})?\\>:")
 
 func (t *TemplateAdapter) extractIdentifiers(line string) []string {
 	m := identifiersRe.FindAllStringSubmatch(line, -1)


### PR DESCRIPTION
Long identifiers will give errors on the format:

```bash
 _default/single.html:5:14: executing "main" at <.ThisIsAVeryLongTitl...>: can't evaluate field ThisIsAVeryLongTitle
```

Hugo use this value to match the "base template or not", so we need to strip the "...".

Fixes #5346