### PR TITLE
commands: Add hint when dir not empty.

### DIFF
--- a/commands/new_site.go
+++ b/commands/new_site.go
@@ -81,7 +81,7 @@ func (n *newSiteCmd) doNewSite(fs *hugofs.Fs, basepath string, force bool) error
 
 		switch {
 		case !isEmpty && !force:
-			return errors.New(basepath + " already exists and is not empty")
+			return errors.New(basepath + " already exists and is not empty. See --force.")
 
 		case !isEmpty && force:
 			all := append(dirs, filepath.Join(basepath, "config."+n.configFormat))


### PR DESCRIPTION
Many users seem to stumble over creating new sites in existing non-empty directories. And that `--force` is the necessary option. So I added *See --force* as a hint to the error.

Fixes #4825.