### PR TITLE
Allow raw string literals in shortcode params

### DIFF
--- a/parser/pageparser/pagelexer_shortcode.go
+++ b/parser/pageparser/pagelexer_shortcode.go
@@ -85,6 +85,8 @@ func lexShortcodeRightDelim(l *pageLexer) stateFunc {
 // 2. "param" or "param\"
 // 3. param="123" or param="123\"
 // 4. param="Some \"escaped\" text"
+// 5. `param`
+// 6. param=`123`
 func lexShortcodeParam(l *pageLexer, escapedQuoteStart bool) stateFunc {
 
 	first := true
@@ -95,14 +97,20 @@ func lexShortcodeParam(l *pageLexer, escapedQuoteStart bool) stateFunc {
 	for {
 		r = l.next()
 		if first {
-			if r == '"' {
+			if r == '"' || (r == '`' && !escapedQuoteStart) {
 				// a positional param with quotes
 				if l.paramElements == 2 {
 					return l.errorf("got quoted positional parameter. Cannot mix named and positional parameters")
 				}
 				l.paramElements = 1
 				l.backup()
-				return lexShortcodeQuotedParamVal(l, !escapedQuoteStart, tScParam)
+				if r == '"' {
+					return lexShortcodeQuotedParamVal(l, !escapedQuoteStart, tScParam)
+				}
+				return lexShortCodeParamRawStringVal(l, tScParam)
+
+			} else if r == '`' && escapedQuoteStart {
+				return l.errorf("unrecognized escape character")
 			}
 			first = false
 		} else if r == '=' {
@@ -143,6 +151,32 @@ func lexShortcodeParamVal(l *pageLexer) stateFunc {
 	return lexInsideShortcode
 }
 
+func lexShortCodeParamRawStringVal(l *pageLexer, typ ItemType) stateFunc {
+	openBacktickFound := false
+
+Loop:
+	for {
+		switch r := l.next(); {
+		case r == '`':
+			if openBacktickFound {
+				l.backup()
+				break Loop
+			} else {
+				openBacktickFound = true
+				l.ignore()
+			}
+		case r == eof, r == '\n':
+			return l.errorf("unterminated raw string in shortcode parameter-argument: '%s'", l.current())
+		}
+	}
+
+	l.emitString(typ)
+	l.next()
+	l.ignore()
+
+	return lexInsideShortcode
+}
+
 func lexShortcodeQuotedParamVal(l *pageLexer, escapedQuotedValuesAllowed bool, typ ItemType) stateFunc {
 	openQuoteFound := false
 	escapedInnerQuoteFound := false
@@ -161,6 +195,8 @@ Loop:
 					escapedInnerQuoteFound = true
 					escapedQuoteState = 1
 				}
+			} else if l.peek() == '`' {
+				return l.errorf("unrecognized escape character")
 			}
 		case r == eof, r == '\n':
 			return l.errorf("unterminated quoted string in shortcode parameter-argument: '%s'", l.current())
@@ -177,7 +213,6 @@ Loop:
 			} else {
 				escapedQuoteState = 0
 			}
-
 		}
 	}
 
@@ -284,6 +319,8 @@ func lexInsideShortcode(l *pageLexer) stateFunc {
 		peek := l.peek()
 		if peek == '"' || peek == '\\' {
 			return lexShortcodeQuotedParamVal(l, peek != '\\', tScParamVal)
+		} else if peek == '`' {
+			return lexShortCodeParamRawStringVal(l, tScParamVal)
 		}
 		return lexShortcodeParamVal
 	case r == '/':
@@ -295,10 +332,10 @@ func lexInsideShortcode(l *pageLexer) stateFunc {
 		l.emit(tScClose)
 	case r == '\\':
 		l.ignore()
-		if l.peek() == '"' {
+		if l.peek() == '"' || l.peek() == '`' {
 			return lexShortcodeParam(l, true)
 		}
-	case l.elementStepNum > 0 && (isAlphaNumericOrHyphen(r) || r == '"'): // positional params can have quotes
+	case l.elementStepNum > 0 && (isAlphaNumericOrHyphen(r) || r == '"' || r == '`'): // positional params can have quotes
 		l.backup()
 		return lexShortcodeParam(l, false)
 	case isAlphaNumeric(r):


### PR DESCRIPTION
Fixes #6726 

This PR allows users to use raw string literals in shortcode params.

Examples for both named and positional params include:
```
{{< param `testparam` >}}
{{< param=`testparam` >}}
```

However, it does not support escaped backticks (eg {{< param \\\`testparam\\\` >}}), because it dosen't work on Go (unrecognized escape character error).  A new error is thrown for this as previously, it used to be handled either by the unrecognized unicode character error for the backtick or the unterminated quote error.