### PR TITLE
helpers: Added definition list extention of Mmark

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -192,6 +192,7 @@ var mmarkExtensionMap = map[string]int{
 	"noEmptyLineBeforeBlock": mmark.EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK,
 	"headerIds":              mmark.EXTENSION_HEADER_IDS,
 	"autoHeaderIds":          mmark.EXTENSION_AUTO_HEADER_IDS,
+	"definitionLists":        mmark.EXTENSION_DEFINITION_LISTS,
 }
 
 // StripHTML accepts a string, strips out all HTML tags and returns it.
@@ -395,6 +396,7 @@ func getMmarkExtensions(ctx *RenderingContext) int {
 	flags |= mmark.EXTENSION_SHORT_REF
 	flags |= mmark.EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK
 	flags |= mmark.EXTENSION_INCLUDE
+	flags |= mmark.EXTENSION_DEFINITION_LISTS
 
 	if ctx.Config == nil {
 		panic(fmt.Sprintf("RenderingContext of %q doesn't have a config", ctx.DocumentID))


### PR DESCRIPTION
Eliminate the problem that definition list is not supported in Mmark.
```
---
title: "Title A"
markup: mmark
---

AAAAAAAAAAAAA
: BBBBBBBBBBBB
: CCCC
```

![hugo_mmark](https://user-images.githubusercontent.com/32133/50958298-b5c23680-1503-11e9-9f3a-b339eec3d92e.png)


Added setting of Extention to helpers / content.go.

Relating to #1970