### PR TITLE
Pass directory name to filters in LstatIfPossible in the same way as Readdir

### DIFF
--- a/hugofs/filter_fs.go
+++ b/hugofs/filter_fs.go
@@ -153,7 +153,8 @@ func (fs *FilterFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
 		return decorateFileInfo(fi, fs, fs.getOpener(name), "", "", nil), false, nil
 	}
 
-	fs.applyFilters(name, -1, fi)
+	parent := filepath.Dir(name)
+	fs.applyFilters(parent, -1, fi)
 
 	return fi, b, nil
 


### PR DESCRIPTION
While I was working on keeping track of build options in filterfs, I noticed an oddity that sometimes the filter function is passed the filepath, and sometimes it is passed the directory path.

This makes the arguments to applyFilters consistent (and then renames the argument to make it more clear).