### PR TITLE
Add render template hooks for headings

### DIFF
--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -49,6 +49,7 @@ Inner Block: {{ .Inner | .Page.RenderString (dict "display" "block" ) }}
 	b.WithTemplatesAdded("_default/_markup/render-link.html", `{{ with .Page }}{{ .Title }}{{ end }}|{{ .Destination | safeURL }}|Title: {{ .Title | safeHTML }}|Text: {{ .Text | safeHTML }}|END`)
 	b.WithTemplatesAdded("docs/_markup/render-link.html", `Link docs section: {{ .Text | safeHTML }}|END`)
 	b.WithTemplatesAdded("_default/_markup/render-image.html", `IMAGE: {{ .Page.Title }}||{{ .Destination | safeURL }}|Title: {{ .Title | safeHTML }}|Text: {{ .Text | safeHTML }}|END`)
+	b.WithTemplatesAdded("_default/_markup/render-heading.html", `HEADING: {{ .Page.Title }}||Level: {{ .Level }}|Anchor: {{ .Anchor | safeURL }}|Text: {{ .Text | safeHTML }}|END`)
 
 	b.WithContent("customview/p1.md", `---
 title: Custom View
@@ -122,6 +123,16 @@ title: With RenderString
 
 {{< myshortcode5 >}}Inner Link: [Inner Link](https://www.gohugo.io "Hugo's Homepage"){{< /myshortcode5 >}}
 
+`, "blog/p7.md", `---
+title: With Headings
+---
+
+# Heading Level 1
+some text
+
+## Heading Level 2
+
+### Heading Level 3
 `)
 
 	for i := 1; i <= 30; i++ {
@@ -135,7 +146,7 @@ title: No Template
 	}
 	counters := &testCounters{}
 	b.Build(BuildCfg{testCounters: counters})
-	b.Assert(int(counters.contentRenderCounter), qt.Equals, 43)
+	b.Assert(int(counters.contentRenderCounter), qt.Equals, 44)
 
 	b.AssertFileContent("public/blog/p1/index.html", `
 <p>Cool Page|https://www.google.com|Title: Google's Homepage|Text: First Link|END</p>
@@ -182,7 +193,7 @@ SHORT3|
 	// We may add type template support later, keep this for then. b.AssertFileContent("public/docs/docs1/index.html", `DOCS EDITED: https://www.google.com|</p>`)
 	b.AssertFileContent("public/blog/p4/index.html", `IMAGE EDITED: /images/Dragster.jpg|`)
 	b.AssertFileContent("public/blog/p6/index.html", "<p>Inner Link: EDITED: https://www.gohugo.io|</p>")
-
+	b.AssertFileContent("public/blog/p7/index.html", "HEADING: With Headings||Level: 1|Anchor: heading-level-1|Text: Heading Level 1|END<p>some text</p>\nHEADING: With Headings||Level: 2|Anchor: heading-level-2|Text: Heading Level 2|ENDHEADING: With Headings||Level: 3|Anchor: heading-level-3|Text: Heading Level 3|END")
 }
 
 func TestRenderHooksDeleteTemplate(t *testing.T) {

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -349,48 +349,54 @@ func (ps *pageState) initCommonProviders(pp pagePaths) error {
 	return nil
 }
 
-func (p *pageState) createRenderHooks(f output.Format) (*hooks.Render, error) {
-
+func (p *pageState) createRenderHooks(f output.Format) (*hooks.Renderers, error) {
 	layoutDescriptor := p.getLayoutDescriptor()
 	layoutDescriptor.RenderingHook = true
 	layoutDescriptor.LayoutOverride = false
 	layoutDescriptor.Layout = ""
 
+	var renderers hooks.Renderers
+
 	layoutDescriptor.Kind = "render-link"
-	linkTempl, linkTemplFound, err := p.s.Tmpl().LookupLayout(layoutDescriptor, f)
+	templ, templFound, err := p.s.Tmpl().LookupLayout(layoutDescriptor, f)
 	if err != nil {
 		return nil, err
+	}
+	if templFound {
+		renderers.LinkRenderer = hookRenderer{
+			templateHandler: p.s.Tmpl(),
+			Provider:        templ.(tpl.Info),
+			templ:           templ,
+		}
 	}
 
 	layoutDescriptor.Kind = "render-image"
-	imgTempl, imgTemplFound, err := p.s.Tmpl().LookupLayout(layoutDescriptor, f)
+	templ, templFound, err = p.s.Tmpl().LookupLayout(layoutDescriptor, f)
 	if err != nil {
 		return nil, err
 	}
-
-	var linkRenderer hooks.LinkRenderer
-	var imageRenderer hooks.LinkRenderer
-
-	if linkTemplFound {
-		linkRenderer = contentLinkRenderer{
+	if templFound {
+		renderers.ImageRenderer = hookRenderer{
 			templateHandler: p.s.Tmpl(),
-			Provider:        linkTempl.(tpl.Info),
-			templ:           linkTempl,
+			Provider:        templ.(tpl.Info),
+			templ:           templ,
 		}
 	}
 
-	if imgTemplFound {
-		imageRenderer = contentLinkRenderer{
+	layoutDescriptor.Kind = "render-heading"
+	templ, templFound, err = p.s.Tmpl().LookupLayout(layoutDescriptor, f)
+	if err != nil {
+		return nil, err
+	}
+	if templFound {
+		renderers.HeadingRenderer = hookRenderer{
 			templateHandler: p.s.Tmpl(),
-			Provider:        imgTempl.(tpl.Info),
-			templ:           imgTempl,
+			Provider:        templ.(tpl.Info),
+			templ:           templ,
 		}
 	}
 
-	return &hooks.Render{
-		LinkRenderer:  linkRenderer,
-		ImageRenderer: imageRenderer,
-	}, nil
+	return &renderers, nil
 }
 
 func (p *pageState) getLayoutDescriptor() output.LayoutDescriptor {

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -245,7 +245,7 @@ type pageContentOutput struct {
 	placeholdersEnabledInit sync.Once
 
 	// May be nil.
-	renderHooks *hooks.Render
+	renderHooks *hooks.Renderers
 	// Set if there are more than one output format variant
 	renderHooksHaveVariants bool // TODO(bep) reimplement this in another way, consolidate with shortcodes
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1647,14 +1647,20 @@ var infoOnMissingLayout = map[string]bool{
 	"404": true,
 }
 
-type contentLinkRenderer struct {
+// hookRenderer is the canonical implementation of all hooks.ITEMRenderer,
+// where ITEM is the thing being hooked.
+type hookRenderer struct {
 	templateHandler tpl.TemplateHandler
 	identity.Provider
 	templ tpl.Template
 }
 
-func (r contentLinkRenderer) Render(w io.Writer, ctx hooks.LinkContext) error {
-	return r.templateHandler.Execute(r.templ, w, ctx)
+func (hr hookRenderer) RenderLink(w io.Writer, ctx hooks.LinkContext) error {
+	return hr.templateHandler.Execute(hr.templ, w, ctx)
+}
+
+func (hr hookRenderer) RenderHeading(w io.Writer, ctx hooks.HeadingContext) error {
+	return hr.templateHandler.Execute(hr.templ, w, ctx)
 }
 
 func (s *Site) renderForTemplate(name, outputFormat string, d interface{}, w io.Writer, templ tpl.Template) (err error) {

--- a/markup/converter/converter.go
+++ b/markup/converter/converter.go
@@ -126,7 +126,7 @@ type DocumentContext struct {
 type RenderContext struct {
 	Src         []byte
 	RenderTOC   bool
-	RenderHooks *hooks.Render
+	RenderHooks *hooks.Renderers
 }
 
 var (


### PR DESCRIPTION
This commit also

* Renames previous types to be non-specific. (e.g. hookedRenderer rather
  than linkRenderer)

Resolves #6713

This was implemented much in the same way the current hooks are implemented, pulling in method definitions from [goldmark](https://github.com/yuin/goldmark). It still needs testing and documentation, but on my personal website I was able to successfully replace the `replaceRE` partial hack described in the issue above with a `render-heading.html` template similar to the one described.