### PR TITLE
Machine readable 'hugo version' and 'hugo env' commands #5642

### DIFF
--- a/commands/env.go
+++ b/commands/env.go
@@ -16,6 +16,7 @@ package commands
 import (
 	"runtime"
 
+	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/spf13/cobra"
 	jww "github.com/spf13/jwalterweatherman"
 )
@@ -32,11 +33,11 @@ func newEnvCmd() *envCmd {
 		Short: "Print Hugo version and environment info",
 		Long:  `Print Hugo version and environment info. This is useful in Hugo bug reports.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			printHugoVersion()
+			jww.FEEDBACK.Printf("HUGOPROGRAM=%q\n", "Hugo Static Site Generator")
+			jww.FEEDBACK.Printf("HUGOVERSION=%q\n", hugo.CurrentVersion.String())
 			jww.FEEDBACK.Printf("GOOS=%q\n", runtime.GOOS)
 			jww.FEEDBACK.Printf("GOARCH=%q\n", runtime.GOARCH)
 			jww.FEEDBACK.Printf("GOVERSION=%q\n", runtime.Version())
-
 			return nil
 		},
 	}),

--- a/commands/version.go
+++ b/commands/version.go
@@ -14,9 +14,12 @@
 package commands
 
 import (
+	"runtime"
+
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/spf13/cobra"
 	jww "github.com/spf13/jwalterweatherman"
+	"gopkg.in/yaml.v2"
 )
 
 var _ cmder = (*versionCmd)(nil)
@@ -32,7 +35,25 @@ func newVersionCmd() *versionCmd {
 			Short: "Print the version number of Hugo",
 			Long:  `All software has versions. This is Hugo's.`,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				printHugoVersion()
+				versionOut := yaml.MapSlice{
+					yaml.MapItem{
+						Key:   "Program",
+						Value: "Hugo Static Site Generator",
+					},
+					yaml.MapItem{
+						Key:   "OS/Arch",
+						Value: runtime.GOOS + "/" + runtime.GOARCH,
+					},
+					yaml.MapItem{
+						Key:   "Version",
+						Value: hugo.CurrentVersion.String(),
+					},
+				}
+				output, err := yaml.Marshal(versionOut)
+				if err != nil {
+					return err
+				}
+				jww.FEEDBACK.Print(string(output))
 				return nil
 			},
 		}),

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/gorilla/websocket v1.4.0
 	github.com/jdkato/prose v1.1.0
 	github.com/kyokomi/emoji v2.1.0+incompatible
-	github.com/magefile/mage v1.4.0
+	github.com/magefile/mage v1.9.0
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/markbates/inflect v1.0.0
 	github.com/mattn/go-isatty v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/kyokomi/emoji v2.1.0+incompatible/go.mod h1:mZ6aGCD7yk8j6QY6KICwnZ2px
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magefile/mage v1.4.0 h1:RI7B1CgnPAuu2O9lWszwya61RLmfL0KCdo+QyyI/Bhk=
 github.com/magefile/mage v1.4.0/go.mod h1:IUDi13rsHje59lecXokTfGX0QIzO45uVPlXnJYsXepA=
+github.com/magefile/mage v1.9.0 h1:t3AU2wNwehMCW97vuqQLtw6puppWXHO+O2MHo5a50XE=
+github.com/magefile/mage v1.9.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=


### PR DESCRIPTION
Changes to YAML the `hugo version` output and adds
version related info to the `hugo env` command.

See #5642