### PR TITLE
Add inline template function to complement markdownify

### DIFF
--- a/tpl/strings/init.go
+++ b/tpl/strings/init.go
@@ -56,7 +56,8 @@ func init() {
 			[][2]string{
 				{
 					`{{ findRE "[G|g]o" "Hugo is a static side generator written in Go." "1" }}`,
-					`[go]`},
+					`[go]`,
+				},
 			},
 		)
 
@@ -80,7 +81,8 @@ func init() {
 			[][2]string{
 				{
 					`{{ replace "Batman and Robin" "Robin" "Catwoman" }}`,
-					`Batman and Catwoman`},
+					`Batman and Catwoman`,
+				},
 			},
 		)
 
@@ -166,7 +168,7 @@ func init() {
 			[]string{"truncate"},
 			[][2]string{
 				{`{{ "this is a very long text" | truncate 10 " ..." }}`, `this is a ...`},
-				{`{{ "With [Markdown](/markdown) inside." | markdownify | truncate 14 }}`, `With <a href="/markdown">Markdown …</a>`},
+				{`{{ "With [Markdown](/markdown) inside." | markdownify | inline | truncate 14 }}`, `With <a href="/markdown">Markdown …</a>`},
 			},
 		)
 
@@ -185,7 +187,6 @@ func init() {
 		)
 
 		return ns
-
 	}
 
 	internal.AddTemplateFuncsNamespace(f)

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -360,7 +360,7 @@ if (!doNotTrack) {
                 {{- with .Get "attrlink" }}
                     <a href="{{ . }}">
                 {{- end -}}
-                {{- .Get "attr" | markdownify | inline  -}}
+                {{- .Get "attr" | markdownify | inline -}}
                 {{- if .Get "attrlink" }}</a>{{ end }}</p>
             {{- end }}
         </figcaption>

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -344,7 +344,7 @@ if (!doNotTrack) {
     {{- end }}
     <img src="{{ .Get "src" }}"
          {{- if or (.Get "alt") (.Get "caption") }}
-         alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
+         alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify | inline | plainify }}{{ end }}"
          {{- end -}}
          {{- with .Get "width" }} width="{{ . }}"{{ end -}}
          {{- with .Get "height" }} height="{{ . }}"{{ end -}}
@@ -356,11 +356,11 @@ if (!doNotTrack) {
                 <h4>{{ . }}</h4>
             {{- end -}}
             {{- if or (.Get "caption") (.Get "attr") -}}<p>
-                {{- .Get "caption" | markdownify -}}
+                {{- .Get "caption" | markdownify | inline -}}
                 {{- with .Get "attrlink" }}
                     <a href="{{ . }}">
                 {{- end -}}
-                {{- .Get "attr" | markdownify -}}
+                {{- .Get "attr" | markdownify | inline  -}}
                 {{- if .Get "attrlink" }}</a>{{ end }}</p>
             {{- end }}
         </figcaption>

--- a/tpl/tplimpl/embedded/templates/shortcodes/figure.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/figure.html
@@ -4,7 +4,7 @@
     {{- end }}
     <img src="{{ .Get "src" }}"
          {{- if or (.Get "alt") (.Get "caption") }}
-         alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
+         alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify | inline | plainify }}{{ end }}"
          {{- end -}}
          {{- with .Get "width" }} width="{{ . }}"{{ end -}}
          {{- with .Get "height" }} height="{{ . }}"{{ end -}}
@@ -16,11 +16,11 @@
                 <h4>{{ . }}</h4>
             {{- end -}}
             {{- if or (.Get "caption") (.Get "attr") -}}<p>
-                {{- .Get "caption" | markdownify -}}
+                {{- .Get "caption" | markdownify | inline -}}
                 {{- with .Get "attrlink" }}
                     <a href="{{ . }}">
                 {{- end -}}
-                {{- .Get "attr" | markdownify -}}
+                {{- .Get "attr" | markdownify | inline  -}}
                 {{- if .Get "attrlink" }}</a>{{ end }}</p>
             {{- end }}
         </figcaption>

--- a/tpl/tplimpl/embedded/templates/shortcodes/figure.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/figure.html
@@ -20,7 +20,7 @@
                 {{- with .Get "attrlink" }}
                     <a href="{{ . }}">
                 {{- end -}}
-                {{- .Get "attr" | markdownify | inline  -}}
+                {{- .Get "attr" | markdownify | inline -}}
                 {{- if .Get "attrlink" }}</a>{{ end }}</p>
             {{- end }}
         </figcaption>

--- a/tpl/transform/init.go
+++ b/tpl/transform/init.go
@@ -46,13 +46,16 @@ func init() {
 			[][2]string{
 				{
 					`{{ htmlEscape "Cathal Garvey & The Sunshine Band <cathal@foo.bar>" | safeHTML}}`,
-					`Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;`},
+					`Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;`,
+				},
 				{
 					`{{ htmlEscape "Cathal Garvey & The Sunshine Band <cathal@foo.bar>"}}`,
-					`Cathal Garvey &amp;amp; The Sunshine Band &amp;lt;cathal@foo.bar&amp;gt;`},
+					`Cathal Garvey &amp;amp; The Sunshine Band &amp;lt;cathal@foo.bar&amp;gt;`,
+				},
 				{
 					`{{ htmlEscape "Cathal Garvey & The Sunshine Band <cathal@foo.bar>" | htmlUnescape | safeHTML }}`,
-					`Cathal Garvey & The Sunshine Band <cathal@foo.bar>`},
+					`Cathal Garvey & The Sunshine Band <cathal@foo.bar>`,
+				},
 			},
 		)
 
@@ -61,23 +64,34 @@ func init() {
 			[][2]string{
 				{
 					`{{ htmlUnescape "Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;" | safeHTML}}`,
-					`Cathal Garvey & The Sunshine Band <cathal@foo.bar>`},
+					`Cathal Garvey & The Sunshine Band <cathal@foo.bar>`,
+				},
 				{
 					`{{"Cathal Garvey &amp;amp; The Sunshine Band &amp;lt;cathal@foo.bar&amp;gt;" | htmlUnescape | htmlUnescape | safeHTML}}`,
-					`Cathal Garvey & The Sunshine Band <cathal@foo.bar>`},
+					`Cathal Garvey & The Sunshine Band <cathal@foo.bar>`,
+				},
 				{
 					`{{"Cathal Garvey &amp;amp; The Sunshine Band &amp;lt;cathal@foo.bar&amp;gt;" | htmlUnescape | htmlUnescape }}`,
-					`Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;`},
+					`Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;`,
+				},
 				{
 					`{{ htmlUnescape "Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;" | htmlEscape | safeHTML }}`,
-					`Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;`},
+					`Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;`,
+				},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.Inline,
+			[]string{"inline"},
+			[][2]string{
+				{`{{ .Title | markdownify | inline }}`, `<strong>BatMan</strong>`},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Markdownify,
 			[]string{"markdownify"},
 			[][2]string{
-				{`{{ .Title | markdownify}}`, `<strong>BatMan</strong>`},
+				{`{{ .Title | markdownify }}`, "<p><strong>BatMan</strong></p>\n"},
 			},
 		)
 
@@ -104,7 +118,6 @@ func init() {
 		)
 
 		return ns
-
 	}
 
 	internal.AddTemplateFuncsNamespace(f)

--- a/tpl/transform/transform.go
+++ b/tpl/transform/transform.go
@@ -90,6 +90,18 @@ func (ns *Namespace) HTMLUnescape(s interface{}) (string, error) {
 	return html.UnescapeString(ss), nil
 }
 
+// Inline strips the surrouding paragraph tags from s.
+func (ns *Namespace) Inline(s interface{}) (template.HTML, error) {
+	ss, err := cast.ToStringE(s)
+	if err != nil {
+		return "", err
+	}
+
+	b := ns.deps.ContentSpec.TrimShortHTML([]byte(ss))
+
+	return helpers.BytesToHTML(b), nil
+}
+
 // Markdownify renders a given input from Markdown to HTML.
 func (ns *Namespace) Markdownify(s interface{}) (template.HTML, error) {
 	ss, err := cast.ToStringE(s)
@@ -98,13 +110,9 @@ func (ns *Namespace) Markdownify(s interface{}) (template.HTML, error) {
 	}
 
 	b, err := ns.deps.ContentSpec.RenderMarkdown([]byte(ss))
-
 	if err != nil {
 		return "", err
 	}
-
-	// Strip if this is a short inline type of text.
-	b = ns.deps.ContentSpec.TrimShortHTML(b)
 
 	return helpers.BytesToHTML(b), nil
 }


### PR DESCRIPTION
Add inline template function to handle the TrimShortHTML call, and
remove the TrimShortHTML call from markdownify.  To get the old behavior
do `. | markdownify | inline`.

Fixes #5975