### PR TITLE
do not build with Azure BLOB support on Solaris #6324

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -38,7 +38,6 @@ import (
 	"golang.org/x/text/unicode/norm"
 
 	"gocloud.dev/blob"
-	_ "gocloud.dev/blob/azureblob" // import
 	_ "gocloud.dev/blob/fileblob"  // import
 	_ "gocloud.dev/blob/gcsblob"   // import
 	_ "gocloud.dev/blob/s3blob"    // import

--- a/deploy/deploy_azure.go
+++ b/deploy/deploy_azure.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !solaris
+
+package deploy
+
+import (
+	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/azureblob" // import
+)


### PR DESCRIPTION
At least until the upstream complete their Solaris work in https://github.com/Azure/azure-storage-blob-go/issues/96