### PR TITLE
Make WARN the new default log log level

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -131,7 +131,7 @@ func (c *commandeer) createLogger(cfg config.Provider, running bool) (*loggers.L
 		logThreshold    = jww.LevelWarn
 		logFile         = cfg.GetString("logFile")
 		outHandle       = os.Stdout
-		stdoutThreshold = jww.LevelError
+		stdoutThreshold = jww.LevelWarn
 	)
 
 	if c.h.verboseLog || c.h.logging || (c.h.logFile != "") {
@@ -294,7 +294,7 @@ func (c *commandeer) fullBuild() error {
 			if !os.IsNotExist(err) {
 				return errors.Wrap(err, "Error copying static files")
 			}
-			c.logger.WARN.Println("No Static directory found")
+			c.logger.INFO.Println("No Static directory found")
 		}
 		langCount = cnt
 		langCount = cnt
@@ -405,7 +405,7 @@ func (c *commandeer) doWithPublishDirs(f func(sourceFs *filesystems.SourceFilesy
 	staticFilesystems := c.hugo.BaseFs.SourceFilesystems.Static
 
 	if len(staticFilesystems) == 0 {
-		c.logger.WARN.Println("No static directories found to sync")
+		c.logger.INFO.Println("No static directories found to sync")
 		return langCount, nil
 	}
 

--- a/hugolib/alias.go
+++ b/hugolib/alias.go
@@ -174,7 +174,7 @@ func (a aliasHandler) targetPathAlias(src string) (string, error) {
 			return "", fmt.Errorf("Cannot create \"%s\": Windows filename restriction", originalAlias)
 		}
 		for _, m := range msgs {
-			a.log.WARN.Println(m)
+			a.log.INFO.Println(m)
 		}
 	}
 

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -326,7 +326,7 @@ func (p *Page) initContent() {
 
 		select {
 		case <-ctx.Done():
-			p.s.Log.WARN.Printf("WARNING: Timed out creating content for page %q (.Content will be empty). This is most likely a circular shortcode content loop that should be fixed. If this is just a shortcode calling a slow remote service, try to set \"timeout=20000\" (or higher, value is in milliseconds) in config.toml.\n", p.pathOrTitle())
+			p.s.Log.WARN.Printf("Timed out creating content for page %q (.Content will be empty). This is most likely a circular shortcode content loop that should be fixed. If this is just a shortcode calling a slow remote service, try to set \"timeout=30000\" (or higher, value is in milliseconds) in config.toml.\n", p.pathOrTitle())
 		case err := <-c:
 			if err != nil {
 				p.s.SendError(err)
@@ -1456,7 +1456,7 @@ func (p *Page) updateMetaData(frontmatter map[string]interface{}) error {
 
 	if draft != nil && published != nil {
 		p.Draft = *draft
-		p.s.Log.WARN.Printf("page %q has both draft and published settings in its frontmatter. Using draft.", p.File.Path())
+		p.s.Log.WARN.Printf("page %q has both draft and published settings in its frontmatter. Using draft.", p.Filename())
 	} else if draft != nil {
 		p.Draft = *draft
 	} else if published != nil {
@@ -1973,8 +1973,6 @@ func (p *Page) initLanguage() {
 		language := ml.Language(p.lang)
 
 		if language == nil {
-			// It can be a file named stefano.chiodino.md.
-			p.s.Log.WARN.Printf("Page language (if it is that) not found in multilang setup: %s.", p.lang)
 			language = ml.DefaultLang
 		}
 

--- a/hugolib/page_content.go
+++ b/hugolib/page_content.go
@@ -188,7 +188,7 @@ func (p *Page) parse(reader io.Reader) error {
 		if gi != nil {
 			p.GitInfo = gi
 		} else if enabled {
-			p.s.Log.WARN.Printf("Failed to find GitInfo for page %q", p.Path())
+			p.s.Log.INFO.Printf("Failed to find GitInfo for page %q", p.Path())
 		}
 	}
 

--- a/hugolib/pagebundler_capture.go
+++ b/hugolib/pagebundler_capture.go
@@ -679,7 +679,7 @@ func (c *capturer) isSeen(dirname string) bool {
 	seen := c.seen[dirname]
 	c.seen[dirname] = true
 	if seen {
-		c.logger.WARN.Printf("Content dir %q already processed; skipped to avoid infinite recursion.", dirname)
+		c.logger.INFO.Printf("Content dir %q already processed; skipped to avoid infinite recursion.", dirname)
 		return true
 
 	}

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -45,11 +45,11 @@ func (t Translator) Func(lang string) bundle.TranslateFunc {
 	if f, ok := t.translateFuncs[lang]; ok {
 		return f
 	}
-	t.logger.WARN.Printf("Translation func for language %v not found, use default.", lang)
+	t.logger.INFO.Printf("Translation func for language %v not found, use default.", lang)
 	if f, ok := t.translateFuncs[t.cfg.GetString("defaultContentLanguage")]; ok {
 		return f
 	}
-	t.logger.WARN.Println("i18n not initialized, check that you have language file (in i18n) that matches the site language or the default language.")
+	t.logger.INFO.Println("i18n not initialized; if you need string translations, check that you have a bundle in /i18n that matches the site language or the default language.")
 	return func(translationID string, args ...interface{}) string {
 		return ""
 	}
@@ -61,7 +61,7 @@ func (t Translator) initFuncs(bndl *bundle.Bundle) {
 
 	defaultT, err := bndl.Tfunc(defaultContentLanguage)
 	if err != nil {
-		t.logger.WARN.Printf("No translation bundle found for default language %q", defaultContentLanguage)
+		t.logger.INFO.Printf("No translation bundle found for default language %q", defaultContentLanguage)
 	}
 
 	enableMissingTranslationPlaceholders := t.cfg.GetBool("enableMissingTranslationPlaceholders")

--- a/tpl/data/data.go
+++ b/tpl/data/data.go
@@ -50,7 +50,7 @@ func (ns *Namespace) GetCSV(sep string, urlParts ...string) (d [][]string, err e
 	url := strings.Join(urlParts, "")
 
 	var clearCacheSleep = func(i int, u string) {
-		ns.deps.Log.WARN.Printf("Retry #%d for %s and sleeping for %s", i, url, resSleep)
+		ns.deps.Log.INFO.Printf("Retry #%d for %s and sleeping for %s", i, url, resSleep)
 		time.Sleep(resSleep)
 		deleteCache(url, ns.deps.Fs.Source, ns.deps.Cfg)
 	}
@@ -109,8 +109,8 @@ func (ns *Namespace) GetJSON(urlParts ...string) (v interface{}, err error) {
 		}
 		err = json.Unmarshal(c, &v)
 		if err != nil {
-			ns.deps.Log.WARN.Printf("Cannot read JSON from resource %s: %s", url, err)
-			ns.deps.Log.WARN.Printf("Retry #%d for %s and sleeping for %s", i, url, resSleep)
+			ns.deps.Log.INFO.Printf("Cannot read JSON from resource %s: %s", url, err)
+			ns.deps.Log.INFO.Printf("Retry #%d for %s and sleeping for %s", i, url, resSleep)
 			time.Sleep(resSleep)
 			deleteCache(url, ns.deps.Fs.Source, ns.deps.Cfg)
 			continue


### PR DESCRIPTION
This commit also pulls down the log level for a set of WARN statements to INFO. There should be no ERRORs or WARNINGs in a regular Hugo build. That is the story about the Boy Who Cried Wolf.

Since the WARN log is now more visible, this commit also improves on some of them, most notably the "layout not found", which now would look something like this:

```bash
WARN 2018/11/02 09:02:18 Found no layout for "home", language "en", output format "CSS": create a template below /layouts with one of these filenames: index.en.css.css, home.en.css.css, list.en.css.css, index.css.css, home.css.css, list.css.css, index.en.css, home.en.css, list.en.css, index.css, home.css, list.css, _default/index.en.css.css, _default/home.en.css.css, _default/list.en.css.css, _default/index.css.css, _default/home.css.css, _default/list.css.css, _default/index.en.css, _default/home.en.css, _default/list.en.css, _default/index.css, _default/home.css, _default/list.css
```

Fixes #5203