### PR TITLE
common/herrors: Make the file error log format configurable

### DIFF
--- a/common/herrors/error_locator_test.go
+++ b/common/herrors/error_locator_test.go
@@ -21,6 +21,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCreateFileLogFormatter(t *testing.T) {
+	assert := require.New(t)
+
+	ctx := ErrorContext{Filename: "/my/file.txt", LineNumber: 12, ColumnNumber: 13}
+
+	assert.Equal("/my/file.txt|13|12", createFileLogFormatter(":file|:col|:line")(ctx))
+	assert.Equal("13|/my/file.txt|12", createFileLogFormatter(":col|:file|:line")(ctx))
+	assert.Equal("好:13", createFileLogFormatter("好::col")(ctx))
+	assert.Equal("\"/my/file.txt:12:13\"", createFileLogFormatter("")(ctx))
+
+}
+
 func TestErrorLocator(t *testing.T) {
 	assert := require.New(t)
 


### PR DESCRIPTION
Will check for an OS environment variable named `HUGO_FILE_LOG_FORMAT`.

The tokens available are `:file` (absolute filename), `:line` (line number) and `:col` (column number).

The default format is: \":file::line::col\"`

How to set OS environment variables is OS specific, but an example on Unix setting an alternative format when running Hugo:

```bash
env HUGO_FILE_LOG_FORMAT="\":file::line\"" hugo
```

The above will include filename and line number quoted.

Fixes #5352