### PR TITLE
tpl: Make getJSON/getCVS accept non-string args

### DIFF
--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -280,9 +280,25 @@ func TestShortcodeTweet(t *testing.T) {
 	t.Parallel()
 
 	for i, this := range []struct {
+		privacy            map[string]interface{}
 		in, resp, expected string
 	}{
 		{
+			map[string]interface{}{
+				"twitter": map[string]interface{}{
+					"simple": true,
+				},
+			},
+			`{{< tweet 666616452582129664 >}}`,
+			`{"url":"https:\/\/twitter.com\/spf13\/status\/666616452582129664","author_name":"Steve Francia","author_url":"https:\/\/twitter.com\/spf13","html":"\u003Cblockquote class=\"twitter-tweet\"\u003E\u003Cp lang=\"en\" dir=\"ltr\"\u003EHugo 0.15 will have 30%+ faster render times thanks to this commit \u003Ca href=\"https:\/\/t.co\/FfzhM8bNhT\"\u003Ehttps:\/\/t.co\/FfzhM8bNhT\u003C\/a\u003E  \u003Ca href=\"https:\/\/twitter.com\/hashtag\/gohugo?src=hash\"\u003E#gohugo\u003C\/a\u003E \u003Ca href=\"https:\/\/twitter.com\/hashtag\/golang?src=hash\"\u003E#golang\u003C\/a\u003E \u003Ca href=\"https:\/\/t.co\/ITbMNU2BUf\"\u003Ehttps:\/\/t.co\/ITbMNU2BUf\u003C\/a\u003E\u003C\/p\u003E&mdash; Steve Francia (@spf13) \u003Ca href=\"https:\/\/twitter.com\/spf13\/status\/666616452582129664\"\u003ENovember 17, 2015\u003C\/a\u003E\u003C\/blockquote\u003E\n\u003Cscript async src=\"\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"\u003E\u003C\/script\u003E","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}`,
+			`.twitter-tweet a`,
+		},
+		{
+			map[string]interface{}{
+				"twitter": map[string]interface{}{
+					"simple": false,
+				},
+			},
 			`{{< tweet 666616452582129664 >}}`,
 			`{"url":"https:\/\/twitter.com\/spf13\/status\/666616452582129664","author_name":"Steve Francia","author_url":"https:\/\/twitter.com\/spf13","html":"\u003Cblockquote class=\"twitter-tweet\"\u003E\u003Cp lang=\"en\" dir=\"ltr\"\u003EHugo 0.15 will have 30%+ faster render times thanks to this commit \u003Ca href=\"https:\/\/t.co\/FfzhM8bNhT\"\u003Ehttps:\/\/t.co\/FfzhM8bNhT\u003C\/a\u003E  \u003Ca href=\"https:\/\/twitter.com\/hashtag\/gohugo?src=hash\"\u003E#gohugo\u003C\/a\u003E \u003Ca href=\"https:\/\/twitter.com\/hashtag\/golang?src=hash\"\u003E#golang\u003C\/a\u003E \u003Ca href=\"https:\/\/t.co\/ITbMNU2BUf\"\u003Ehttps:\/\/t.co\/ITbMNU2BUf\u003C\/a\u003E\u003C\/p\u003E&mdash; Steve Francia (@spf13) \u003Ca href=\"https:\/\/twitter.com\/spf13\/status\/666616452582129664\"\u003ENovember 17, 2015\u003C\/a\u003E\u003C\/blockquote\u003E\n\u003Cscript async src=\"\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"\u003E\u003C\/script\u003E","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}`,
 			`(?s)^<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Hugo 0.15 will have 30%. faster render times thanks to this commit <a href="https://t.co/FfzhM8bNhT">https://t.co/FfzhM8bNhT</a>  <a href="https://twitter.com/hashtag/gohugo.src=hash">#gohugo</a> <a href="https://twitter.com/hashtag/golang.src=hash">#golang</a> <a href="https://t.co/ITbMNU2BUf">https://t.co/ITbMNU2BUf</a></p>&mdash; Steve Francia .@spf13. <a href="https://twitter.com/spf13/status/666616452582129664">November 17, 2015</a></blockquote>.*?<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>`,
@@ -290,7 +306,7 @@ func TestShortcodeTweet(t *testing.T) {
 	} {
 		// overload getJSON to return mock API response from Twitter
 		tweetFuncMap := template.FuncMap{
-			"getJSON": func(urlParts ...string) interface{} {
+			"getJSON": func(urlParts ...interface{}) interface{} {
 				var v interface{}
 				err := json.Unmarshal([]byte(this.resp), &v)
 				if err != nil {
@@ -305,6 +321,8 @@ func TestShortcodeTweet(t *testing.T) {
 			cfg, fs = newTestCfg()
 			th      = newTestHelper(cfg, fs, t)
 		)
+
+		cfg.Set("privacy", this.privacy)
 
 		withTemplate := func(templ tpl.TemplateHandler) error {
 			templ.(tpl.TemplateTestMocker).SetFuncs(tweetFuncMap)

--- a/hugolib/testhelpers_test.go
+++ b/hugolib/testhelpers_test.go
@@ -753,7 +753,11 @@ func (th testHelper) assertFileContentRegexp(filename string, matches ...string)
 	for _, match := range matches {
 		match = th.replaceDefaultContentLanguageValue(match)
 		r := regexp.MustCompile(match)
-		th.Assert(r.MatchString(content), qt.Equals, true)
+		matches := r.MatchString(content)
+		if !matches {
+			fmt.Println(content)
+		}
+		th.Assert(matches, qt.Equals, true)
 	}
 }
 

--- a/tpl/data/data.go
+++ b/tpl/data/data.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/spf13/cast"
+
 	"github.com/gohugoio/hugo/cache/filecache"
 	"github.com/gohugoio/hugo/deps"
 	_errors "github.com/pkg/errors"
@@ -54,8 +56,8 @@ type Namespace struct {
 // The data separator can be a comma, semi-colon, pipe, etc, but only one character.
 // If you provide multiple parts for the URL they will be joined together to the final URL.
 // GetCSV returns nil or a slice slice to use in a short code.
-func (ns *Namespace) GetCSV(sep string, urlParts ...string) (d [][]string, err error) {
-	url := strings.Join(urlParts, "")
+func (ns *Namespace) GetCSV(sep string, urlParts ...interface{}) (d [][]string, err error) {
+	url := joinURL(urlParts)
 	cache := ns.cacheGetCSV
 
 	unmarshal := func(b []byte) (bool, error) {
@@ -93,9 +95,9 @@ func (ns *Namespace) GetCSV(sep string, urlParts ...string) (d [][]string, err e
 // GetJSON expects one or n-parts of a URL to a resource which can either be a local or a remote one.
 // If you provide multiple parts they will be joined together to the final URL.
 // GetJSON returns nil or parsed JSON to use in a short code.
-func (ns *Namespace) GetJSON(urlParts ...string) (interface{}, error) {
+func (ns *Namespace) GetJSON(urlParts ...interface{}) (interface{}, error) {
 	var v interface{}
-	url := strings.Join(urlParts, "")
+	url := joinURL(urlParts)
 	cache := ns.cacheGetJSON
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -120,6 +122,10 @@ func (ns *Namespace) GetJSON(urlParts ...string) (interface{}, error) {
 	}
 
 	return v, nil
+}
+
+func joinURL(urlParts []interface{}) string {
+	return strings.Join(cast.ToStringSlice(urlParts), "")
 }
 
 // parseCSV parses bytes of CSV data into a slice slice string or an error

--- a/tpl/data/data_test.go
+++ b/tpl/data/data_test.go
@@ -204,6 +204,12 @@ func TestGetJSON(t *testing.T) {
 	}
 }
 
+func TestJoinURL(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	c.Assert(joinURL([]interface{}{"https://foo?id=", 32}), qt.Equals, "https://foo?id=32")
+}
+
 func TestParseCSV(t *testing.T) {
 	t.Parallel()
 	c := qt.New(t)


### PR DESCRIPTION
This broke for the Twitter simple shortcode now that Shortcodes accepts typed arguments.

Fixes #6382