### PR TITLE
Add KaTeX server side math rendering support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/gohugoio/testmodBuilder/mods v0.0.0-20190520184928-c56af20f2e95
 	github.com/google/go-cmp v0.3.2-0.20191028172631-481baca67f93
 	github.com/gorilla/websocket v1.4.1
+	github.com/graemephi/goldmark-qjs-katex v0.1.1
 	github.com/jdkato/prose v1.1.1
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/kyokomi/emoji v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,8 @@ github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/graemephi/goldmark-qjs-katex v0.1.1 h1:2skPiibjg++QgAUqYQ4wet9T7YzXSSrAyB2N52lgSvs=
+github.com/graemephi/goldmark-qjs-katex v0.1.1/go.mod h1:dvErD0A+vEbYEU/ZblFhTycpa/mzXYpN61qOtkoL8CQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=

--- a/markup/goldmark/convert.go
+++ b/markup/goldmark/convert.go
@@ -39,6 +39,8 @@ import (
 	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
+
+	qjskatex "github.com/graemephi/goldmark-qjs-katex"
 )
 
 // Provider is the package entry point.
@@ -133,6 +135,10 @@ func newMarkdown(pcfg converter.ProviderConfig) goldmark.Markdown {
 
 	if cfg.Extensions.Footnote {
 		extensions = append(extensions, extension.Footnote)
+	}
+
+	if cfg.Extensions.KaTeX {
+		extensions = append(extensions, &qjskatex.Extension{})
 	}
 
 	if cfg.Parser.AutoHeadingID {

--- a/markup/goldmark/goldmark_config/config.go
+++ b/markup/goldmark/goldmark_config/config.go
@@ -30,6 +30,7 @@ var Default = Config{
 		Strikethrough:  true,
 		Linkify:        true,
 		TaskList:       true,
+		KaTeX:          false,
 	},
 	Renderer: Renderer{
 		Unsafe: false,
@@ -58,6 +59,8 @@ type Extensions struct {
 	Strikethrough bool
 	Linkify       bool
 	TaskList      bool
+
+	KaTeX bool
 }
 
 type Renderer struct {


### PR DESCRIPTION
Addresses #6544

To enable, set in `config.toml`:
```text
[markup]
  [markup.goldmark]
    [markup.goldmark.extensions]
      katex = true
```

Renders inline math `$1+2=3$` as well as display math `$$ \dfrac{1}{2} = 0.5 $$`.