### PR TITLE
Properly close <meta "robots" ... > tags

### DIFF
--- a/docs/_vendor/github.com/gohugoio/gohugoioTheme/layouts/_default/baseof.html
+++ b/docs/_vendor/github.com/gohugoio/gohugoioTheme/layouts/_default/baseof.html
@@ -16,9 +16,9 @@
   {{ hugo.Generator }}
 
   {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
-  <meta name="robots" content="index, follow">
+  <meta name="robots" content="index, follow" />
   {{ else }}
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="noindex, nofollow" />
   {{ end }}
 
   {{ range .AlternativeOutputFormats -}}

--- a/docs/content/en/content-management/urls.md
+++ b/docs/content/en/content-management/urls.md
@@ -161,7 +161,7 @@ Assuming a `baseURL` of `example.com`, the contents of the auto-generated alias 
   <head>
     <title>https://example.com/posts/my-intended-url</title>
     <link rel="canonical" href="https://example.com/posts/my-intended-url"/>
-    <meta name="robots" content="noindex">
+    <meta name="robots" content="noindex" />
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
     <meta http-equiv="refresh" content="0; url=https://example.com/posts/my-intended-url"/>
   </head>

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -92,7 +92,7 @@ var EmbeddedTemplates = [][2]string{
 	{{ end }}
 </sitemapindex>
 `},
-	{`alias.html`, `<!DOCTYPE html><html><head><title>{{ .Permalink }}</title><link rel="canonical" href="{{ .Permalink }}"/><meta name="robots" content="noindex"><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url={{ .Permalink }}" /></head></html>`},
+	{`alias.html`, `<!DOCTYPE html><html><head><title>{{ .Permalink }}</title><link rel="canonical" href="{{ .Permalink }}"/><meta name="robots" content="noindex" /><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url={{ .Permalink }}" /></head></html>`},
 	{`disqus.html`, `{{- $pc := .Site.Config.Privacy.Disqus -}}
 {{- if not $pc.Disable -}}
 {{ if .Site.DisqusShortname }}<div id="disqus_thread"></div>

--- a/tpl/tplimpl/embedded/templates/alias.html
+++ b/tpl/tplimpl/embedded/templates/alias.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html><head><title>{{ .Permalink }}</title><link rel="canonical" href="{{ .Permalink }}"/><meta name="robots" content="noindex"><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url={{ .Permalink }}" /></head></html>
+<!DOCTYPE html><html><head><title>{{ .Permalink }}</title><link rel="canonical" href="{{ .Permalink }}"/><meta name="robots" content="noindex" /><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url={{ .Permalink }}" /></head></html>


### PR DESCRIPTION
In the generated output HTML files, Hugo didn't close some meta tags, raising warning in strict HTML validity checks.
This PR addresses this issue.