### PR TITLE
build "extended".  support docker args: TAGS, WORKDIR, CGO. speed up repetitive builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 .circleci
 docs
 examples
+Dockerfile


### PR DESCRIPTION
I've modified Dockerfile to be a bit more flexible (see example builds, below):
* support "extended" build with `docker build   --build-arg BUILD_TAGS=extended --build-arg CGO=1  . -t hugo:extended`
* support renaming the volume e.g. `docker build --build-arg WORKDIR=/workspace --build-arg . -t hugo` . This was needed for compatibility with GCP Cloud Builders (CI/CD)
* use stretch for build image (final image is still 33mb) -- this is due to a segfault bug with binutils/musl on alpine. See [this bug](https://www.openwall.com/lists/musl/2018/07/18/15)  .  
* rearranged steps to make repeat builds cache-friendly (e.g. separate `go get` , added `Dockerfile` to .dockerignore, moved ENV vars to where they are referenced)


## Building a standard (non-extended) build
No change from before. Default build is CGO=0, non-extended, workdir=/site
```
docker build  . -t hugo:non-extended
```

## Building an extended build
Turn on CGO and set `--build-arg BUILD_TAGS=extended`
```
docker build   --build-arg BUILD_TAGS=extended --build-arg CGO=1  . -t hugo:extended
```