### PR TITLE
Add NoSuffix output format option to support MultiViews-style content negotiation

### DIFF
--- a/output/outputFormat.go
+++ b/output/outputFormat.go
@@ -79,6 +79,12 @@ type Format struct {
 	// behaviour is wanted.
 	Permalinkable bool `json:"permalinkable"`
 
+	// Enable NoSuffix to omit the MediaType suffix of links to
+	// Pages rendered with this output format.  It is up to the
+	// server to map URIs to the correct file (for example, with
+	// Apache's MultiViews option).
+	NoSuffix bool `json:"noSuffix"`
+
 	// Setting this to a non-zero value will be used as the first sort criteria.
 	Weight int `json:"weight"`
 }

--- a/resources/page/page_paths.go
+++ b/resources/page/page_paths.go
@@ -306,6 +306,10 @@ func CreateTargetPaths(d TargetPathDescriptor) (tp TargetPaths) {
 		link = slash + link
 	}
 
+	if isUgly && d.Type.NoSuffix {
+		link = strings.TrimSuffix(link, d.Type.MediaType.FullSuffix())
+	}
+
 	linkDir = strings.TrimSuffix(path.Join(slash, linkDir), slash)
 
 	// Note: MakePathSanitized will lower case the path if


### PR DESCRIPTION
If the noSuffix option is set on an output format and uglyURLs are enabled, strip the MediaType.FullSuffix() from links to the Page. The intent is to support Apache MultiViews-style content negotiation (see #5618) on such links.

For example, given a config.toml with
```toml
[outputFormats.HTML]
noSuffix = true
```
example.md would be rendered to example.html but links to it would be simply example, without a suffix. I'm still looking into how to do language negotiation (for example, creating files example.en.html and example.fr.html).