### PR TITLE
Add support for newline in raw string shortcode

### DIFF
--- a/parser/pageparser/pagelexer_shortcode.go
+++ b/parser/pageparser/pagelexer_shortcode.go
@@ -165,7 +165,7 @@ Loop:
 				openBacktickFound = true
 				l.ignore()
 			}
-		case r == eof, r == '\n':
+		case r == eof:
 			return l.errorf("unterminated raw string in shortcode parameter-argument: '%s'", l.current())
 		}
 	}

--- a/parser/pageparser/pageparser_shortcode_test.go
+++ b/parser/pageparser/pageparser_shortcode_test.go
@@ -89,6 +89,12 @@ var shortCodeLexerTests = []lexerTest{
 		tstLeftNoMD, tstSC1, nti(tScParam, "-ziL-.%QigdO-4"), tstRightNoMD, tstEOF}},
 	{"raw string", `{{< sc1` + "`" + "Hello World" + "`" + ` >}}`, []Item{
 		tstLeftNoMD, tstSC1, nti(tScParam, "Hello World"), tstRightNoMD, tstEOF}},
+	{"raw string with newline", `{{< sc1` + "`" + `Hello 
+	World` + "`" + ` >}}`, []Item{
+		tstLeftNoMD, tstSC1, nti(tScParam, `Hello 
+	World`), tstRightNoMD, tstEOF}},
+	{"raw string with escape character", `{{< sc1` + "`" + `Hello \b World` + "`" + ` >}}`, []Item{
+		tstLeftNoMD, tstSC1, nti(tScParam, `Hello \b World`), tstRightNoMD, tstEOF}},
 	{"two params", `{{< sc1 param1   param2 >}}`, []Item{
 		tstLeftNoMD, tstSC1, tstParam1, tstParam2, tstRightNoMD, tstEOF}},
 	// issue #934


### PR DESCRIPTION
Fixes #6766.

Previously, newline characters were not supported in param shortcode. This fixes it to make it in line with Go raw string behaviour.