### PR TITLE
Update go-org & fix includes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/muesli/smartcrop v0.0.0-20180228075044-f6ebaa786a12
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/nicksnyder/go-i18n v1.10.0
-	github.com/niklasfasching/go-org v0.1.4
+	github.com/niklasfasching/go-org v0.1.6
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/nicksnyder/go-i18n v1.10.0 h1:5AzlPKvXBH4qBzmZ09Ua9Gipyruv6uApMcrNZdo96+Q=
 github.com/nicksnyder/go-i18n v1.10.0/go.mod h1:HrK7VCrbOvQoUAQ7Vpy7i87N7JZZZ7R2xBGjv0j365Q=
-github.com/niklasfasching/go-org v0.1.4 h1:nEuzptQcLsKZYPjxs/+0m+9RqMvcK+34lGDCtcQOwGQ=
-github.com/niklasfasching/go-org v0.1.4/go.mod h1:AsLD6X7djzRIz4/RFZu8vwRL0VGjUvGZCCH1Nz0VdrU=
+github.com/niklasfasching/go-org v0.1.6 h1:F521WcqRNl8OJumlgAnekZgERaTA2HpfOYYfVEKOeI8=
+github.com/niklasfasching/go-org v0.1.6/go.mod h1:AsLD6X7djzRIz4/RFZu8vwRL0VGjUvGZCCH1Nz0VdrU=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84 h1:fiKJgB4JDUd43CApkmCeTSQlWjtTtABrU2qsgbuP0BI=

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -27,6 +27,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/hugolib/filesystems"
 	"github.com/niklasfasching/go-org/org"
 
 	bp "github.com/gohugoio/hugo/bufferpool"
@@ -34,6 +35,7 @@ import (
 	"github.com/miekg/mmark"
 	"github.com/mitchellh/mapstructure"
 	"github.com/russross/blackfriday"
+	"github.com/spf13/afero"
 	jww "github.com/spf13/jwalterweatherman"
 
 	"strings"
@@ -466,6 +468,7 @@ func ExtractTOC(content []byte) (newcontent []byte, toc []byte) {
 // for a given content rendering.
 // By creating you must set the Config, otherwise it will panic.
 type RenderingContext struct {
+	BaseFs       *filesystems.BaseFs
 	Content      []byte
 	PageFmt      string
 	DocumentID   string
@@ -752,6 +755,9 @@ func getPandocContent(ctx *RenderingContext) []byte {
 func orgRender(ctx *RenderingContext, c ContentSpec) []byte {
 	config := org.New()
 	config.Log = jww.WARN
+	config.ReadFile = func(filename string) ([]byte, error) {
+		return afero.ReadFile(ctx.BaseFs.Content.Fs, filename)
+	}
 	writer := org.NewHTMLWriter()
 	writer.HighlightCodeBlock = func(source, lang string) string {
 		highlightedSource, err := c.Highlight(source, lang, "")

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -143,6 +143,7 @@ func newPageContentOutput(p *pageState) func(f output.Format) (*pageContentOutpu
 					html := cp.p.s.ContentSpec.RenderBytes(&helpers.RenderingContext{
 						Content: []byte(cp.p.m.summary), RenderTOC: false, PageFmt: cp.p.m.markup,
 						Cfg:        p.Language(),
+						BaseFs:     p.s.BaseFs,
 						DocumentID: p.File().UniqueID(), DocumentName: p.File().Path(),
 						Config: cp.p.getRenderingConfig()})
 					html = cp.p.s.ContentSpec.TrimShortHTML(html)
@@ -314,6 +315,7 @@ func (cp *pageContentOutput) renderContent(p page.Page, content []byte) []byte {
 	return cp.p.s.ContentSpec.RenderBytes(&helpers.RenderingContext{
 		Content: content, RenderTOC: true, PageFmt: cp.p.m.markup,
 		Cfg:        p.Language(),
+		BaseFs:     cp.p.s.BaseFs,
 		DocumentID: p.File().UniqueID(), DocumentName: p.File().Path(),
 		Config: cp.p.getRenderingConfig()})
 }


### PR DESCRIPTION
see #6322 



The org mode renderer supports including other files [1]. To resolve relative
paths we need the path of the current file - either absolute or relative to the
directory hugo is run from. DocumentName is the path relative to the content
directory, not the base directory that hugo is run from - we could get the full
path by looking up the content directory from the config and merging both; or
we just make the absolute path of rendered files available in the
RenderingContext.

[1]: e.g. `#+INCLUDE: ./foo.py src python` includes `foo.py` as a python source
block.

