### PR TITLE
Support typed bool, int and float in shortcode params

### DIFF
--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -151,14 +151,7 @@ func (scp *ShortcodeWithPage) Get(key interface{}) interface{} {
 		}
 	}
 
-	switch x.Kind() {
-	case reflect.String:
-		return x.String()
-	case reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8, reflect.Int:
-		return x.Int()
-	default:
-		return x
-	}
+	return x.Interface()
 
 }
 
@@ -219,17 +212,17 @@ func (sc shortcode) String() string {
 	// for testing (mostly), so any change here will break tests!
 	var params interface{}
 	switch v := sc.params.(type) {
-	case map[string]string:
+	case map[string]interface{}:
 		// sort the keys so test assertions won't fail
 		var keys []string
 		for k := range v {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
-		var tmp = make([]string, len(keys))
+		var tmp = make(map[string]interface{})
 
-		for i, k := range keys {
-			tmp[i] = k + ":" + v[k]
+		for _, k := range keys {
+			tmp[k] = v[k]
 		}
 		params = tmp
 
@@ -539,12 +532,12 @@ Loop:
 			} else if pt.Peek().IsShortcodeParamVal() {
 				// named params
 				if sc.params == nil {
-					params := make(map[string]string)
-					params[currItem.ValStr()] = pt.Next().ValStr()
+					params := make(map[string]interface{})
+					params[currItem.ValStr()] = pt.Next().ValTyped()
 					sc.params = params
 				} else {
-					if params, ok := sc.params.(map[string]string); ok {
-						params[currItem.ValStr()] = pt.Next().ValStr()
+					if params, ok := sc.params.(map[string]interface{}); ok {
+						params[currItem.ValStr()] = pt.Next().ValTyped()
 					} else {
 						return sc, errShortCodeIllegalState
 					}
@@ -553,12 +546,12 @@ Loop:
 			} else {
 				// positional params
 				if sc.params == nil {
-					var params []string
-					params = append(params, currItem.ValStr())
+					var params []interface{}
+					params = append(params, currItem.ValTyped())
 					sc.params = params
 				} else {
-					if params, ok := sc.params.([]string); ok {
-						params = append(params, currItem.ValStr())
+					if params, ok := sc.params.([]interface{}); ok {
+						params = append(params, currItem.ValTyped())
 						sc.params = params
 					} else {
 						return sc, errShortCodeIllegalState

--- a/parser/pageparser/item_test.go
+++ b/parser/pageparser/item_test.go
@@ -1,0 +1,35 @@
+// Copyright 2019 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pageparser
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestItemValTyped(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(Item{Val: []byte("3.14")}.ValTyped(), qt.Equals, float64(3.14))
+	c.Assert(Item{Val: []byte(".14")}.ValTyped(), qt.Equals, float64(.14))
+	c.Assert(Item{Val: []byte("314")}.ValTyped(), qt.Equals, 314)
+	c.Assert(Item{Val: []byte("314x")}.ValTyped(), qt.Equals, "314x")
+	c.Assert(Item{Val: []byte("314 ")}.ValTyped(), qt.Equals, "314 ")
+	c.Assert(Item{Val: []byte("314"), isString: true}.ValTyped(), qt.Equals, "314")
+	c.Assert(Item{Val: []byte("true")}.ValTyped(), qt.Equals, true)
+	c.Assert(Item{Val: []byte("false")}.ValTyped(), qt.Equals, false)
+	c.Assert(Item{Val: []byte("trues")}.ValTyped(), qt.Equals, "trues")
+
+}

--- a/parser/pageparser/pageparser.go
+++ b/parser/pageparser/pageparser.go
@@ -80,7 +80,7 @@ func (t *Iterator) Input() []byte {
 	return t.l.Input()
 }
 
-var errIndexOutOfBounds = Item{tError, 0, []byte("no more tokens")}
+var errIndexOutOfBounds = Item{tError, 0, []byte("no more tokens"), true}
 
 // Current will repeatably return the current item.
 func (t *Iterator) Current() Item {

--- a/parser/pageparser/pageparser_intro_test.go
+++ b/parser/pageparser/pageparser_intro_test.go
@@ -27,7 +27,7 @@ type lexerTest struct {
 }
 
 func nti(tp ItemType, val string) Item {
-	return Item{tp, 0, []byte(val)}
+	return Item{tp, 0, []byte(val), false}
 }
 
 var (
@@ -119,6 +119,7 @@ func equal(i1, i2 []Item) bool {
 		if i1[k].Type != i2[k].Type {
 			return false
 		}
+
 		if !reflect.DeepEqual(i1[k].Val, i2[k].Val) {
 			return false
 		}

--- a/parser/pageparser/pageparser_shortcode_test.go
+++ b/parser/pageparser/pageparser_shortcode_test.go
@@ -16,22 +16,26 @@ package pageparser
 import "testing"
 
 var (
-	tstEOF       = nti(tEOF, "")
-	tstLeftNoMD  = nti(tLeftDelimScNoMarkup, "{{<")
-	tstRightNoMD = nti(tRightDelimScNoMarkup, ">}}")
-	tstLeftMD    = nti(tLeftDelimScWithMarkup, "{{%")
-	tstRightMD   = nti(tRightDelimScWithMarkup, "%}}")
-	tstSCClose   = nti(tScClose, "/")
-	tstSC1       = nti(tScName, "sc1")
-	tstSC1Inline = nti(tScNameInline, "sc1.inline")
-	tstSC2Inline = nti(tScNameInline, "sc2.inline")
-	tstSC2       = nti(tScName, "sc2")
-	tstSC3       = nti(tScName, "sc3")
-	tstSCSlash   = nti(tScName, "sc/sub")
-	tstParam1    = nti(tScParam, "param1")
-	tstParam2    = nti(tScParam, "param2")
-	tstVal       = nti(tScParamVal, "Hello World")
-	tstText      = nti(tText, "Hello World")
+	tstEOF            = nti(tEOF, "")
+	tstLeftNoMD       = nti(tLeftDelimScNoMarkup, "{{<")
+	tstRightNoMD      = nti(tRightDelimScNoMarkup, ">}}")
+	tstLeftMD         = nti(tLeftDelimScWithMarkup, "{{%")
+	tstRightMD        = nti(tRightDelimScWithMarkup, "%}}")
+	tstSCClose        = nti(tScClose, "/")
+	tstSC1            = nti(tScName, "sc1")
+	tstSC1Inline      = nti(tScNameInline, "sc1.inline")
+	tstSC2Inline      = nti(tScNameInline, "sc2.inline")
+	tstSC2            = nti(tScName, "sc2")
+	tstSC3            = nti(tScName, "sc3")
+	tstSCSlash        = nti(tScName, "sc/sub")
+	tstParam1         = nti(tScParam, "param1")
+	tstParam2         = nti(tScParam, "param2")
+	tstParamBoolTrue  = nti(tScParam, "true")
+	tstParamBoolFalse = nti(tScParam, "false")
+	tstParamInt       = nti(tScParam, "32")
+	tstParamFloat     = nti(tScParam, "3.14")
+	tstVal            = nti(tScParamVal, "Hello World")
+	tstText           = nti(tText, "Hello World")
 )
 
 var shortCodeLexerTests = []lexerTest{
@@ -69,6 +73,12 @@ var shortCodeLexerTests = []lexerTest{
 	{"close with extra keyword", `{{< sc1 >}}{{< /sc1 keyword>}}`, []Item{
 		tstLeftNoMD, tstSC1, tstRightNoMD, tstLeftNoMD, tstSCClose, tstSC1,
 		nti(tError, "unclosed shortcode")}},
+	{"float param, positional", `{{< sc1 3.14 >}}`, []Item{
+		tstLeftNoMD, tstSC1, nti(tScParam, "3.14"), tstRightNoMD, tstEOF}},
+	{"float param, named", `{{< sc1 param1=3.14 >}}`, []Item{
+		tstLeftNoMD, tstSC1, tstParam1, nti(tScParamVal, "3.14"), tstRightNoMD, tstEOF}},
+	{"float param, named, space before", `{{< sc1 param1= 3.14 >}}`, []Item{
+		tstLeftNoMD, tstSC1, tstParam1, nti(tScParamVal, "3.14"), tstRightNoMD, tstEOF}},
 	{"Youtube id", `{{< sc1 -ziL-Q_456igdO-4 >}}`, []Item{
 		tstLeftNoMD, tstSC1, nti(tScParam, "-ziL-Q_456igdO-4"), tstRightNoMD, tstEOF}},
 	{"non-alphanumerics param quoted", `{{< sc1 "-ziL-.%QigdO-4" >}}`, []Item{

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -422,7 +422,7 @@ if (!doNotTrack) {
 {{- if $pc.Simple -}}
 {{ template "_internal/shortcodes/twitter_simple.html" . }}
 {{- else -}}
-{{- $url := printf "https://api.twitter.com/1/statuses/oembed.json?id=%s&dnt=%t" (index .Params 0) $pc.EnableDNT -}}
+{{- $url := printf "https://api.twitter.com/1/statuses/oembed.json?id=%v&dnt=%t" (index .Params 0) $pc.EnableDNT -}}
 {{- $json := getJSON $url -}}
 {{ $json.html | safeHTML }}
 {{- end -}}

--- a/tpl/tplimpl/embedded/templates/shortcodes/twitter.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/twitter.html
@@ -3,7 +3,7 @@
 {{- if $pc.Simple -}}
 {{ template "_internal/shortcodes/twitter_simple.html" . }}
 {{- else -}}
-{{- $url := printf "https://api.twitter.com/1/statuses/oembed.json?id=%s&dnt=%t" (index .Params 0) $pc.EnableDNT -}}
+{{- $url := printf "https://api.twitter.com/1/statuses/oembed.json?id=%v&dnt=%t" (index .Params 0) $pc.EnableDNT -}}
 {{- $json := getJSON $url -}}
 {{ $json.html | safeHTML }}
 {{- end -}}

--- a/tpl/urls/urls.go
+++ b/tpl/urls/urls.go
@@ -126,7 +126,13 @@ func (ns *Namespace) refArgsToMap(args interface{}) (map[string]interface{}, err
 		s  string
 		of string
 	)
-	switch v := args.(type) {
+
+	v := args
+	if _, ok := v.([]interface{}); ok {
+		v = cast.ToStringSlice(v)
+	}
+
+	switch v := v.(type) {
 	case map[string]interface{}:
 		return v, nil
 	case map[string]string:
@@ -152,6 +158,7 @@ func (ns *Namespace) refArgsToMap(args interface{}) (map[string]interface{}, err
 		}
 
 	}
+
 	return map[string]interface{}{
 		"path":         s,
 		"outputFormat": of,


### PR DESCRIPTION
This means that you now can do:

    {{< vidur 9KvBeKu false true 32 3.14 >}}

And the boolean and numeric values will be converted to `bool`, `int` and `float64`.

If you want these to be  strings, they must be quoted:

    {{< vidur 9KvBeKu "false" "true" "32" "3.14" >}}

Fixes #6371