### PR TITLE
[Incorrect fix?] tpl/data: Prevent getJSON and getCSV fetch failure from aborting build

### DIFF
--- a/tpl/data/data.go
+++ b/tpl/data/data.go
@@ -83,7 +83,8 @@ func (ns *Namespace) GetCSV(sep string, urlParts ...string) (d [][]string, err e
 
 	err = ns.getResource(cache, unmarshal, req)
 	if err != nil {
-		return nil, _errors.Wrapf(err, "failed to read CSV resource %q", url)
+		ns.deps.Log.ERROR.Printf("Failed to get CSV resource %q: %s", url, err)
+		return nil, nil
 	}
 
 	return
@@ -113,19 +114,18 @@ func (ns *Namespace) GetJSON(urlParts ...string) (interface{}, error) {
 	req.Header.Add("Accept", "application/json")
 
 	err = ns.getResource(cache, unmarshal, req)
-
 	if err != nil {
-		return nil, _errors.Wrapf(err, "failed to get getJSON resource %q", url)
+		ns.deps.Log.ERROR.Printf("Failed to get JSON resource %q: %s", url, err)
+		return nil, nil
 	}
 
 	return v, nil
-
 }
 
 // parseCSV parses bytes of CSV data into a slice slice string or an error
 func parseCSV(c []byte, sep string) ([][]string, error) {
 	if len(sep) != 1 {
-		return nil, errors.New("Incorrect length of csv separator: " + sep)
+		return nil, errors.New("Incorrect length of CSV separator: " + sep)
 	}
 	b := bytes.NewReader(c)
 	r := csv.NewReader(b)


### PR DESCRIPTION
This PR supposedly fixes #5643, but how that this PR is pushed, I become convinced that this is not the right fix because the context of the error is lost:

Before (0.53):

> Error: Error building site: failed to render pages: render of "home" failed: "/home/foka/web/example.ca/layouts/index.html:24:13": execute of template failed: template: index.html:24:13: executing "main" at <getJSON "https://api...>: error calling getJSON: failed to get getJSON resource "https://api.example.com/test?q=abc": Failed to retrieve remote file: Not Found

After (with this PR):

> Building sites … ERROR 2019/01/28 17:05:11 failed to get getJSON resource "https://api.example.com/cards/test?q=abc": Failed to retrieve remote file: Not Found

So, perhaps this PR is not the right fix?  More discussion at the issue #5643.