### PR TITLE
Always load GitHub Gists over HTTPS

### DIFF
--- a/tpl/tplimpl/embedded/templates/shortcodes/gist.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/gist.html
@@ -1,1 +1,1 @@
-<script type="application/javascript" src="//gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }}?file={{ index .Params 2 }}{{end}}"></script>
+<script type="application/javascript" src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }}?file={{ index .Params 2 }}{{end}}"></script>


### PR DESCRIPTION
Specify gists to always load over HTTPS by specifying the protocol.