### PR TITLE
tmp: add `rel="noopener"` for external links

### DIFF
--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -380,7 +380,7 @@ if (!doNotTrack) {
 	<div class="card-header">
     <a href="{{ $item.author_url | safeURL }}" class="card-link">{{ $item.author_name }}</a>
   </div>
-	<a href="{{ $mediaURL }}" target="_blank"><img class="card-img-top img-fluid" src="{{ $item.thumbnail_url }}" width="{{ $item.thumbnail_width }}"  height="{{ $item.thumbnail_height }}" alt="Instagram Image"></a>
+	<a href="{{ $mediaURL }}" rel="noopener" target="_blank"><img class="card-img-top img-fluid" src="{{ $item.thumbnail_url }}" width="{{ $item.thumbnail_width }}"  height="{{ $item.thumbnail_height }}" alt="Instagram Image"></a>
 	<div class="card-body">
 		{{ if not $hideCaption }}<p class="card-text"><a href="{{ $item.author_url | safeURL }}" class="card-link">{{ $item.author_name }}</a> {{ $item.title}}</p>{{ end }}
 		<a href="{{ $item.author_url | safeURL }}" class="card-link">View More on Instagram</a>
@@ -486,7 +486,7 @@ if (!doNotTrack) {
 {{ $secondClass := "s_video_simple" }}
 <div class="{{ $secondClass }} {{ $class }}">
 {{- with $item }}
-<a href="{{ .provider_url }}{{ .video_id }}" target="_blank">
+<a href="{{ .provider_url }}{{ .video_id }}" rel="noopener" target="_blank">
 {{ $thumb := .thumbnail_url }}
 {{ $original := $thumb | replaceRE "(_.*\\.)" "." }}
 <img src="{{ $thumb }}" srcset="{{ $thumb }} 1x, {{ $original }} 2x" alt="{{ .title }}">

--- a/tpl/tplimpl/embedded/templates/shortcodes/instagram_simple.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/instagram_simple.html
@@ -15,7 +15,7 @@
 	<div class="card-header">
     <a href="{{ $item.author_url | safeURL }}" class="card-link">{{ $item.author_name }}</a>
   </div>
-	<a href="{{ $mediaURL }}" target="_blank"><img class="card-img-top img-fluid" src="{{ $item.thumbnail_url }}" width="{{ $item.thumbnail_width }}"  height="{{ $item.thumbnail_height }}" alt="Instagram Image"></a>
+	<a href="{{ $mediaURL }}" rel="noopener" target="_blank"><img class="card-img-top img-fluid" src="{{ $item.thumbnail_url }}" width="{{ $item.thumbnail_width }}"  height="{{ $item.thumbnail_height }}" alt="Instagram Image"></a>
 	<div class="card-body">
 		{{ if not $hideCaption }}<p class="card-text"><a href="{{ $item.author_url | safeURL }}" class="card-link">{{ $item.author_name }}</a> {{ $item.title}}</p>{{ end }}
 		<a href="{{ $item.author_url | safeURL }}" class="card-link">View More on Instagram</a>

--- a/tpl/tplimpl/embedded/templates/shortcodes/vimeo_simple.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/vimeo_simple.html
@@ -10,7 +10,7 @@
 {{ $secondClass := "s_video_simple" }}
 <div class="{{ $secondClass }} {{ $class }}">
 {{- with $item }}
-<a href="{{ .provider_url }}{{ .video_id }}" target="_blank">
+<a href="{{ .provider_url }}{{ .video_id }}" rel="noopener" target="_blank">
 {{ $thumb := .thumbnail_url }}
 {{ $original := $thumb | replaceRE "(_.*\\.)" "." }}
 <img src="{{ $thumb }}" srcset="{{ $thumb }} 1x, {{ $original }} 2x" alt="{{ .title }}">


### PR DESCRIPTION
This could be a security and performance issue.

See https://developers.google.com/web/tools/lighthouse/audits/noopener