### PR TITLE
hugolib: Change to output non-panic error message if missing shortcode template

### DIFF
--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -473,9 +473,10 @@ Loop:
 				pt.Backup()
 				nested, err := s.extractShortcode(nestedOrdinal, nextLevel, pt)
 				nestedOrdinal++
-				if nested.name != "" {
+				if nested != nil && nested.name != "" {
 					s.nameSet[nested.name] = true
 				}
+
 				if err == nil {
 					sc.inner = append(sc.inner, nested)
 				} else {


### PR DESCRIPTION
A panic occurred when the `nested` variable was nil.
Changed to check if the `nested` variable is nil.

Fixes #6075