### PR TITLE
tpl: Fix error with unicode in file paths

### DIFF
--- a/tpl/data/data_test.go
+++ b/tpl/data/data_test.go
@@ -157,6 +157,11 @@ func TestGetJSON(t *testing.T) {
 			"",
 			false,
 		},
+		{
+			`pass/üńīçøðê-url.json`,
+			`{"gomeetup":["Sydney","San Francisco","Stockholm"]}`,
+			map[string]interface{}{"gomeetup": []interface{}{"Sydney", "San Francisco", "Stockholm"}},
+		},
 	} {
 
 		msg := qt.Commentf("Test %d", i)

--- a/tpl/data/resources.go
+++ b/tpl/data/resources.go
@@ -16,6 +16,7 @@ package data
 import (
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"time"
 
@@ -107,7 +108,11 @@ func getLocal(url string, fs afero.Fs, cfg config.Provider) ([]byte, error) {
 func (ns *Namespace) getResource(cache *filecache.Cache, unmarshal func(b []byte) (bool, error), req *http.Request) error {
 	switch req.URL.Scheme {
 	case "":
-		b, err := getLocal(req.URL.String(), ns.deps.Fs.Source, ns.deps.Cfg)
+		url, err := url.QueryUnescape(req.URL.String())
+		if err != nil {
+			return err
+		}
+		b, err := getLocal(url, ns.deps.Fs.Source, ns.deps.Cfg)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Add url.QueryUnescape before reading file which allows files with unicode in their paths to be read.

Fixes #6996