### PR TITLE
common/herrors: Fix typos in comments

### DIFF
--- a/common/herrors/error_locator.go
+++ b/common/herrors/error_locator.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package errors contains common Hugo errors and error related utilities.
+// Package herrors contains common Hugo errors and error related utilities.
 package herrors
 
 import (

--- a/common/herrors/error_locator_test.go
+++ b/common/herrors/error_locator_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package errors contains common Hugo errors and error related utilities.
+// Package herrors contains common Hugo errors and error related utilities.
 package herrors
 
 import (

--- a/common/herrors/file_error.go
+++ b/common/herrors/file_error.go
@@ -9,7 +9,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitatio	ns under the License.
+// limitations under the License.
 
 package herrors
 

--- a/common/herrors/line_number_extractors.go
+++ b/common/herrors/line_number_extractors.go
@@ -9,7 +9,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitatio	ns under the License.
+// limitations under the License.
 
 package herrors
 


### PR DESCRIPTION
I probably found typos in comments.

- In license comment: `limitatio	ns` -> `limitations`
- In package comment: `Package errors` -> `Package herrors`