### PR TITLE
hugolib: Fix draft etc. handling of _index.md pages

### DIFF
--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -67,6 +67,10 @@ func newPageContentOutput(p *pageState) func(f output.Format) (*pageContentOutpu
 		}
 
 		initContent := func() (err error) {
+			if p.cmap == nil {
+				// Nothing to do.
+				return nil
+			}
 			defer func() {
 				// See https://github.com/gohugoio/hugo/issues/6210
 				if r := recover(); r != nil {

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -352,3 +352,33 @@ categories: ["regular"]
 	b.Assert(dra, qt.IsNil)
 
 }
+
+// See https://github.com/gohugoio/hugo/issues/6222
+// We need to revisit this once we figure out what to do with the
+// draft etc _index pages, but for now we need to avoid the crash.
+func TestTaxonomiesIndexDraft(t *testing.T) {
+	t.Parallel()
+
+	b := newTestSitesBuilder(t)
+	b.WithContent(
+		"categories/_index.md", `---
+title: "The Categories"
+draft: true
+---
+
+This is the invisible content.
+
+`)
+
+	b.WithTemplates("index.html", `
+{{ range .Site.Pages }}
+{{ .RelPermalink }}|{{ .Title }}|{{ .WordCount }}|{{ .Content }}|
+{{ end }}
+`)
+
+	b.Build(BuildCfg{})
+
+	// We publish the index page, but the content will be empty.
+	b.AssertFileContent("public/index.html", " /categories/|The Categories|0||")
+
+}


### PR DESCRIPTION
We will need to revisit this with a proper spec, but this commit makes sure that draft/expiryDate etc. set in front matter on _index.md content files that should disable the page will:

* Not crash
* Make the rendered page not render any `.Content`.

Fixes #6222
Fixes #6210