### PR TITLE
Support nested keys/fields with missing values with the `where` function

### DIFF
--- a/tpl/collections/where.go
+++ b/tpl/collections/where.go
@@ -357,7 +357,7 @@ func (ns *Namespace) checkWhereArray(seqv, kv, mv reflect.Value, path []string, 
 				var err error
 				vvv, err = evaluateSubElem(vvv, elemName)
 				if err != nil {
-					return nil, err
+					continue
 				}
 			}
 		} else {


### PR DESCRIPTION
Before this commit `where` would produce an error and bail building the
site. Now, `where` simply skips an element of a collection and does not
add it to the final result.

Closes #5637
Closes #5416