### PR TITLE
Store supported config formats in a variable

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -167,8 +167,7 @@ Complete documentation is available at http://gohugo.io/.`,
 	cc.cmd.PersistentFlags().BoolVar(&cc.quiet, "quiet", false, "build in quiet mode")
 
 	// Set bash-completion
-	validConfigFilenames := []string{"json", "js", "yaml", "yml", "toml", "tml"}
-	_ = cc.cmd.PersistentFlags().SetAnnotation("config", cobra.BashCompFilenameExt, validConfigFilenames)
+	_ = cc.cmd.PersistentFlags().SetAnnotation("config", cobra.BashCompFilenameExt, config.ValidConfigFileExtensions)
 
 	cc.cmd.PersistentFlags().BoolVarP(&cc.verbose, "verbose", "v", false, "verbose output")
 	cc.cmd.PersistentFlags().BoolVarP(&cc.debug, "debug", "", false, "debug output")

--- a/config/configLoader.go
+++ b/config/configLoader.go
@@ -20,6 +20,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+var (
+	ValidConfigFileExtensions = []string{"toml", "yaml", "yml", "json"}
+)
+
 // FromConfigString creates a config from the given YAML, JSON or TOML config. This is useful in tests.
 func FromConfigString(config, configType string) (Provider, error) {
 	v := newViper()

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -202,7 +202,7 @@ func (l configLoader) loadConfig(configName string, v *viper.Viper) (string, err
 			filename = baseFilename
 		}
 	} else {
-		for _, ext := range []string{"toml", "yaml", "yml", "json"} {
+		for _, ext := range config.ValidConfigFileExtensions {
 			filenameToCheck := baseFilename + "." + ext
 			exists, _ := helpers.Exists(filenameToCheck, l.Fs)
 			if exists {

--- a/hugolib/paths/themes.go
+++ b/hugolib/paths/themes.go
@@ -120,7 +120,7 @@ func (c *themesCollector) getConfigFileIfProvided(theme string) string {
 	)
 
 	// Viper supports more, but this is the sub-set supported by Hugo.
-	for _, configFormats := range []string{"toml", "yaml", "yml", "json"} {
+	for _, configFormats := range config.ValidConfigFileExtensions {
 		configFilename = filepath.Join(configDir, "config."+configFormats)
 		exists, _ = afero.Exists(c.fs, configFilename)
 		if exists {


### PR DESCRIPTION
Reduces duplication and defines a single source of truth for config formats.