### PR TITLE
Fix OpenGraph image fallback to site params

### DIFF
--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -175,7 +175,7 @@ if (!doNotTrack) {
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
-{{- with .Params.images }}{{ range first 6 . }}
+{{ with $.Param "images" }}{{ range first 6 . }}
 <meta property="og:image" content="{{ . | absURL }}" />
 {{ end }}{{ end }}
 

--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -2,7 +2,7 @@
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
-{{- with .Params.images }}{{ range first 6 . }}
+{{ with $.Param "images" }}{{ range first 6 . }}
 <meta property="og:image" content="{{ . | absURL }}" />
 {{ end }}{{ end }}
 


### PR DESCRIPTION
In other parts of the opengraph internal template and in the twitter_cards internal template, the template falls back to using site-level parameters when page level parameters are not specified.

This change fixes the opengraph internal template to have this same behavior for the image meta tags.

I believe this was a simple bug, and with this change the behavior now matches what the documentation describes.