### PR TITLE
FIX: Do not trigger warning when a user customizes a theme's data files

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -868,7 +868,7 @@ func (h *HugoSites) handleDataFile(r source.ReadableFile) error {
 			higherPrecedentMap := higherPrecedentData.(map[string]interface{})
 			for key, value := range data.(map[string]interface{}) {
 				if _, exists := higherPrecedentMap[key]; exists {
-					h.Log.WARN.Printf("Data for key '%s' in path '%s' is overridden by higher precedence data already in the data tree", key, r.Path())
+					h.Log.INFO.Printf("Data for key '%s' in path '%s' is overridden by higher precedence data already in the data tree", key, r.Path())
 				} else {
 					higherPrecedentMap[key] = value
 				}


### PR DESCRIPTION
A recent change was made to `hugo_sites.go` which caused a warning to be generated and displayed in `hugo` command output when a user purposely overrides the data file of a theme to customize parameters.

Overriding files is a *feature* of Hugo and should not generate Warnings/Errors in this scenario of a user customizing a theme's data files.

This PR fixes that logging bug that was introduced by correcting the log level from WARN to INFO.

See https://discourse.gohugo.io/t/hugo-bug-warning-higher-precedence-data-already-in-the-data-tree/19236