### PR TITLE
Support target image format  for image transformations

### DIFF
--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -140,8 +140,11 @@ var (
 	YAMLType       = Type{MainType: "application", SubType: "yaml", Suffixes: []string{"yaml", "yml"}, Delimiter: defaultDelimiter}
 
 	// Common image types
-	PNGType = Type{MainType: "image", SubType: "png", Suffixes: []string{"png"}, Delimiter: defaultDelimiter}
-	JPGType = Type{MainType: "image", SubType: "jpg", Suffixes: []string{"jpg", "jpeg"}, Delimiter: defaultDelimiter}
+	PNGType  = Type{MainType: "image", SubType: "png", Suffixes: []string{"png"}, Delimiter: defaultDelimiter}
+	JPGType  = Type{MainType: "image", SubType: "jpg", Suffixes: []string{"jpg", "jpeg"}, Delimiter: defaultDelimiter}
+	GIFType  = Type{MainType: "image", SubType: "gif", Suffixes: []string{"gif"}, Delimiter: defaultDelimiter}
+	TIFFType = Type{MainType: "image", SubType: "tiff", Suffixes: []string{"tif", "tiff"}, Delimiter: defaultDelimiter}
+	BMPType  = Type{MainType: "image", SubType: "bmp", Suffixes: []string{"bmp"}, Delimiter: defaultDelimiter}
 
 	OctetType = Type{MainType: "application", SubType: "octet-stream"}
 )

--- a/resources/images/config.go
+++ b/resources/images/config.go
@@ -187,7 +187,8 @@ func DecodeImageConfig(action, config string, defaults Imaging) (ImageConfig, er
 			} else {
 				return c, errors.New("invalid image dimensions")
 			}
-
+		} else if f, ok := ImageFormatFromExt("." + part); ok {
+			c.TargetFormat = f
 		}
 	}
 
@@ -212,6 +213,9 @@ func DecodeImageConfig(action, config string, defaults Imaging) (ImageConfig, er
 
 // ImageConfig holds configuration to create a new image from an existing one, resize etc.
 type ImageConfig struct {
+	// This defines the output format of the output image. It defaults to the source format
+	TargetFormat Format
+
 	Action string
 
 	// If set, this will be used as the key in filenames etc.

--- a/resources/images/image.go
+++ b/resources/images/image.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/resources/images/exif"
 
 	"github.com/disintegration/gift"
@@ -59,7 +60,7 @@ type Image struct {
 }
 
 func (i *Image) EncodeTo(conf ImageConfig, img image.Image, w io.Writer) error {
-	switch i.Format {
+	switch conf.TargetFormat {
 	case JPEG:
 
 		var rgba *image.RGBA
@@ -249,6 +250,35 @@ const (
 	TIFF
 	BMP
 )
+
+// RequiresDefaultQuality returns if the default quality needs to be applied to images of this format
+func (f Format) RequiresDefaultQuality() bool {
+	return f == JPEG
+}
+
+// DefaultExtension returns the default file extension of this format, starting with a dot.
+// For example: .jpg for JPEG
+func (f Format) DefaultExtension() string {
+	return f.MediaType().FullSuffix()
+}
+
+// MediaType returns the media type of this image, e.g. image/jpeg for JPEG
+func (f Format) MediaType() media.Type {
+	switch f {
+	case JPEG:
+		return media.JPGType
+	case PNG:
+		return media.PNGType
+	case GIF:
+		return media.GIFType
+	case TIFF:
+		return media.TIFFType
+	case BMP:
+		return media.BMPType
+	default:
+		panic(fmt.Sprintf("%d is not a valid image format", f))
+	}
+}
 
 type imageConfig struct {
 	config       image.Config

--- a/resources/resource.go
+++ b/resources/resource.go
@@ -220,6 +220,10 @@ func (l *genericResource) MediaType() media.Type {
 	return l.mediaType
 }
 
+func (l *genericResource) setMediaType(mediaType media.Type) {
+	l.mediaType = mediaType
+}
+
 func (l *genericResource) Name() string {
 	return l.name
 }

--- a/resources/resource_metadata.go
+++ b/resources/resource_metadata.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 
 	"github.com/gohugoio/hugo/hugofs/glob"
+	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/resources/resource"
 
 	"github.com/pkg/errors"
@@ -42,6 +43,7 @@ type metaAssignerProvider interface {
 type metaAssigner interface {
 	setTitle(title string)
 	setName(name string)
+	setMediaType(mediaType media.Type)
 	updateParams(params map[string]interface{})
 }
 


### PR DESCRIPTION
## Changes
The image format is defined as the image extension of the known formats.
All of `img.Resize "600x jpeg"`, `img.Resize "600x jpg"`, `img.Resize "600x png"` are valid
format definitions.
If the target format is defined in the operation definition string, then the converted image will be stored in this format.
Unknown extensions passed in the operation definition have not effect.

## Notes
Tests were already failing (for me) with the `master` branch. I've added a partial fix for one of these, but haven't fully fixed that particular test. Tests are still failing, but not more than with `master`.
[Log of go test ./... on master](https://github.com/gohugoio/hugo/files/3637245/tests-master.txt)

See #6298