### PR TITLE
Handle themes in the new file cache (for images, assets)

### DIFF
--- a/cache/filecache/filecache_test.go
+++ b/cache/filecache/filecache_test.go
@@ -25,10 +25,10 @@ import (
 	"time"
 
 	"github.com/gohugoio/hugo/common/hugio"
-
 	"github.com/gohugoio/hugo/config"
+	"github.com/gohugoio/hugo/helpers"
+
 	"github.com/gohugoio/hugo/hugofs"
-	"github.com/gohugoio/hugo/hugolib/paths"
 	"github.com/spf13/afero"
 
 	"github.com/stretchr/testify/require"
@@ -44,6 +44,13 @@ func TestFileCache(t *testing.T) {
 workingDir = "/my/work"
 resourceDir = "resources"
 cacheDir = "CACHEDIR"
+contentDir = "content"
+dataDir = "data"
+i18nDir = "i18n"
+layoutDir = "layouts"
+assetDir = "assets"
+archeTypedir = "archetypes"
+
 [caches]
 [caches.getJSON]
 maxAge = "10h"
@@ -56,10 +63,10 @@ dir = ":cacheDir/c"
 		assert.NoError(err)
 
 		fs := hugofs.NewMem(cfg)
-		p, err := paths.New(fs, cfg)
+		p, err := helpers.NewPathSpec(fs, cfg)
 		assert.NoError(err)
 
-		caches, err := NewCachesFromPaths(p)
+		caches, err := NewCaches(p)
 		assert.NoError(err)
 
 		c := caches.Get("GetJSON")
@@ -83,7 +90,7 @@ dir = ":cacheDir/c"
 		bfs, ok = c.Fs.(*afero.BasePathFs)
 		assert.True(ok)
 		filename, _ = bfs.RealPath("key")
-		assert.Equal(filepath.FromSlash("/my/work/resources/_gen/images/key"), filename)
+		assert.Equal(filepath.FromSlash("_gen/images/key"), filename)
 
 		rf := func(s string) func() (io.ReadCloser, error) {
 			return func() (io.ReadCloser, error) {
@@ -160,6 +167,13 @@ func TestFileCacheConcurrent(t *testing.T) {
 
 	configStr := `
 resourceDir = "myresources"
+contentDir = "content"
+dataDir = "data"
+i18nDir = "i18n"
+layoutDir = "layouts"
+assetDir = "assets"
+archeTypedir = "archetypes"
+
 [caches]
 [caches.getjson]
 maxAge = "1s"
@@ -170,10 +184,10 @@ dir = "/cache/c"
 	cfg, err := config.FromConfigString(configStr, "toml")
 	assert.NoError(err)
 	fs := hugofs.NewMem(cfg)
-	p, err := paths.New(fs, cfg)
+	p, err := helpers.NewPathSpec(fs, cfg)
 	assert.NoError(err)
 
-	caches, err := NewCachesFromPaths(p)
+	caches, err := NewCaches(p)
 	assert.NoError(err)
 
 	const cacheName = "getjson"

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -193,7 +193,7 @@ func New(cfg DepsCfg) (*Deps, error) {
 		return nil, err
 	}
 
-	fileCaches, err := filecache.NewCachesFromPaths(ps.Paths)
+	fileCaches, err := filecache.NewCaches(ps)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create file caches from configuration")
 	}

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,7 @@ github.com/tdewolff/test v1.0.0 h1:jOwzqCXr5ePXEPGJaq2ivoR6HOCi+D5TPfpoyg8yvmU=
 github.com/tdewolff/test v1.0.0/go.mod h1:DiQUlutnqlEvdvhSn2LPGy4TFwRauAaYDsL+683RNX4=
 github.com/wellington/go-libsass v0.0.0-20180624165032-615eaa47ef79 h1:ivqgxj/zO3UZuzX7ZnlcyX8cAbNqLl1oes4zPddAO5Q=
 github.com/wellington/go-libsass v0.0.0-20180624165032-615eaa47ef79/go.mod h1:mxgxgam0N0E+NAUMHLcu20Ccfc3mVpDkyrLDayqfiTs=
+github.com/wellington/go-libsass v0.9.3-0.20181113175235-c63644206701 h1:9vG9vvVNVupO4Y7uwFkRgIMNe9rdaJMCINDe8vhAhLo=
 github.com/wellington/go-libsass v0.9.3-0.20181113175235-c63644206701/go.mod h1:mxgxgam0N0E+NAUMHLcu20Ccfc3mVpDkyrLDayqfiTs=
 github.com/yosssi/ace v0.0.5 h1:tUkIP/BLdKqrlrPwcmH0shwEEhTRHoGnc1wFIWmaBUA=
 github.com/yosssi/ace v0.0.5/go.mod h1:ALfIzm2vT7t5ZE7uoIZqF3TQ7SAOyupFZnkrF5id+K0=

--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -81,6 +81,7 @@ type SourceFilesystems struct {
 	Layouts    *SourceFilesystem
 	Archetypes *SourceFilesystem
 	Assets     *SourceFilesystem
+	Resources  *SourceFilesystem
 
 	// This is a unified read-only view of the project's and themes' workdir.
 	Work *SourceFilesystem
@@ -374,6 +375,13 @@ func (b *sourceFilesystemsBuilder) Build() (*SourceFilesystems, error) {
 		return nil, err
 	}
 	b.result.Assets = sfs
+
+	sfs, err = b.createFs(true, false, "resourceDir", "resources")
+	if err != nil {
+		return nil, err
+	}
+
+	b.result.Resources = sfs
 
 	sfs, err = b.createFs(false, true, "", "")
 	if err != nil {

--- a/hugolib/filesystems/basefs_test.go
+++ b/hugolib/filesystems/basefs_test.go
@@ -108,6 +108,7 @@ theme = ["atheme"]
 	checkFileCount(bfs.Data.Fs, "", assert, 9)        // 7 + 2 themes
 	checkFileCount(bfs.Archetypes.Fs, "", assert, 10) // 8 + 2 themes
 	checkFileCount(bfs.Assets.Fs, "", assert, 9)
+	checkFileCount(bfs.Resources.Fs, "", assert, 10)
 	checkFileCount(bfs.Work.Fs, "", assert, 78)
 
 	assert.Equal([]string{filepath.FromSlash("/my/work/mydata"), filepath.FromSlash("/my/work/themes/btheme/data"), filepath.FromSlash("/my/work/themes/atheme/data")}, bfs.Data.Dirnames)
@@ -227,6 +228,8 @@ func TestRealDirs(t *testing.T) {
 	assert.Equal(2, len(realDirs))
 	assert.Equal(filepath.Join(root, "myassets/scss"), realDirs[0])
 	assert.Equal(filepath.Join(themesDir, "mytheme/assets/scss"), realDirs[len(realDirs)-1])
+
+	checkFileCount(bfs.Resources.Fs, "", assert, 3)
 
 	assert.NotNil(bfs.themeFs)
 	fi, b, err := bfs.themeFs.(afero.Lstater).LstatIfPossible(filepath.Join("resources", "t1.txt"))

--- a/resource/testhelpers_test.go
+++ b/resource/testhelpers_test.go
@@ -52,7 +52,7 @@ func newTestResourceSpecForBaseURL(assert *require.Assertions, baseURL string) *
 	s, err := helpers.NewPathSpec(fs, cfg)
 	assert.NoError(err)
 
-	filecaches, err := filecache.NewCachesFromPaths(s.Paths)
+	filecaches, err := filecache.NewCaches(s)
 	assert.NoError(err)
 
 	spec, err := NewSpec(s, filecaches, nil, output.DefaultFormats, media.DefaultTypes)
@@ -88,7 +88,7 @@ func newTestResourceOsFs(assert *require.Assertions) *Spec {
 	s, err := helpers.NewPathSpec(fs, cfg)
 	assert.NoError(err)
 
-	filecaches, err := filecache.NewCachesFromPaths(s.Paths)
+	filecaches, err := filecache.NewCaches(s)
 	assert.NoError(err)
 
 	spec, err := NewSpec(s, filecaches, nil, output.DefaultFormats, media.DefaultTypes)

--- a/tpl/data/resources_test.go
+++ b/tpl/data/resources_test.go
@@ -23,13 +23,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gohugoio/hugo/hugolib/paths"
+	"github.com/gohugoio/hugo/helpers"
 
 	"github.com/gohugoio/hugo/cache/filecache"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/deps"
-	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/hugofs"
 	"github.com/gohugoio/hugo/langs"
 	"github.com/spf13/afero"
@@ -181,6 +180,12 @@ func TestScpGetRemoteParallel(t *testing.T) {
 
 func newDeps(cfg config.Provider) *deps.Deps {
 	cfg.Set("resourceDir", "resources")
+	cfg.Set("dataDir", "resources")
+	cfg.Set("i18nDir", "i18n")
+	cfg.Set("assetDir", "assets")
+	cfg.Set("layoutDir", "layouts")
+	cfg.Set("archetypeDir", "archetypes")
+
 	l := langs.NewLanguage("en", cfg)
 	l.Set("i18nDir", "i18n")
 	cs, err := helpers.NewContentSpec(l)
@@ -190,9 +195,13 @@ func newDeps(cfg config.Provider) *deps.Deps {
 
 	fs := hugofs.NewMem(l)
 	logger := loggers.NewErrorLogger()
-	p, _ := paths.New(fs, cfg)
 
-	fileCaches, err := filecache.NewCachesFromPaths(p)
+	p, err := helpers.NewPathSpec(fs, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	fileCaches, err := filecache.NewCaches(p)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
In the newly consolidated file cache implementation, we forgot that we also look in the theme(s) for assets (SCSS transformations etc.), which is not good for Netlify and the demo sites.

Fixes #5460