### PR TITLE
Make the missing layout file warning more verbose

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1589,7 +1589,7 @@ func (s *Site) renderForLayouts(name, outputFormat string, d interface{}, w io.W
 			log = s.Log.INFO
 		}
 
-		errMsg := "You should create a template file which matches Hugo Layouts Lookup Rules for this combination."
+		errMsg := "You should create a template file which matches one of these paths in a \"templates\" directory."
 		var args []interface{}
 		msg := "found no layout file for"
 		if outputFormat != "" {
@@ -1601,7 +1601,8 @@ func (s *Site) renderForLayouts(name, outputFormat string, d interface{}, w io.W
 			args = append(args, name)
 		}
 
-		msg += ": " + errMsg
+		msg += " in these paths: %v: " + errMsg
+		args = append(args, layouts)
 
 		log.Printf(msg, args...)
 


### PR DESCRIPTION
Print the full list of template file paths being searched when an
appropriate layout file is not found, with the advice that one of these
missing files needs to be created.

Closes: #6636