### PR TITLE
resources: Ensure same dirinfos sort order in TestImageOperationsGolden

### DIFF
--- a/resources/image_test.go
+++ b/resources/image_test.go
@@ -15,6 +15,7 @@ package resources
 
 import (
 	"fmt"
+	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -567,15 +568,9 @@ func TestImageOperationsGolden(t *testing.T) {
 	dir2 := filepath.FromSlash("testdata/golden")
 
 	// The two dirs above should now be the same.
-	d1, err := os.Open(dir1)
+	dirinfos1, err := ioutil.ReadDir(dir1)
 	c.Assert(err, qt.IsNil)
-	d2, err := os.Open(dir2)
-	c.Assert(err, qt.IsNil)
-
-	dirinfos1, err := d1.Readdir(-1)
-	c.Assert(err, qt.IsNil)
-	dirinfos2, err := d2.Readdir(-1)
-
+	dirinfos2, err := ioutil.ReadDir(dir2)
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(dirinfos1), qt.Equals, len(dirinfos2))
 


### PR DESCRIPTION
Fix filename mismatch errors on Debian auto-building machines
possibly due to different directory order on ext4 vs tmpfs file systems.

----

### Supplementary information

Filename mismatch error seen with TestImageOperationsGolden on Debian buildd machines and reproduced on Debian's amd64 porterbox barriere.debian.org:

    image_test.go:518: filter all /a/gohugoio24_huc57dd738f4724f4b341121e66fd85555_267952_cfc2eacca4b2748852f953954207d615.png
    quicktest.go:288: 
        error:
          values are not equal
        got:
          "gohugoio24_huc57dd738f4724f4b341121e66fd85555_267952_cfc2eacca4b2748852f953954207d615.png"
        want:
          "gohugoio8_hu7f72c00afdf7634587afaa5eff2a25b2_73538_200x100_resize_box_2.png"
        stack:
          /home/foka/hugo-0.58.3/obj-x86_64-linux-gnu/src/github.com/gohugoio/hugo/resources/image_test.go:547
            c.Assert(fi1.Name(), qt.Equals, fi2.Name())

Full logs on buildd.debian.org:

* http://web.archive.org/web/20191003050740/https://buildd.debian.org/status/package.php?p=hugo

References that helped me come up with a patch:

* https://groups.google.com/forum/#!topic/golang-nuts/6dli1CkSdgI
* https://golang.org/pkg/os/#File.Readdir
* https://golang.org/pkg/io/ioutil/#ReadDir