### PR TITLE
Improve org mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Hugo stands on the shoulder of many great open source libraries, in lexical orde
  | [github.com/bep/debounce](https://github.com/bep/debounce) |    MIT License |
  | [github.com/bep/gitmap](https://github.com/bep/gitmap) |  MIT License |
  | [github.com/bep/go-tocss](https://github.com/bep/go-tocss) | MIT License |
- | [github.com/chaseadamsio/goorgeous](https://github.com/chaseadamsio/goorgeous) | MIT License |
+ | [github.com/niklasfasching/go-org](https://github.com/niklasfasching/go-org) | MIT License |
  | [github.com/cpuguy83/go-md2man](https://github.com/cpuguy83/go-md2man) | MIT License |
  | [github.com/danwakefield/fnmatch](https://github.com/danwakefield/fnmatch) | BSD 2-Clause "Simplified" License |
  | [github.com/disintegration/imaging](https://github.com/disintegration/imaging) |  MIT License |

--- a/docs/content/en/content-management/formats.md
+++ b/docs/content/en/content-management/formats.md
@@ -19,7 +19,7 @@ toc: true
 
 **Markdown is the main content format** and comes in two flavours:  The excellent [Blackfriday project][blackfriday] (name your files `*.md` or set `markup = "markdown"` in front matter) or its fork [Mmark][mmark] (name your files `*.mmark` or set `markup = "mmark"` in front matter), both very fast markdown engines written in Go.
 
-For Emacs users, [goorgeous](https://github.com/chaseadamsio/goorgeous) provides built-in native support for Org-mode  (name your files `*.org` or set `markup = "org"` in front matter)
+For Emacs users, [go-org](https://github.com/niklasfasching/go-org) provides built-in native support for Org-mode  (name your files `*.org` or set `markup = "org"` in front matter)
 
 But in many situations, plain HTML is what you want. Just name your files with `.html` or `.htm` extension inside your content folder. Note that if you want your HTML files to have a layout, they need front matter. It can be empty, but it has to be there:
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/bep/debounce v1.2.0
 	github.com/bep/gitmap v1.1.0
 	github.com/bep/go-tocss v0.6.0
-	github.com/chaseadamsio/goorgeous v1.1.0
 	github.com/cpuguy83/go-md2man v1.0.8 // indirect
 	github.com/disintegration/imaging v1.6.0
 	github.com/dustin/go-humanize v1.0.0
@@ -38,6 +37,7 @@ require (
 	github.com/muesli/smartcrop v0.0.0-20180228075044-f6ebaa786a12
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/nicksnyder/go-i18n v1.10.0
+	github.com/niklasfasching/go-org v0.0.0-20190112190817-da99094e202f
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1
@@ -66,7 +66,5 @@ require (
 	google.golang.org/genproto v0.0.0-20190522204451-c2c4e71fbf69 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
-
-exclude github.com/chaseadamsio/goorgeous v2.0.0+incompatible
 
 replace github.com/markbates/inflect => github.com/markbates/inflect v0.0.0-20171215194931-a12c3aec81a6

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -27,8 +27,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/gohugoio/hugo/common/maps"
+	"github.com/niklasfasching/go-org/org"
 
-	"github.com/chaseadamsio/goorgeous"
 	bp "github.com/gohugoio/hugo/bufferpool"
 	"github.com/gohugoio/hugo/config"
 	"github.com/miekg/mmark"
@@ -756,10 +756,24 @@ func getPandocContent(ctx *RenderingContext) []byte {
 }
 
 func orgRender(ctx *RenderingContext, c ContentSpec) []byte {
-	content := ctx.Content
-	cleanContent := bytes.Replace(content, []byte("# more"), []byte(""), 1)
-	return goorgeous.Org(cleanContent,
-		c.getHTMLRenderer(blackfriday.HTML_TOC, ctx))
+	config := org.New()
+	config.Log = jww.WARN
+	writer := org.NewHTMLWriter()
+	writer.HighlightCodeBlock = func(source, lang string) string {
+		highlightedSource, err := c.Highlight(source, lang, "")
+		if err != nil {
+			jww.ERROR.Printf("Could not highlight source as lang %s. Using raw source.", lang)
+			return source
+		}
+		return highlightedSource
+	}
+
+	html, err := config.Parse(bytes.NewReader(ctx.Content), ctx.DocumentName).Write(writer)
+	if err != nil {
+		jww.ERROR.Printf("Could not render org: %s. Using unrendered content.", err)
+		return ctx.Content
+	}
+	return []byte(html)
 }
 
 func externallyRenderContent(ctx *RenderingContext, path string, args []string) []byte {

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1216,12 +1216,12 @@ CONTENT:{{ .Content }}
 	)
 
 	b.AssertFileContent("public/page-org-shortcode/index.html",
-		"SUMMARY:<p>This is a a shortcode.</p>:END",
-		"CONTENT:<p>This is a a shortcode.</p>\n\n<p>Content.\t</p>\n",
+		"SUMMARY:<p>\nThis is a a shortcode.\n</p>:END",
+		"CONTENT:<p>\nThis is a a shortcode.\n</p>\n<p>\nContent.\t\n</p>\n",
 	)
 	b.AssertFileContent("public/page-org-variant1/index.html",
-		"SUMMARY:<p>Summary.</p>:END",
-		"CONTENT:<p>Summary.</p>\n\n<p>Content.\t</p>\n",
+		"SUMMARY:<p>\nSummary.\n</p>:END",
+		"CONTENT:<p>\nSummary.\n</p>\n<p>\nContent.\t\n</p>\n",
 	)
 
 	b.AssertFileContent("public/page-md-only-shortcode/index.html",

--- a/parser/metadecoders/decoder.go
+++ b/parser/metadecoders/decoder.go
@@ -187,7 +187,10 @@ func (d Decoder) unmarshalORG(data []byte, v interface{}) error {
 	frontMatter := make(map[string]interface{}, len(document.BufferSettings))
 	for k, v := range document.BufferSettings {
 		k = strings.ToLower(k)
-		if k == "tags" || k == "categories" || k == "aliases" {
+		if strings.HasSuffix(k, "[]") {
+			frontMatter[k[:len(k)-2]] = strings.Fields(v)
+		} else if k == "tags" || k == "categories" || k == "aliases" {
+			jww.WARN.Printf("Please use '#+%s[]:' notation, automatic conversion is deprecated.", k)
 			frontMatter[k] = strings.Fields(v)
 		} else {
 			frontMatter[k] = v


### PR DESCRIPTION
As the title says, this PR improves the Org mode support of hugo. For a basic overview of the changes, check out [this page](https://niklasfasching.github.io/go-org/go-org-vs-goorgeous) - it showcases the html output of `goorgeous` (left, currently included with hugo) and `go-org` (right, this PR) for the same input. The css is adapted to `go-org`, so open up dev tools for a more fair comparison.

For an overview of the open issues of `goorgeous` that are fixed in `go-org` take a look [here](https://niklasfasching.github.io/go-org/#misc.org)

If you want to try out any Org mode snippets, you can do so in your browser [here](https://niklasfasching.github.io/go-org/).

Also take a look at the [discussion](https://discourse.gohugo.io/t/improved-org-mode-support/15859/18) for more information.

I included a second commit in this PR that adds the Org mode front matter to the main content as Org mode itself also uses the front matter for configuration - the impact of this is much smaller (as go-org only uses the `TODO` front matter variable right now - so we could move that to a separate PR.