### PR TITLE
tpl: Change error message on missing resource

### DIFF
--- a/tpl/resources/resources.go
+++ b/tpl/resources/resources.go
@@ -299,6 +299,9 @@ func (ns *Namespace) resolveArgs(args []interface{}) (resources.ResourceTransfor
 
 	r, ok := args[1].(resources.ResourceTransformer)
 	if !ok {
+		if _, ok := args[1].(map[string]interface{}); !ok {
+			return nil, nil, fmt.Errorf("no Resource provided in transformation")
+		}
 		return nil, nil, fmt.Errorf("type %T not supported in Resource transformations", args[0])
 	}
 


### PR DESCRIPTION
I just added a check to see if the argument should be a ResourceTransformer is actually a map[string]interface, which would imply that the resource is missing, and put a more useful error message on that. Fixes #6942