### PR TITLE
Fix nextStepsText() description

### DIFF
--- a/commands/new_site.go
+++ b/commands/new_site.go
@@ -149,7 +149,7 @@ func nextStepsText() string {
 	nextStepsText.WriteString(`Just a few more steps and you're ready to go:
 
 1. Download a theme into the same-named folder.
-   Choose a theme from https://themes.gohugo.io/, or
+   Choose a theme from https://themes.gohugo.io/ or 
    create your own with the "hugo new theme <THEMENAME>" command.
 2. Perhaps you want to add some content. You can add single files
    with "hugo new `)


### PR DESCRIPTION
Fix function `nextStepsText()` (`./commands/new_site.go`):

- Delete comma in description at line 152.

Reasons:

- [VS Code] After `hugo new site <NAME>`, if click (CMD+Click) on the themes Hugo link, browser go to wrong address `https://themes.gohugo.io/,` (with ended comma) and show 404 Error page.

![Screenshot 2019-05-26 at 11 27 23](https://user-images.githubusercontent.com/11155743/58379304-57758c00-7faa-11e9-9df8-a51527a453a5.png)

![Screenshot 2019-05-26 at 11 28 10](https://user-images.githubusercontent.com/11155743/58379305-57758c00-7faa-11e9-8264-b0e51d1d41b9.png)