### PR TITLE
Add safety barrier between concatenated javascript resources

### DIFF
--- a/hugolib/resource_chain_test.go
+++ b/hugolib/resource_chain_test.go
@@ -244,6 +244,13 @@ T2: Content: {{ $combinedText.Content }}|{{ $combinedText.RelPermalink }}
 {{ $css := "body { color: blue; }" | resources.FromString "styles.css" }}
 {{ $minified := resources.Get "css/styles1.css" | minify }}
 {{ slice $css $minified | resources.Concat "bundle/mixed.css" }} 
+{{/* https://github.com/gohugoio/hugo/issues/5403 */}}
+{{ $d := "function D {} // A comment" | resources.FromString "d.js"}}
+{{ $e := "(function E {})" | resources.FromString "e.js"}}
+{{ $f := "(function F {})()" | resources.FromString "f.js"}}
+{{ $jsResources := .Resources.Match "*.js" }}
+{{ $combinedJs := slice $d $e $f | resources.Concat "bundle/concatjs.js" }}
+T3: Content: {{ $combinedJs.Content }}|{{ $combinedJs.RelPermalink }}
 `)
 		}, func(b *sitesBuilder) {
 			b.AssertFileContent("public/index.html", `T1: Content: ABC|RelPermalink: /bundle/concat.txt|Permalink: http://example.com/bundle/concat.txt|MediaType: text/plain`)
@@ -251,6 +258,17 @@ T2: Content: {{ $combinedText.Content }}|{{ $combinedText.RelPermalink }}
 
 			b.AssertFileContent("public/index.html", `T2: Content: t1t|t2t|`)
 			b.AssertFileContent("public/bundle/concattxt.txt", "t1t|t2t|")
+
+			b.AssertFileContent("public/index.html", `T3: Content: function D {} // A comment
+;
+(function E {})
+;
+(function F {})()|`)
+			b.AssertFileContent("public/bundle/concatjs.js", `function D {} // A comment
+;
+(function E {})
+;
+(function F {})()`)
 		}},
 		{"fromstring", func() bool { return true }, func(b *sitesBuilder) {
 			b.WithTemplates("home.html", `


### PR DESCRIPTION
Adds a `\n;\n` between concatenated JavaScript files to ensure that the combined files are interpreted the same as if they were loaded separately.  There are a variety of ways that just straight concatenation can change the result but here are two examples:

<hr>

File A: `# A comment` 
File B: `console.log("Hello world");`

(In the real world, the most common time you'd hit this is pre-minified source files that end with a `#sourceMap=...` comment on their last line)

Before: 
```
# A commentconsole.log("Hello world");
```
Result: Nothing is printed because the entire combined file is a comment.

After: 
```
# A comment
;
console.log("Hello world")
```
Result: Hello world is printed to the console.

<hr>

File A: `(function A() {})()`
File B: `(function B() {})()`

Before:
```
(function A() {})()(function B() {}())
```
Result: "undefined is not a function" error, or similar. `(function A() {})()` is evaluated and returns nothing in this case, then `(function B() {})` is now interpreted to be parameters to use to invoke the previous (undefined) result.  

After:
```
(function A() {})()
;
(function B() {}())

```
Result: Both IIFEs are evaluated independently as expected.


<hr>

Fixes #5403