### PR TITLE
Org mode improvements (extend markdownify to support all markup formats)

### DIFF
--- a/docs/content/en/functions/markdownify.md
+++ b/docs/content/en/functions/markdownify.md
@@ -1,7 +1,7 @@
 ---
 title: markdownify
 linktitle: markdownify
-description: Runs the provided string through the Markdown processor.
+description: Runs the provided string through the Markdown processor. Takes an optional options map specifying the markup format.
 godocref:
 date: 2017-02-01
 publishdate: 2017-02-01
@@ -19,7 +19,8 @@ deprecated: false
 aliases: []
 ---
 
-
 ```
 {{ .Title | markdownify }}
+{{ .Title | markdownify (dict "format" "org") }}
+{{ .Title | markdownify (dict "format" "asciidoc") }}
 ```

--- a/tpl/transform/init.go
+++ b/tpl/transform/init.go
@@ -78,6 +78,8 @@ func init() {
 			[]string{"markdownify"},
 			[][2]string{
 				{`{{ .Title | markdownify}}`, `<strong>BatMan</strong>`},
+				{`{{ "*BatMan*" | markdownify (dict "format" "org")}}`, `<strong>BatMan</strong>`},
+				{`{{ "**BatMan**" | markdownify (dict "format" "markdown")}}`, `<strong>BatMan</strong>`},
 			},
 		)
 

--- a/tpl/transform/transform.go
+++ b/tpl/transform/transform.go
@@ -19,6 +19,7 @@ import (
 	"html/template"
 
 	"github.com/gohugoio/hugo/cache/namedmemcache"
+	"github.com/pkg/errors"
 
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/helpers"
@@ -91,17 +92,24 @@ func (ns *Namespace) HTMLUnescape(s interface{}) (string, error) {
 }
 
 // Markdownify renders a given input from Markdown to HTML.
-func (ns *Namespace) Markdownify(s interface{}) (template.HTML, error) {
-	ss, err := cast.ToStringE(s)
+func (ns *Namespace) Markdownify(args ...interface{}) (template.HTML, error) {
+	if len(args) == 0 || len(args) > 2 {
+		return "", errors.New("markdownify takes 1 or 2 arguments")
+	}
+	s, err := cast.ToStringE(args[len(args)-1])
 	if err != nil {
 		return "", err
 	}
 
+	options := map[string]string{"format": "markdown"}
+	if len(args) == 2 {
+		options = cast.ToStringMapString(args[0])
+	}
 	m := ns.deps.ContentSpec.RenderBytes(
 		&helpers.RenderingContext{
 			Cfg:     ns.deps.Cfg,
-			Content: []byte(ss),
-			PageFmt: "markdown",
+			Content: []byte(s),
+			PageFmt: options["format"],
 			Config:  ns.deps.ContentSpec.BlackFriday,
 		},
 	)


### PR DESCRIPTION
- document org front matter format
- introduce htmlify (#5589)