### PR TITLE
multilingual.md: Update tree to reflect 'fr', 'en'

### DIFF
--- a/docs/content/en/content-management/multilingual.md
+++ b/docs/content/en/content-management/multilingual.md
@@ -115,7 +115,7 @@ With the above, the two sites will be generated into `public` with their own roo
 ```bash
 public
 ├── en
-└── no
+└── fr
 ```
 
 **All URLs (i.e `.Permalink` etc.) will be generated from that root. So the English home page above will have its `.Permalink` set to `https://example.com/`.**


### PR DESCRIPTION
Config file suggests `fr` and `en` are the multiple languages
under consideration. I know @bep 's personal multilang site
is `en` and `no`, presumably an erroneous carry-over from
that codebase.