### PR TITLE
Removed comma after URL in new site output

### DIFF
--- a/commands/new_site.go
+++ b/commands/new_site.go
@@ -149,7 +149,7 @@ func nextStepsText() string {
 	nextStepsText.WriteString(`Just a few more steps and you're ready to go:
 
 1. Download a theme into the same-named folder.
-   Choose a theme from https://themes.gohugo.io/, or
+   Choose a theme from https://themes.gohugo.io/ or
    create your own with the "hugo new theme <THEMENAME>" command.
 2. Perhaps you want to add some content. You can add single files
    with "hugo new `)


### PR DESCRIPTION
This PR makes a small change to the message printed when running `hugo new site`.

Some terminals (e.g. VS Code) include the comma in the URL when hyperlinking, resulting in a 404.

![image](https://user-images.githubusercontent.com/3883947/59798348-cc9e5d80-92d9-11e9-98ad-3c8523d77a68.png)
