### PR TITLE
main: WIP add support for HUGOFLAGS

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,12 +15,17 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"github.com/gohugoio/hugo/commands"
 )
 
 func main() {
-	resp := commands.Execute(os.Args[1:])
+
+	hugoflags := os.Getenv("HUGOFLAGS")
+	hugoargs := strings.Split(hugoflags, " ")
+
+	resp := commands.Execute(append(hugoargs, os.Args[1:]...))
 
 	if resp.Err != nil {
 		if resp.IsUserError() {


### PR DESCRIPTION
Implements use of `HUGOFLAGS` env variable to supply flags. This is
useful for personal setups or scripts that require multiple invocation
of hugo with same set of flags. Inspired by `GOFLAGS`

Fixes #5947