### PR TITLE
common/maps: Do not return error on params dot access on incompatible types

### DIFF
--- a/common/maps/params.go
+++ b/common/maps/params.go
@@ -16,8 +16,6 @@ package maps
 import (
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/spf13/cast"
 )
 
@@ -72,7 +70,7 @@ func traverseNestedParams(keySegments []string, lookupFn func(key string) interf
 		v, key, owner := traverseParams(rest, m)
 		return v, key, owner, nil
 	default:
-		return nil, "", nil, errors.Errorf("unsupported Params type: %T", result)
+		return nil, "", nil, nil
 	}
 }
 

--- a/common/maps/params_test.go
+++ b/common/maps/params_test.go
@@ -22,10 +22,14 @@ import (
 func TestGetNestedParam(t *testing.T) {
 
 	m := map[string]interface{}{
+		"string":          "value",
 		"first":           1,
 		"with_underscore": 2,
 		"nested": map[string]interface{}{
 			"color": "blue",
+			"nestednested": map[string]interface{}{
+				"color": "green",
+			},
 		},
 	}
 
@@ -41,5 +45,7 @@ func TestGetNestedParam(t *testing.T) {
 	assert.Equal(1, must("First", "_", m))
 	assert.Equal(2, must("with_underscore", "_", m))
 	assert.Equal("blue", must("nested_color", "_", m))
+	assert.Equal("green", must("nested.nestednested.color", ".", m))
+	assert.Nil(must("string.name", ".", m))
 
 }


### PR DESCRIPTION
This error was introduced in 0.56 and has shown some site breakage in the wild.

Fixes #6121