### PR TITLE
Remove unneeded type attribute from gist embed shortcode

### DIFF
--- a/tpl/tplimpl/embedded/templates/shortcodes/gist.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/gist.html
@@ -1,1 +1,1 @@
-<script type="application/javascript" src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }}?file={{ index .Params 2 }}{{end}}"></script>
+<script src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }}?file={{ index .Params 2 }}{{end}}"></script>


### PR DESCRIPTION
Gist itself uses the embed code as:
`<script src="https://gist.github.com/spf13/7896402.js"></script>`
I think it makes sense to use that and keep things shorter.