### PR TITLE
Fix WeightedPages in union etc.

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1584,7 +1584,7 @@ func (s *Site) assembleTaxonomies() error {
 			// last one will win, e.g. "hugo" vs "Hugo".
 			n.term = term
 
-			w := page.NewWeightedPage(weight, p, n.getOwner)
+			w := page.NewWeightedPage(weight, p, n.owner)
 
 			s.Taxonomies[plural].add(key, w)
 

--- a/hugolib/taxonomy.go
+++ b/hugolib/taxonomy.go
@@ -175,7 +175,7 @@ type taxonomyNodeInfo struct {
 	parent *taxonomyNodeInfo
 
 	// Either of Kind taxonomyTerm (parent) or taxonomy
-	owner page.Page
+	owner *page.PageWrapper
 }
 
 func (t *taxonomyNodeInfo) UpdateFromPage(p page.Page) {
@@ -185,15 +185,10 @@ func (t *taxonomyNodeInfo) UpdateFromPage(p page.Page) {
 }
 
 func (t *taxonomyNodeInfo) TransferValues(p *pageState) {
-	t.owner = p
+	t.owner.Page = p
 	if p.Lastmod().IsZero() && p.Date().IsZero() {
 		p.m.Dates.UpdateDateAndLastmodIfAfter(t.dates)
 	}
-}
-
-// callback sent to the child nodes.
-func (t *taxonomyNodeInfo) getOwner() page.Page {
-	return t.owner
 }
 
 // Maps either plural or plural/term to a taxonomy node.
@@ -216,6 +211,7 @@ func (t taxonomyNodeInfos) GetOrCreate(plural, termKey, term string) *taxonomyNo
 		plural:  plural,
 		termKey: termKey,
 		term:    term,
+		owner:   &page.PageWrapper{}, // Page will be assigned later.
 	}
 
 	t[key] = n

--- a/resources/page/weighted.go
+++ b/resources/page/weighted.go
@@ -38,11 +38,11 @@ func (p WeightedPages) Page() Page {
 	first := p[0]
 
 	// TODO(bep) fix tests
-	if first.getOwner == nil {
+	if first.owner == nil {
 		return nil
 	}
 
-	return first.getOwner()
+	return first.owner.Page
 }
 
 // A WeightedPage is a Page with a weight.
@@ -50,15 +50,20 @@ type WeightedPage struct {
 	Weight int
 	Page
 
-	// A callback used to fetch the owning Page. This avoids having to do
+	// Reference to the owning Page. This avoids having to do
 	// manual .Site.GetPage lookups. It is implemented in this roundabout way
 	// because we cannot add additional state to the WeightedPages slice
 	// without breaking lots of templates in the wild.
-	getOwner func() Page
+	owner *PageWrapper
 }
 
-func NewWeightedPage(weight int, p Page, getOwner func() Page) WeightedPage {
-	return WeightedPage{Weight: weight, Page: p, getOwner: getOwner}
+// PageWrapper wraps a Page.
+type PageWrapper struct {
+	Page
+}
+
+func NewWeightedPage(weight int, p Page, owner *PageWrapper) WeightedPage {
+	return WeightedPage{Weight: weight, Page: p, owner: owner}
 }
 
 func (w WeightedPage) String() string {


### PR DESCRIPTION
We introduced a callback func() to get the owner Page in 0.55.0.

Sadly, `func` is  not a comparable type in Go.

This commit replaces the func with a struct pointer that wraps the Page.

Fixes #5850