### PR TITLE
Stop navigating to draft and future pages on edits with livereload

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -981,11 +981,20 @@ func (c *commandeer) handleEvents(watcher *watcher.Batcher,
 					}
 				}
 
-				if p != nil {
-					livereload.NavigateToPathForPort(p.RelPermalink(), p.Site.ServerPort())
-				} else {
+				if p == nil {
 					livereload.ForceRefresh()
+					return
 				}
+
+				if p.IsDraft() && !c.Cfg.GetBool("buildDrafts") {
+					return
+				}
+
+				if p.IsFuture() && !c.Cfg.GetBool("buildFuture") {
+					return
+				}
+
+				livereload.NavigateToPathForPort(p.RelPermalink(), p.Site.ServerPort())
 			}
 		}
 	}


### PR DESCRIPTION
If hugo was run with
```bash
hugo server --navigateToChanged
```
and a user edited a draft or future page then hugo would navigate to it. Since
drafts don't have urls the navigation would be buggy, sometimes resulting in
404s.
This commit fixes it. Now, the navigation will only be performed only with
--buildDrafts or --buildFuture enabled, like so
```bash
hugo server --navigateToChanged -D
```

Closes #5385