### PR TITLE
Emit log when omitting paginator output

### DIFF
--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -170,10 +170,14 @@ func pageRenderer(s *Site, pages <-chan *Page, results chan<- error, wg *sync.Wa
 					results <- err
 				}
 
-				// Only render paginators for the main output format
-				if i == 0 && pageOutput.IsNode() {
-					if err := s.renderPaginator(pageOutput); err != nil {
-						results <- err
+				if pageOutput.IsNode() {
+					// Only render paginators for the main output format
+					if i == 0 {
+						if err := s.renderPaginator(pageOutput); err != nil {
+							results <- err
+						}
+					} else if pageOutput.paginator != nil {
+						s.Log.INFO.Printf("Ignored paginator for secondary output %q for page %q", outFormat.Name, page)
 					}
 				}
 			}


### PR DESCRIPTION
We observed a strange behavior where the paginator on the home page would emit links to `/page/2`, but would not actually generate file `/page/2/index.html`.
 
The root cause was the configuration of home outputs: 

    [outputs]
    home = [ "RSS", "HTML" ]

There was no warning or any information in the logs that could explain this. 

We then discovered (by reading the source code) that hugo will only render the paginator for the main output format of a page, and will silently ignore the paginators for other output formats. Swapping the home outputs (`"HTML", "RSS"`) fixed the issue. 

After this commit, hugo will still ignore secondary paginators, but will emit an log message when doing so that would hopefully help other people with the same issue. 

This message has log level INFO and is therefore only visible in verbose mode, to avoid generating false positives on existing sites where this behaviour is expected.