### PR TITLE
common/collections: Allow a mix of slice types in append/Scratch.Add

### DIFF
--- a/common/collections/append_test.go
+++ b/common/collections/append_test.go
@@ -46,10 +46,12 @@ func TestAppend(t *testing.T) {
 		{testSlicerInterfaces{&tstSlicerIn1{"a"}, &tstSlicerIn1{"b"}},
 			[]interface{}{&tstSlicerIn1{"c"}},
 			testSlicerInterfaces{&tstSlicerIn1{"a"}, &tstSlicerIn1{"b"}, &tstSlicerIn1{"c"}}},
+		//https://github.com/gohugoio/hugo/issues/5361
+		{[]string{"a", "b"}, []interface{}{tstSlicers{&tstSlicer{"a"}, &tstSlicer{"b"}}},
+			[]interface{}{"a", "b", &tstSlicer{"a"}, &tstSlicer{"b"}}},
+		{[]string{"a", "b"}, []interface{}{&tstSlicer{"a"}},
+			[]interface{}{"a", "b", &tstSlicer{"a"}}},
 		// Errors
-		{testSlicerInterfaces{&tstSlicerIn1{"a"}, &tstSlicerIn1{"b"}},
-			[]interface{}{"c"},
-			false},
 		{"", []interface{}{[]string{"a", "b"}}, false},
 		// No string concatenation.
 		{"ab",

--- a/common/maps/scratch_test.go
+++ b/common/maps/scratch_test.go
@@ -96,6 +96,20 @@ func TestScratchAddTypedSliceToInterfaceSlice(t *testing.T) {
 
 }
 
+// https://github.com/gohugoio/hugo/issues/5361
+func TestScratchAddDifferentTypedSliceToInterfaceSlice(t *testing.T) {
+	t.Parallel()
+	assert := require.New(t)
+
+	scratch := NewScratch()
+	scratch.Set("slice", []string{"foo"})
+
+	_, err := scratch.Add("slice", []int{1, 2})
+	assert.NoError(err)
+	assert.Equal([]interface{}{"foo", 1, 2}, scratch.Get("slice"))
+
+}
+
 func TestScratchSet(t *testing.T) {
 	t.Parallel()
 	assert := require.New(t)


### PR DESCRIPTION
The type handling in these was improved in Hugo 0.49, but this also meant that it was no longer possible to start out with a string slice and later append `Page` etc. to it.

This commit makes sure that the old behaviour is now possible again by falling back to a `[]interface{}` as a last resort.

Fixes #5361