### PR TITLE
hugolib: Add parameter option for .Summary

### DIFF
--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -29,6 +29,28 @@ import (
 
 const tstHTMLContent = "<!DOCTYPE html><html><head><script src=\"http://two/foobar.js\"></script></head><body><nav><ul><li hugo-nav=\"section_0\"></li><li hugo-nav=\"section_1\"></li></ul></nav><article>content <a href=\"http://two/foobar\">foobar</a>. Follow up</article><p>This is some text.<br>And some more.</p></body></html>"
 
+func TestTrimShortHTML(t *testing.T) {
+	tests := []struct {
+		input, output []byte
+	}{
+		{[]byte(""), []byte("")},
+		{[]byte("Plain text"), []byte("Plain text")},
+		{[]byte("  \t\n Whitespace text\n\n"), []byte("Whitespace text")},
+		{[]byte("<p>Simple paragraph</p>"), []byte("Simple paragraph")},
+		{[]byte("\n  \n \t  <p> \t Whitespace\nHTML  \n\t </p>\n\t"), []byte("Whitespace\nHTML")},
+		{[]byte("<p>Multiple</p><p>paragraphs</p>"), []byte("<p>Multiple</p><p>paragraphs</p>")},
+		{[]byte("<p>Nested<p>paragraphs</p></p>"), []byte("<p>Nested<p>paragraphs</p></p>")},
+	}
+
+	c := newTestContentSpec()
+	for i, test := range tests {
+		output := c.TrimShortHTML(test.input)
+		if bytes.Compare(test.output, output) != 0 {
+			t.Errorf("Test %d failed. Expected %q got %q", i, test.output, output)
+		}
+	}
+}
+
 func TestStripHTML(t *testing.T) {
 	type test struct {
 		input, expected string

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -63,6 +63,8 @@ type pageMeta struct {
 	title     string
 	linkTitle string
 
+	summary string
+
 	resourcePath string
 
 	weight int
@@ -360,6 +362,9 @@ func (pm *pageMeta) setMetadata(p *pageState, frontmatter map[string]interface{}
 		case "linktitle":
 			pm.linkTitle = cast.ToString(v)
 			pm.params[loki] = pm.linkTitle
+		case "summary":
+			pm.summary = cast.ToString(v)
+			pm.params[loki] = pm.summary
 		case "description":
 			pm.description = cast.ToString(v)
 			pm.params[loki] = pm.description

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -134,10 +134,7 @@ func newPageContentOutput(p *pageState) func(f output.Format) (*pageContentOutpu
 						Cfg:        p.Language(),
 						DocumentID: p.File().UniqueID(), DocumentName: p.File().Path(),
 						Config: cp.p.getRenderingConfig()})
-					// Strip enclosing <p>
-					html = []byte(strings.TrimSpace(string(html)))
-					html = []byte(strings.TrimPrefix(string(html), "<p>"))
-					html = []byte(strings.TrimSuffix(string(html), "</p>"))
+					html = cp.p.s.ContentSpec.TrimShortHTML(html)
 					cp.summary = helpers.BytesToHTML(html)
 				}
 			}

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -128,6 +128,17 @@ func newPageContentOutput(p *pageState) func(f output.Format) (*pageContentOutpu
 							cp.summary = helpers.BytesToHTML(summary)
 						}
 					}
+				} else if cp.p.m.summary != "" {
+					html := cp.p.s.ContentSpec.RenderBytes(&helpers.RenderingContext{
+						Content: []byte(cp.p.m.summary), RenderTOC: false, PageFmt: cp.p.m.markup,
+						Cfg:        p.Language(),
+						DocumentID: p.File().UniqueID(), DocumentName: p.File().Path(),
+						Config: cp.p.getRenderingConfig()})
+					// Strip enclosing <p>
+					html = []byte(strings.TrimSpace(string(html)))
+					html = []byte(strings.TrimPrefix(string(html), "<p>"))
+					html = []byte(strings.TrimSuffix(string(html), "</p>"))
+					cp.summary = helpers.BytesToHTML(html)
 				}
 			}
 
@@ -271,7 +282,7 @@ func (p *pageContentOutput) WordCount() int {
 }
 
 func (p *pageContentOutput) setAutoSummary() error {
-	if p.p.source.hasSummaryDivider {
+	if p.p.source.hasSummaryDivider || p.p.m.summary != "" {
 		return nil
 	}
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -45,6 +45,16 @@ const (
 
 	simplePageRFC3339Date = "---\ntitle: RFC3339 Date\ndate: \"2013-05-17T16:59:30Z\"\n---\nrfc3339 content"
 
+	simplePageWithoutSummaryDelimiter = `---
+title: SimpleWithoutSummaryDelimiter
+---
+[Lorem ipsum](https://lipsum.com/) dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Additional text.
+
+Further text.
+`
+
 	simplePageWithSummaryDelimiter = `---
 title: Simple
 ---
@@ -52,6 +62,16 @@ Summary Next Line
 
 <!--more-->
 Some more text
+`
+
+	simplePageWithSummaryParameter = `---
+title: SimpleWithSummaryParameter
+summary: "Page with summary parameter and [a link](http://www.example.com/)"
+---
+
+Some text.
+
+Some more text.
 `
 
 	simplePageWithSummaryDelimiterAndMarkdownThatCrossesBorder = `---
@@ -491,6 +511,22 @@ func TestCreateNewPage(t *testing.T) {
 	testAllMarkdownEnginesForPages(t, assertFunc, settings, simplePage)
 }
 
+func TestPageSummary(t *testing.T) {
+	t.Parallel()
+	assertFunc := func(t *testing.T, ext string, pages page.Pages) {
+		p := pages[0]
+		checkPageTitle(t, p, "SimpleWithoutSummaryDelimiter")
+		// Source is not RST-compatibile so don't test for it
+		if ext != "rst" {
+			checkPageContent(t, p, normalizeExpected(ext, "<p><a href=\"https://lipsum.com/\">Lorem ipsum</a> dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n\n<p>Additional text.</p>\n\n<p>Further text.</p>\n"), ext)
+			checkPageSummary(t, p, normalizeExpected(ext, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Additional text."), ext)
+		}
+		checkPageType(t, p, "page")
+	}
+
+	testAllMarkdownEnginesForPages(t, assertFunc, nil, simplePageWithoutSummaryDelimiter)
+}
+
 func TestPageWithDelimiter(t *testing.T) {
 	t.Parallel()
 	assertFunc := func(t *testing.T, ext string, pages page.Pages) {
@@ -502,6 +538,22 @@ func TestPageWithDelimiter(t *testing.T) {
 	}
 
 	testAllMarkdownEnginesForPages(t, assertFunc, nil, simplePageWithSummaryDelimiter)
+}
+
+func TestPageWithSummaryParameter(t *testing.T) {
+	t.Parallel()
+	assertFunc := func(t *testing.T, ext string, pages page.Pages) {
+		p := pages[0]
+		checkPageTitle(t, p, "SimpleWithSummaryParameter")
+		checkPageContent(t, p, normalizeExpected(ext, "<p>Some text.</p>\n\n<p>Some more text.</p>\n"), ext)
+		// Summary is not RST-compatibile so don't test for it
+		if ext != "rst" {
+			checkPageSummary(t, p, normalizeExpected(ext, "Page with summary parameter and <a href=\"http://www.example.com/\">a link</a>"), ext)
+		}
+		checkPageType(t, p, "page")
+	}
+
+	testAllMarkdownEnginesForPages(t, assertFunc, nil, simplePageWithSummaryParameter)
 }
 
 // Issue #3854

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -516,8 +516,8 @@ func TestPageSummary(t *testing.T) {
 	assertFunc := func(t *testing.T, ext string, pages page.Pages) {
 		p := pages[0]
 		checkPageTitle(t, p, "SimpleWithoutSummaryDelimiter")
-		// Source is not RST-compatibile so don't test for it
-		if ext != "rst" {
+		// Source is not Asciidoctor- or RST-compatibile so don't test them
+		if ext != "ad" && ext != "rst" {
 			checkPageContent(t, p, normalizeExpected(ext, "<p><a href=\"https://lipsum.com/\">Lorem ipsum</a> dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n\n<p>Additional text.</p>\n\n<p>Further text.</p>\n"), ext)
 			checkPageSummary(t, p, normalizeExpected(ext, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Additional text."), ext)
 		}
@@ -546,8 +546,8 @@ func TestPageWithSummaryParameter(t *testing.T) {
 		p := pages[0]
 		checkPageTitle(t, p, "SimpleWithSummaryParameter")
 		checkPageContent(t, p, normalizeExpected(ext, "<p>Some text.</p>\n\n<p>Some more text.</p>\n"), ext)
-		// Summary is not RST-compatibile so don't test for it
-		if ext != "rst" {
+		// Summary is not Asciidoctor- or RST-compatibile so don't test them
+		if ext != "ad" && ext != "rst" {
 			checkPageSummary(t, p, normalizeExpected(ext, "Page with summary parameter and <a href=\"http://www.example.com/\">a link</a>"), ext)
 		}
 		checkPageType(t, p, "page")

--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -55,6 +55,9 @@ func TestRSSOutput(t *testing.T) {
 	if c != rssLimit {
 		t.Errorf("incorrect RSS item count: expected %d, got %d", rssLimit, c)
 	}
+
+	// Encoded summary
+	th.assertFileContent(filepath.Join("public", rssURI), "<?xml", "description", "A &lt;em&gt;custom&lt;/em&gt; summary")
 }
 
 // Before Hugo 0.49 we set the pseudo page kind RSS on the page when output to RSS.

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -586,6 +586,7 @@ date = "2012-01-01"
 publishdate = "2012-01-01"
 my_param = "baz"
 my_date = 2010-05-27T07:32:00Z
+summary = "A _custom_ summary"
 categories = [ "hugo" ]
 +++
 Front Matter with Ordered Pages 4. This is longer content`

--- a/tpl/transform/transform.go
+++ b/tpl/transform/transform.go
@@ -15,7 +15,6 @@
 package transform
 
 import (
-	"bytes"
 	"html"
 	"html/template"
 
@@ -91,12 +90,6 @@ func (ns *Namespace) HTMLUnescape(s interface{}) (string, error) {
 	return html.UnescapeString(ss), nil
 }
 
-var (
-	markdownTrimPrefix         = []byte("<p>")
-	markdownTrimSuffix         = []byte("</p>\n")
-	markdownParagraphIndicator = []byte("<p")
-)
-
 // Markdownify renders a given input from Markdown to HTML.
 func (ns *Namespace) Markdownify(s interface{}) (template.HTML, error) {
 	ss, err := cast.ToStringE(s)
@@ -114,14 +107,9 @@ func (ns *Namespace) Markdownify(s interface{}) (template.HTML, error) {
 	)
 
 	// Strip if this is a short inline type of text.
-	first := bytes.Index(m, markdownParagraphIndicator)
-	last := bytes.LastIndex(m, markdownParagraphIndicator)
-	if first == last {
-		m = bytes.TrimPrefix(m, markdownTrimPrefix)
-		m = bytes.TrimSuffix(m, markdownTrimSuffix)
-	}
+	m = ns.deps.ContentSpec.TrimShortHTML(m)
 
-	return template.HTML(m), nil
+	return helpers.BytesToHTML(m), nil
 }
 
 // Plainify returns a copy of s with all HTML tags removed.


### PR DESCRIPTION
Add the ability to have a `summary` page variable that overrides
the auto-generated summary.  Logic for obtaining summary becomes:

  * if summary divider is present in content use the text above it
  * if summary variables is present in page metadata use that
  * auto-generate summary from first _x_ words of the content

Fixes #5800 

Tests have been added to ensure all three cases work as expected.  Note that in the tests the summary has markdown elements to ensure that processing occurs correctly; as such RST is explicitly excluded from the list of tested engines in the tests added in `hugolib/page_test.go`.

There is a discrepancy between the summary when auto-generated and when generated using the explicit delimiter; in the former case the output is plain and in the latter case it is wrapped with `<p>`.  I chose to go for the former option when generating from the summary metadata, as in general the summary would be wrapped in `<div> or similar` anyway, and it's cleaner for RSS output.

Talking of which, I added a custom summary to one of the test pages in `hugolib/site_test.go` to ensure that the output XML is correct with summary metadata that contains markdown; test is in `hugolib/rss_test.go`.

I haven't studied the Hugo codebase to any great depth so please do take a good look at the changes and let me know if there is anything that's incorrect here.  Thanks.