### PR TITLE
Remove inaccurate comment about .Pages on homepage documentation

### DIFF
--- a/docs/content/en/templates/homepage.md
+++ b/docs/content/en/templates/homepage.md
@@ -54,8 +54,7 @@ The following is an example of a homepage template that uses [partial][partials]
         {{.Content}}
       </div>
       <div>
-        <!-- Note that .Pages is the same as .Site.RegularPages on the homepage template. -->
-        {{ range first 10 .Pages }}
+        {{ range first 10 .Site.RegularPages }}
             {{ .Render "summary"}}
         {{ end }}
       </div>


### PR DESCRIPTION
This PR removes a line of the documentation which contains an inaccurate statement.

It is related to #6510