### PR TITLE
Skip over temporary files when building pages

### DIFF
--- a/hugofs/decorators.go
+++ b/hugofs/decorators.go
@@ -191,6 +191,26 @@ func (l *baseFileDecoratorFile) Readdir(c int) (ofi []os.FileInfo, err error) {
 	for _, dirname := range dirnames {
 		filename := dirname
 
+		ext := filepath.Ext(filename)
+		baseName := filepath.Base(filename)
+		istemp := strings.HasSuffix(ext, "~") ||
+			(ext == ".swp") || // vim
+			(ext == ".swx") || // vim
+			(ext == ".tmp") || // generic temp file
+			(ext == ".DS_Store") || // OSX Thumbnail
+			baseName == "4913" || // vim
+			strings.HasPrefix(ext, ".goutputstream") || // gnome
+			strings.HasSuffix(ext, "jb_old___") || // intelliJ
+			strings.HasSuffix(ext, "jb_tmp___") || // intelliJ
+			strings.HasSuffix(ext, "jb_bak___") || // intelliJ
+			strings.HasPrefix(ext, ".sb-") || // byword
+			strings.HasPrefix(baseName, ".#") || // emacs
+			strings.HasPrefix(baseName, "#") // emacs
+
+		if istemp {
+			continue
+		}
+
 		if l.Name() != "" && l.Name() != filepathSeparator {
 			filename = filepath.Join(l.Name(), dirname)
 		}

--- a/hugofs/walk_test.go
+++ b/hugofs/walk_test.go
@@ -47,6 +47,34 @@ func TestWalk(t *testing.T) {
 	c.Assert(names, qt.DeepEquals, []string{"a.txt", "b.txt", "c.txt"})
 }
 
+func TestWalkIgnoreTemp(t *testing.T) {
+	c := qt.New(t)
+
+	fs := NewBaseFileDecorator(afero.NewMemMapFs())
+
+	afero.WriteFile(fs, "b.txt", []byte("content"), 0777)
+	afero.WriteFile(fs, "c.txt", []byte("content"), 0777)
+	afero.WriteFile(fs, "a.txt", []byte("content"), 0777)
+	afero.WriteFile(fs, "4913.txt", []byte("content"), 0777)
+	afero.WriteFile(fs, "a.txt.swp", []byte("ignoreme"), 0777)
+	afero.WriteFile(fs, "a.txt.swx", []byte("ignoreme"), 0777)
+	afero.WriteFile(fs, "a.txt.tmp", []byte("ignoreme"), 0777)
+	afero.WriteFile(fs, "a.DS_Store", []byte("ignoreme"), 0777)
+	afero.WriteFile(fs, "4913", []byte("ignoreme"), 0777)
+	afero.WriteFile(fs, ".goutputstream", []byte("ignoreme"), 0777)
+	afero.WriteFile(fs, "a.jb_old___", []byte("ignoreme"), 0777)
+	afero.WriteFile(fs, "a.jb_tmp___", []byte("ignoreme"), 0777)
+	afero.WriteFile(fs, "a.jb_bak___", []byte("ignoreme"), 0777)
+	afero.WriteFile(fs, "a.txt.sb-", []byte("ignoreme"), 0777)
+	afero.WriteFile(fs, ".#a.txt", []byte("ignoreme"), 0777)
+	afero.WriteFile(fs, "#a.txt", []byte("ignoreme"), 0777)
+
+	names, err := collectFilenames(fs, "", "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(names, qt.DeepEquals, []string{"4913.txt", "a.txt", "b.txt", "c.txt"})
+}
+
 func TestWalkRootMappingFs(t *testing.T) {
 	c := qt.New(t)
 	fs := NewBaseFileDecorator(afero.NewMemMapFs())


### PR DESCRIPTION
The same logic for ignoring a temp-related filesystem event in
`handleEvents` from `commands/hugo.go` is now used to ignore files
when (re)building the site.

Fixes #6773 and #7345