### PR TITLE
hugolib: Allow relative URLs in front matter

### DIFF
--- a/hugolib/page_permalink_test.go
+++ b/hugolib/page_permalink_test.go
@@ -104,3 +104,43 @@ Content
 	}
 
 }
+
+func TestRelativeURLInFrontMatter(t *testing.T) {
+
+	config := `
+
+defaultContentLanguage = "en"
+defaultContentLanguageInSubdir = false
+
+[Languages]
+[Languages.en]
+weight = 10
+contentDir = "content/en"
+[Languages.nn]
+weight = 20
+contentDir = "content/nn"
+
+`
+
+	pageTempl := `---
+title: "A page"
+url: %q
+---
+
+Some content.
+`
+
+	b := newTestSitesBuilder(t).WithConfigFile("toml", config)
+	b.WithContent("content/en/blog/page1.md", fmt.Sprintf(pageTempl, "myblog/p1/"))
+	b.WithContent("content/en/blog/_index.md", fmt.Sprintf(pageTempl, "this-is-my-english-blog"))
+	b.WithContent("content/nn/blog/page1.md", fmt.Sprintf(pageTempl, "myblog/p1/"))
+	b.WithContent("content/nn/blog/_index.md", fmt.Sprintf(pageTempl, "this-is-my-blog"))
+
+	b.Build(BuildCfg{})
+
+	b.AssertFileContent("public/nn/myblog/p1/index.html", "Single: A page|Hello|nn|RelPermalink: /nn/myblog/p1/|")
+	b.AssertFileContent("public/nn/this-is-my-blog/index.html", "List Page 1|A page|Hello|/nn/this-is-my-blog/|")
+	b.AssertFileContent("public/this-is-my-english-blog/index.html", "List Page 1|A page|Hello|/this-is-my-english-blog/|")
+	b.AssertFileContent("public/myblog/p1/index.html", "Single: A page|Hello|en|RelPermalink: /myblog/p1/|Permalink: /myblog/p1/|")
+
+}

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -208,7 +208,7 @@ func (s *Site) render404() error {
 		s:    s,
 		kind: kind404,
 		urlPaths: pagemeta.URLPath{
-			URL: path.Join(s.GetURLLanguageBasePath(), "404.html"),
+			URL: "404.html",
 		},
 	},
 		output.HTMLFormat,
@@ -271,7 +271,7 @@ func (s *Site) renderRobotsTXT() error {
 		s:    s,
 		kind: kindRobotsTXT,
 		urlPaths: pagemeta.URLPath{
-			URL: path.Join(s.GetURLLanguageBasePath(), "robots.txt"),
+			URL: "robots.txt",
 		},
 	},
 		output.RobotsTxtFormat)

--- a/resources/page/page_paths.go
+++ b/resources/page/page_paths.go
@@ -124,6 +124,11 @@ func CreateTargetPaths(d TargetPathDescriptor) (tp TargetPaths) {
 
 	}
 
+	if d.URL != "" && !strings.HasPrefix(d.URL, "/") {
+		// Treat this as a context relative URL
+		d.ForcePrefix = true
+	}
+
 	pagePath := slash
 
 	var (


### PR DESCRIPTION
Before this commit you would have to do this in multilingual setups:

```
---
title: "Custom!"
url: "/jp/custom/foo"
---
```

This commit allows for relative URLs, e.g:

```
---
title: "Custom!"
url: "custom/foo"
---
```

Which is obviously easier and more portable.

The meaning of relative may change to include more in the future (e.g. role based access).

Fixes #5704