### PR TITLE
Work in progress: Outputs path of changed file in "watch" mode for easier debugging. #2609

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -860,6 +860,15 @@ func (c *commandeer) printChangeDetected(typ string) {
 		msg += " of " + typ
 	}
 	msg += " detected, rebuilding site."
+	watchDirs, err := c.getDirList()
+	if err != nil {
+		return err
+	}
+
+	baseWatchDir := c.Cfg.GetString("workingDir")
+	rootWatchDirs := getRootWatchDirsStr(baseWatchDir, watchDirs)
+
+	c.logger.FEEDBACK.Printf("Changes in %s%s{%s}\n", baseWatchDir, helpers.FilePathSeparator, rootWatchDirs)
 
 	c.logger.FEEDBACK.Println(msg)
 	const layout = "2006-01-02 15:04:05.000 -0700"

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/gorilla/websocket v1.4.0
 	github.com/jdkato/prose v1.1.0
 	github.com/kyokomi/emoji v2.1.0+incompatible
-	github.com/magefile/mage v1.4.0
+	github.com/magefile/mage v1.9.0
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/markbates/inflect v1.0.0
 	github.com/mattn/go-isatty v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/kyokomi/emoji v2.1.0+incompatible/go.mod h1:mZ6aGCD7yk8j6QY6KICwnZ2px
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magefile/mage v1.4.0 h1:RI7B1CgnPAuu2O9lWszwya61RLmfL0KCdo+QyyI/Bhk=
 github.com/magefile/mage v1.4.0/go.mod h1:IUDi13rsHje59lecXokTfGX0QIzO45uVPlXnJYsXepA=
+github.com/magefile/mage v1.9.0 h1:t3AU2wNwehMCW97vuqQLtw6puppWXHO+O2MHo5a50XE=
+github.com/magefile/mage v1.9.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=


### PR DESCRIPTION
Similar to #2609

Hello. I know this does not totally add the intended enhancement for that request. 

I am a college student in the US and we were tasked with finding a project on GitHub and studying the language and trying to solve an open issue while maintaining all intended quality assurance and following the project's contribution instructions.

**While in -w Watch Mode, when a change is made to a file this addition will print the filepath for easier debugging.**