### PR TITLE
Use short token for code highlighting

### DIFF
--- a/docs/content/en/content-management/formats.md
+++ b/docs/content/en/content-management/formats.md
@@ -42,7 +42,7 @@ tool on your machine to be able to use these formats.
 Hugo passes reasonable default arguments to these external helpers by default:
 
 - `asciidoctor`: `--no-header-footer -`
-- `rst2html`: `--leave-comments --initial-header-level=2`
+- `rst2html`: `--leave-comments --initial-header-level=2 --syntax-highlight=short`
 - `pandoc`: `--mathjax`
 
 {{% note %}}

--- a/markup/rst/convert.go
+++ b/markup/rst/convert.go
@@ -82,10 +82,10 @@ func (c *rstConverter) getRstContent(src []byte, ctx converter.DocumentContext) 
 	// handle Windows manually because it doesn't do shebangs
 	if runtime.GOOS == "windows" {
 		pythonBinary, _ := internal.GetPythonBinaryAndExecPath()
-		args := []string{binaryPath, "--leave-comments", "--initial-header-level=2"}
+		args := []string{binaryPath, "--leave-comments", "--initial-header-level=2", "--syntax-highlight=short"}
 		result, err = internal.ExternallyRenderContent(c.cfg, ctx, src, pythonBinary, args)
 	} else {
-		args := []string{"--leave-comments", "--initial-header-level=2"}
+		args := []string{"--leave-comments", "--initial-header-level=2", "--syntax-highlight=short"}
 		result, err = internal.ExternallyRenderContent(c.cfg, ctx, src, binaryName, args)
 	}
 


### PR DESCRIPTION
Closes: #5349

As noted in #5349, `rst2html` can generate HTML with short or long form class names for syntax highlighting. Pygments (via the `pygmentize` command) seems to generate short form by default without any way to switch this. This means most/any stylesheets for code provided with various themes won't work when using rST output. This can easily be fixed by providing the `--syntax-highlight=short` flag to `rst2html`.