### PR TITLE
Recursively merge if both sides are maps

### DIFF
--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -524,3 +524,41 @@ resamplefilter = "CatmullRom"
 	c.Assert(cfg.Get("intSlice"), qt.DeepEquals, []interface{}{5, 8, 9})
 
 }
+
+func TestRecursiveMerging(t *testing.T) {
+
+	c := qt.New(t)
+
+	left := map[string]interface{}{
+		"foo": "test",
+		"bar": 12,
+		"baz": map[string]interface{}{
+			"foo": "nested",
+			"bar": nil,
+		},
+	}
+
+	right := map[string]interface{}{
+		"foo": "not applied",
+		"qux": "applied",
+		"baz": map[string]interface{}{
+			"foo": "ignored",
+			"bar": "untouched",
+			"baz": "is set",
+		},
+	}
+
+	result := map[string]interface{}{
+		"foo": "test",
+		"bar": 12,
+		"qux": "applied",
+		"baz": map[string]interface{}{
+			"foo": "nested",
+			"bar": nil,
+			"baz": "is set",
+		},
+	}
+
+	mergeStringMapRecursively(left, right)
+	c.Assert(left, qt.DeepEquals, result)
+}


### PR DESCRIPTION
Recursively merging ensures that modules get to keep the configuration
items they set, while allowing the user config to override anything.
Recursion only happens if the key in both user and module configurations
are maps.

Fixes #5192

I added a test for the recursive merging function, including making sure that map keys explicitly set to `nil` do not get overwritten. I did not do anything with testing that merged configurations were otherwise "correct"/as expected, as there do not seem to have been tests for that previously. At least, it didn't break the ones that exist.

I also did not update documentation as I am not sure where that would be added outside of release notes. I am more than willing to make an update there if the maintainers deem that necessary, though.