### PR TITLE
add skipHTML option to blackfriday config

### DIFF
--- a/docs/content/en/readfiles/bfconfig.md
+++ b/docs/content/en/readfiles/bfconfig.md
@@ -71,6 +71,11 @@
     Example: Include `autoHeaderIds` as `false` in the list to disable Blackfriday's `EXTENSION_AUTO_HEADER_IDS`. <br>
     *See [Blackfriday extensions](#blackfriday-extensions) section for information on all extensions.*
 
+`skipHTML`
+: default: **`false`** <br>
+    Blackfriday flag: **`HTML_SKIP_HTML`** <br>
+    Purpose: `true` causes any HTML in the markdown files to be skipped.
+
 ## Blackfriday extensions
 
 `noIntraEmphasis`

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -136,7 +136,7 @@ func newBlackfriday(config map[string]interface{}) *BlackFriday {
 		"latexDashes":           true,
 		"plainIDAnchors":        true,
 		"taskLists":             true,
-		"skipHTML":              true,
+		"skipHTML":              false,
 	}
 
 	maps.ToLower(defaultParam)

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -119,6 +119,7 @@ type BlackFriday struct {
 	PlainIDAnchors        bool
 	Extensions            []string
 	ExtensionsMask        []string
+	SkipHTML              bool
 }
 
 // NewBlackfriday creates a new Blackfriday filled with site config or some sane defaults.
@@ -135,6 +136,7 @@ func newBlackfriday(config map[string]interface{}) *BlackFriday {
 		"latexDashes":           true,
 		"plainIDAnchors":        true,
 		"taskLists":             true,
+		"skipHTML":              true,
 	}
 
 	maps.ToLower(defaultParam)
@@ -298,6 +300,10 @@ func (c *ContentSpec) getHTMLRenderer(defaultFlags int, ctx *RenderingContext) b
 
 	if ctx.Config.LatexDashes {
 		htmlFlags |= blackfriday.HTML_SMARTYPANTS_LATEX_DASHES
+	}
+
+	if ctx.Config.SkipHTML {
+		htmlFlags |= blackfriday.HTML_SKIP_HTML
 	}
 
 	return &HugoHTMLRenderer{


### PR DESCRIPTION
My use-case here is that I have external users which contribute to my hugo site. I want to use this option in order to prevent them from accidentally/unknowingly pasting in arbitrary HTML or JavaScript from potentially unauthorised sources.

I'm unsure if/how a test-case should be added to this. It's my first time ever writing Go. Feel free to tear my PR apart if it doesn't meet your standards!