### PR TITLE
Add permalink configuration for non-zero padded dates

### DIFF
--- a/docs/content/en/content-management/urls.md
+++ b/docs/content/en/content-management/urls.md
@@ -48,13 +48,19 @@ The following is a list of values that can be used in a `permalink` definition i
 : the 4-digit year
 
 `:month`
-: the 2-digit month
+: the 2-digit month (zero padded)
+
+`:monthnopad`
+: the 2-digit month with no zero padding
 
 `:monthname`
 : the name of the month
 
 `:day`
-: the 2-digit day
+: the 2-digit day (zero padded)
+
+`:daynopad`
+: the 2-digit day with no zero padding
 
 `:weekday`
 : the 1-digit day of the week (Sunday = 0)

--- a/resources/page/permalinks.go
+++ b/resources/page/permalinks.go
@@ -47,8 +47,10 @@ func NewPermalinkExpander(ps *helpers.PathSpec) (PermalinkExpander, error) {
 	p.knownPermalinkAttributes = map[string]pageToPermaAttribute{
 		"year":        p.pageToPermalinkDate,
 		"month":       p.pageToPermalinkDate,
+		"monthnopad":  p.pageToPermalinkDate,
 		"monthname":   p.pageToPermalinkDate,
 		"day":         p.pageToPermalinkDate,
+		"daynopad":    p.pageToPermalinkDate,
 		"weekday":     p.pageToPermalinkDate,
 		"weekdayname": p.pageToPermalinkDate,
 		"yearday":     p.pageToPermalinkDate,
@@ -203,10 +205,14 @@ func (l PermalinkExpander) pageToPermalinkDate(p Page, dateField string) (string
 		return strconv.Itoa(p.Date().Year()), nil
 	case "month":
 		return fmt.Sprintf("%02d", int(p.Date().Month())), nil
+	case "monthnopad":
+		return fmt.Sprintf("%d", int(p.Date().Month())), nil
 	case "monthname":
 		return p.Date().Month().String(), nil
 	case "day":
 		return fmt.Sprintf("%02d", p.Date().Day()), nil
+	case "daynopad":
+		return fmt.Sprintf("%d", p.Date().Day()), nil
 	case "weekday":
 		return strconv.Itoa(int(p.Date().Weekday())), nil
 	case "weekdayname":

--- a/resources/page/permalinks_test.go
+++ b/resources/page/permalinks_test.go
@@ -32,6 +32,7 @@ var testdataPermalinks = []struct {
 	{":title", true, "spf13-vim-3.0-release-and-new-website"},
 	{"/:year-:month-:title", true, "/2012-04-spf13-vim-3.0-release-and-new-website"},
 	{"/:year/:yearday/:month/:monthname/:day/:weekday/:weekdayname/", true, "/2012/97/04/April/06/5/Friday/"}, // Dates
+	{"/:year/:monthnopad/:daynopad", true, "/2012/4/6"},           // Dates without padding
 	{"/:section/", true, "/blue/"},                                // Section
 	{"/:title/", true, "/spf13-vim-3.0-release-and-new-website/"}, // Title
 	{"/:slug/", true, "/the-slug/"},                               // Slug


### PR DESCRIPTION
This adds new permalink configuration to allow non-zero padded months (`:monthnopad`) and days (`:daynopad`) to be used in URLs. For example, `2018-01-06` can be rendered as `/2018/1/6`.

See: https://discourse.gohugo.io/t/implementing-additional-date-formats-for-permalinks/17860

I also looked into implementing this using `strftime` escapes, as hinted at by this TODO comment introduced way back in 07978e4a4922bc21c230fee65052232b829bd1ab:

https://github.com/gohugoio/hugo/blob/cafecca440e495ec915cc6290fe09d2a343e9c95/resources/page/permalinks.go#L217-L218

I did find a very nice [pure Go strftime library](https://github.com/lestrrat-go/strftime). However, it wasn't clear to me how to fit stftime escapes into the permalink configuration that exists today, so I went with the straightforward solution of adding new configuration.
