### PR TITLE
docs: Fix build listing improvements version

### DIFF
--- a/docs/content/en/content-management/build-options.md
+++ b/docs/content/en/content-management/build-options.md
@@ -30,7 +30,7 @@ If true, the page will be treated as a published page, holding its dedicated out
 
 #### list
 
-Note that we extended this property from a boolean to an enum in Hugo 0.58.0.
+Note that we extended this property from a boolean to an enum in Hugo 0.68.0.
 
 Valid values are:
 
@@ -41,7 +41,7 @@ always (default)
 : The page will be included in all page collections, e.g. `site.RegularPages`, `$page.Pages`.
 
 local
-: The page will be included in any _local_ page collection, e.g. `$page.RegularPages`, `$page.Pages`. One use case for this would be to create fully navigable, but headless content sections. {{< new-in "0.58.0" >}}
+: The page will be included in any _local_ page collection, e.g. `$page.RegularPages`, `$page.Pages`. One use case for this would be to create fully navigable, but headless content sections. {{< new-in "0.68.0" >}}
 
 If true, the page will be treated as part of the project's collections and, when appropriate, returned by Hugo's listing methods (`.Pages`, `.RegularPages` etc...).
 


### PR DESCRIPTION
Additional build options for listing pages were introduced in v0.68. Original commit (https://github.com/gohugoio/hugo/commit/99958f90fedec11d749a1397300860aa8e8459c2) added a note to docs mentioning version 0.58. This change corrects the version.