### PR TITLE
deploy: Support invalidating a CloudFront CDN cache

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -68,6 +68,7 @@ func newDeployCmd() *deployCmd {
 	cc.cmd.Flags().Bool("confirm", false, "ask for confirmation before making changes to the target")
 	cc.cmd.Flags().Bool("dryRun", false, "dry run")
 	cc.cmd.Flags().Bool("force", false, "force upload of all files")
+	cc.cmd.Flags().Bool("invalidateCDN", true, "invalidate the CDN cache via the CloudFrontDistributionID listed in the deployment target")
 	cc.cmd.Flags().Int("maxDeletes", 256, "maximum # of files to delete, or -1 to disable")
 
 	return cc

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -213,6 +213,7 @@ func initializeFlags(cmd *cobra.Command, cfg config.Provider) {
 		"force",
 		"gc",
 		"i18n-warnings",
+		"invalidateCDN",
 		"layoutDir",
 		"logFile",
 		"maxDeletes",

--- a/deploy/cloudfront.go
+++ b/deploy/cloudfront.go
@@ -1,0 +1,51 @@
+// Copyright 2019 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+)
+
+// InvalidateCloudFront invalidates the CloudFront cache for distributionID.
+// It uses the default AWS credentials from the environment.
+func InvalidateCloudFront(ctx context.Context, distributionID string) error {
+	// SharedConfigEnable enables loading "shared config (~/.aws/config) and
+	// shared credentials (~/.aws/credentials) files".
+	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more
+	// details.
+	// This is the same codepath used by Go CDK when creating an s3 URL.
+	// TODO: Update this to a Go CDK helper once available
+	// (https://github.com/google/go-cloud/issues/2003).
+	sess, err := session.NewSessionWithOptions(session.Options{SharedConfigState: session.SharedConfigEnable})
+	if err != nil {
+		return err
+	}
+	req := &cloudfront.CreateInvalidationInput{
+		DistributionId: aws.String(distributionID),
+		InvalidationBatch: &cloudfront.InvalidationBatch{
+			CallerReference: aws.String(time.Now().Format("20060102150405")),
+			Paths: &cloudfront.Paths{
+				Items:    []*string{aws.String("/*")},
+				Quantity: aws.Int64(1),
+			},
+		},
+	}
+	_, err = cloudfront.New(sess).CreateInvalidationWithContext(ctx, req)
+	return err
+}

--- a/deploy/deployConfig.go
+++ b/deploy/deployConfig.go
@@ -32,6 +32,8 @@ type deployConfig struct {
 type target struct {
 	Name string
 	URL  string
+
+	CloudFrontDistributionID string
 }
 
 // matcher represents configuration to be applied to files whose paths match

--- a/deploy/deployConfig_test.go
+++ b/deploy/deployConfig_test.go
@@ -32,9 +32,12 @@ someOtherValue = "foo"
 [[deployment.targets]]
 Name = "name1"
 URL = "url1"
+CloudFrontDistributionID = "cdn1"
+
 [[deployment.targets]]
 name = "name2"
 url = "url2"
+cloudfrontdistributionid = "cdn2"
 
 [[deployment.matchers]]
 Pattern = "^pattern1$"
@@ -59,8 +62,10 @@ content-type = "contenttype2"
 	assert.Equal(2, len(dcfg.Targets))
 	assert.Equal("name1", dcfg.Targets[0].Name)
 	assert.Equal("url1", dcfg.Targets[0].URL)
+	assert.Equal("cdn1", dcfg.Targets[0].CloudFrontDistributionID)
 	assert.Equal("name2", dcfg.Targets[1].Name)
 	assert.Equal("url2", dcfg.Targets[1].URL)
+	assert.Equal("cdn2", dcfg.Targets[1].CloudFrontDistributionID)
 
 	assert.Equal(2, len(dcfg.Matchers))
 	assert.Equal("^pattern1$", dcfg.Matchers[0].Pattern)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
 	github.com/alecthomas/chroma v0.6.3
 	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 // indirect
+	github.com/aws/aws-sdk-go v1.16.23
 	github.com/bep/debounce v1.2.0
 	github.com/bep/gitmap v1.0.0
 	github.com/bep/go-tocss v0.6.0


### PR DESCRIPTION
Fixes #5929.

* Adds a `invalidateCDN` boolean flag (defaults to true) that enables invalidation of a CloudFront CDN cache if any files changed during the "deploy".
* The CloudFront `DistributionID` is configured as part of the `target` in the config.
* Only CloudFront is supported for now, but other providers could be added.
* The invalidation is for the entire cache, not per-file. `s3deploy` supports a more complicated version which tries to invalidate individual files, but falls back to invalidating the entire cache if more than 8 files have changed. That added a lot of complexity in terms of keeping track of files changes, mapping paths, etc., and my guess is that a fairly high percentage of the time more than 8 files changed anyway, so I'd like to start with this.