### PR TITLE
Allow the partial template func to return any type

### DIFF
--- a/compare/compare.go
+++ b/compare/compare.go
@@ -20,6 +20,12 @@ type Eqer interface {
 	Eq(other interface{}) bool
 }
 
+// ProbablyEq is an equal check that may return false positives, but never
+// a false negative.
+type ProbablyEqer interface {
+	ProbablyEq(other interface{}) bool
+}
+
 // Comparer can be used to compare two values.
 // This will be used when using the le, ge etc. operators in the templates.
 // Compare returns -1 if the given version is less than, 0 if equal and 1 if greater than

--- a/hugolib/template_test.go
+++ b/hugolib/template_test.go
@@ -264,3 +264,44 @@ Hugo: {{ hugo.Generator }}
 	)
 
 }
+
+func TestPartialWithReturn(t *testing.T) {
+
+	b := newTestSitesBuilder(t).WithSimpleConfigFile()
+
+	b.WithTemplatesAdded(
+		"index.html", `
+Test Partials With Return Values:
+
+add42: 50: {{ partial "add42.tpl" 8 }}
+dollarContext: 60: {{ partial "dollarContext.tpl" 18 }}
+adder: 70: {{ partial "dict.tpl" (dict "adder" 28) }}
+complex: 80: {{ partial "complex.tpl" 38 }}
+`,
+		"partials/add42.tpl", `
+		{{ $v := add . 42 }}
+		{{ return $v }}
+		`,
+		"partials/dollarContext.tpl", `
+{{ $v := add $ 42 }}
+{{ return $v }}
+`,
+		"partials/dict.tpl", `
+{{ $v := add $.adder 42 }}
+{{ return $v }}
+`,
+		"partials/complex.tpl", `
+{{ return add . 42 }}
+`,
+	)
+
+	b.CreateSites().Build(BuildCfg{})
+
+	b.AssertFileContent("public/index.html",
+		"add42: 50: 50",
+		"dollarContext: 60: 60",
+		"adder: 70: 70",
+		"complex: 80: 80",
+	)
+
+}

--- a/tpl/partials/init.go
+++ b/tpl/partials/init.go
@@ -36,6 +36,13 @@ func init() {
 			},
 		)
 
+		// TODO(bep) we need the return to be a valid identifier, but
+		// should consider another way of adding it.
+		ns.AddMethodMapping(func() string { return "" },
+			[]string{"return"},
+			[][2]string{},
+		)
+
 		ns.AddMethodMapping(ctx.IncludeCached,
 			[]string{"partialCached"},
 			[][2]string{},

--- a/tpl/template_info.go
+++ b/tpl/template_info.go
@@ -22,8 +22,15 @@ type Info struct {
 	// Set for shortcode templates with any {{ .Inner }}
 	IsInner bool
 
+	// Set for partials with a return statement.
+	HasReturn bool
+
 	// Config extracted from template.
 	Config Config
+}
+
+func (info Info) IsZero() bool {
+	return info.Config.Version == 0
 }
 
 type Config struct {

--- a/tpl/tplimpl/ace.go
+++ b/tpl/tplimpl/ace.go
@@ -51,15 +51,17 @@ func (t *templateHandler) addAceTemplate(name, basePath, innerPath string, baseC
 		return err
 	}
 
-	isShort := isShortcode(name)
+	typ := resolveTemplateType(name)
 
-	info, err := applyTemplateTransformersToHMLTTemplate(isShort, templ)
+	info, err := applyTemplateTransformersToHMLTTemplate(typ, templ)
 	if err != nil {
 		return err
 	}
 
-	if isShort {
+	if typ == templateShortcode {
 		t.addShortcodeVariant(name, info, templ)
+	} else {
+		t.templateInfo[name] = info
 	}
 
 	return nil

--- a/tpl/tplimpl/shortcodes.go
+++ b/tpl/tplimpl/shortcodes.go
@@ -139,6 +139,18 @@ func templateNameAndVariants(name string) (string, []string) {
 	return name, variants
 }
 
+func resolveTemplateType(name string) templateType {
+	if isShortcode(name) {
+		return templateShortcode
+	}
+
+	if strings.Contains(name, "partials/") {
+		return templatePartial
+	}
+
+	return templateUndefined
+}
+
 func isShortcode(name string) bool {
 	return strings.Contains(name, "shortcodes/")
 }


### PR DESCRIPTION
This commit adds support for return values in partials.

This means that you can now do this and similar:

    {{ $v := add . 42 }}
    {{ return $v }}

Partials without a `return` statement will be rendered as before.

Fixes #5783