### PR TITLE
tpl: fix test to pass with gccgo

### DIFF
--- a/tpl/internal/templatefuncRegistry_test.go
+++ b/tpl/internal/templatefuncRegistry_test.go
@@ -31,7 +31,7 @@ func TestMethodToName(t *testing.T) {
 	test := &Test{}
 
 	if runtime.Compiler == "gccgo" {
-		require.Equal(t, "$thunk0", methodToName(test.MyTestMethod))
+		require.Contains(t, methodToName(test.MyTestMethod), "thunk")
 	} else {
 		require.Equal(t, "MyTestMethod", methodToName(test.MyTestMethod))
 	}


### PR DESCRIPTION
When run under gccgo, the test looks for the name that gccgo gives to
a thunk method.  This name is not normally visible, but can be seen
when using reflect.FuncForPC as this code does.  That name changed in
https://golang.org/cl/89555.  Change the test to work with both the
old name "$thunk0" and the new name "thunk0".

Fixes golang/go#28669