### PR TITLE
docs: Remove the space in `. RelPermalink`

### DIFF
--- a/docs/content/en/variables/page.md
+++ b/docs/content/en/variables/page.md
@@ -124,7 +124,7 @@ See also `.ExpiryDate`, `.Date`, `.PublishDate`, and [`.GitInfo`][gitinfo].
 : the date on which the content was or will be published; `.Publishdate` pulls from the `publishdate` field in a content's front matter. See also `.ExpiryDate`, `.Date`, and `.Lastmod`.
 
 .RSSLink (deprecated)
-: link to the page's RSS feed. This is deprecated. You should instead do something like this: `{{ with .OutputFormats.Get "RSS" }}{{ . RelPermalink }}{{ end }}`.
+: link to the page's RSS feed. This is deprecated. You should instead do something like this: `{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}`.
 
 .RawContent
 : raw markdown content without the front matter. Useful with [remarkjs.com](


### PR DESCRIPTION
The same fix as 3b86b4a9f5ce010c9714d813d5b8ecddda22c69f, applied to doc.