### PR TITLE
List future dates in CSV format

### DIFF
--- a/commands/list.go
+++ b/commands/list.go
@@ -14,7 +14,10 @@
 package commands
 
 import (
+	"encoding/csv"
+	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/gohugoio/hugo/hugolib"
 	"github.com/spf13/cobra"
@@ -101,11 +104,16 @@ posted in the future.`,
 					return newSystemError("Error Processing Source Content", err)
 				}
 
+				writer := csv.NewWriter(os.Stdout)
+				defer writer.Flush()
+
 				for _, p := range sites.Pages() {
 					if p.IsFuture() {
-						jww.FEEDBACK.Println(filepath.Join(p.File.Dir(), p.File.LogicalName()))
+						err := writer.Write([]string{filepath.Join(p.File.Dir(), p.File.LogicalName()), p.PublishDate.Format(time.RFC3339)})
+						if err != nil {
+							return newSystemError("Error writing future posts to stdout", err)
+						}
 					}
-
 				}
 
 				return nil
@@ -137,11 +145,16 @@ expired.`,
 					return newSystemError("Error Processing Source Content", err)
 				}
 
+				writer := csv.NewWriter(os.Stdout)
+				defer writer.Flush()
+
 				for _, p := range sites.Pages() {
 					if p.IsExpired() {
-						jww.FEEDBACK.Println(filepath.Join(p.File.Dir(), p.File.LogicalName()))
+						err := writer.Write([]string{filepath.Join(p.File.Dir(), p.File.LogicalName()), p.ExpiryDate.Format(time.RFC3339)})
+						if err != nil {
+							return newSystemError("Error writing expired posts to stdout", err)
+						}
 					}
-
 				}
 
 				return nil


### PR DESCRIPTION
Prints future dated posts as CSV, including the future date the post will be available from.

Prints like this:

```
$ hugo list future
episodes/19.md,2019-04-09T07:46:51+13:00
```

Things I'm not sure about:

* Should I somehow be writing the CSV through jww? I wasn't sure how to do that here.
* Do you want me to change the output format for the other list commands? Especially `expired`, that seems like a similar kind of case. Not sure what you'd want to do for `draft`, I suppose it could be useful to see the draft dates listed too (note that Hugo doesn't return future dated drafts when listing either drafts or future).

Fixes #5610