### PR TITLE
Reuse frontmatter parser in classifier

### DIFF
--- a/hugolib/site_benchmark_new_test.go
+++ b/hugolib/site_benchmark_new_test.go
@@ -38,6 +38,10 @@ func getBenchmarkSiteDeepContent(b testing.TB) *sitesBuilder {
 		return getBenchmarkTestDataPageContentForMarkdown(size, "", benchmarkMarkdownSnippets)
 	}
 
+	htmlContent := func(size int) string {
+		return getBenchmarkTestDataPageContentForHtml(size, "", benchmarkHtmlSnippets)
+	}
+
 	sb := newTestSitesBuilder(b).WithConfigFile("toml", `
 baseURL = "https://example.com"
 
@@ -64,7 +68,7 @@ contentDir="content/sv"
 	createBundledFiles := func(dir string) {
 		sb.WithContent(filepath.Join("content", dir, "data.json"), `{ "hello": "world" }`)
 		for i := 1; i <= 3; i++ {
-			sb.WithContent(filepath.Join("content", dir, fmt.Sprintf("page%d.md", i)), pageContent(1))
+			sb.WithContent(filepath.Join("content", dir, fmt.Sprintf("page%d.html", i)), htmlContent(1))
 		}
 	}
 
@@ -117,6 +121,37 @@ This is [Relative](/all-is-relative).
 See my [About](/about/) page for details. 
 `
 
+func getBenchmarkTestDataPageContentForHtml(size int, category, html string) string {
+	base := `---
+title: "My Page"
+%s
+---
+<html>
+<body>
+<p>My page content.</p>
+`
+
+	var categoryKey string
+	if category != "" {
+		categoryKey = fmt.Sprintf("categories: [%s]", category)
+	}
+	base = fmt.Sprintf(base, categoryKey)
+
+	return base + strings.Repeat(html, size) + "\n</html>"
+}
+
+const benchmarkHtmlSnippets = `
+<h2>Links</h2>
+
+<p>This is <a href="http://example.com" title="Title">an example</a> inline link.</p>
+
+<p><a href="http://example.net/">This link</a> has no title attribute.</p>
+
+<p>This is <a href="/all-is-relative">Relative</a>.</p>
+
+See my <a href="/about/">About</a> page for details.</p>
+`
+
 func getBenchmarkSiteNewTestCases() []siteBenchmarkTestcase {
 
 	pageContentWithCategory := func(size int, category string) string {
@@ -124,7 +159,7 @@ func getBenchmarkSiteNewTestCases() []siteBenchmarkTestcase {
 	}
 
 	pageContent := func(size int) string {
-		return getBenchmarkTestDataPageContentForMarkdown(size, "", benchmarkMarkdownSnippets)
+		return pageContentWithCategory(size, "")
 	}
 
 	config := `

--- a/hugolib/site_benchmark_new_test.go
+++ b/hugolib/site_benchmark_new_test.go
@@ -67,8 +67,8 @@ contentDir="content/sv"
 
 	createBundledFiles := func(dir string) {
 		sb.WithContent(filepath.Join("content", dir, "data.json"), `{ "hello": "world" }`)
-		for i := 1; i <= 3; i++ {
-			sb.WithContent(filepath.Join("content", dir, fmt.Sprintf("page%d.html", i)), htmlContent(1))
+		for i := 1; i <= 5; i++ {
+			sb.WithContent(filepath.Join("content", dir, fmt.Sprintf("page%d.html", i)), htmlContent(i*6))
 		}
 	}
 
@@ -247,7 +247,7 @@ canonifyURLs = true
 				s.CheckExists("public/blog/mybundle/index.html")
 				s.Assert(len(s.H.Sites), qt.Equals, 4)
 				s.Assert(len(s.H.Sites[0].RegularPages()), qt.Equals, len(s.H.Sites[1].RegularPages()))
-				s.Assert(len(s.H.Sites[0].RegularPages()), qt.Equals, 30)
+				s.Assert(len(s.H.Sites[0].RegularPages()), qt.Equals, 40)
 
 			},
 		},
@@ -498,7 +498,7 @@ Edited!!`, p.Title()))
 
 	// We currently rebuild all the language versions of the same content file.
 	// We could probably optimize that case, but it's not trivial.
-	b.Assert(int(counters.contentRenderCounter), qt.Equals, 4)
+	b.Assert(int(counters.contentRenderCounter), qt.Equals, 24)
 	b.AssertFileContent("public"+p.RelPermalink()+"index.html", "Edited!!")
 
 }

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -447,11 +447,11 @@ func doTestSectionNaming(t *testing.T, canonify, uglify, pluralize bool) {
 	}
 
 	sources := [][2]string{
-		{filepath.FromSlash("sect/doc1.html"), "doc1"},
+		{filepath.FromSlash("sect/doc1.html"), "---\ntitle: doc\n---\ndoc1"},
 		// Add one more page to sect to make sure sect is picked in mainSections
-		{filepath.FromSlash("sect/sect.html"), "sect"},
-		{filepath.FromSlash("Fish and Chips/doc2.html"), "doc2"},
-		{filepath.FromSlash("ラーメン/doc3.html"), "doc3"},
+		{filepath.FromSlash("sect/sect.md"), "sect"},
+		{filepath.FromSlash("Fish and Chips/doc2.html"), "---\ntitle: Fish and Chips\n---\ndoc2"},
+		{filepath.FromSlash("ラーメン/doc3.html"), "---\ntitle: ラーメン\n---\ndoc3"},
 	}
 
 	cfg, fs := newTestCfg()


### PR DESCRIPTION
While looking at #4691 , I noticed that the code in `classifier.go` does some ad-hoc parsing for HTML vs other content.

Given that a page without frontmatter can't be usefully parsed, it seemed more straightforward to reuse the frontmatter parser to determine whether the HTML file was content or a plain file.

Unfortunately, it turns out that TestSectionNaming has some HTML documents that are just strings without frontmatter, so I ended up needing to adjust those tests.

I'm wondering whether it makes sense to apply this "has frontmatter" test universally in ClassifyContentFile; it appears that doing so would need updates in the following tests from hugolib:

    TestCascade
    TestContentMap
    TestRenderStringOnListPage
    TestSiteBuildErrors
    TestShortCodesInSite
    TestSectionNaming
    TestRefLinking
    TestCrossrefs
    TestDataFromShortcode
    