### PR TITLE
Updated README.md: added missing build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ cd $HOME/src
 git clone https://github.com/gohugoio/hugo.git
 cd hugo
 go install
+go build
 ```
 
 **If you are a Windows user, substitute the `$HOME` environment variable above with `%USERPROFILE%`.**


### PR DESCRIPTION
When following the build instructions in the README there is no `hugo` binary generated. The missing step is:

```
go build
```