### PR TITLE
Add goldmark renderer, with no options (yet)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/tdewolff/minify/v2 v2.5.2
 	github.com/yosssi/ace v0.0.5
+	github.com/yuin/goldmark v1.1.0
 	go.opencensus.io v0.22.0 // indirect
 	gocloud.dev v0.15.0
 	golang.org/x/image v0.0.0-20190523035834-f03afa92d3ff

--- a/go.sum
+++ b/go.sum
@@ -345,6 +345,8 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yosssi/ace v0.0.5 h1:tUkIP/BLdKqrlrPwcmH0shwEEhTRHoGnc1wFIWmaBUA=
 github.com/yosssi/ace v0.0.5/go.mod h1:ALfIzm2vT7t5ZE7uoIZqF3TQ7SAOyupFZnkrF5id+K0=
+github.com/yuin/goldmark v1.1.0 h1:Z5ZerZZLUdCBKw7nhz0z14LMkpPvHmo7j2MdbzD39LI=
+github.com/yuin/goldmark v1.1.0/go.mod h1:hDgn8A2EV4OniExoeJs1fSrmEc/T7w8+Teyq8YkThxQ=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.mongodb.org/mongo-driver v1.0.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -429,6 +429,18 @@ func TestMmarkRender(t *testing.T) {
 	}
 }
 
+func TestGoldmarkRender(t *testing.T) {
+	c := newTestContentSpec()
+	ctx := &RenderingContext{Cfg: c.Cfg, PageFmt: "goldmark"}
+	ctx.Content = []byte("# TestContent\n\nand more")
+	got := c.RenderBytes(ctx)
+	want := []byte("<h1>TestContent</h1>\n<p>and more</p>\n")
+	// TODO(evankanderson): use go-cmp
+	if !bytes.Equal(got, want) {
+		t.Errorf("Expected %q to render as %q, got %q", ctx.Content, want, got)
+	}
+}
+
 func TestExtractTOCNormalContent(t *testing.T) {
 	content := []byte("<nav>\n<ul>\nTOC<li><a href=\"#")
 


### PR DESCRIPTION
Applies to #5963 

I tested on a local build of https://knative.dev/docs/install/knative-with-aks/

Note that this does not yet include features like https://github.com/yuin/goldmark-highlighting

Also, error handling in the existing `RenderBytes` method seemed not great, so I just used a `panic`. I'm willing to plumb an `error` parameter higher if needed.

Signed-off-by: Evan Anderson <evan.k.anderson@gmail.com>