### PR TITLE
dockerfile:  Switch base image for final build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN go install -ldflags '-w -extldflags "-static"' -tags ${BUILD_TAGS}
 
 # ---
 
-FROM scratch
+FROM alpine:3.9
+RUN apk add --no-cache ca-certificates
 COPY --from=build /go/bin/hugo /hugo
 ARG  WORKDIR="/site"
 WORKDIR ${WORKDIR}


### PR DESCRIPTION
Switching the base image for the final build to alpine as it still
provides a minimal interface, but has a mechanism for easily including
relevant CA certificates.  This is currently pinned to a tagged version,
though since none of the underlying mechanisms are used this should
balance both remaining stable, supported for a period of time, and
providing usable functionality.

Resolves #5970
Affects #5056