### PR TITLE
Use subtests with server_test.go

### DIFF
--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -97,21 +97,23 @@ func TestFixURL(t *testing.T) {
 		{"No config", "", "", true, 1313, "//localhost:1313/"},
 	}
 
-	for i, test := range tests {
-		b := newCommandsBuilder()
-		s := b.newServerCmd()
-		v := viper.New()
-		baseURL := test.CLIBaseURL
-		v.Set("baseURL", test.CfgBaseURL)
-		s.serverAppend = test.AppendPort
-		s.serverPort = test.Port
-		result, err := s.fixURL(v, baseURL, s.serverPort)
-		if err != nil {
-			t.Errorf("Test #%d %s: unexpected error %s", i, test.TestName, err)
-		}
-		if result != test.Result {
-			t.Errorf("Test #%d %s: expected %q, got %q", i, test.TestName, test.Result, result)
-		}
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			b := newCommandsBuilder()
+			s := b.newServerCmd()
+			v := viper.New()
+			baseURL := test.CLIBaseURL
+			v.Set("baseURL", test.CfgBaseURL)
+			s.serverAppend = test.AppendPort
+			s.serverPort = test.Port
+			result, err := s.fixURL(v, baseURL, s.serverPort)
+			if err != nil {
+				t.Errorf("Unexpected error %s", err)
+			}
+			if result != test.Result {
+				t.Errorf("Expected %q, got %q", test.Result, result)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Use Golang's subtests to provide a convenient way to run specific tests.
Example:
go test -run=TestFixURL/Basic_production

If you find this one useful, I could go through the codebase and find some other places to add subtests.