### PR TITLE
Retrieve GitInfo from contentDir

### DIFF
--- a/docs/content/en/variables/git.md
+++ b/docs/content/en/variables/git.md
@@ -25,7 +25,7 @@ Hugo's Git integrations should be fairly performant but *can* increase your buil
 
 ## `.GitInfo` Prerequisites
 
-1. The Hugo site must be in a Git-enabled directory.
+1. The global `contentDir` must be in a Git-enabled directory. Any language-specific `contentDir` must be in the same repo as the global `contentDir`.
 2. The Git executable must be installed and in your system `PATH`.
 3. The `.GitInfo` feature must be enabled in your Hugo project by passing `--enableGitInfo` flag on the command line or by setting `enableGitInfo` to `true` in your [site's configuration file][configuration].
 

--- a/hugolib/gitinfo.go
+++ b/hugolib/gitinfo.go
@@ -36,9 +36,12 @@ func (g *gitInfo) forPage(p page.Page) *gitmap.GitInfo {
 }
 
 func newGitInfo(cfg config.Provider) (*gitInfo, error) {
-	workingDir := cfg.GetString("workingDir")
+	contentDir := cfg.GetString("contentDir")
+	if !filepath.IsAbs(contentDir) {
+		contentDir = filepath.Join(cfg.GetString("workingDir"), contentDir)
+	}
 
-	gitRepo, err := gitmap.Map(workingDir, "")
+	gitRepo, err := gitmap.Map(contentDir, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Get metadata for `GitInfo` from `contentDir` instead of `workingDir`.
This decouples the `GitInfo` feature from the working directory, making
it dependent on configuration, not the directory `hugo` is run in.

Rationale
---------

This patch aligns the `GitInfo` feature more closely with the way the
rest of Hugo works. The standard `cd /my/site && hugo` build idiom also
works when content isn't in the same repo as site, and it allows the
`GitInfo` feature to be used regardless of which directory `hugo` is run
from (when configured correctly), as is the case for other features.

Currently, Hugo searches the working directory for the git repo to
populate `GitInfo` content metadata. This means that, in order to
retrieve the correct metadata, `hugo` must be run from within the repo
containing the content.

If `hugo` isn't run from within a repo, `--enableGitInfo` causes a
repo-not-found build error, even if the content *is* in a repo. And if
`hugo` is run in a different repo, say if content is a submodule of
site, it will find no/bad data, as it's looking in the wrong repo.

This restriction is unique to `GitInfo` (AFAIK). If you aren't using
that feature, you can run Hugo in any directory you want, as long as you
pass the appropriate flags.

This patch makes it possible to use the standard `cd /my/site && hugo`
build process also when the content is in a different repo.

More generally, it makes it possible to run `hugo` from any directory
when using `--enableGitInfo`, as you can when not using it.

Effects
-------

`GitInfo` currently only works correctly if `workingDir` and
`contentDir` are in the same repo, so it will continue to work
everywhere it already works, particularly in the normal case of having
site and content in a single repo.

This patch will also make `GitInfo` Just Work ^(TM) when content is in a
separate repo to the site. Currently, using `GitInfo` requires `cd`-ing
to the content repo and running `hugo` from there with a bunch of flags.

If the content is unversioned, this patch will cause Hugo to *always*
fail to build the site when run with `--enableGitInfo`.

Currently, because Hugo looks in the working directory, not the content
directory, a build with unversioned content can succeed when Hugo is
called with `--enableGitInfo` as long as Hugo is *run* within a git
repo. Hugo won't find any (correct) file metadata, but missing file
metadata don't cause a build error, whereas a missing git repo does.

Fixes #5533