### PR TITLE
Remove type="application/javascript" type from Analytics

### DIFF
--- a/tpl/tplimpl/embedded/templates/google_analytics_async.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics_async.html
@@ -1,7 +1,7 @@
 {{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
 {{- if not $pc.Disable -}}
 {{ with .Site.GoogleAnalytics }}
-<script type="application/javascript">
+<script>
 {{ template "__ga_js_set_doNotTrack" $ }}
 if (!doNotTrack) {
 	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;


### PR DESCRIPTION
This PR removes ` type="application/javascript"` from Google Analytics snippet. If type was to be used it should be ` type="text/javascript"`, but the type isn't needed to be there anyway.

REF:
- https://google.github.io/styleguide/htmlcssguide.html#type_Attributes
- https://codeguide.co/#html-style-script
- https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tracking_snippet