### PR TITLE
Make hugo server -t work again

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -250,7 +250,7 @@ func (cc *hugoBuilderCommon) handleFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("cacheDir", "", "", "filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/")
 	cmd.Flags().BoolP("ignoreCache", "", false, "ignores the cache directory")
 	cmd.Flags().StringP("destination", "d", "", "filesystem path to write files to")
-	cmd.Flags().StringP("theme", "t", "", "theme to use (located in /themes/THEMENAME/)")
+	cmd.Flags().StringSliceP("theme", "t", []string{}, "themes to use (located in /themes/THEMENAME/)")
 	cmd.Flags().StringP("themesDir", "", "", "filesystem path to themes directory")
 	cmd.Flags().StringVarP(&cc.baseURL, "baseURL", "b", "", "hostname (and path) to the root, e.g. http://spf13.com/")
 	cmd.Flags().Bool("enableGitInfo", false, "add Git revision, date and author info to the pages")

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -104,7 +104,7 @@ func TestCommandsPersistentFlags(t *testing.T) {
 		assert.Equal("/tmp/mydestination", cfg.GetString("publishDir"))
 		assert.Equal("mycontent", cfg.GetString("contentDir"))
 		assert.Equal("mylayouts", cfg.GetString("layoutDir"))
-		assert.Equal("mytheme", cfg.GetString("theme"))
+		assert.Equal([]string{"mytheme"}, cfg.GetStringSlice("theme"))
 		assert.Equal("mythemes", cfg.GetString("themesDir"))
 		assert.Equal("https://example.com/b/", cfg.GetString("baseURL"))
 

--- a/hugolib/paths/paths.go
+++ b/hugolib/paths/paths.go
@@ -176,7 +176,7 @@ func New(fs *hugofs.Fs, cfg config.Provider) (*Paths, error) {
 		PaginatePath: cfg.GetString("paginatePath"),
 	}
 
-	if cfg.IsSet("allThemes") {
+	if !cfg.IsSet("theme") && cfg.IsSet("allThemes") {
 		p.AllThemes = cfg.Get("allThemes").([]ThemeConfig)
 	} else {
 		p.AllThemes, err = collectThemeNames(p)


### PR DESCRIPTION
This commit solves an issue where hugo would ignore the cli -t flag
and only use a theme defined in config.toml.

Also allow -t flag to accept a string slice.

Closes #5569
Closes #5061
Related #4868 