### PR TITLE
Escape RSS description as XML

### DIFF
--- a/docs/content/en/functions/xmlEscape.md
+++ b/docs/content/en/functions/xmlEscape.md
@@ -1,0 +1,28 @@
+---
+title: xmlEscape
+linktitle:
+description: Returns the given string with the reserved XML characters escaped.
+godocref:
+date: 2018-10-13
+publishdate: 2018-10-13
+lastmod: 2018-10-13
+categories: [functions]
+menu:
+  docs:
+    parent: "functions"
+keywords: [strings, xml]
+signature: ["xmlEscape INPUT"]
+workson: []
+hugoversion:
+relatedfuncs:
+deprecated: false
+aliases: []
+---
+
+In the result `&` becomes `&amp;` and so on. It escapes characters with
+special meaning in XML 1.0. If a character is not valid for XML 1.0, it
+gets replaced with the Unicode replacement character (U+FFFD).
+
+```
+{{ xmlEscape "Hugo & Caddy > Wordpress & Apache" }} → "Hugo &amp; Caddy &gt; Wordpress &amp; Apache"
+```

--- a/docs/content/en/templates/rss.md
+++ b/docs/content/en/templates/rss.md
@@ -80,7 +80,7 @@ This is the default RSS template that ships with Hugo. It adheres to the [RSS 2.
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | html }}</description>
+      <description>{{ .Summary | xmlEscape }}</description>
     </item>
     {{ end }}
   </channel>

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -654,7 +654,7 @@ my_date = 2010-05-27T07:32:00Z
 summary = "A _custom_ summary"
 categories = [ "hugo" ]
 +++
-Front Matter with Ordered Pages 4. This is longer content`
+Front Matter with Ordered Pages 4. <div>This is longer content with vertical tab: .</div>`
 
 var weightedSources = [][2]string{
 	{filepath.FromSlash("sect/doc1.md"), weightedPage1},

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -48,7 +48,7 @@ var EmbeddedTemplates = [][2]string{
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | html }}</description>
+      <description>{{ .Summary | xmlEscape }}</description>
     </item>
     {{ end }}
   </channel>

--- a/tpl/tplimpl/embedded/templates/_default/rss.xml
+++ b/tpl/tplimpl/embedded/templates/_default/rss.xml
@@ -27,7 +27,7 @@
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | html }}</description>
+      <description>{{ .Summary | xmlEscape }}</description>
     </item>
     {{ end }}
   </channel>

--- a/tpl/transform/init.go
+++ b/tpl/transform/init.go
@@ -74,6 +74,14 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.XMLEscape,
+			[]string{"xmlEscape"},
+			[][2]string{
+				{"Bat&Man", "Bat&amplMan"},
+				{"\u000b", "\ufffd"},
+			},
+		)
+
 		ns.AddMethodMapping(ctx.Markdownify,
 			[]string{"markdownify"},
 			[][2]string{

--- a/tpl/transform/transform.go
+++ b/tpl/transform/transform.go
@@ -18,8 +18,11 @@ import (
 	"html"
 	"html/template"
 
+	"encoding/xml"
+
 	"github.com/gohugoio/hugo/cache/namedmemcache"
 
+	"github.com/gohugoio/hugo/bufferpool"
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/spf13/cast"
@@ -88,6 +91,21 @@ func (ns *Namespace) HTMLUnescape(s interface{}) (string, error) {
 	}
 
 	return html.UnescapeString(ss), nil
+}
+
+// XMLEscape returns a copy of s with reserved XML characters escaped.
+func (ns *Namespace) XMLEscape(s interface{}) (string, error) {
+	ss, err := cast.ToStringE(s)
+	if err != nil {
+		return "", err
+	}
+
+	buf := bufferpool.GetBuffer()
+	defer bufferpool.PutBuffer(buf)
+	if err := xml.EscapeText(buf, []byte(ss)); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }
 
 // Markdownify renders a given input from Markdown to HTML.

--- a/tpl/transform/transform_test.go
+++ b/tpl/transform/transform_test.go
@@ -149,6 +149,37 @@ func TestHTMLUnescape(t *testing.T) {
 	}
 }
 
+func TestXMLEscape(t *testing.T) {
+	t.Parallel()
+
+	v := viper.New()
+	v.Set("contentDir", "content")
+	ns := New(newDeps(v))
+
+	for i, test := range []struct {
+		s      interface{}
+		expect interface{}
+	}{
+		{`"Foo & Bar's Diner" <y@z>`, `&#34;Foo &amp; Bar&#39;s Diner&#34; &lt;y@z&gt;`},
+		{"Hugo & Caddy > Wordpress & Apache", "Hugo &amp; Caddy &gt; Wordpress &amp; Apache"},
+		{"\u000bhello there\u000b", "\ufffdhello there\ufffd"},
+		// errors
+		{tstNoStringer{}, false},
+	} {
+		errMsg := fmt.Sprintf("[%d] %s", i, test.s)
+
+		result, err := ns.XMLEscape(test.s)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			require.Error(t, err, errMsg)
+			continue
+		}
+
+		require.NoError(t, err, errMsg)
+		assert.Equal(t, test.expect, result, errMsg)
+	}
+}
+
 func TestMarkdownify(t *testing.T) {
 	t.Parallel()
 	c := qt.New(t)


### PR DESCRIPTION
This is to avoid including characters invalid for XML.

Fixes #3268

I just found an Hugo built rss feed failing at https://pawelgrzybek.com/feed.xml. I think it is due to this old issue. I tested the latest version of Hugo and it still fails as described in #3268. The fix written there by @horgh still seems to work as well, so I've rebased his branch here for your consideration. Thanks.