### PR TITLE
Config flag to disable root domain redirect when default language in …

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -559,6 +559,7 @@ type SiteInfo struct {
 	s                              *Site
 	language                       *langs.Language
 	defaultContentLanguageInSubdir bool
+	disableDefaultLanguageSubdirRedir bool
 	sectionPagesMenu               string
 }
 

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -349,6 +349,12 @@ func (s *Site) renderMainLanguageRedirect() error {
 		return nil
 	}
 
+	if s.Cfg.GetBool("disableDefaultLanguageSubdirRedir") {
+		// Do not generate the redirect to default language in subfolder.
+		// todo( Write in docs how to use URL front-matter to place  the /index.html file.
+		return nil
+	}
+
 	html, found := s.outputFormatsConfig.GetByName("HTML")
 	if found {
 		mainLang := s.h.multilingual.DefaultLang


### PR DESCRIPTION
Following with #6064 , I created a simple patch with a flag for config files:
disableDefaultLanguageSubdirRedir can be set to True or False:
When the config flag: defaultContentLanguageInSubdir is set to True, Hugo manually creates a redirect file in the alias format that redirects from the root domain to the subfolder for the language.

* When the key is not present Hugo behaves according to its defaults: the alias at the root path of /index.html will redirect to the default language subfolder,
* The same will be true when this key will be set to False,
* When this key will be set to True the alias file at: /index.html wil not be created.

Things still to consider:
* Updating the docs with simple instruction on how to use: URL front-matter variable to create a /index.html file for the default language, so it is not placed in teh subfolder,
* Maybe changing he config flag name to: disableDefaultLanguageRootRedirect to combine the case of the root domain and default langauge in subdir setting,
* Adding the code to handle this flag and generate this file automatically.

The rational behind this fix is that most if not all websites have content at their root / baseURL in Hugo's terminology. This alias with a redirect was created manually, and was not possible to be overwridden with regular Hugo's logic where content with the same filename overwrites the alias file of the same name.
It changes just 5 lines of code, has no sideeffects when the key is not present.