### PR TITLE
Fix incorrect MIME type from image/jpg to image/jpeg

### DIFF
--- a/docs/content/en/content-management/image-processing/index.md
+++ b/docs/content/en/content-management/image-processing/index.md
@@ -88,7 +88,7 @@ Sometimes it can be useful to create the filter chain once and then reuse it:
 
 Provides an [Exif](https://en.wikipedia.org/wiki/Exif) object with metadata about the image.
 
-Note that this is only suported for JPG and TIFF images, so it's recommended to wrap the access with a `with`, e.g.:
+Note that this is only suported for JPEG and TIFF images, so it's recommended to wrap the access with a `with`, e.g.:
 
 ```go-html-template
 {{ with $img.Exif }}

--- a/docs/content/en/content-management/page-resources.md
+++ b/docs/content/en/content-management/page-resources.md
@@ -17,7 +17,7 @@ menu:
 ## Properties
 
 ResourceType
-: The main type of the resource. For example, a file of MIME type `image/jpg` has the ResourceType `image`.
+: The main type of the resource. For example, a file of MIME type `image/jpeg` has the ResourceType `image`.
 
 Name
 : Default value is the filename (relative to the owning page). Can be set in front matter.
@@ -35,7 +35,7 @@ Content
 : The content of the resource itself. For most resources, this returns a string with the contents of the file. This can be used to inline some resources, such as `<script>{{ (.Resources.GetMatch "myscript.js").Content | safeJS }}</script>` or `<img src="{{ (.Resources.GetMatch "mylogo.png").Content | base64Encode }}">`.
 
 MediaType
-: The MIME type of the resource, such as `image/jpg`.
+: The MIME type of the resource, such as `image/jpeg`.
 
 MediaType.MainType
 : The main type of the resource's MIME type. For example, a file of MIME type `application/pdf` has for MainType `application`.

--- a/docs/data/docs.json
+++ b/docs/data/docs.json
@@ -1501,10 +1501,10 @@
         ]
       },
       {
-        "type": "image/jpg",
-        "string": "image/jpg",
+        "type": "image/jpeg",
+        "string": "image/jpeg",
         "mainType": "image",
-        "subType": "jpg",
+        "subType": "jpeg",
         "delimiter": ".",
         "suffixes": [
           "jpg",

--- a/hugolib/image_test.go
+++ b/hugolib/image_test.go
@@ -126,12 +126,12 @@ BG4: {{ $blurryGrayscale4.RelPermalink }}/{{ $blurryGrayscale4.Width }}
 	b := newBuilder("10ns")
 
 	imgExpect := `
-Resized1: images/sunset.jpg|123|234|image/jpg|/images/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_123x234_resize_q75_box.jpg|
-Resized2: images/sunset.jpg|12|23|image/jpg|/images/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_ada4bb1a57f77a63306e3bd67286248e.jpg|
-Resized3: sunset.jpg|345|678|image/jpg|/mybundle/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_345x678_resize_q75_box.jpg|
-Resized4: sunset.jpg|34|67|image/jpg|/mybundle/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_44d8c928664d7c5a67377c6ec58425ce.jpg|
-Resized5: images/sunset.jpg|456|789|image/jpg|/images/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_456x789_resize_q75_box.jpg|
-Resized6: images/sunset.jpg|350|219|image/jpg|/images/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_350x0_resize_q75_box.a86fe88d894e5db613f6aa8a80538fefc25b20fa24ba0d782c057adcef616f56.jpg|
+Resized1: images/sunset.jpg|123|234|image/jpeg|/images/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_123x234_resize_q75_box.jpg|
+Resized2: images/sunset.jpg|12|23|image/jpeg|/images/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_ada4bb1a57f77a63306e3bd67286248e.jpg|
+Resized3: sunset.jpg|345|678|image/jpeg|/mybundle/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_345x678_resize_q75_box.jpg|
+Resized4: sunset.jpg|34|67|image/jpeg|/mybundle/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_44d8c928664d7c5a67377c6ec58425ce.jpg|
+Resized5: images/sunset.jpg|456|789|image/jpeg|/images/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_456x789_resize_q75_box.jpg|
+Resized6: images/sunset.jpg|350|219|image/jpeg|/images/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_350x0_resize_q75_box.a86fe88d894e5db613f6aa8a80538fefc25b20fa24ba0d782c057adcef616f56.jpg|
 BG1: /images/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_2ae8bb993431ec1aec40fe59927b46b4.jpg/123
 BG2: /images/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_2ae8bb993431ec1aec40fe59927b46b4.jpg/123
 BG3: /images/sunset_hu59e56ffff1bc1d8d122b1403d34e039f_90587_ed7740a90b82802261c2fbdb98bc8082.jpg/123

--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -140,7 +140,7 @@ var (
 
 	// Common image types
 	PNGType  = Type{MainType: "image", SubType: "png", Suffixes: []string{"png"}, Delimiter: defaultDelimiter}
-	JPGType  = Type{MainType: "image", SubType: "jpg", Suffixes: []string{"jpg", "jpeg"}, Delimiter: defaultDelimiter}
+	JPEGType = Type{MainType: "image", SubType: "jpeg", Suffixes: []string{"jpg", "jpeg"}, Delimiter: defaultDelimiter}
 	GIFType  = Type{MainType: "image", SubType: "gif", Suffixes: []string{"gif"}, Delimiter: defaultDelimiter}
 	TIFFType = Type{MainType: "image", SubType: "tiff", Suffixes: []string{"tif", "tiff"}, Delimiter: defaultDelimiter}
 	BMPType  = Type{MainType: "image", SubType: "bmp", Suffixes: []string{"bmp"}, Delimiter: defaultDelimiter}
@@ -174,7 +174,7 @@ var DefaultTypes = Types{
 	YAMLType,
 	TOMLType,
 	PNGType,
-	JPGType,
+	JPEGType,
 	AVIType,
 	MPEGType,
 	MP4Type,

--- a/resources/images/image.go
+++ b/resources/images/image.go
@@ -275,7 +275,7 @@ func (f Format) DefaultExtension() string {
 func (f Format) MediaType() media.Type {
 	switch f {
 	case JPEG:
-		return media.JPGType
+		return media.JPEGType
 	case PNG:
 		return media.PNGType
 	case GIF:


### PR DESCRIPTION
According to multiple sources, both official ([IANA] and [RFC2046]) and
otherwise (eg, [Mozilla] and [Wikipedia]), the official MIME type for
JPEG images is `image/jpeg`, not `image/jpg`.  Change Hugo to match.

[IANA]: https://www.iana.org/assignments/media-types/media-types.xhtml#image
[RFC2046]: https://tools.ietf.org/html/rfc2046
[Mozilla]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
[Wikipedia]: https://en.wikipedia.org/wiki/JPEG