### PR TITLE
Update alpine base image in Dockerfile to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN mage hugo && mage install
 
 # ---
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 COPY --from=build /go/bin/hugo /usr/bin/hugo
 


### PR DESCRIPTION
When building the extended version of Hugo using the Dockerfile and `--build-arg HUGO_BUILD_TAGS=extended`, the obtained Docker container is broken, because the source is built under alpine 3.11 and the compiled binary is copied to an image based on alpine 3.10. This problem was most likely introduced due to an update of the golang base image.

This commit changes the base image from alpine:3.10 to alpine:3.11, fixing extended version builds.