### PR TITLE
Renaming doWithCommandeer to cfgInit to make clearer what it does and for consistency

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -171,7 +171,7 @@ func newCommandeer(mustHaveConfigFile, running bool, h *hugoBuilderCommon, f fla
 		h:                   h,
 		ftch:                f,
 		commandeerHugoState: newCommandeerHugoState(),
-		cfgInit:    cfgInit,
+		cfgInit:             cfgInit,
 		visitedURLs:         types.NewEvictingStringQueue(10),
 		debounce:            rebuildDebouncer,
 		fullRebuildSem:      semaphore.NewWeighted(1),

--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -284,7 +284,7 @@ func (c *commandeer) loadConfig(mustHaveConfigFile, running bool) error {
 		return nil
 	}
 
-	setCfgAndInit := func(cfg config.Provider) error {
+	cfgSetAndInit := func(cfg config.Provider) error {
 		c.Cfg = cfg
 		if c.cfgInit == nil {
 			return nil
@@ -307,7 +307,7 @@ func (c *commandeer) loadConfig(mustHaveConfigFile, running bool) error {
 			AbsConfigDir: c.h.getConfigDir(dir),
 			Environ:      os.Environ(),
 			Environment:  environment},
-		setCfgAndInit,
+		cfgSetAndInit,
 		doWithConfig)
 
 	if err != nil && mustHaveConfigFile {

--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -72,7 +72,7 @@ type commandeer struct {
 
 	visitedURLs *types.EvictingStringQueue
 
-	doWithCommandeer func(c *commandeer) error
+	cfgInit func(c *commandeer) error
 
 	// We watch these for changes.
 	configFiles []string
@@ -152,7 +152,7 @@ func (c *commandeer) initFs(fs *hugofs.Fs) error {
 	return nil
 }
 
-func newCommandeer(mustHaveConfigFile, running bool, h *hugoBuilderCommon, f flagsToConfigHandler, doWithCommandeer func(c *commandeer) error, subCmdVs ...*cobra.Command) (*commandeer, error) {
+func newCommandeer(mustHaveConfigFile, running bool, h *hugoBuilderCommon, f flagsToConfigHandler, cfgInit func(c *commandeer) error, subCmdVs ...*cobra.Command) (*commandeer, error) {
 
 	var rebuildDebouncer func(f func())
 	if running {
@@ -171,7 +171,7 @@ func newCommandeer(mustHaveConfigFile, running bool, h *hugoBuilderCommon, f fla
 		h:                   h,
 		ftch:                f,
 		commandeerHugoState: newCommandeerHugoState(),
-		doWithCommandeer:    doWithCommandeer,
+		cfgInit:    cfgInit,
 		visitedURLs:         types.NewEvictingStringQueue(10),
 		debounce:            rebuildDebouncer,
 		fullRebuildSem:      semaphore.NewWeighted(1),
@@ -284,12 +284,12 @@ func (c *commandeer) loadConfig(mustHaveConfigFile, running bool) error {
 		return nil
 	}
 
-	doWithCommandeer := func(cfg config.Provider) error {
+	setCfgAndInit := func(cfg config.Provider) error {
 		c.Cfg = cfg
-		if c.doWithCommandeer == nil {
+		if c.cfgInit == nil {
 			return nil
 		}
-		err := c.doWithCommandeer(c)
+		err := c.cfgInit(c)
 		return err
 	}
 
@@ -307,7 +307,7 @@ func (c *commandeer) loadConfig(mustHaveConfigFile, running bool) error {
 			AbsConfigDir: c.h.getConfigDir(dir),
 			Environ:      os.Environ(),
 			Environment:  environment},
-		doWithCommandeer,
+		setCfgAndInit,
 		doWithConfig)
 
 	if err != nil && mustHaveConfigFile {
@@ -330,8 +330,8 @@ func (c *commandeer) loadConfig(mustHaveConfigFile, running bool) error {
 
 	// This is potentially double work, but we need to do this one more time now
 	// that all the languages have been configured.
-	if c.doWithCommandeer != nil {
-		if err := c.doWithCommandeer(c); err != nil {
+	if c.cfgInit != nil {
+		if err := c.cfgInit(c); err != nil {
 			return err
 		}
 	}

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -118,9 +118,9 @@ func Execute(args []string) Response {
 func initializeConfig(mustHaveConfigFile, running bool,
 	h *hugoBuilderCommon,
 	f flagsToConfigHandler,
-	doWithCommandeer func(c *commandeer) error) (*commandeer, error) {
+	cfgInit func(c *commandeer) error) (*commandeer, error) {
 
-	c, err := newCommandeer(mustHaveConfigFile, running, h, f, doWithCommandeer)
+	c, err := newCommandeer(mustHaveConfigFile, running, h, f, cfgInit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Regarding my [proposal to simplify doWithCommandeer](#6880), I found that renaming alone will clear things up.

For one, I realized that there are two different object types:
1. `doWithCommandeer func(c *commandeer) error`
2. `doWithCommandeer func(cfg config.Provider) error`

When `initializeConfig(mustHaveConfigFile, running bool, h *hugoBuilderCommon, f flagsToConfigHandler, doWithCommandeer func(c *commandeer) error)` is called, the last argument is either `nil` or was named `cfgInit`.

Therefore, renaming 1. to `cfgInit` clears things up because it's the only thing it ever does.
I renamed 2. `cfgSetAndInit` because it sets the Cfg field of commandeer (to a *viper.Viper pointer) and runs `cfgInit`.