### PR TITLE
tpl: Add internal template enabling web monetization

### DIFF
--- a/docs/content/en/templates/internal.md
+++ b/docs/content/en/templates/internal.md
@@ -197,6 +197,27 @@ To add Twitter card metadata, include the following line between the `<head>` ta
 {{ template "_internal/twitter_cards.html" . }}
 ```
 
+## Web Monetization
+
+An internal template to enable [web monetization](https://webmonetization.org/). It allows the creator of the website to receive micropayments from readers. 
+
+### Configure Web Monetization
+
+Provide your [payment pointer](https://paymentpointers.org/) under the params section in your configuration file:
+
+{{< code-toggle file="config" >}}
+[params]
+  monetization = "$twitter.xrptipbot.com/sabinebertram_"
+{{</ code-toggle >}}
+
+### Use the Web Monetization Template
+
+You can then include the Web Monetization internal template:
+
+```
+{{ template "_internal/webmonetization.html" . }}
+```
+
 ## The Internal Templates
 
 * `_internal/disqus.html`
@@ -206,7 +227,7 @@ To add Twitter card metadata, include the following line between the `<head>` ta
 * `_internal/opengraph.html`
 * `_internal/pagination.html`
 * `_internal/schema.html`
-* `_internal/twitter_cards.html`
+* `_internal/webmonetization.html`
 
 [disqus]: https://disqus.com
 [disqussignup]: https://disqus.com/profile/signup/

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -550,4 +550,5 @@ if (!doNotTrack) {
 <meta name="twitter:creator" content="@{{ . }}"/>
 {{ end -}}
 {{ end -}}`},
+	{`webmonetization.html`, `<meta name="monetization" content='{{ $.Site.Params.monetization }}'>`},
 }

--- a/tpl/tplimpl/embedded/templates/webmonetization.html
+++ b/tpl/tplimpl/embedded/templates/webmonetization.html
@@ -1,0 +1,1 @@
+<meta name="monetization" content='{{ $.Site.Params.monetization }}'>


### PR DESCRIPTION
Add internal template that enables web monetization by adding a meta tag to the head of each page. It grabs the payment pointer from the params section in the config file.
Documentation has been added to explain how to include web monetization into the website, just like google analytics.

**Background**
[Web monetization](https://webmonetization.org/) is a proposed W3C standard that allows the creation of a payment stream from the user agent to the website. It uses the [Interledger Protocol](https://interledger.org/), a currency agnostic micro-payment protocol, to stream money while a user is visiting the website. 
That user has to have a means of streaming payments. There is no visible difference for users who are streaming and for those who are not streaming. 
Web monetization offers a new possibility for content creators to monetize their work. It is an alternative to the advertisement model.