### PR TITLE
Do not attempt to build if there is no config file

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -313,6 +313,8 @@ func (c *commandeer) loadConfig(mustHaveConfigFile, running bool) error {
 			return err
 		}
 
+	} else if mustHaveConfigFile && len(configFiles) == 0 {
+		return hugolib.ErrNoConfigFile
 	}
 
 	c.configFiles = configFiles


### PR DESCRIPTION
As of now, if one attempts to run `hugo` in a directory without a config file, it will fail.

```
$ hugo
Error: Unable to locate config file or config directory. Perhaps you need to create a new site.
       Run `hugo help new` for details.
```

This addresses #5896. It is worth noting that if the directory has a go.mod file, building will still continue, as it is still considered a config file. I'm not 100% on how to deal with this, as it seems that we still do want these to be considered config files for Hugo's module system. It's a small edge case, but this will catch _most_ cases.