### PR TITLE
livereload: Ensure LibreJS compliance

### DIFF
--- a/transform/livereloadinject/livereloadinject.go
+++ b/transform/livereloadinject/livereloadinject.go
@@ -28,7 +28,12 @@ func New(port int) transform.Transformer {
 		b := ft.From().Bytes()
 		endBodyTag := "</body>"
 		match := []byte(endBodyTag)
-		replaceTemplate := `<script data-no-instant>document.write('<script src="/livereload.js?port=%d&mindelay=10&v=2"></' + 'script>')</script>%s`
+		replaceTemplate := `<script data-no-instant>
+// @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt Apache-2.0
+document.write('<script src="/livereload.js?port=%d&mindelay=10&v=2"></' + 'script>')
+// @license-end
+</script>
+%s`
 		replace := []byte(fmt.Sprintf(replaceTemplate, port, endBodyTag))
 
 		newcontent := bytes.Replace(b, match, replace, 1)

--- a/transform/livereloadinject/livereloadinject_test.go
+++ b/transform/livereloadinject/livereloadinject_test.go
@@ -34,7 +34,12 @@ func doTestLiveReloadInject(t *testing.T, bodyEndTag string) {
 	tr := transform.New(New(1313))
 	tr.Apply(out, in)
 
-	expected := fmt.Sprintf(`<script data-no-instant>document.write('<script src="/livereload.js?port=1313&mindelay=10&v=2"></' + 'script>')</script>%s`, bodyEndTag)
+	expected := fmt.Sprintf(`<script data-no-instant>
+// @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt Apache-2.0
+document.write('<script src="/livereload.js?port=1313&mindelay=10&v=2"></' + 'script>')
+// @license-end
+</script>
+%s`, bodyEndTag)
 	if out.String() != expected {
 		t.Errorf("Expected %s got %s", expected, out.String())
 	}


### PR DESCRIPTION
This commit means that when Hugo injects the livereload code onto a page when
the user is using 'hugo server', and a user using LibreJS tries to access a
webpage, the script is not incorrectly flagged as being non-free. It uses special
comments to inform the LibreJS browser extension that Hugo uses the Apache 2.0
license.
[See GNU's page about correctly flagging free JS.](http://www.gnu.org/software/librejs/free-your-javascript.html)