### PR TITLE
Workaround/fix for relative urls in css url function.

### DIFF
--- a/transform/urlreplacers/absurlreplacer.go
+++ b/transform/urlreplacers/absurlreplacer.go
@@ -46,6 +46,7 @@ type prefix struct {
 func newPrefixState() []*prefix {
 	return []*prefix{
 		{b: []byte("src="), f: checkCandidateBase},
+		{b: []byte("url("), f: checkCandidateBase},
 		{b: []byte("href="), f: checkCandidateBase},
 		{b: []byte("action="), f: checkCandidateBase},
 		{b: []byte("srcset="), f: checkCandidateSrcset},


### PR DESCRIPTION
Fixes the issue where

	background-image: url("/images/myimage.png")
would not translate to relative urls e.g:

	background-image: url("../images/myimage.png")