### PR TITLE
Enable page exclusion from sitemap.xml

### DIFF
--- a/config/commonConfig.go
+++ b/config/commonConfig.go
@@ -79,6 +79,7 @@ type Sitemap struct {
 	ChangeFreq string
 	Priority   float64
 	Filename   string
+	Exclude    bool
 }
 
 func DecodeSitemap(prototype Sitemap, input map[string]interface{}) Sitemap {
@@ -91,6 +92,8 @@ func DecodeSitemap(prototype Sitemap, input map[string]interface{}) Sitemap {
 			prototype.Priority = cast.ToFloat64(value)
 		case "filename":
 			prototype.Filename = cast.ToString(value)
+		case "exclude":
+			prototype.Exclude = cast.ToBool(value)
 		default:
 			jww.WARN.Printf("Unknown Sitemap field: %s\n", key)
 		}

--- a/docs/content/en/templates/sitemap-template.md
+++ b/docs/content/en/templates/sitemap-template.md
@@ -33,11 +33,14 @@ A sitemap is a `Page` and therefore has all the [page variables][pagevars] avail
 `.Sitemap.Filename`
 : The sitemap filename
 
+.Sitemap.Exclude
+: Whether or not to exclude the page from the sitemap. A boolean that defaults to false.
+
 If provided, Hugo will use `/layouts/sitemap.xml` instead of the internal `sitemap.xml` template that ships with Hugo.
 
 ## Sitemap Templates
 
-Hugo has built-on Sitemap templates, but you can provide your own if needed, in either `layouts/sitemap.xml` or `layouts/_default/sitemap.xml`.
+Hugo has built-in Sitemap templates, but you can provide your own if needed, in either `layouts/sitemap.xml` or `layouts/_default/sitemap.xml`.
 
 For multilingual sites, we also create a Sitemap index. You can provide a custom layout for that in either `layouts/sitemapindex.xml` or `layouts/_default/sitemapindex.xml`.
 
@@ -49,7 +52,7 @@ This template respects the version 0.9 of the [Sitemap Protocol](http://www.site
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range where .Pages ".Sitemap.Exclude" false }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -90,13 +93,14 @@ This is used to create a Sitemap index in multilingual mode:
 
 ## Configure `sitemap.xml`
 
-Defaults for `<changefreq>`, `<priority>` and `filename` values can be set in the site's config file, e.g.:
+Defaults for `<changefreq>`, `<priority>`, `<filename>`, and `<exclude>` can be set in the site's config file, e.g.:
 
 {{< code-toggle file="config" >}}
 [sitemap]
   changefreq = "monthly"
   priority = 0.5
   filename = "sitemap.xml"
+  exclude = true
 {{</ code-toggle >}}
 
 The same fields can be specified in an individual content file's front matter in order to override the value assigned to that piece of content at render time.

--- a/docs/content/en/variables/sitemap.md
+++ b/docs/content/en/variables/sitemap.md
@@ -29,4 +29,7 @@ A sitemap is a `Page` and therefore has all the [page variables][pagevars] avail
 .Sitemap.Filename
 : the sitemap filename
 
+.Sitemap.Exclude
+: whether or not to exclude the page from the sitemap, defaults to false
+
 [pagevars]: /variables/page/

--- a/hugolib/sitemap_test.go
+++ b/hugolib/sitemap_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const sitemapTemplate = `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {{ range .Data.Pages }}
+  {{ range where .Pages ".Sitemap.Exclude" false }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -87,11 +87,12 @@ func doTestSitemapOutput(t *testing.T, internal bool) {
 
 func TestParseSitemap(t *testing.T) {
 	t.Parallel()
-	expected := config.Sitemap{Priority: 3.0, Filename: "doo.xml", ChangeFreq: "3"}
+	expected := config.Sitemap{Priority: 3.0, Filename: "doo.xml", ChangeFreq: "3", Exclude: true}
 	input := map[string]interface{}{
 		"changefreq": "3",
 		"priority":   3.0,
 		"filename":   "doo.xml",
+		"exclude":    true,
 		"unknown":    "ignore",
 	}
 	result := config.DecodeSitemap(config.Sitemap{}, input)

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -61,7 +61,7 @@ var EmbeddedTemplates = [][2]string{
 	{`_default/sitemap.xml`, `{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range where .Pages ".Sitemap.Exclude" false }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -79,7 +79,8 @@ var EmbeddedTemplates = [][2]string{
                 />{{ end }}
   </url>
   {{ end }}
-</urlset>`},
+</urlset>
+`},
 	{`_default/sitemapindex.xml`, `{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	{{ range . }}

--- a/tpl/tplimpl/embedded/templates/_default/sitemap.xml
+++ b/tpl/tplimpl/embedded/templates/_default/sitemap.xml
@@ -1,7 +1,7 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range where .Pages ".Sitemap.Exclude" false }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}


### PR DESCRIPTION
This PR adds a new key to .Sitemap called `Exclude`. `Exclude` is a
boolean that is set to false by default meaning all available pages are
included. This is the behavior currently. When `Exclude` is set to true,
it will not appear in any `sitemap.xml` files that Hugo may generate.

`Exclude` can be set to true in the Hugo config turning `sitemap.xml`
into an opt-in rather than an opt-out.

Fixes #653

This is a rebased version of #5259 which was closed.