### PR TITLE
[WIP] add issue templates and action to reduce support requests in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: 'Bug report'
+labels: Bug
+assignees: bep
+about: Create a report to help us improve
+---
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Build:**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,29 +1,6 @@
 ---
 name: 'Bug report'
-labels: Bug
-assignees: bep
+labels: ''
+assignees: ''
 about: Create a report to help us improve
 ---
-**Describe the bug**
-A clear and concise description of what the bug is.
-
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-**Expected behavior**
-A clear and concise description of what you expected to happen.
-
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Build:**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Additional context**
-Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,19 +2,7 @@
 name: Proposal
 about: Suggest an idea for Hugo
 title: ''
-labels: Proposal
+labels: ''
 assignees: ''
 
 ---
-
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Proposal
+about: Suggest an idea for Hugo
+title: ''
+labels: Proposal
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,10 @@
+---
+name: Support (Do not use)
+about: Please do not use Github for support requests. Visit https://discourse.gohugo.io for support
+title: ''
+labels: support
+assignees: ''
+
+---
+
+Issues created with this template will be automatically closed. Please visit https://discourse.gohugo.io for the support you really, really, want!

--- a/.github/workflows/auto_close_support.yml
+++ b/.github/workflows/auto_close_support.yml
@@ -1,0 +1,14 @@
+on:
+  schedule:
+  - cron: 0 5 * * 3 
+name: Weekly Issue Closure
+jobs:
+  cycle-weekly-close:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: weekly-issue-closure
+      uses: bdougie/close-issues-based-on-label@master
+      env:
+        LABEL: support
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See https://discourse.gohugo.io/t/github-issue-template-to-reduce-support-issues/20873

The bug and proposal issue templates were not modified from the defaults provided by the Github template builder. Support requests that make it through with the support template will be given the label "Support" and automatically closed weekly by https://github.com/bdougie/close-issues-based-on-label 