### PR TITLE
tpl: Add support to sort and where to access elements of a slice

### DIFF
--- a/tpl/collections/where.go
+++ b/tpl/collections/where.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -332,6 +333,20 @@ func evaluateSubElem(obj reflect.Value, elemName string) (reflect.Value, error) 
 			return obj.MapIndex(kv), nil
 		}
 		return zero, fmt.Errorf("%s isn't a key of map type %s", elemName, typ)
+	case reflect.Slice:
+		// If obj is a slice then access the elemName-index element
+		index, err := strconv.Atoi(elemName)
+		if err != nil {
+			return zero, fmt.Errorf("%s isn't a valid index of type int", elemName)
+		}
+
+		sl := obj.Interface().([]string)
+		if len(sl) <= index || index < 0 {
+			return zero, fmt.Errorf("index is out of bounds")
+		}
+
+		var val interface{} = sl[index]
+		return reflect.ValueOf(val), nil
 	}
 	return zero, fmt.Errorf("%s is neither a struct field, a method nor a map element of type %s", elemName, typ)
 }

--- a/tpl/collections/where_test.go
+++ b/tpl/collections/where_test.go
@@ -725,7 +725,10 @@ func TestEvaluateSubElem(t *testing.T) {
 		{reflect.ValueOf((*TstX)(nil)), "A", false},
 		{reflect.ValueOf(tstx), "C", false},
 		{reflect.ValueOf(map[int]string{1: "foo", 2: "bar"}), "1", false},
-		{reflect.ValueOf([]string{"foo", "bar"}), "1", false},
+		{reflect.ValueOf([]string{"foo", "bar"}), "0", "foo"},
+		{reflect.ValueOf([]string{"foo", "bar"}), "1", "bar"},
+		{reflect.ValueOf([]string{"foo", "bar"}), "-1", false},
+		{reflect.ValueOf([]string{"foo", "bar"}), "3", false},
 	} {
 		result, err := evaluateSubElem(test.value, test.key)
 		if b, ok := test.expect.(bool); ok && !b {


### PR DESCRIPTION
Template functions sort and where accept a key in order to perform their taks. However when the key is a slice it is not possible to access elements using their index. This commit adds support to access elements of a slice by appending a period followed by the element's index.

For example:
`{{ range (sort .Pages ".Params.dates.0") }}`
will sort the pages by using the first element of the slice
.Params.dates


This is a possible solution to: #6018

If the proposed solution is viable I can update the documentation to reflect the changes.