### PR TITLE
Update travis-ci to work for forked builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 
 install:
   - mkdir -p $HOME/src
-  - mv $HOME/gopath/src/github.com/gohugoio/hugo $HOME/src
+  - mv $TRAVIS_BUILD_DIR $HOME/src
   - export TRAVIS_BUILD_DIR=$HOME/src/hugo
   - cd $HOME/src/hugo
   - go get github.com/magefile/mage


### PR DESCRIPTION
After forking hugo the travis build fails due to the hard coded path coded into the travis-ci.yml.

```
$ mv $HOME/gopath/src/github.com/gohugoio/hugo $HOME/src
mv: cannot stat ‘/home/travis/gopath/src/github.com/gohugoio/hugo’: No such file or directory
The command "mv $HOME/gopath/src/github.com/gohugoio/hugo $HOME/src" failed and exited with 1 during .

Your build has been stopped.
```
By using the TRAVIS_BUILD_DIR environment variable the build will work for forked projects.

This allows the validation of changes, using ci, on forked hugo builds before submitting PRs.