### PR TITLE
Fix goMinorVersion on non-final Go releases.

### DIFF
--- a/common/hugo/version.go
+++ b/common/hugo/version.go
@@ -15,7 +15,7 @@ package hugo
 
 import (
 	"fmt"
-	"strconv"
+	"io"
 
 	"runtime"
 	"strings"
@@ -245,7 +245,15 @@ func goMinorVersion(version string) int {
 	if strings.HasPrefix(version, "devel") {
 		return 9999 // magic
 	}
-	i, _ := strconv.Atoi(strings.Split(version, ".")[1])
-	return i
-
+	var major, minor int
+	var trailing string
+	n, err := fmt.Sscanf(version, "go%d.%d%s", &major, &minor, &trailing)
+	if n == 2 && err == io.EOF {
+		// Means there were no trailing characters (i.e., not an alpha/beta)
+		err = nil
+	}
+	if err != nil {
+		return 0
+	}
+	return minor
 }

--- a/common/hugo/version_test.go
+++ b/common/hugo/version_test.go
@@ -84,5 +84,6 @@ func TestParseHugoVersion(t *testing.T) {
 func TestGoMinorVersion(t *testing.T) {
 	c := qt.New(t)
 	c.Assert(goMinorVersion("go1.12.5"), qt.Equals, 12)
+	c.Assert(goMinorVersion("go1.14rc1"), qt.Equals, 14)
 	c.Assert(GoMinorVersion() >= 11, qt.Equals, true)
 }


### PR DESCRIPTION
This should work for alpha/beta/rc releases.

Fixes #6910.