### PR TITLE
Deleting unnecessary javascript

### DIFF
--- a/docs/content/en/content-management/formats.md
+++ b/docs/content/en/content-management/formats.md
@@ -172,17 +172,6 @@ MathJax.Hub.Config({
 });
 </script>
 
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Queue(function() {
-    // Fix <code> tags after MathJax finishes running. This is a
-    // hack to overcome a shortcoming of Markdown. Discussion at
-    // https://github.com/mojombo/jekyll/issues/199
-    var all = MathJax.Hub.getAllJax(), i;
-    for(i = 0; i < all.length; i += 1) {
-        all[i].SourceElement().parentNode.className += ' has-jax';
-    }
-});
-</script>
 {{< /code >}}
 
 


### PR DESCRIPTION
This chunk of code now seems to break MathJax, rather than help!  Deleting seems to allow me to see Latex rendered when viewing my website under Chrome.

https://stackoverflow.com/questions/56648378/rendering-latex-on-hugo-websites-with-mathjax