### PR TITLE
Fix #5685. Convert numeric values to float64 and compare them

### DIFF
--- a/tpl/collections/where.go
+++ b/tpl/collections/where.go
@@ -114,6 +114,17 @@ func (ns *Namespace) checkCondition(v, mv reflect.Value, op string) (bool, error
 			slv = v.Interface()
 			slmv = mv.Interface()
 		}
+	} else if isNumber(v.Kind()) && isNumber(mv.Kind()) {
+		fv, err := toFloat(v)
+		if err != nil {
+			return false, err
+		}
+		fvp = &fv
+		fmv, err := toFloat(mv)
+		if err != nil {
+			return false, err
+		}
+		fmvp = &fmv
 	} else {
 		if mv.Kind() != reflect.Array && mv.Kind() != reflect.Slice {
 			return false, nil
@@ -425,6 +436,8 @@ func toFloat(v reflect.Value) (float64, error) {
 	switch v.Kind() {
 	case reflect.Float32, reflect.Float64:
 		return v.Float(), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Convert(reflect.TypeOf(float64(0))).Float(), nil
 	case reflect.Interface:
 		return toFloat(v.Elem())
 	}

--- a/tpl/collections/where_test.go
+++ b/tpl/collections/where_test.go
@@ -88,6 +88,27 @@ func TestWhere(t *testing.T) {
 			seq: []map[string]float64{
 				{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "x": 4},
 			},
+			key: "b", match: 4, op: "<",
+			expect: []map[string]float64{{"a": 1, "b": 2}},
+		},
+		{
+			seq: []map[string]int{
+				{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "x": 4},
+			},
+			key: "b", match: 4.0, op: "<",
+			expect: []map[string]int{{"a": 1, "b": 2}},
+		},
+		{
+			seq: []map[string]int{
+				{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "x": 4},
+			},
+			key: "b", match: 4.2, op: "<",
+			expect: []map[string]int{{"a": 1, "b": 2}, {"a": 3, "b": 4}},
+		},
+		{
+			seq: []map[string]float64{
+				{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "x": 4},
+			},
 			key: "b", match: 4.0, op: "<=",
 			expect: []map[string]float64{{"a": 1, "b": 2}, {"a": 3, "b": 4}},
 		},


### PR DESCRIPTION
Hi. We just need check here if both values are numbers, convert them to float64, and then compare.

Fix #5685