### PR TITLE
Documentation and Template Author Updates

### DIFF
--- a/docs/content/en/getting-started/code-toggle.md
+++ b/docs/content/en/getting-started/code-toggle.md
@@ -30,12 +30,13 @@ permalinks:
   posts: /:year/:month/:title/
 params:
   Subtitle: "Hugo is Absurdly Fast!"
-  AuthorName: "Jon Doe"
   GitHubUser: "spf13"
   ListOfFoo:
     - "foo1"
     - "foo2"
   SidebarRecentLimit: 5
+Author:
+  name: "Jon Doe"
 {{< /code-toggle >}}
 
 ## Another Config Toggler!

--- a/docs/content/en/getting-started/configuration.md
+++ b/docs/content/en/getting-started/configuration.md
@@ -320,12 +320,17 @@ permalinks:
   posts: /:year/:month/:title/
 params:
   Subtitle: "Hugo is Absurdly Fast!"
-  AuthorName: "Jon Doe"
   GitHubUser: "spf13"
   ListOfFoo:
     - "foo1"
     - "foo2"
   SidebarRecentLimit: 5
+Author:
+  name: "Jon Doe"
+  email: "jondoe@example.com"
+  Social:
+    facebook: jondoe_example
+    twitter: jondoe_example
 {{< /code-toggle >}}
 
 ## Configure with Environment Variables

--- a/docs/content/en/templates/internal.md
+++ b/docs/content/en/templates/internal.md
@@ -127,8 +127,22 @@ Hugo's Open Graph template is configured using a mix of configuration variables 
   title = "My cool site"
   images = ["site-feature-image.jpg"]
   description = "Text about my cool site"
+[[params.Authors]]
+  name = "Multi Author Mode, Author Uno"
+[params.Authors.Social]
+  facebook = "authoruno_facebook"
+[[params.Authors]]
+  name = "Multi Author Mode, Author Dos"
+[params.Authors.Social]
+  facebook = "authordos_facebook"
+[Author]
+  name = "Single Author Mode, Author Name"
+  [Author.Social]
+    facebook = "singleauthor_facebook"
 [taxonomies]
   series = "series"
+[Social]
+  facebook = "website_facebook_page"
 {{</ code-toggle >}}
 
 {{< code-toggle file="content/blog/my-post" >}}
@@ -136,6 +150,10 @@ title = "Post title"
 description = "Text about this post"
 date = "2006-01-02"
 images = ["post-cover.png"]
+authors = [
+        { name: "Article Author 1", Social = { facebook = "auth1fb" } },
+        { name: "Article Author 2", Social = { facebook = "auth2fb" } },
+    ]
 audio = []
 videos = []
 series = []
@@ -151,6 +169,8 @@ Various optional metadata can also be set:
 - `audio` and `videos` are URL arrays like `images` for the audio and video metadata tags, respectively.
 - The first 6 `tags` on the page are used for the tags metadata.
 - The `series` taxonomy is used to specify related "see also" pages by placing them in the same series.
+- `author` gets set for each page author, if page authors are set, or site authors otherwise.
+- `publisher` is set to the `.Site.Social.facebook` value, and could correspond to a Facebook page for your website
 
 If using YouTube this will produce a og:video tag like `<meta property="og:video" content="url">`. If using a YouTube link make sure this is in **https://www.youtube.com/v/NlXVWtgLNjY** not __https://www.youtube.com/watch?v=NlXVWtgLNjY__
 
@@ -175,12 +195,28 @@ Hugo's Twitter Card template is configured using a mix of configuration variable
 [params]
   images = ["site-feature-image.jpg"]
   description = "Text about my cool site"
+[[params.Authors]]
+  name = "Multi Author Mode, Author Uno"
+[params.Authors.Social]
+  twitter = "authoruno_twitter"
+[[params.Authors]]
+  name = "Multi Author Mode, Author Dos"
+[params.Authors.Social]
+  twitter = "authordos_twitter"
+[Author]
+  name = "Single Author Mode, Author Name"
+  [Author.Social]
+    twitter = "singleauthor_twitter"
 {{</ code-toggle >}}
 
 {{< code-toggle file="content/blog/my-post" >}}
 title = "Post title"
 description = "Text about this post"
 images = ["post-cover.png"]
+authors = [
+        { name: "Article Author 1", Social = { twitter = "auth1tw" } },
+        { name: "Article Author 2", Social = { twitter = "auth2tw" } },
+    ]
 {{</ code-toggle >}}
 
 If `images` aren't specified in the page front-matter, then hugo searches for [image page resources](/content-management/image-processing/) with `feature`, `cover`, or `thumbnail` in their name.

--- a/docs/content/en/templates/internal.md
+++ b/docs/content/en/templates/internal.md
@@ -151,8 +151,8 @@ description = "Text about this post"
 date = "2006-01-02"
 images = ["post-cover.png"]
 authors = [
-        { name: "Article Author 1", Social = { facebook = "auth1fb" } },
-        { name: "Article Author 2", Social = { facebook = "auth2fb" } },
+        { name = "Article Author 1", Social = { facebook = "auth1fb" } },
+        { name = "Article Author 2", Social = { facebook = "auth2fb" } },
     ]
 audio = []
 videos = []

--- a/docs/content/en/templates/internal.md
+++ b/docs/content/en/templates/internal.md
@@ -214,8 +214,8 @@ title = "Post title"
 description = "Text about this post"
 images = ["post-cover.png"]
 authors = [
-        { name: "Article Author 1", Social = { twitter = "auth1tw" } },
-        { name: "Article Author 2", Social = { twitter = "auth2tw" } },
+        { name = "Article Author 1", Social = { twitter = "auth1tw" } },
+        { name = "Article Author 2", Social = { twitter = "auth2tw" } },
     ]
 {{</ code-toggle >}}
 

--- a/docs/content/en/templates/rss.md
+++ b/docs/content/en/templates/rss.md
@@ -63,8 +63,8 @@ Additionally, an author specified in a page's front matter will be used for the 
 title: "My Page"
 description: "All about my page"
 author:
-  name: "My Name Here"
-  email: "myemailaddress@example.com"
+    name: "My Name Here"
+    email: "myemailaddress@example.com"
 ---
 ```
 

--- a/docs/content/en/templates/rss.md
+++ b/docs/content/en/templates/rss.md
@@ -49,8 +49,23 @@ The following values will also be included in the RSS output if specified in you
 languageCode = "en-us"
 copyright = "This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License."
 
-[author]
+[Author]
     name = "My Name Here"
+    email = "myemailaddress@example.com
+```
+
+To include an author's name, you must have the `email` key set.
+
+Additionally, an author specified in a page's front matter will be used for the corresponding RSS item.  Again, to include the author's name you must have the `email` key set.  An example page front matter is below.
+
+```yaml
+---
+title: "My Page"
+description: "All about my page"
+author:
+  name: "My Name Here"
+  email: "myemailaddress@example.com"
+---
 ```
 
 ## The Embedded rss.xml

--- a/docs/content/en/variables/site.md
+++ b/docs/content/en/variables/site.md
@@ -110,7 +110,7 @@ baseURL = "https://yoursite.example.com/"
 
 [params]
   description = "Tesla's Awesome Hugo Site"
-  author = "Nikola Tesla"
+  famousPerson = "Nikola Tesla"
 {{</ code-toggle >}}
 
 You can use `.Site.Params` in a [partial template](/templates/partials/) to call the default site description:

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -234,13 +234,10 @@ if (!doNotTrack) {
 {{ end }}{{ end }}
 
 {{- if .IsPage }}
-{{- $site_authors := .Site.Params.Authors | default (slice .Site.Author) -}}
-{{- $author_list := .Params.authors | default $site_authors -}}
-{{- range $author_list }}
-{{- $social_map := cond (reflect.IsMap .Social) .Social (cond (reflect.IsMap .social) .social (dict)) }}
-{{- $social_facebook := index $social_map "facebook" }}
-{{- with $social_facebook }}
-<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}{{ end }}{{ with .Site.Social.facebook }}
+{{- $author_list := .Params.authors | default .Site.Params.Authors | default (slice .Site.Author) -}}
+{{ range $author_list }}{{ if reflect.IsMap . }}
+{{- with (.Social.facebook | default .social.facebook) }}
+<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}{{ end }}{{ end }}{{ with .Site.Social.facebook }}
 <meta property="article:publisher" content="https://www.facebook.com/{{ . }}" />{{ end }}
 <meta property="article:section" content="{{ .Section }}" />
 {{- with .Params.tags }}{{ range first 6 . }}
@@ -555,14 +552,11 @@ if (!doNotTrack) {
 {{ with .Site.Social.twitter -}}
 <meta name="twitter:site" content="@{{ . }}"/>
 {{ end }}
-{{ $site_authors := .Site.Params.Authors | default (slice .Site.Author) -}}
-{{- $author_list := .Params.authors | default $site_authors -}}
-{{ range $author_list }}
-{{- $social_map := cond (reflect.IsMap .Social) .Social (cond (reflect.IsMap .social) .social (dict)) }}
-{{- $social_twitter := index $social_map "twitter" }}
-{{- with $social_twitter -}}
+{{- $author_list := .Params.authors | default .Site.Params.Authors | default (slice .Site.Author) -}}
+{{ range $author_list }}{{ if reflect.IsMap . }}
+{{- with (.Social.twitter | default .social.twitter) -}}
 <meta name="twitter:creator" content="@{{ . }}"/>
-{{ end -}}
+{{ end }}{{ end -}}
 {{ end -}}
 `},
 }

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -236,7 +236,10 @@ if (!doNotTrack) {
 {{- if .IsPage }}
 {{- $site_authors := .Site.Params.Authors | default (slice .Site.Author) -}}
 {{- $author_list := .Params.authors | default $site_authors -}}
-{{- range $author_list }}{{ with .Social.facebook | default .social.facebook }}
+{{- range $author_list }}
+{{- $social_map := cond (reflect.IsMap .Social) .Social (cond (reflect.IsMap .social) .social (dict)) }}
+{{- $social_facebook := index $social_map "facebook" }}
+{{- with $social_facebook }}
 <meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}{{ end }}{{ with .Site.Social.facebook }}
 <meta property="article:publisher" content="https://www.facebook.com/{{ . }}" />{{ end }}
 <meta property="article:section" content="{{ .Section }}" />
@@ -555,7 +558,9 @@ if (!doNotTrack) {
 {{ $site_authors := .Site.Params.Authors | default (slice .Site.Author) -}}
 {{- $author_list := .Params.authors | default $site_authors -}}
 {{ range $author_list }}
-{{- with .Social.twitter | default .social.twitter -}}
+{{- $social_map := cond (reflect.IsMap .Social) .Social (cond (reflect.IsMap .social) .social (dict)) }}
+{{- $social_twitter := index $social_map "twitter" }}
+{{- with $social_twitter -}}
 <meta name="twitter:creator" content="@{{ . }}"/>
 {{ end -}}
 {{ end -}}

--- a/tpl/tplimpl/embedded/templates/_default/rss.xml
+++ b/tpl/tplimpl/embedded/templates/_default/rss.xml
@@ -25,7 +25,8 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{- $author := .Params.author | default .Site.Author }}
+      {{ with $author.email }}<author>{{.}}{{ with $author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
     </item>

--- a/tpl/tplimpl/embedded/templates/_default/rss.xml
+++ b/tpl/tplimpl/embedded/templates/_default/rss.xml
@@ -25,8 +25,11 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{- $author := .Params.author | default .Site.Author }}
-      {{ with $author.email }}<author>{{.}}{{ with $author.name }} ({{.}}){{end}}</author>{{end}}
+      {{- $page_auth := cond (reflect.IsMap .Params.author) .Params.author (dict) }}
+      {{- $auth_src := cond (isset $page_auth "email") $page_auth .Site.Author }}
+      {{- $author_email := index $auth_src "email" }}
+      {{- $author_name := index $auth_src "name" }}
+      {{ with $author_email }}<author>{{.}}{{ with $author_name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
     </item>

--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -45,13 +45,10 @@
 {{ end }}{{ end }}
 
 {{- if .IsPage }}
-{{- $site_authors := .Site.Params.Authors | default (slice .Site.Author) -}}
-{{- $author_list := .Params.authors | default $site_authors -}}
-{{- range $author_list }}
-{{- $social_map := cond (reflect.IsMap .Social) .Social (cond (reflect.IsMap .social) .social (dict)) }}
-{{- $social_facebook := index $social_map "facebook" }}
-{{- with $social_facebook }}
-<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}{{ end }}{{ with .Site.Social.facebook }}
+{{- $author_list := .Params.authors | default .Site.Params.Authors | default (slice .Site.Author) -}}
+{{ range $author_list }}{{ if reflect.IsMap . }}
+{{- with (.Social.facebook | default .social.facebook) }}
+<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}{{ end }}{{ end }}{{ with .Site.Social.facebook }}
 <meta property="article:publisher" content="https://www.facebook.com/{{ . }}" />{{ end }}
 <meta property="article:section" content="{{ .Section }}" />
 {{- with .Params.tags }}{{ range first 6 . }}

--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -45,13 +45,15 @@
 {{ end }}{{ end }}
 
 {{- if .IsPage }}
-{{- range .Site.Authors }}{{ with .Social.facebook }}
-<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}{{ with .Site.Social.facebook }}
+{{- $site_authors := .Site.Params.Authors | default (slice .Site.Author) -}}
+{{- $author_list := .Params.authors | default $site_authors -}}
+{{- range $author_list }}{{ with .Social.facebook | default .social.facebook }}
+<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}{{ end }}{{ with .Site.Social.facebook }}
 <meta property="article:publisher" content="https://www.facebook.com/{{ . }}" />{{ end }}
 <meta property="article:section" content="{{ .Section }}" />
 {{- with .Params.tags }}{{ range first 6 . }}
 <meta property="article:tag" content="{{ . }}" />{{ end }}{{ end }}
-{{- end }}{{ end }}
+{{- end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
 {{- with .Site.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}

--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -47,7 +47,10 @@
 {{- if .IsPage }}
 {{- $site_authors := .Site.Params.Authors | default (slice .Site.Author) -}}
 {{- $author_list := .Params.authors | default $site_authors -}}
-{{- range $author_list }}{{ with .Social.facebook | default .social.facebook }}
+{{- range $author_list }}
+{{- $social_map := cond (reflect.IsMap .Social) .Social (cond (reflect.IsMap .social) .social (dict)) }}
+{{- $social_facebook := index $social_map "facebook" }}
+{{- with $social_facebook }}
 <meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}{{ end }}{{ with .Site.Social.facebook }}
 <meta property="article:publisher" content="https://www.facebook.com/{{ . }}" />{{ end }}
 <meta property="article:section" content="{{ .Section }}" />

--- a/tpl/tplimpl/embedded/templates/twitter_cards.html
+++ b/tpl/tplimpl/embedded/templates/twitter_cards.html
@@ -22,12 +22,9 @@
 {{ with .Site.Social.twitter -}}
 <meta name="twitter:site" content="@{{ . }}"/>
 {{ end }}
-{{ $site_authors := .Site.Params.Authors | default (slice .Site.Author) -}}
-{{- $author_list := .Params.authors | default $site_authors -}}
-{{ range $author_list }}
-{{- $social_map := cond (reflect.IsMap .Social) .Social (cond (reflect.IsMap .social) .social (dict)) }}
-{{- $social_twitter := index $social_map "twitter" }}
-{{- with $social_twitter -}}
+{{- $author_list := .Params.authors | default .Site.Params.Authors | default (slice .Site.Author) -}}
+{{ range $author_list }}{{ if reflect.IsMap . }}
+{{- with (.Social.twitter | default .social.twitter) -}}
 <meta name="twitter:creator" content="@{{ . }}"/>
-{{ end -}}
+{{ end }}{{ end -}}
 {{ end -}}

--- a/tpl/tplimpl/embedded/templates/twitter_cards.html
+++ b/tpl/tplimpl/embedded/templates/twitter_cards.html
@@ -25,7 +25,9 @@
 {{ $site_authors := .Site.Params.Authors | default (slice .Site.Author) -}}
 {{- $author_list := .Params.authors | default $site_authors -}}
 {{ range $author_list }}
-{{- with .Social.twitter | default .social.twitter -}}
+{{- $social_map := cond (reflect.IsMap .Social) .Social (cond (reflect.IsMap .social) .social (dict)) }}
+{{- $social_twitter := index $social_map "twitter" }}
+{{- with $social_twitter -}}
 <meta name="twitter:creator" content="@{{ . }}"/>
 {{ end -}}
 {{ end -}}

--- a/tpl/tplimpl/embedded/templates/twitter_cards.html
+++ b/tpl/tplimpl/embedded/templates/twitter_cards.html
@@ -21,9 +21,11 @@
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
 {{ with .Site.Social.twitter -}}
 <meta name="twitter:site" content="@{{ . }}"/>
-{{ end -}}
-{{ range .Site.Authors }}
-{{ with .twitter -}}
+{{ end }}
+{{ $site_authors := .Site.Params.Authors | default (slice .Site.Author) -}}
+{{- $author_list := .Params.authors | default $site_authors -}}
+{{ range $author_list }}
+{{- with .Social.twitter | default .social.twitter -}}
 <meta name="twitter:creator" content="@{{ . }}"/>
 {{ end -}}
 {{ end -}}


### PR DESCRIPTION
I was confused about how to get author to show up in RSS feeds, and as I figured that out I realized some of the documentation around specifying authors was wrong.  The method used in the RSS template is partially consistent with methods in a couple other places, and the templates for opengraph and twitter_cards do things slightly differently and sometimes slightly impossibly...

[Initial question on Discourse here.](https://discourse.gohugo.io/t/author-configuration-for-rss/23140/2)

These commits should bring that into standardization, and update documentation to explain.

I'm sorry - I don't have "mage".  I have modified some internal templates here, but not combined them into the go file in the parent directory...