### PR TITLE
Fix figure whitespace issue, introduced in PR #5276

### DIFF
--- a/tpl/tplimpl/embedded/templates/shortcodes/figure.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/figure.html
@@ -17,7 +17,7 @@
             {{- end -}}
             {{- if or (.Get "caption") (.Get "attr") -}}<p>
                 {{- .Get "caption" | markdownify -}}
-                {{- with .Get "attrlink" -}}
+                {{- with .Get "attrlink" }}
                     <a href="{{ . }}">
                 {{- end -}}
                 {{- .Get "attr" | markdownify -}}


### PR DESCRIPTION
As a result of #5276, there is no space between the caption and the attribution link of the `figure` shortcode. I.e. this:

`<p>Image by<a href="http://example.com">Author</a></p>`

renders in browser as:

`Image byAuthor`.

This patch should fix it.