### PR TITLE
Fix menu URL when multiple permalinkable output formats

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1416,7 +1416,8 @@ func (s *Site) getMenusFromConfig() navigation.Menus {
 					}
 
 					menuEntry.MarshallMap(ime)
-					menuEntry.URL = s.Info.createNodeMenuEntryURL(menuEntry.URL)
+					// TODO(bep) clean up all of this
+					menuEntry.ConfiguredURL = s.Info.createNodeMenuEntryURL(menuEntry.ConfiguredURL)
 
 					if ret[name] == nil {
 						ret[name] = navigation.Menu{}
@@ -1477,7 +1478,7 @@ func (s *Site) assembleMenus() {
 				me := navigation.MenuEntry{Identifier: id,
 					Name:   p.LinkTitle(),
 					Weight: p.Weight(),
-					URL:    p.RelPermalink()}
+					Page:   p}
 				flat[twoD{sectionPagesMenu, me.KeyName()}] = &me
 			}
 		}
@@ -1506,7 +1507,7 @@ func (s *Site) assembleMenus() {
 		_, ok := flat[twoD{p.MenuName, p.EntryName}]
 		if !ok {
 			// if parent does not exist, create one without a URL
-			flat[twoD{p.MenuName, p.EntryName}] = &navigation.MenuEntry{Name: p.EntryName, URL: ""}
+			flat[twoD{p.MenuName, p.EntryName}] = &navigation.MenuEntry{Name: p.EntryName}
 		}
 		flat[twoD{p.MenuName, p.EntryName}].Children = childmenu
 	}

--- a/navigation/pagemenus.go
+++ b/navigation/pagemenus.go
@@ -50,9 +50,7 @@ func PageMenusFromPage(p Page) (PageMenus, error) {
 		return nil, nil
 	}
 
-	link := p.RelPermalink()
-
-	me := MenuEntry{Page: p, Name: p.LinkTitle(), Weight: p.Weight(), URL: link}
+	me := MenuEntry{Page: p, Name: p.LinkTitle(), Weight: p.Weight()}
 
 	// Could be the name of the menu to attach it to
 	mname, err := cast.ToStringE(ms)
@@ -81,7 +79,7 @@ func PageMenusFromPage(p Page) (PageMenus, error) {
 	}
 
 	for name, menu := range menus {
-		menuEntry := MenuEntry{Page: p, Name: p.LinkTitle(), URL: link, Weight: p.Weight(), Menu: name}
+		menuEntry := MenuEntry{Page: p, Name: p.LinkTitle(), Weight: p.Weight(), Menu: name}
 		if menu != nil {
 			ime, err := cast.ToStringMapE(menu)
 			if err != nil {
@@ -153,7 +151,7 @@ func (pm *pageMenus) HasMenuCurrent(menuID string, me *MenuEntry) bool {
 
 	// The following logic is kept from back when Hugo had both Page and Node types.
 	// TODO(bep) consolidate / clean
-	nme := MenuEntry{Page: pm.p, Name: pm.p.LinkTitle(), URL: pm.p.RelPermalink()}
+	nme := MenuEntry{Page: pm.p, Name: pm.p.LinkTitle()}
 
 	for _, child := range me.Children {
 		if nme.IsSameResource(child) {
@@ -183,7 +181,7 @@ func (pm *pageMenus) IsMenuCurrent(menuID string, inme *MenuEntry) bool {
 
 	// The following logic is kept from back when Hugo had both Page and Node types.
 	// TODO(bep) consolidate / clean
-	me := MenuEntry{Page: pm.p, Name: pm.p.LinkTitle(), URL: pm.p.RelPermalink()}
+	me := MenuEntry{Page: pm.p, Name: pm.p.LinkTitle()}
 
 	if !me.IsSameResource(inme) {
 		return false


### PR DESCRIPTION
In Hugo `0.55` we introduced the `permalinkable` config attribute on Output Format, default enabled for `AMP` and `HTML`.

This meant that a Page could have different `RelPermalink` and `Permalink` depending on the rendering format.

The menu `URL` did not reflect that fact.

Fixes #5849