### PR TITLE
WIP Support fetching remotes files with resources.Get

### DIFF
--- a/tpl/resources/resources.go
+++ b/tpl/resources/resources.go
@@ -17,7 +17,6 @@ package resources
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 
 	_errors "github.com/pkg/errors"
 
@@ -75,8 +74,6 @@ func (ns *Namespace) Get(filename interface{}) (resource.Resource, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	filenamestr = filepath.Clean(filenamestr)
 
 	// Resource Get'ing is currently limited to /assets to make it simpler
 	// to control the behaviour of publishing and partial rebuilding.

--- a/tpl/resources/resources.go
+++ b/tpl/resources/resources.go
@@ -17,6 +17,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"net/url"
 
 	_errors "github.com/pkg/errors"
 
@@ -74,11 +75,18 @@ func (ns *Namespace) Get(filename interface{}) (resource.Resource, error) {
 	if err != nil {
 		return nil, err
 	}
+	u, err := url.Parse(filenamestr)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Scheme != "" {
+		return ns.createClient.GetRemote(ns.deps.BaseFs.Assets.Fs, filenamestr)
+	}
 
 	// Resource Get'ing is currently limited to /assets to make it simpler
 	// to control the behaviour of publishing and partial rebuilding.
 	return ns.createClient.Get(ns.deps.BaseFs.Assets.Fs, filenamestr)
-
 }
 
 // Concat concatenates a slice of Resource objects. These resources must


### PR DESCRIPTION
It'll let developers use inline CSS as in the example below:

```
{{ $externalCSS := resources.Get "https://fonts.googleapis.com/css?family=Space+Mono:400,700" }}
<style>
     {{ $externalCSS.Content | safeCSS }} Or .RelPermalink would also work.
</style>
```

Closes #5255