### PR TITLE
hugolib: No links for bundled pages

### DIFF
--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -98,6 +98,9 @@ type pageMeta struct {
 	// 3. But you can get it via .Site.GetPage
 	headless bool
 
+	// Set if this page is bundled inside another.
+	bundled bool
+
 	// A key that maps to translation(s) of this page. This value is fetched
 	// from the page front matter.
 	translationKey string

--- a/hugolib/page__new.go
+++ b/hugolib/page__new.go
@@ -166,14 +166,14 @@ func newPageStandalone(m *pageMeta, f output.Format) (*pageState, error) {
 
 }
 
-func newPageWithContent(f *fileInfo, s *Site, content resource.OpenReadSeekCloser) (*pageState, error) {
+func newPageWithContent(f *fileInfo, s *Site, bundled bool, content resource.OpenReadSeekCloser) (*pageState, error) {
 	sections := s.sectionsFromFile(f)
 	kind := s.kindFromFileInfoOrSections(f, sections)
 	if kind == page.KindTaxonomy {
 		s.PathSpec.MakePathsSanitized(sections)
 	}
 
-	metaProvider := &pageMeta{kind: kind, sections: sections, s: s, f: f}
+	metaProvider := &pageMeta{kind: kind, sections: sections, bundled: bundled, s: s, f: f}
 
 	ps, err := newPageBase(metaProvider)
 	if err != nil {

--- a/hugolib/page__paths.go
+++ b/hugolib/page__paths.go
@@ -52,7 +52,9 @@ func newPagePaths(
 
 		var relPermalink, permalink string
 
-		if !pm.headless {
+		// If a page is headless or bundled in another, it will not get published
+		// on its own and it will have no links.
+		if !pm.headless && !pm.bundled {
 			relPermalink = paths.RelPermalink(s.PathSpec)
 			permalink = paths.PermalinkForOutputFormat(s.PathSpec, f)
 		}

--- a/hugolib/pagebundler_handlers.go
+++ b/hugolib/pagebundler_handlers.go
@@ -197,7 +197,7 @@ func (c *contentHandlers) parsePage(h contentHandler) contentHandler {
 			return f, nil
 		}
 
-		ps, err := newPageWithContent(fi, c.s, content)
+		ps, err := newPageWithContent(fi, c.s, ctx.parentPage != nil, content)
 		if err != nil {
 			return handlerResult{err: err}
 		}

--- a/hugolib/pagebundler_test.go
+++ b/hugolib/pagebundler_test.go
@@ -237,10 +237,17 @@ func TestPageBundlerSiteRegular(t *testing.T) {
 								"Short Thumb Width: 56",
 								"1: Image Title: Sunset Galore 1",
 								"1: Image Params: map[myparam:My Sunny Param]",
+								relPermalinker("1: Image RelPermalink: %s/2017/pageslug/sunset1.jpg"),
 								"2: Image Title: Sunset Galore 2",
 								"2: Image Params: map[myparam:My Sunny Param]",
 								"1: Image myParam: Lower: My Sunny Param Caps: My Sunny Param",
+								"0: Page Title: Bundle Galore",
 							)
+
+							// https://github.com/gohugoio/hugo/issues/5882
+							th.assertFileContent(
+								filepath.FromSlash("/work/public/2017/pageslug.html"), "0: Page RelPermalink: |")
+
 							th.assertFileContent(filepath.FromSlash("/work/public/cpath/2017/pageslug.html"), "TheContent")
 
 							// 은행
@@ -642,11 +649,16 @@ Thumb Name: {{ $thumb.Name }}
 Thumb Title: {{ $thumb.Title }}
 Thumb RelPermalink: {{ $thumb.RelPermalink }}
 {{ end }}
-{{ range $i, $e := .Resources.ByType "image" }}
-{{ $i }}: Image Title: {{ .Title }}
-{{ $i }}: Image Name: {{ .Name }}
-{{ $i }}: Image Params: {{ printf "%v" .Params }}
-{{ $i }}: Image myParam: Lower: {{ .Params.myparam }} Caps: {{ .Params.MYPARAM }}
+{{ $types := slice "image" "page" }}
+{{ range $types }}
+{{ $typeTitle := . | title }}
+{{ range $i, $e := $.Resources.ByType . }}
+{{ $i }}: {{ $typeTitle }} Title: {{ .Title }}
+{{ $i }}: {{ $typeTitle }} Name: {{ .Name }}
+{{ $i }}: {{ $typeTitle }} RelPermalink: {{ .RelPermalink }}|
+{{ $i }}: {{ $typeTitle }} Params: {{ printf "%v" .Params }}
+{{ $i }}: {{ $typeTitle }} myParam: Lower: {{ .Params.myparam }} Caps: {{ .Params.MYPARAM }}
+{{ end }}
 {{ end }}
 `
 


### PR DESCRIPTION
This fixes a bug introduced in Hugo 0.55.

Fixes #5882