### PR TITLE
hugolib: Fix Pages reinitialization on rebuilds

### DIFF
--- a/hugolib/hugo_sites_rebuild_test.go
+++ b/hugolib/hugo_sites_rebuild_test.go
@@ -52,13 +52,16 @@ Content.
 
 	b.WithTemplatesAdded("index.html", `
 {{ range (.Paginate .Site.RegularPages).Pages }}
-* Page: {{ .Title }}|Summary: {{ .Summary }}|Content: {{ .Content }}
+* Page Paginate: {{ .Title }}|Summary: {{ .Summary }}|Content: {{ .Content }}
+{{ end }}
+{{ range .Pages }}
+* Page Pages: {{ .Title }}|Summary: {{ .Summary }}|Content: {{ .Content }}
 {{ end }}
 `)
 
 	b.Running().Build(BuildCfg{})
 
-	b.AssertFileContent("public/index.html", "* Page: Page 1|Summary: Initial summary|Content: <p>Content.</p>")
+	b.AssertFileContent("public/index.html", "* Page Paginate: Page 1|Summary: Initial summary|Content: <p>Content.</p>")
 
 	b.EditFiles(contentFilename, `
 ---
@@ -72,6 +75,9 @@ Edited content.
 
 	b.Build(BuildCfg{})
 
-	b.AssertFileContent("public/index.html", "* Page: Page 1 edit|Summary: Edited summary|Content: <p>Edited content.</p>")
+	b.AssertFileContent("public/index.html", "* Page Paginate: Page 1 edit|Summary: Edited summary|Content: <p>Edited content.</p>")
+
+	// https://github.com/gohugoio/hugo/issues/5833
+	b.AssertFileContent("public/index.html", "* Page Pages: Page 1 edit|Summary: Edited summary|Content: <p>Edited content.</p>")
 
 }

--- a/hugolib/page__common.go
+++ b/hugolib/page__common.go
@@ -87,8 +87,7 @@ type pageCommon struct {
 	page.InternalDependencies
 
 	// The children. Regular pages will have none.
-	pages     page.Pages
-	pagesInit sync.Once
+	*pagePages
 
 	// Any bundled resources
 	resources            resource.Resources
@@ -110,4 +109,9 @@ type pageCommon struct {
 
 	// Set in fast render mode to force render a given page.
 	forceRender bool
+}
+
+type pagePages struct {
+	pages     page.Pages
+	pagesInit sync.Once
 }

--- a/hugolib/page__new.go
+++ b/hugolib/page__new.go
@@ -57,6 +57,7 @@ func newPageBase(metaProvider *pageMeta) (*pageState, error) {
 			RefProvider:             page.NopPage,
 			ShortcodeInfoProvider:   page.NopPage,
 			LanguageProvider:        s,
+			pagePages:               &pagePages{},
 
 			InternalDependencies: s,
 			init:                 lazy.New(),

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1630,6 +1630,7 @@ func (s *Site) resetBuildState() {
 	s.init.Reset()
 
 	for _, p := range s.rawAllPages {
+		p.pagePages = &pagePages{}
 		p.subSections = page.Pages{}
 		p.parent = nil
 		p.Scratcher = maps.NewScratcher()


### PR DESCRIPTION
Which had some unpredictable behaviour when using `.Pages` on home page etc. that had a content page.

Fixes #5833