### PR TITLE
travis: Increase timeout to 30000 for mage -v check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ script:
   - if [ "$TRAVIS_ARCH" = "amd64" ]; then
         mage -v check;
     else
-        mage -v check || true;
+        HUGO_TIMEOUT=30000 mage -v check;
     fi
   - mage -v hugo
   - ./hugo -s docs/


### PR DESCRIPTION
The default timeout of 15000 millisecond is too short
for go test -race on arm64.

See golang/go#35308