### PR TITLE
resources/images: Add exception for new test image

### DIFF
--- a/resources/image_test.go
+++ b/resources/image_test.go
@@ -651,7 +651,8 @@ func TestImageOperationsGolden(t *testing.T) {
 			switch fi1.Name() {
 			case "gohugoio8_hu7f72c00afdf7634587afaa5eff2a25b2_73538_4c320010919da2d8b63ed24818b4d8e1.png",
 				"gohugoio8_hu7f72c00afdf7634587afaa5eff2a25b2_73538_9d4c2220235b3c2d9fa6506be571560f.png",
-				"gohugoio8_hu7f72c00afdf7634587afaa5eff2a25b2_73538_c74bb417b961e09cf1aac2130b7b9b85.png":
+				"gohugoio8_hu7f72c00afdf7634587afaa5eff2a25b2_73538_c74bb417b961e09cf1aac2130b7b9b85.png",
+				"gohugoio8_hu7f72c00afdf7634587afaa5eff2a25b2_73538_300x200_fill_gaussian_smart1_2.png":
 				c.Log("expectedly differs from golden due to dithering:", fi1.Name())
 			default:
 				t.Errorf("resulting image differs from golden: %s", fi1.Name())


### PR DESCRIPTION
Add exception for new test image in TestImageOperationsGolden due to "fused multiply and add" (FMA) instruction on s390x, ppc64* and arm64.

See #6439

---

(I was alerted by automated email telling me of snap build failure on those platforms and redirecting me to https://launchpad.net/~gohugoio/+snap/hugo-dev etc.)