### PR TITLE
docs: Fix error in mathjax-markdown-solution.html

### DIFF
--- a/docs/content/en/content-management/formats.md
+++ b/docs/content/en/content-management/formats.md
@@ -162,7 +162,7 @@ Another option is to tell Markdown to treat the MathJax code as verbatim code an
 MathJax.Hub.Config({
   tex2jax: {
     inlineMath: [['$','$'], ['\\(','\\)']],
-    displayMath: [['$$','$$'], ['\[','\]']],
+    displayMath: [['$$','$$'], ['\\[','\\]']],
     processEscapes: true,
     processEnvironments: true,
     skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],


### PR DESCRIPTION
With present value
    please see [1] for more information
resuls in the "[1]" being recognised as display mathematics.

Present value is
    displayMath: [['$$','$$'], ['\[','\]']],

Change value to
    displayMath: [['$$','$$'], ['\\[','\\]']],

This follows the advice in:
http://docs.mathjax.org/en/v2.7-latest/configuration.html#using-in-line-configuration-options

Fixes #6515