### PR TITLE
content_renderer: support mmark code-fence captions

### DIFF
--- a/helpers/content_renderer_test.go
+++ b/helpers/content_renderer_test.go
@@ -89,6 +89,37 @@ func TestCodeFence(t *testing.T) {
 	}
 }
 
+func TestMmarkCodeFence(t *testing.T) {
+	assert := require.New(t)
+
+	python := `<div class="highlight">` +
+		`<pre class="chroma"><code class="language-python" data-lang="python">` +
+		`<span class="kn">import</span> <span class="nn">this</span></code></pre></div>`
+	for i, this := range []struct {
+		markdown string
+		expect   string
+	}{
+		{"~~~ python\nimport this\n~~~", python},
+		{"~~~ python\nimport this\n~~~\nFigure: fig",
+			`<figure>` + python + `<figcaption>fig</figcaption></figure>`},
+	} {
+		v := viper.New()
+		v.Set("pygmentsStyle", "monokai")
+		v.Set("pygmentsUseClasses", true)
+		v.Set("pygmentsCodeFences", true)
+		c, err := NewContentSpec(v)
+		assert.NoError(err)
+		ctx := &RenderingContext{Cfg: c.cfg, Config: c.BlackFriday}
+		ctx.Content = []byte(this.markdown)
+		actualRenderedMarkdown := c.mmarkRender(ctx)
+		expectedRenderedMarkdown := []byte(this.expect)
+		if !bytes.Equal(actualRenderedMarkdown, expectedRenderedMarkdown) {
+			t.Errorf("[%d] Actual rendered Markdown (%s) did not match expected markdown (%s)", i, actualRenderedMarkdown, expectedRenderedMarkdown)
+		}
+	}
+
+}
+
 func TestBlackfridayTaskList(t *testing.T) {
 	c := newTestContentSpec()
 


### PR DESCRIPTION
Mmark supports captions on code-fences like:

    ~~~ python
    import this
    ~~~
    Figure: this is a caption

Add hugo support by copying some of the render code from Mmark. Ideally, we'd reuse the MMark BlockCode function, but that would change how code is rendered in HTML and is a breaking change.

There's two more MMark code-fence features that aren't supported by this PR:

1. Callouts
2. Manually specifying a code prefix through an attribute

Fixes #4129