### PR TITLE
Support Go time format strings in permalinks

### DIFF
--- a/docs/content/en/content-management/urls.md
+++ b/docs/content/en/content-management/urls.md
@@ -38,6 +38,13 @@ permalinks:
 
 Only the content under `posts/` will have the new URL structure. For example, the file `content/posts/sample-entry.md` with `date: 2017-02-27T19:20:00-05:00` in its front matter will render to `public/2017/02/sample-entry/index.html` at build time and therefore be reachable at `https://example.com/2017/02/sample-entry/`.
 
+If the standard date-based permalink configuration does not meet your needs, you can also format URL segments using [Go time formatting directives](https://golang.org/pkg/time/#Time.Format). For example, a URL structure with two digit years and month and day digits without zero padding can be accomplished with:
+
+{{< code-toggle file="config" copy="false" >}}
+permalinks:
+  posts: /:06/:1/:2/:title/
+{{< /code-toggle >}}
+
 You can also configure permalinks of taxonomies with the same syntax, by using the plural form of the taxonomy instead of the section. You will probably only want to use the configuration values `:slug` or `:title`.
 
 ### Permalink Configuration Values
@@ -79,6 +86,8 @@ The following is a list of values that can be used in a `permalink` definition i
 
 `:filename`
 : the content's filename (without extension)
+
+Additionally, a Go time format string prefixed with `:` may be used.
 
 ## Aliases
 

--- a/resources/page/permalinks_test.go
+++ b/resources/page/permalinks_test.go
@@ -32,16 +32,21 @@ var testdataPermalinks = []struct {
 	{":title", true, "spf13-vim-3.0-release-and-new-website"},
 	{"/:year-:month-:title", true, "/2012-04-spf13-vim-3.0-release-and-new-website"},
 	{"/:year/:yearday/:month/:monthname/:day/:weekday/:weekdayname/", true, "/2012/97/04/April/06/5/Friday/"}, // Dates
-	{"/:section/", true, "/blue/"},                                // Section
-	{"/:title/", true, "/spf13-vim-3.0-release-and-new-website/"}, // Title
-	{"/:slug/", true, "/the-slug/"},                               // Slug
-	{"/:filename/", true, "/test-page/"},                          // Filename
+	{"/:section/", true, "/blue/"},                                  // Section
+	{"/:title/", true, "/spf13-vim-3.0-release-and-new-website/"},   // Title
+	{"/:slug/", true, "/the-slug/"},                                 // Slug
+	{"/:filename/", true, "/test-page/"},                            // Filename
+	{"/:06-:1-:2-:Monday", true, "/12-4-6-Friday"},                  // Dates with Go formatting
+	{"/:2006_01_02_15_04_05.000", true, "/2012_04_06_03_01_59.000"}, // Complicated custom date format
 	// TODO(moorereason): need test scaffolding for this.
 	//{"/:sections/", false, "/blue/"},                              // Sections
 
 	// Failures
 	{"/blog/:fred", false, ""},
 	{"/:year//:title", false, ""},
+	{"/:TITLE", false, ""},      // case is not normalized
+	{"/:2017", false, ""},       // invalid date format
+	{"/:2006-01-02", false, ""}, // valid date format but invalid attribute name
 }
 
 func TestPermalinkExpansion(t *testing.T) {
@@ -51,7 +56,7 @@ func TestPermalinkExpansion(t *testing.T) {
 
 	page := newTestPageWithFile("/test-page/index.md")
 	page.title = "Spf13 Vim 3.0 Release and new website"
-	d, _ := time.Parse("2006-01-02", "2012-04-06")
+	d, _ := time.Parse("2006-01-02 15:04:05", "2012-04-06 03:01:59")
 	page.date = d
 	page.section = "blue"
 	page.slug = "The Slug"


### PR DESCRIPTION
In the vein of an [ancient TODO](https://github.com/gohugoio/hugo/commit/07978e4a4922bc21c230fee65052232b829bd1ab#diff-0688a3b65c7f5d01aa216f8d9b57fd00R111-R112) about supporting custom date formatting with strftime, this allows `:`-prefixed Go time format strings in permalink segments. This allows users to customize date-based permalinks any way they need to.

For example, with a date of 2019-11-09, the permalink `/:06/:1/:2` will render as `/19/11/9`.

See:

- [Discourse thread](https://discourse.gohugo.io/t/implementing-additional-date-formats-for-permalinks/17860)
- [Discussion of alternative approach](https://github.com/gohugoio/hugo/pull/6488)