### PR TITLE
Make IsZero take the entire PageMeta into account

### DIFF
--- a/resources/page/pagemeta/pagemeta.go
+++ b/resources/page/pagemeta/pagemeta.go
@@ -58,7 +58,7 @@ func (b *BuildConfig) Disable() {
 }
 
 func (b BuildConfig) IsZero() bool {
-	return !b.set
+	return b == BuildConfig{}
 }
 
 func DecodeBuildConfig(m interface{}) (BuildConfig, error) {


### PR DESCRIPTION
I can't see where `set` is filled out (for example), by `DecodeBuildConfig`, which makes me suspect that `IsZero` is returning true in `pageMeta.applyDefaultValues` when it shouldn't.

All tests still passed with this change, but I'm not entirely sure where the right place to add a test would be.