### PR TITLE
POC: implement starlight plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist
 
 
 vendor
+
+# visual studio code settings files
+.vscode

--- a/go.mod
+++ b/go.mod
@@ -51,10 +51,12 @@ require (
 	github.com/spf13/nitro v0.0.0-20131003134307-24d7ef30a12d
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.1
+	github.com/starlight-go/starlight v0.0.0-20181207205707-b06f321544f3
 	github.com/stretchr/testify v1.2.3-0.20181014000028-04af85275a5c
 	github.com/tdewolff/minify/v2 v2.3.7
 	github.com/ugorji/go/codec v0.0.0-20181206144755-e72634d4d386 // indirect
 	github.com/yosssi/ace v0.0.5
+	go.starlark.net v0.0.0-20181213015430-66ac3a2d309f // indirect
 	golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81
 	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/spf13/viper v1.3.0 h1:cO6QlTTeK9RQDhFAbGLV5e3fHXbRpin/Gi8qfL4rdLk=
 github.com/spf13/viper v1.3.0/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.3.1 h1:5+8j8FTpnFV4nEImW/ofkzEt8VoOiLXxdYIDsB73T38=
 github.com/spf13/viper v1.3.1/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/starlight-go/starlight v0.0.0-20181207205707-b06f321544f3 h1:/fBh1Ot84ILt/ociFHO98wJ9LxIMA3UG8B0unUJPFpY=
+github.com/starlight-go/starlight v0.0.0-20181207205707-b06f321544f3/go.mod h1:pxOc2ZuBV+CNlQgzq/HJ9Z9G/eoEMHFeuGohOvva4Co=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.3-0.20181014000028-04af85275a5c h1:03OmljzZYsezlgAfa+f/cY8E8XXPiFh5bgANMhUlDI4=
@@ -144,6 +146,8 @@ github.com/wellington/go-libsass v0.9.3-0.20181113175235-c63644206701/go.mod h1:
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yosssi/ace v0.0.5 h1:tUkIP/BLdKqrlrPwcmH0shwEEhTRHoGnc1wFIWmaBUA=
 github.com/yosssi/ace v0.0.5/go.mod h1:ALfIzm2vT7t5ZE7uoIZqF3TQ7SAOyupFZnkrF5id+K0=
+go.starlark.net v0.0.0-20181213015430-66ac3a2d309f h1:8Fs2MRAY3gcipeW5YuV7PR0PYZ30uyRurWJSON4km/I=
+go.starlark.net v0.0.0-20181213015430-66ac3a2d309f/go.mod h1:c1/X6cHgvdXj6pUlmWKMkuqRnW4K8x2vwt6JAaaircg=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81 h1:00VmoueYNlNz/aHIilyyQz/MHSqGoWJzpFv/HW8xpzI=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=

--- a/tpl/plugins/init.go
+++ b/tpl/plugins/init.go
@@ -30,12 +30,7 @@ func init() {
 			Context: func(args ...interface{}) interface{} { return ctx },
 		}
 
-		ns.AddMethodMapping(ctx.Starlight,
-			[]string{"starlight"},
-			[][2]string{
-				{`{{plugins.starlight "uppercase.star" .Page.Title }}`, `Blockhead`},
-			},
-		)
+		ns.AddMethodMapping(ctx.Starlight, nil, nil)
 		return ns
 	}
 

--- a/tpl/plugins/init.go
+++ b/tpl/plugins/init.go
@@ -1,0 +1,43 @@
+// Copyright 2018 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package plugins implements plugins of various sorts for Hugo templates.
+package plugins
+
+import (
+	"github.com/gohugoio/hugo/deps"
+	"github.com/gohugoio/hugo/tpl/internal"
+)
+
+const name = "plugins"
+
+func init() {
+	f := func(d *deps.Deps) *internal.TemplateFuncsNamespace {
+		ctx := New(d)
+
+		ns := &internal.TemplateFuncsNamespace{
+			Name:    name,
+			Context: func(args ...interface{}) interface{} { return ctx },
+		}
+
+		ns.AddMethodMapping(ctx.Starlight,
+			[]string{"starlight"},
+			[][2]string{
+				{`{{plugins.starlight "uppercase.star" .Page.Title }}`, `Blockhead`},
+			},
+		)
+		return ns
+	}
+
+	internal.AddTemplateFuncsNamespace(f)
+}

--- a/tpl/plugins/plugins.go
+++ b/tpl/plugins/plugins.go
@@ -14,8 +14,6 @@
 package plugins
 
 import (
-	"errors"
-	"fmt"
 	"path/filepath"
 
 	"github.com/gohugoio/hugo/deps"
@@ -33,56 +31,15 @@ func New(d *deps.Deps) *Namespace {
 	}
 	theme := d.Cfg.GetString("theme")
 	themeDir := filepath.Join("./themes", theme, "plugins")
-	return &Namespace{cache: starlight.New(dir, themeDir), deps: d}
+	return newNamespace(dir, themeDir)
+}
+
+func newNamespace(userDir, themeDir string) *Namespace {
+	return &Namespace{cache: starlight.New(userDir, themeDir)}
 }
 
 // Namespace provides template functions for the "plugins" namespace.
 // Each plugin type should implement its own function.
 type Namespace struct {
 	cache *starlight.Cache
-	deps  *deps.Deps
-}
-
-// Starlight runs the given starlight script with the given values as globals.
-// The globals are expected to be associated pairs of name (string) and value,
-// which will be passed to the script. It's an error if you don't pass the
-// values in pairs. The value of the template function is set by calling the
-// "output" function in the script with the value you wish to output.
-//
-// e.g. {{plugins.starlight "foo.star" "page" .Page "site" .Site }}
-//
-// plugins/hello.star:
-//
-// output("hello" + site.Title)
-func (ns *Namespace) Starlight(filename interface{}, vals ...interface{}) (interface{}, error) {
-	s, ok := filename.(string)
-	if !ok {
-		return nil, fmt.Errorf("expected first argument to be filename (string), but was %v (%T)", filename, filename)
-	}
-
-	if len(vals)%2 != 0 {
-		return nil, fmt.Errorf("expected values to be pairs of <name> <value>")
-	}
-
-	var ret interface{}
-	output := func(v interface{}) {
-		ret = v
-	}
-	globals := map[string]interface{}{
-		"output": output,
-	}
-
-	for i := 0; i < len(vals); i += 2 {
-		name, ok := vals[i].(string)
-		if !ok {
-			return nil, fmt.Errorf("expected argument %d to be string label, but was %v (%T)", i, vals[i], vals[i])
-		}
-		if name == "output" {
-			return nil, errors.New("argument label `output` is a reserved word and cannot be used")
-		}
-		globals[name] = vals[i+1]
-	}
-
-	_, err := ns.cache.Run(s, globals)
-	return ret, err
 }

--- a/tpl/plugins/plugins.go
+++ b/tpl/plugins/plugins.go
@@ -1,0 +1,88 @@
+// Copyright 2018 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/gohugoio/hugo/deps"
+	"github.com/starlight-go/starlight"
+)
+
+// New returns a new instance of the plugins-namespaced template functions.  We
+// allow the user to specify a plugins directory, and the theme may also have a
+// plugin directory.  Plugins in the user's directory will override plugins in
+// the theme directory if they have the same name.
+func New(d *deps.Deps) *Namespace {
+	dir := d.Cfg.GetString("plugin_dir")
+	if dir == "" {
+		dir = "plugins"
+	}
+	theme := d.Cfg.GetString("theme")
+	themeDir := filepath.Join("./themes", theme, "plugins")
+	return &Namespace{cache: starlight.New(dir, themeDir), deps: d}
+}
+
+// Namespace provides template functions for the "plugins" namespace.
+// Each plugin type should implement its own function.
+type Namespace struct {
+	cache *starlight.Cache
+	deps  *deps.Deps
+}
+
+// Starlight runs the given starlight script with the given values as globals.
+// The globals are expected to be associated pairs of name (string) and value,
+// which will be passed to the script. It's an error if you don't pass the
+// values in pairs. The value of the template function is set by calling the
+// "output" function in the script with the value you wish to output.
+//
+// e.g. {{plugins.starlight "foo.star" "page" .Page "site" .Site }}
+//
+// plugins/hello.star:
+//
+// output("hello" + site.Title)
+func (ns *Namespace) Starlight(filename interface{}, vals ...interface{}) (interface{}, error) {
+	s, ok := filename.(string)
+	if !ok {
+		return nil, fmt.Errorf("expected first argument to be filename (string), but was %v (%T)", filename, filename)
+	}
+
+	if len(vals)%2 != 0 {
+		return nil, fmt.Errorf("expected values to be pairs of <name> <value>")
+	}
+
+	var ret interface{}
+	output := func(v interface{}) {
+		ret = v
+	}
+	globals := map[string]interface{}{
+		"output": output,
+	}
+
+	for i := 0; i < len(vals); i += 2 {
+		name, ok := vals[i].(string)
+		if !ok {
+			return nil, fmt.Errorf("expected argument %d to be string label, but was %v (%T)", i, vals[i], vals[i])
+		}
+		if name == "output" {
+			return nil, errors.New("argument label `output` is a reserved word and cannot be used")
+		}
+		globals[name] = vals[i+1]
+	}
+
+	_, err := ns.cache.Run(s, globals)
+	return ret, err
+}

--- a/tpl/plugins/starlight.go
+++ b/tpl/plugins/starlight.go
@@ -1,0 +1,50 @@
+package plugins
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Starlight runs the given starlight script with the given values as globals.
+// The globals are expected to be associated pairs of name (string) and value,
+// which will be passed to the script. It's an error if you don't pass the
+// values in pairs. The value of the template function is set by calling the
+// "output" function in the script with the value you wish to output.
+//
+// e.g. {{plugins.starlight "foo.star" "page" .Page "site" .Site }}
+//
+// plugins/hello.star:
+//
+// output("hello" + site.Title)
+func (ns *Namespace) Starlight(filename interface{}, vals ...interface{}) (interface{}, error) {
+	s, ok := filename.(string)
+	if !ok {
+		return nil, fmt.Errorf("expected first argument to be filename (string), but was %v (%T)", filename, filename)
+	}
+
+	if len(vals)%2 != 0 {
+		return nil, fmt.Errorf("expected values to be pairs of <name> <value>")
+	}
+
+	var ret interface{}
+	output := func(v interface{}) {
+		ret = v
+	}
+	globals := map[string]interface{}{
+		"output": output,
+	}
+
+	for i := 0; i < len(vals); i += 2 {
+		name, ok := vals[i].(string)
+		if !ok {
+			return nil, fmt.Errorf("expected argument %d to be string label, but was %v (%T)", i, vals[i], vals[i])
+		}
+		if name == "output" {
+			return nil, errors.New("argument label `output` is a reserved word and cannot be used")
+		}
+		globals[name] = vals[i+1]
+	}
+
+	_, err := ns.cache.Run(s, globals)
+	return ret, err
+}

--- a/tpl/plugins/starlight_test.go
+++ b/tpl/plugins/starlight_test.go
@@ -1,0 +1,111 @@
+package plugins
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gohugoio/hugo/config"
+	"github.com/gohugoio/hugo/deps"
+)
+
+type testPage struct {
+	title string
+}
+
+func (t *testPage) Title() string {
+	return t.title
+}
+
+func TestStarlightUserScriptOverride(t *testing.T) {
+	cfg, err := config.FromConfigString(`
+plugin_dir = "plugins"
+theme = "test"
+`, "toml")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := &deps.Deps{Cfg: cfg}
+
+	userDir := "plugins"
+	err = os.Mkdir(userDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(userDir)
+	themeDir := filepath.Join("themes", "test", "plugins")
+	err = os.MkdirAll(themeDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll("themes")
+	err = ioutil.WriteFile(filepath.Join(userDir, "hello.star"), []byte(`output("hello user " + name + " from: " + page.Title())`), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(filepath.Join(themeDir, "hello.star"), []byte(`output("hello theme " + name + " from: " + page.Title())`), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := New(d)
+
+	page := &testPage{title: "Moby Dick"}
+	i, err := ns.Starlight("hello.star", "name", "bob", "page", page)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, ok := i.(string)
+	if !ok {
+		t.Fatalf("expected to get string out of script, but got %v (%T)", i, i)
+	}
+	expected := "hello user bob from: Moby Dick"
+	if s != expected {
+		t.Fatalf("expected %q but got %q", expected, s)
+	}
+}
+
+func TestStarlightThemeScript(t *testing.T) {
+	cfg, err := config.FromConfigString(`
+plugin_dir = "plugins"
+theme = "test"
+`, "toml")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := &deps.Deps{Cfg: cfg}
+
+	userDir := "plugins"
+	err = os.Mkdir(userDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(userDir)
+	themeDir := filepath.Join("themes", "test", "plugins")
+	err = os.MkdirAll(themeDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll("themes")
+	err = ioutil.WriteFile(filepath.Join(themeDir, "hello.star"), []byte(`output("hello theme " + name + " from: " + page.Title())`), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := New(d)
+
+	page := &testPage{title: "Moby Dick"}
+	i, err := ns.Starlight("hello.star", "name", "bob", "page", page)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, ok := i.(string)
+	if !ok {
+		t.Fatalf("expected to get string out of script, but got %v (%T)", i, i)
+	}
+	expected := "hello theme bob from: Moby Dick"
+	if s != expected {
+		t.Fatalf("expected %q but got %q", expected, s)
+	}
+}

--- a/tpl/tplimpl/template_funcs.go
+++ b/tpl/tplimpl/template_funcs.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/gohugoio/hugo/tpl/os"
 	_ "github.com/gohugoio/hugo/tpl/partials"
 	_ "github.com/gohugoio/hugo/tpl/path"
+	_ "github.com/gohugoio/hugo/tpl/plugins"
 	_ "github.com/gohugoio/hugo/tpl/resources"
 	_ "github.com/gohugoio/hugo/tpl/safe"
 	_ "github.com/gohugoio/hugo/tpl/site"


### PR DESCRIPTION
This is a proof of concept of how hugo could leverage [starlight](https://github.com/starlight-go/starlight) to run plugins written in the [starlark](https://github.com/google/starlark-go) python dialect.

Example:

Template:
```
{{plugins.Starlight "hello.star" "page" .Page}}
```

plugins/hello.star:
```
output("hello " + page.Title)
```

