### PR TITLE
markup/highlight: Fix chroma highlight

### DIFF
--- a/markup/highlight/highlight.go
+++ b/markup/highlight/highlight.go
@@ -15,9 +15,9 @@ package highlight
 
 import (
 	"fmt"
+	gohtml "html"
 	"io"
 	"strings"
-	gohtml "html"
 
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/formatters/html"

--- a/markup/highlight/highlight.go
+++ b/markup/highlight/highlight.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	gohtml "html"
 
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/formatters/html"
@@ -63,7 +64,7 @@ func highlight(code, lang string, cfg Config) (string, error) {
 	if lexer == nil {
 		wrapper := getPreWrapper(lang)
 		fmt.Fprint(w, wrapper.Start(true, ""))
-		fmt.Fprint(w, code)
+		fmt.Fprint(w, gohtml.EscapeString(code))
 		fmt.Fprint(w, wrapper.End(true))
 		return w.String(), nil
 	}
@@ -72,6 +73,7 @@ func highlight(code, lang string, cfg Config) (string, error) {
 	if style == nil {
 		style = styles.Fallback
 	}
+	lexer = chroma.Coalesce(lexer)
 
 	iterator, err := lexer.Tokenise(nil, code)
 	if err != nil {

--- a/markup/highlight/highlight_test.go
+++ b/markup/highlight/highlight_test.go
@@ -29,6 +29,13 @@ LINE3
 LINE4
 LINE5
 `
+	coalesceNeeded := `GET /foo HTTP/1.1
+Content-Type: application/json
+User-Agent: foo
+
+{
+  "hello": "world"
+}`
 
 	c.Run("Basic", func(c *qt.C) {
 		cfg := DefaultConfig
@@ -38,9 +45,10 @@ LINE5
 		result, _ := h.Highlight(`echo "Hugo Rocks!"`, "bash", "")
 		c.Assert(result, qt.Equals, `<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash"><span class="nb">echo</span> <span class="s2">&#34;Hugo Rocks!&#34;</span></code></pre></div>`)
 		result, _ = h.Highlight(`echo "Hugo Rocks!"`, "unknown", "")
-		c.Assert(result, qt.Equals, `<pre><code class="language-unknown" data-lang="unknown">echo "Hugo Rocks!"</code></pre>`)
+		c.Assert(result, qt.Equals, `<pre><code class="language-unknown" data-lang="unknown">echo &#34;Hugo Rocks!&#34;</code></pre>`)
 
 	})
+
 
 	c.Run("Highlight lines, default config", func(c *qt.C) {
 		cfg := DefaultConfig
@@ -106,4 +114,24 @@ LINE5
 		result, _ := h.Highlight(lines, "", "")
 		c.Assert(result, qt.Contains, "<span class=\"ln\">2</span>LINE2\n<")
 	})
+
+	c.Run("No language, Escape HTML string", func(c *qt.C) {
+		cfg := DefaultConfig
+		cfg.NoClasses = false
+		h := New(cfg)
+
+		result, _ := h.Highlight("Escaping less-than in code block? <fail>" , "", "")
+		c.Assert(result, qt.Contains, "&lt;fail&gt;")
+	})
+
+	c.Run("Highlight lines, default config", func(c *qt.C) {
+		cfg := DefaultConfig
+		cfg.NoClasses = false
+		h := New(cfg)
+
+		result, _ := h.Highlight(coalesceNeeded, "http", "linenos=true,hl_lines=2")
+		c.Assert(result, qt.Contains, "hello")
+		c.Assert(result, qt.Contains, "}")
+	})
+
 }

--- a/markup/highlight/highlight_test.go
+++ b/markup/highlight/highlight_test.go
@@ -49,7 +49,6 @@ User-Agent: foo
 
 	})
 
-
 	c.Run("Highlight lines, default config", func(c *qt.C) {
 		cfg := DefaultConfig
 		cfg.NoClasses = false
@@ -120,7 +119,7 @@ User-Agent: foo
 		cfg.NoClasses = false
 		h := New(cfg)
 
-		result, _ := h.Highlight("Escaping less-than in code block? <fail>" , "", "")
+		result, _ := h.Highlight("Escaping less-than in code block? <fail>", "", "")
 		c.Assert(result, qt.Contains, "&lt;fail&gt;")
 	})
 


### PR DESCRIPTION
* Use chroma.Coalesce
    * for https://github.com/gohugoio/hugo/issues/6877
    * This method was used in [Hugo < v0.60.0](https://github.com/gohugoio/hugo/blob/07a203406a1863ba7c48f9090de7c4587fae913d/helpers/pygments.go#L188) and are missing in >= v0.60.0
* Escape code strings if lexer is nil
    * for https://github.com/gohugoio/hugo/issues/6856

Note: this fixation is only for `choma`'s highlight. 
We need more fixation of highlight function with `goldmark` because its highlight does not  work properly in CodeFences yet.
