### PR TITLE
A solution to easily enable full-text RSS feeds

### DIFF
--- a/tpl/tplimpl/embedded/templates/_default/rss.xml
+++ b/tpl/tplimpl/embedded/templates/_default/rss.xml
@@ -27,7 +27,7 @@
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | html }}</description>
+      <description>{{ if .Site.fullTextRSS }}{{ .Content | html }}{{ else }}{{ .Summary | html }}{{ end }}</description>
     </item>
     {{ end }}
   </channel>


### PR DESCRIPTION
A proposed `fullTextRSS` Boolean site config parameter that can optionally be used to easily switch between .Summary and .Content to generate either truncated or full-text RSS feeds as required. In my opinion this has to be core Hugo RSS functionality.