### PR TITLE
tpl: Support GitInfo for content folders

### DIFF
--- a/docs/content/en/variables/git.md
+++ b/docs/content/en/variables/git.md
@@ -56,3 +56,9 @@ The `GitInfo` object contains the following fields:
 If the `.GitInfo` feature is enabled, `.Lastmod` (on `Page`) is fetched from Git i.e. `.GitInfo.AuthorDate`. This behaviour can be changed by adding your own [front matter configuration for dates](/getting-started/configuration/#configure-front-matter).
 
 [configuration]: /getting-started/configuration/
+
+## Using contentDir instead of workingDir
+
+If your content directory is under a submodule, you can add `useContentDirGitInfo` to `true` to your [site's configuration file][configuration].
+Hugo will then get its content metadata from the content repository (instead of the repository in the working directory).
+

--- a/hugolib/gitinfo.go
+++ b/hugolib/gitinfo.go
@@ -36,9 +36,16 @@ func (g *gitInfo) forPage(p page.Page) *gitmap.GitInfo {
 }
 
 func newGitInfo(cfg config.Provider) (*gitInfo, error) {
-	workingDir := cfg.GetString("workingDir")
+	useContentGitInfo := cfg.GetBool("useContentDirGitInfo")
+	var gitDir string
+	if useContentGitInfo {
+		gitDir = cfg.GetString("contentDir")
+	} else {
+		gitDir = cfg.GetString("workingDir")
 
-	gitRepo, err := gitmap.Map(workingDir, "")
+	}
+
+	gitRepo, err := gitmap.Map(gitDir, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add an option to get git metadata from the content dir instead of the
working dir

Fixes #5533