### PR TITLE
Remove historical rssURI config

### DIFF
--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -630,7 +630,6 @@ func loadDefaultSettingsFor(v *viper.Viper) error {
 	v.SetDefault("paginatePath", "page")
 	v.SetDefault("summaryLength", 70)
 	v.SetDefault("blackfriday", c.BlackFriday)
-	v.SetDefault("rSSUri", "index.xml")
 	v.SetDefault("rssLimit", -1)
 	v.SetDefault("sectionPagesMenu", "")
 	v.SetDefault("disablePathToLower", false)

--- a/hugolib/hugo_sites_build_test.go
+++ b/hugolib/hugo_sites_build_test.go
@@ -953,7 +953,6 @@ var tocPageWithShortcodesInHeadingsExpected = `<nav id="TableOfContents">
 
 var multiSiteTOMLConfigTemplate = `
 baseURL = "http://example.com/blog"
-rssURI = "index.xml"
 
 paginate = 1
 disablePathToLower = true
@@ -1011,7 +1010,6 @@ lag = "lag"
 
 var multiSiteYAMLConfigTemplate = `
 baseURL: "http://example.com/blog"
-rssURI: "index.xml"
 
 disablePathToLower: true
 paginate: 1
@@ -1071,7 +1069,6 @@ Languages:
 var multiSiteJSONConfigTemplate = `
 {
   "baseURL": "http://example.com/blog",
-  "rssURI": "index.xml",
   "paginate": 1,
   "disablePathToLower": true,
   "defaultContentLanguage": "{{ .DefaultContentLanguage }}",

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -291,7 +291,6 @@ func doTestShouldAlwaysHaveUglyURLs(t *testing.T, uglyURLs bool) {
 
 	cfg.Set("verbose", true)
 	cfg.Set("baseURL", "http://auth/bub")
-	cfg.Set("rssURI", "index.xml")
 	cfg.Set("blackfriday",
 		map[string]interface{}{
 			"plainIDAnchors": true})


### PR DESCRIPTION
In this issue #5593 , I confuse with this `v.SetDefault("rSSUri", "index.xml")` default config.

After I read all the source code about this config, I found that rssURI config is no longer need instead of using [Custom Output Formats](https://gohugo.io/templates/output-formats/) . 

Actually, in [hugo v0.49 release note](https://github.com/gohugoio/hugo/blob/master/docs/content/en/news/0.49-relnotes/index.md) , commits  here [hugolib: Remove deprecated rssURI](https://github.com/gohugoio/hugo/commit/f1a00b2069ede85feb487d29b9f690396e2402c6) has remove config with rssURI.

So, I think this config with rssURI is historical and I remove all this config with rssURI.

I'm new to commit code to hugo master branch, if I have some mistake with my pull request, please feel free to let me know. And more, @appspot account is another account use in company commit env, lazy to modify it to take this commit, just let it go.

Thanks