### PR TITLE
Make the "is this a Hugo Module" logic more lenient

### DIFF
--- a/hugolib/config.toml
+++ b/hugolib/config.toml
@@ -1,0 +1,1 @@
+workingdir = "/private/var/folders/n6/s_85mm8d31j6yctssnmn_g1r0000gn/T/hugo-no-mod217094359"

--- a/hugolib/hugo_modules_test.go
+++ b/hugolib/hugo_modules_test.go
@@ -541,3 +541,28 @@ title: "My Page"
 
 	b.AssertFileContent("public/mypage/index.html", "Permalink: https://example.org/mypage/")
 }
+
+// https://github.com/gohugoio/hugo/issues/6299
+func TestSiteWithGoModButNoModules(t *testing.T) {
+	t.Parallel()
+
+	c := qt.New(t)
+	// We need to use the OS fs for this.
+	workDir, clean, err := htesting.CreateTempDir(hugofs.Os, "hugo-no-mod")
+	c.Assert(err, qt.IsNil)
+
+	cfg := viper.New()
+	cfg.Set("workingDir", workDir)
+	fs := hugofs.NewFrom(hugofs.Os, cfg)
+
+	defer clean()
+
+	b := newTestSitesBuilder(t)
+	b.Fs = fs
+
+	b.WithWorkingDir(workDir).WithViper(cfg)
+
+	b.WithSourceFile("go.mod", "")
+	b.Build(BuildCfg{})
+
+}

--- a/modules/client.go
+++ b/modules/client.go
@@ -279,12 +279,12 @@ func (c *Client) Init(path string) error {
 	return nil
 }
 
-func (c *Client) isProbablyModule(path string) bool {
+func isProbablyModule(path string) bool {
 	return module.CheckPath(path) == nil
 }
 
 func (c *Client) listGoMods() (goModules, error) {
-	if c.GoModulesFilename == "" {
+	if c.GoModulesFilename == "" || !c.moduleConfig.hasModuleImport() {
 		return nil, nil
 	}
 

--- a/modules/collect.go
+++ b/modules/collect.go
@@ -250,8 +250,7 @@ func (c *collector) add(owner *moduleAdapter, moduleImport Import, disabled bool
 		}
 
 		if moduleDir == "" {
-
-			if c.GoModulesFilename != "" && c.isProbablyModule(modulePath) {
+			if c.GoModulesFilename != "" && isProbablyModule(modulePath) {
 				// Try to "go get" it and reload the module configuration.
 				if err := c.Get(modulePath); err != nil {
 					return nil, err
@@ -299,10 +298,6 @@ func (c *collector) add(owner *moduleAdapter, moduleImport Import, disabled bool
 
 	if mod == nil {
 		ma.path = modulePath
-	}
-
-	if err := ma.validateAndApplyDefaults(c.fs); err != nil {
-		return nil, err
 	}
 
 	if !moduleImport.IgnoreConfig {

--- a/modules/config.go
+++ b/modules/config.go
@@ -235,6 +235,17 @@ type Config struct {
 	Private string
 }
 
+// hasModuleImport reports whether the project config have one or more
+// modules imports, e.g. github.com/bep/myshortcodes.
+func (c Config) hasModuleImport() bool {
+	for _, imp := range c.Imports {
+		if isProbablyModule(imp.Path) {
+			return true
+		}
+	}
+	return false
+}
+
 // HugoVersion holds Hugo binary version requirements for a module.
 type HugoVersion struct {
 	// The minimum Hugo version that this module works with.

--- a/modules/module.go
+++ b/modules/module.go
@@ -18,7 +18,6 @@ package modules
 
 import (
 	"github.com/gohugoio/hugo/config"
-	"github.com/spf13/afero"
 )
 
 var _ Module = (*moduleAdapter)(nil)
@@ -172,25 +171,4 @@ func (m *moduleAdapter) Watch() bool {
 	}
 
 	return false
-}
-
-func (m *moduleAdapter) validateAndApplyDefaults(fs afero.Fs) error {
-
-	/*if len(m.modImport.Mounts) == 0 {
-		// Create default mount points for every component folder that
-		// exists in the module.
-		for _, componentFolder := range files.ComponentFolders {
-			sourceDir := filepath.Join(dir, componentFolder)
-			_, err := fs.Stat(sourceDir)
-			if err == nil {
-				m.modImport.Mounts = append(m.modImport.Mounts, Mount{
-					Source: componentFolder,
-					Target: componentFolder,
-				})
-			}
-		}
-	}*/
-
-	return nil
-
 }


### PR DESCRIPTION
Now we only try to load modules via Go if there is one or more modules imported in project config.

Fixes #6299