### PR TITLE
output: Fix permalink in sitemap etc. when multiple permalinkable output formats

### DIFF
--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -35,7 +35,7 @@ type siteRenderContext struct {
 	sitesOutIdx int
 
 	// Zero based index of the output formats configured within a Site.
-	// Note that these outputs are sorted, so CSS will come before HTML.
+	// Note that these outputs are sorted.
 	outIdx int
 
 	multihost bool

--- a/hugolib/sitemap_test.go
+++ b/hugolib/sitemap_test.go
@@ -100,3 +100,22 @@ func TestParseSitemap(t *testing.T) {
 	}
 
 }
+
+// https://github.com/gohugoio/hugo/issues/5910
+func TestSitemapOutputFormats(t *testing.T) {
+
+	b := newTestSitesBuilder(t).WithSimpleConfigFile()
+
+	b.WithContent("blog/html-amp.md", `
+---
+Title: AMP and HTML
+outputs: [ "html", "amp" ]
+---
+
+`)
+
+	b.Build(BuildCfg{})
+
+	// Should link to the HTML version.
+	b.AssertFileContent("public/sitemap.xml", " <loc>http://example.com/blog/html-amp/</loc>")
+}

--- a/output/outputFormat_test.go
+++ b/output/outputFormat_test.go
@@ -15,6 +15,7 @@ package output
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/gohugoio/hugo/media"
@@ -224,4 +225,26 @@ func TestDecodeFormats(t *testing.T) {
 			test.assert(t, test.name, result)
 		}
 	}
+}
+
+func TestSort(t *testing.T) {
+	assert := require.New(t)
+	assert.Equal("HTML", DefaultFormats[0].Name)
+	assert.Equal("AMP", DefaultFormats[1].Name)
+
+	json := JSONFormat
+	json.Weight = 1
+
+	formats := Formats{
+		AMPFormat,
+		HTMLFormat,
+		json,
+	}
+
+	sort.Sort(formats)
+
+	assert.Equal("JSON", formats[0].Name)
+	assert.Equal("HTML", formats[1].Name)
+	assert.Equal("AMP", formats[2].Name)
+
 }


### PR DESCRIPTION
In Hugo 0.55.0 we made AMP `permalinkable`. We also render the output formats in their natural sort order, meaning
`AMP` will be rendered before `HTML`. References in the sitemap would then point to the AMP version,
and this is normally not what you'd want.

This commit fixes that by making `HTML` by default sort before the others. If this is not you want, you can set `weight` on
the output format configuration.

Fixes #5910