### PR TITLE
i18n: Avoid rebuilding the Translations map for every lookup

### DIFF
--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gohugoio/hugo/helpers"
 
 	"github.com/nicksnyder/go-i18n/i18n/bundle"
+	"github.com/nicksnyder/go-i18n/i18n/translation"
 )
 
 var (
@@ -64,6 +65,8 @@ func (t Translator) initFuncs(bndl *bundle.Bundle) {
 		t.logger.INFO.Printf("No translation bundle found for default language %q", defaultContentLanguage)
 	}
 
+	translations := bndl.Translations()
+
 	enableMissingTranslationPlaceholders := t.cfg.GetBool("enableMissingTranslationPlaceholders")
 	for _, lang := range bndl.LanguageTags() {
 		currentLang := lang
@@ -82,7 +85,7 @@ func (t Translator) initFuncs(bndl *bundle.Bundle) {
 			// then Tfunc returns translationID itself.
 			// But if user set same translationID and translation, we should check
 			// if it really untranslated:
-			if isIDTranslated(currentLang, translationID, bndl) {
+			if isIDTranslated(translations, currentLang, translationID) {
 				return translated
 			}
 
@@ -97,7 +100,7 @@ func (t Translator) initFuncs(bndl *bundle.Bundle) {
 				if translated != translationID {
 					return translated
 				}
-				if isIDTranslated(defaultContentLanguage, translationID, bndl) {
+				if isIDTranslated(translations, defaultContentLanguage, translationID) {
 					return translated
 				}
 			}
@@ -106,9 +109,9 @@ func (t Translator) initFuncs(bndl *bundle.Bundle) {
 	}
 }
 
-// If bndl contains the translationID for specified currentLang,
+// If the translation map contains translationID for specified currentLang,
 // then the translationID is actually translated.
-func isIDTranslated(lang, id string, b *bundle.Bundle) bool {
-	_, contains := b.Translations()[lang][id]
+func isIDTranslated(translations map[string]map[string]translation.Translation, lang, id string) bool {
+	_, contains := translations[lang][id]
 	return contains
 }


### PR DESCRIPTION
```bash
benchmark                                                    old ns/op     new ns/op     delta
BenchmarkI18nTranslate/all-present-4                         764           757           -0.92%
BenchmarkI18nTranslate/present-in-default-4                  2578          1457          -43.48%
BenchmarkI18nTranslate/present-in-current-4                  764           766           +0.26%
BenchmarkI18nTranslate/missing-4                             3362          1103          -67.19%
BenchmarkI18nTranslate/file-missing-4                        4646          3611          -22.28%
BenchmarkI18nTranslate/context-provided-4                    2013          2014          +0.05%
BenchmarkI18nTranslate/same-id-and-translation-4             1961          784           -60.02%
BenchmarkI18nTranslate/same-id-and-translation-default-4     3717          1405          -62.20%
BenchmarkI18nTranslate/unknown-language-code-4               1775          1787          +0.68%

benchmark                                                    old allocs     new allocs     delta
BenchmarkI18nTranslate/all-present-4                         6              6              +0.00%
BenchmarkI18nTranslate/present-in-default-4                  16             10             -37.50%
BenchmarkI18nTranslate/present-in-current-4                  6              6              +0.00%
BenchmarkI18nTranslate/missing-4                             20             8              -60.00%
BenchmarkI18nTranslate/file-missing-4                        27             21             -22.22%
BenchmarkI18nTranslate/context-provided-4                    15             15             +0.00%
BenchmarkI18nTranslate/same-id-and-translation-4             12             6              -50.00%
BenchmarkI18nTranslate/same-id-and-translation-default-4     22             10             -54.55%
BenchmarkI18nTranslate/unknown-language-code-4               13             13             +0.00%

benchmark                                                    old bytes     new bytes     delta
BenchmarkI18nTranslate/all-present-4                         152           152           +0.00%
BenchmarkI18nTranslate/present-in-default-4                  1144          216           -81.12%
BenchmarkI18nTranslate/present-in-current-4                  152           152           +0.00%
BenchmarkI18nTranslate/missing-4                             2008          152           -92.43%
BenchmarkI18nTranslate/file-missing-4                        1208          600           -50.33%
BenchmarkI18nTranslate/context-provided-4                    704           704           +0.00%
BenchmarkI18nTranslate/same-id-and-translation-4             1080          152           -85.93%
BenchmarkI18nTranslate/same-id-and-translation-default-4     2073          216           -89.58%
BenchmarkI18nTranslate/unknown-language-code-4               696           696           +0.00%
```

Fixes #5892