### PR TITLE
hugolib: Fix panic for unused taxonomy content files

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -746,8 +746,10 @@ func (p *pageState) getTaxonomyNodeInfo() *taxonomyNodeInfo {
 	info := p.s.taxonomyNodes.Get(p.SectionsEntries()...)
 
 	if info == nil {
-		// This should never happpen
-		panic(fmt.Sprintf("invalid taxonomy state for %q with sections %v", p.pathOrTitle(), p.SectionsEntries()))
+		// There can be unused content pages for taxonomies (e.g. author that
+		// has not written anything, yet), and these will not have a taxonomy
+		// node created in the assemble taxonomies step.
+		return nil
 	}
 
 	return info

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -94,7 +94,7 @@ type Site struct {
 
 	Taxonomies TaxonomyList
 
-	taxonomyNodes taxonomyNodeInfos
+	taxonomyNodes *taxonomyNodeInfos
 
 	Sections Taxonomy
 	Info     SiteInfo
@@ -1566,23 +1566,22 @@ func (s *Site) assembleTaxonomies() error {
 		s.Taxonomies[plural] = make(Taxonomy)
 	}
 
-	s.taxonomyNodes = make(taxonomyNodeInfos)
+	s.taxonomyNodes = &taxonomyNodeInfos{
+		m:      make(map[string]*taxonomyNodeInfo),
+		getKey: s.getTaxonomyKey,
+	}
 
 	s.Log.INFO.Printf("found taxonomies: %#v\n", taxonomies)
 
 	for singular, plural := range taxonomies {
-		parent := s.taxonomyNodes.GetOrCreate(plural, "", "")
+		parent := s.taxonomyNodes.GetOrCreate(plural, "")
 		parent.singular = singular
 
 		addTaxonomy := func(plural, term string, weight int, p page.Page) {
 			key := s.getTaxonomyKey(term)
 
-			n := s.taxonomyNodes.GetOrCreate(plural, key, term)
+			n := s.taxonomyNodes.GetOrCreate(plural, term)
 			n.parent = parent
-
-			// There may be different spellings before normalization, so the
-			// last one will win, e.g. "hugo" vs "Hugo".
-			n.term = term
 
 			w := page.NewWeightedPage(weight, p, n.owner)
 

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -117,6 +117,9 @@ permalinkeds:
 	writeNewContentFile(t, fs.Source, "Category Terms", "2017-01-01", "content/categories/_index.md", 10)
 	writeNewContentFile(t, fs.Source, "Tag1 List", "2017-01-01", "content/tags/Tag1/_index.md", 10)
 
+	// https://github.com/gohugoio/hugo/issues/5847
+	writeNewContentFile(t, fs.Source, "Unused Tag List", "2018-01-01", "content/tags/not-used/_index.md", 10)
+
 	err := h.Build(BuildCfg{})
 
 	require.NoError(t, err)
@@ -159,7 +162,7 @@ permalinkeds:
 	// Make sure that each page.KindTaxonomyTerm page has an appropriate number
 	// of page.KindTaxonomy pages in its Pages slice.
 	taxonomyTermPageCounts := map[string]int{
-		"tags":         2,
+		"tags":         3,
 		"categories":   2,
 		"others":       2,
 		"empties":      0,


### PR DESCRIPTION
In Hugo 0.55 we connected the taxonomy nodes with their owning Page.

This failed if you had, say, a content file for a author that did not author anything in the site:

```
content/authors/silent-persin/_index.md
```

Fixes #5847