### PR TITLE
Add hugo.IsExtended function

### DIFF
--- a/common/hugo/hugo_test.go
+++ b/common/hugo/hugo_test.go
@@ -32,7 +32,6 @@ func TestHugoInfo(t *testing.T) {
 	c.Assert(hugoInfo.Environment, qt.Equals, "production")
 	c.Assert(string(hugoInfo.Generator()), qt.Contains, fmt.Sprintf("Hugo %s", hugoInfo.Version()))
 	c.Assert(hugoInfo.IsProduction(), qt.Equals, true)
-	c.Assert(hugoInfo.IsExtended(), qt.Equals, true)
 
 	devHugoInfo := NewInfo("development")
 	c.Assert(devHugoInfo.IsProduction(), qt.Equals, false)

--- a/common/hugo/hugo_test.go
+++ b/common/hugo/hugo_test.go
@@ -32,6 +32,7 @@ func TestHugoInfo(t *testing.T) {
 	c.Assert(hugoInfo.Environment, qt.Equals, "production")
 	c.Assert(string(hugoInfo.Generator()), qt.Contains, fmt.Sprintf("Hugo %s", hugoInfo.Version()))
 	c.Assert(hugoInfo.IsProduction(), qt.Equals, true)
+	c.Assert(hugoInfo.IsExtended(), qt.Equals, true)
 
 	devHugoInfo := NewInfo("development")
 	c.Assert(devHugoInfo.IsProduction(), qt.Equals, false)


### PR DESCRIPTION
Function that would allow to check whether current version of Hugo is 'Extended'.

It is currently possible to show warning if Hugo is (or not) extended. See [this](https://gohugo.io/hugo-modules/configuration/#module-config-hugoversion). But, this PR allows theme devs and layout devs to ensure, by using an if conditional and hugo.IsExtended variable, that their Hugo project runs whether or not Hugo installed is extended or not.

See [this](https://discourse.gohugo.io/t/how-to-check-whether-extended-hugo-or-not/24476/5) topic on Hugo Discourse for discussion.