### PR TITLE
Fix links for output formats for non-HTML outputs for regular pages

### DIFF
--- a/resources/page/page_paths.go
+++ b/resources/page/page_paths.go
@@ -235,7 +235,7 @@ func CreateTargetPaths(d TargetPathDescriptor) (tp TargetPaths) {
 			pagePath = pjoin(pagePath, d.Type.BaseName+d.Type.MediaType.FullSuffix())
 		}
 
-		if isUgly && !isHtmlIndex(pagePath) {
+		if !isHtmlIndex(pagePath) {
 			link = pagePath
 		}
 


### PR DESCRIPTION
They were not correct for regular pages.

Fixes #5877