### PR TITLE
Change documentation of the url front-matter variable

### DIFF
--- a/docs/content/en/content-management/front-matter.md
+++ b/docs/content/en/content-management/front-matter.md
@@ -128,7 +128,7 @@ type
 : the type of the content; this value will be automatically derived from the directory (i.e., the [section][]) if not specified in front matter.
 
 url
-: the full path to the content from the web root. It makes no assumptions about the path of the content file. _Note that the language prefix will still be prepended to this given URL._
+: the full path to the content from the web root. It makes no assumptions about the path of the content file. _Note that the language prefix in a multi language setup will still be prepended to this given URL._
 
 videos
 : an array of paths to videos related to the page; used by the `opengraph` [internal template](/templates/internal) to populate `og:video`.

--- a/docs/content/en/content-management/front-matter.md
+++ b/docs/content/en/content-management/front-matter.md
@@ -128,8 +128,7 @@ type
 : the type of the content; this value will be automatically derived from the directory (i.e., the [section][]) if not specified in front matter.
 
 url
-: the full path to the content from the web root. It makes no assumptions about the path of the content file. It also ignores any language prefixes of
-the multilingual feature.
+: the full path to the content from the web root. It makes no assumptions about the path of the content file. _Note that the language prefix will still be prepended to this given URL._
 
 videos
 : an array of paths to videos related to the page; used by the `opengraph` [internal template](/templates/internal) to populate `og:video`.


### PR DESCRIPTION
See https://github.com/gohugoio/hugo/issues/6448

The documentation currently states

> **url**
>
> the full path to the content from the web root. It makes no assumptions about the path of the content file. It also ignores any language prefixes of the multilingual feature.

However, the latter is not true any more since Hugo ~0.58. Instead, the language prefix will still be prepended to the given front-matter `url`.