### PR TITLE
deploy: Support configuration of upload order

### DIFF
--- a/deploy/deployConfig.go
+++ b/deploy/deployConfig.go
@@ -27,6 +27,9 @@ const deploymentConfigKey = "deployment"
 type deployConfig struct {
 	Targets  []*target
 	Matchers []*matcher
+	Order    []string
+
+	ordering []*regexp.Regexp // compiled Order
 }
 
 type target struct {
@@ -85,6 +88,13 @@ func decodeConfig(cfg config.Provider) (deployConfig, error) {
 		if err != nil {
 			return dcfg, fmt.Errorf("invalid deployment.matchers.pattern: %v", err)
 		}
+	}
+	for _, o := range dcfg.Order {
+		re, err := regexp.Compile(o)
+		if err != nil {
+			return dcfg, fmt.Errorf("invalid deployment.orderings.pattern: %v", err)
+		}
+		dcfg.ordering = append(dcfg.ordering, re)
 	}
 	return dcfg, nil
 }


### PR DESCRIPTION
Fixes #5932.

Adds support for ordering of uploads, via a sequence of regular expressions configured in the `order` config under `deployments`. Uploads are sorted by path by default, but paths that match one of the `order` regexes are uploaded in that order.

I think this is similar to https://github.com/bep/s3deploy/pull/37, but (IMO) simpler.