### PR TITLE
hugolib: Move Scratch initialization

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -429,7 +429,7 @@ func (cfg *BuildCfg) shouldRender(p *Page) bool {
 
 	if cfg.RecentlyVisited[p.RelPermalink()] {
 		if cfg.PartialReRender {
-			_ = p.initMainOutputFormat()
+			_ = p.initForRender()
 		}
 		return true
 	}

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1147,12 +1147,12 @@ func (p *Page) subResourceTargetPathFactory(base string) string {
 func (p *Page) prepareForRender(start bool) error {
 	p.setContentInit(start)
 	if start {
-		return p.initMainOutputFormat()
+		return p.initForRender()
 	}
 	return nil
 }
 
-func (p *Page) initMainOutputFormat() error {
+func (p *Page) initForRender() error {
 	outFormat := p.outputFormats[0]
 	pageOutput, err := newPageOutput(p, false, false, outFormat)
 
@@ -1161,6 +1161,7 @@ func (p *Page) initMainOutputFormat() error {
 	}
 
 	p.mainPageOutput = pageOutput
+	p.scratch = maps.NewScratch()
 
 	return nil
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -36,7 +36,6 @@ import (
 
 	_errors "github.com/pkg/errors"
 
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/publisher"
 	"github.com/gohugoio/hugo/resource"
 
@@ -1559,8 +1558,6 @@ func (s *Site) resetBuildState() {
 	for _, p := range s.rawAllPages {
 		p.subSections = Pages{}
 		p.parent = nil
-		p.scratch = maps.NewScratch()
-		p.mainPageOutput = nil
 	}
 }
 


### PR DESCRIPTION
So it also is included when we're doing "lazy rendering" of pages visited in browser.

See #5406