### PR TITLE
Proposal: Add "ContentData" to customize TableOfContents

### DIFF
--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gohugoio/hugo/tpl"
 
 	"github.com/gohugoio/hugo/helpers"
-	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/gohugoio/hugo/output"
 	"github.com/gohugoio/hugo/resources/page"
 	"github.com/gohugoio/hugo/resources/resource"
@@ -142,7 +141,7 @@ func newPageContentOutput(p *pageState, po *pageOutput) (*pageContentOutput, err
 						cfg.TableOfContents.Ordered,
 					),
 				)
-				cp.tableOfContentsHeaders = toc.Headers
+				cp.contentData.TableOfContents = toc.Headers
 			} else {
 				tmpContent, tmpTableOfContents := helpers.ExtractTOC(cp.workContent)
 				cp.tableOfContents = helpers.BytesToHTML(tmpTableOfContents)
@@ -272,10 +271,10 @@ type pageContentOutput struct {
 	contentPlaceholders map[string]string
 
 	// Content sections
-	content                template.HTML
-	summary                template.HTML
-	tableOfContents        template.HTML
-	tableOfContentsHeaders tableofcontents.Headers
+	content         template.HTML
+	summary         template.HTML
+	tableOfContents template.HTML
+	contentData     page.ContentData
 
 	truncated bool
 
@@ -345,9 +344,9 @@ func (p *pageContentOutput) TableOfContents() template.HTML {
 	return p.tableOfContents
 }
 
-func (p *pageContentOutput) TableOfContentsCollection() tableofcontents.Headers {
+func (p *pageContentOutput) ContentData() page.ContentData {
 	p.p.s.initInit(p.initMain, p.p)
-	return p.tableOfContentsHeaders
+	return p.contentData
 }
 
 func (p *pageContentOutput) Truncated() bool {

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -107,7 +107,6 @@ func newPageContentOutput(p *pageState, po *pageOutput) (*pageContentOutput, err
 		}
 
 		enableReuse := !(hasShortcodeVariants || cp.renderHooksHaveVariants)
-		// enableReuse := !(hasShortcodeVariants || cp.renderHooksHaveVariants || hasShortcodeVariants2)
 
 		if enableReuse {
 			// Reuse this for the other output formats.

--- a/hugolib/shortcode_page.go
+++ b/hugolib/shortcode_page.go
@@ -16,7 +16,6 @@ package hugolib
 import (
 	"html/template"
 
-	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/gohugoio/hugo/resources/page"
 )
 
@@ -56,8 +55,8 @@ func (p *pageForShortcode) TableOfContents() template.HTML {
 	return p.toc
 }
 
-func (p *pageForShortcode) TableOfContentsCollection() tableofcontents.Headers {
-	return p.p.cp.tableOfContentsHeaders
+func (p *pageForShortcode) ContentData() page.ContentData {
+	return p.p.cp.contentData
 }
 
 // This is what is sent into the content render hooks (link, image).

--- a/hugolib/shortcode_page.go
+++ b/hugolib/shortcode_page.go
@@ -16,6 +16,7 @@ package hugolib
 import (
 	"html/template"
 
+	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/gohugoio/hugo/resources/page"
 )
 
@@ -53,6 +54,10 @@ func (p *pageForShortcode) page() page.Page {
 func (p *pageForShortcode) TableOfContents() template.HTML {
 	p.p.enablePlaceholders()
 	return p.toc
+}
+
+func (p *pageForShortcode) TableOfContentsCollection() tableofcontents.Headers {
+	return p.p.cp.tableOfContentsHeaders
 }
 
 // This is what is sent into the content render hooks (link, image).

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -149,12 +149,12 @@ func TestShortcodeRelated(t *testing.T) {
 	CheckShortCodeMatch(t, "{{< a >}}", "0", wt)
 }
 
-func TestShortcodeTableOfContentsCollection(t *testing.T) {
+func TestShortcodeTableOfContentsInContentData(t *testing.T) {
 	t.Parallel()
 	wt := func(tem tpl.TemplateManager) error {
 		tem.AddTemplate(
 			"_internal/shortcodes/toc.html",
-			`{{ range $h1 := .Page.TableOfContentsCollection }}{{ $h1.ID }}{{ $h1.HTML }}{{ end }}`,
+			`{{ range $h1 := .Page.ContentData.TableOfContents }}{{ $h1.ID }}{{ $h1.HTML }}{{ end }}`,
 		)
 		return nil
 	}

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -149,6 +149,28 @@ func TestShortcodeRelated(t *testing.T) {
 	CheckShortCodeMatch(t, "{{< a >}}", "0", wt)
 }
 
+func TestShortcodeTableOfContentsCollection(t *testing.T) {
+	t.Parallel()
+	wt := func(tem tpl.TemplateManager) error {
+		tem.AddTemplate(
+			"_internal/shortcodes/toc.html",
+			`{{ range $h1 := .Page.TableOfContentsCollection }}{{ $h1.ID }}{{ $h1.HTML }}{{ end }}`,
+		)
+		return nil
+	}
+
+	CheckShortCodeMatch(t, `# head1
+
+# head2
+
+{{< toc >}}
+
+`, `
+<h1 id="head1">head1</h1>
+
+<h1 id="head2">head2</h1>`, wt)
+}
+
 func TestShortcodeInnerMarkup(t *testing.T) {
 	t.Parallel()
 	wt := func(tem tpl.TemplateManager) error {

--- a/markup/tableofcontents/tableofcontents.go
+++ b/markup/tableofcontents/tableofcontents.go
@@ -14,6 +14,7 @@
 package tableofcontents
 
 import (
+	"html/template"
 	"strings"
 )
 
@@ -26,6 +27,11 @@ type Header struct {
 	Text string
 
 	Headers Headers
+}
+
+// HTML is produces safe, escaped HTML output of Text
+func (h Header) HTML() template.HTML {
+	return template.HTML(h.Text)
 }
 
 // IsZero is true when no ID or Text is set.

--- a/resources/page/page.go
+++ b/resources/page/page.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gohugoio/hugo/compare"
 	"github.com/gohugoio/hugo/hugofs/files"
 
-	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/gohugoio/hugo/navigation"
 	"github.com/gohugoio/hugo/related"
 	"github.com/gohugoio/hugo/resources/resource"
@@ -83,6 +82,7 @@ type ContentProvider interface {
 	WordCount() int
 	ReadingTime() int
 	Len() int
+	ContentData() ContentData
 }
 
 // FileProvider provides the source file.
@@ -312,7 +312,6 @@ type SitesProvider interface {
 // TableOfContentsProvider provides the table of contents for a Page.
 type TableOfContentsProvider interface {
 	TableOfContents() template.HTML
-	TableOfContentsCollection() tableofcontents.Headers
 }
 
 // TranslationsProvider provides access to any translations.

--- a/resources/page/page.go
+++ b/resources/page/page.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gohugoio/hugo/compare"
 	"github.com/gohugoio/hugo/hugofs/files"
 
+	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/gohugoio/hugo/navigation"
 	"github.com/gohugoio/hugo/related"
 	"github.com/gohugoio/hugo/resources/resource"
@@ -311,6 +312,7 @@ type SitesProvider interface {
 // TableOfContentsProvider provides the table of contents for a Page.
 type TableOfContentsProvider interface {
 	TableOfContents() template.HTML
+	TableOfContentsCollection() tableofcontents.Headers
 }
 
 // TranslationsProvider provides access to any translations.

--- a/resources/page/page_content_data.go
+++ b/resources/page/page_content_data.go
@@ -1,0 +1,23 @@
+// Copyright 2019 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package page
+
+import (
+	"github.com/gohugoio/hugo/markup/tableofcontents"
+)
+
+// ContentData contains data structures about a page.
+type ContentData struct {
+	TableOfContents tableofcontents.Headers
+}

--- a/resources/page/page_nop.go
+++ b/resources/page/page_nop.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/langs"
+	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/related"
 	"github.com/gohugoio/hugo/resources/resource"
@@ -443,6 +444,10 @@ func (p *nopPage) Summary() template.HTML {
 
 func (p *nopPage) TableOfContents() template.HTML {
 	return ""
+}
+
+func (p *nopPage) TableOfContentsCollection() tableofcontents.Headers {
+	return []tableofcontents.Header{}
 }
 
 func (p *nopPage) Title() string {

--- a/resources/page/page_nop.go
+++ b/resources/page/page_nop.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/langs"
-	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/related"
 	"github.com/gohugoio/hugo/resources/resource"
@@ -96,6 +95,10 @@ func (p *nopPage) Content() (interface{}, error) {
 
 func (p *nopPage) ContentBaseName() string {
 	return ""
+}
+
+func (p *nopPage) ContentData() ContentData {
+	return ContentData{}
 }
 
 func (p *nopPage) CurrentSection() Page {
@@ -444,10 +447,6 @@ func (p *nopPage) Summary() template.HTML {
 
 func (p *nopPage) TableOfContents() template.HTML {
 	return ""
-}
-
-func (p *nopPage) TableOfContentsCollection() tableofcontents.Headers {
-	return []tableofcontents.Header{}
 }
 
 func (p *nopPage) Title() string {

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/hugofs"
 	"github.com/gohugoio/hugo/langs"
+	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/related"
 
@@ -522,6 +523,10 @@ func (p *testPage) Summary() template.HTML {
 }
 
 func (p *testPage) TableOfContents() template.HTML {
+	panic("not implemented")
+}
+
+func (p *testPage) TableOfContentsCollection() tableofcontents.Headers {
 	panic("not implemented")
 }
 

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -526,7 +526,7 @@ func (p *testPage) TableOfContents() template.HTML {
 	panic("not implemented")
 }
 
-func (p *testPage) TableOfContentsCollection() tableofcontents.Headers {
+func (p *testPage) ContentData() ContentData {
 	panic("not implemented")
 }
 

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/hugofs"
 	"github.com/gohugoio/hugo/langs"
-	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/related"
 


### PR DESCRIPTION
This is proposal.  Further improvements will be required.
Any comments are welcome.

Add new Page Param ".TableOfContentsCollection" with goldmark.
This enables users to customize table of contents as they like.
You can be used it in shortcodes but have to use with `{{< >}}` (as non-markdown shortcode) because headers in contents cannot be determined until markdown shortcodes (`{{% %}}`) are rendered.

First, I was tackling the issue #7095 . It was harder than it looks.
Rather than fixing the single issue, I added the new param that gives Hugo some flexibility

Here is [usage example](https://github.com/satotake/hugo-test/tree/proposal-toc-collection)

---

Addresses #7095, #6811, #6081, #225