### PR TITLE
Keep ".git" file in in --cleanDestinationDir

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -636,7 +636,7 @@ func (c *commandeer) copyStaticTo(sourceFs *filesystems.SourceFilesystem) (uint6
 		c.logger.INFO.Println("removing all files from destination that don't exist in static dirs")
 
 		syncer.DeleteFilter = func(f os.FileInfo) bool {
-			return f.IsDir() && strings.HasPrefix(f.Name(), ".")
+			return (f.IsDir() && strings.HasPrefix(f.Name(), ".")) || (!f.IsDir() && f.Name() == ".git")
 		}
 	}
 	c.logger.INFO.Println("syncing static files to", publishDir)


### PR DESCRIPTION
Ignore files specifically called ".git" in order to preserve submodule information for Git post-1.7.8 (which seems to be the point things changed from having an entire “.git” directory inside the submodule to having a “.git” _file_ pointing to a gitdir outside of the submodule)

This should restore what I believe was the intended behaviour of #3202 and fix the issue for pojebunny in #4546

See #3202 and #4546