### PR TITLE
common/herrors: Fix args order in strings.TrimPrefix

### DIFF
--- a/common/herrors/error_locator.go
+++ b/common/herrors/error_locator.go
@@ -173,7 +173,7 @@ func chromaLexerFromType(fileType string) string {
 }
 
 func extNoDelimiter(filename string) string {
-	return strings.TrimPrefix(".", filepath.Ext(filename))
+	return strings.TrimPrefix(filepath.Ext(filename), ".")
 }
 
 func chromaLexerFromFilename(filename string) string {


### PR DESCRIPTION
Old code always returned "." or "" (if filepath.Ext(filename) returned ".").
Now it properly trims the prefix.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>

Sorry for the branch name.
GitHub web UI automatically creates branches like `patch-N` when editing from the site.
It's probably a good idea to give them a feature request to provide an imput for a branch name.