### PR TITLE
Document unexpected mardownify behaviour

### DIFF
--- a/docs/content/en/functions/markdownify.md
+++ b/docs/content/en/functions/markdownify.md
@@ -23,3 +23,5 @@ aliases: []
 ```
 {{ .Title | markdownify }}
 ```
+
+Note that if the content being processed is a single line of text, `markdownify` will not add any HTML tags. Multiple lines of text seperated by new lines will be wrapped in `<p>` tags. 


### PR DESCRIPTION
From an end user standpoint the behaviour is confusing and needs to be documented at least. I'm not sure I fully understand the reasoning so I haven't attempted to explain it, but now it's at least documented. 

See: 

* https://github.com/gohugoio/hugo/issues/3040
* https://discourse.gohugo.io/t/single-paragraph-rendered-withing-shortcode-using-inner-is-missing-p-tag/21155
* https://discourse.gohugo.io/t/prevent-markdownify-to-strip-first-p-tags/7854/5