### PR TITLE
resources/images: Adding webp support

### DIFF
--- a/docs/content/en/content-management/image-processing/index.md
+++ b/docs/content/en/content-management/image-processing/index.md
@@ -193,11 +193,15 @@ See https://github.com/disintegration/imaging for more. If you want to trade qua
 
 By default the images is encoded in the source format, but you can set the target format as an option.
 
-Valid values are `jpg`, `png`, `tif`, `bmp`, and `gif`.
+Valid values are `jpg`, `png`, `tif`, `bmp`, `gif`, `webp`.
 
 ```go
 {{ $image.Resize "600x jpg" }}
 ```
+
+{{% note %}}
+The target format WebP (`webp`) requires the `cwebp` binary ([can be obtained here](https://developers.google.com/speed/webp)) to be installed either in `PATH`, available via `LIBWEBP_HOME` or in the current working directory.
+{{% /note %}}
 
 ## Image Processing Examples
 

--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -144,6 +144,7 @@ var (
 	GIFType  = Type{MainType: "image", SubType: "gif", Suffixes: []string{"gif"}, Delimiter: defaultDelimiter}
 	TIFFType = Type{MainType: "image", SubType: "tiff", Suffixes: []string{"tif", "tiff"}, Delimiter: defaultDelimiter}
 	BMPType  = Type{MainType: "image", SubType: "bmp", Suffixes: []string{"bmp"}, Delimiter: defaultDelimiter}
+	WEBPType = Type{MainType: "image", SubType: "webp", Suffixes: []string{"webp"}, Delimiter: defaultDelimiter}
 
 	// Common video types
 	AVIType  = Type{MainType: "video", SubType: "x-msvideo", Suffixes: []string{"avi"}, Delimiter: defaultDelimiter}

--- a/resources/images/config.go
+++ b/resources/images/config.go
@@ -40,6 +40,7 @@ var (
 		".tiff": TIFF,
 		".bmp":  BMP,
 		".gif":  GIF,
+		".webp": WEBP,
 	}
 
 	// Add or increment if changes to an image format's processing requires

--- a/resources/images/image.go
+++ b/resources/images/image.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/resources/images/exif"
+	"github.com/gohugoio/hugo/resources/images/webp"
 
 	"github.com/disintegration/gift"
 	"golang.org/x/image/bmp"
@@ -89,6 +90,10 @@ func (i *Image) EncodeTo(conf ImageConfig, img image.Image, w io.Writer) error {
 
 	case BMP:
 		return bmp.Encode(w, img)
+
+	case WEBP:
+		return webp.Encode(w, img, &webp.Options{Quality: conf.Quality})
+
 	default:
 		return errors.New("format not supported")
 	}
@@ -253,6 +258,7 @@ const (
 	GIF
 	TIFF
 	BMP
+	WEBP
 )
 
 // RequiresDefaultQuality returns if the default quality needs to be applied to images of this format
@@ -284,6 +290,8 @@ func (f Format) MediaType() media.Type {
 		return media.TIFFType
 	case BMP:
 		return media.BMPType
+	case WEBP:
+		return media.WEBPType
 	default:
 		panic(fmt.Sprintf("%d is not a valid image format", f))
 	}

--- a/resources/images/webp/common_libwebp_test.go
+++ b/resources/images/webp/common_libwebp_test.go
@@ -1,0 +1,208 @@
+package webp
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	// This version is required because the build agents of Travis are currently (2020-04-14) still on macOS 10.13.6
+	// and later version of libwebp are not already supported.
+	libwebpVersion             = "1.0.1"
+	libwebpDownloadBase        = "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/"
+	libwebpDownloadFileLinux   = "libwebp-{version}-linux-x86-64.tar.gz"
+	libwebpDownloadFileMacOs   = "libwebp-{version}-mac-10.13.tar.gz"
+	libwebpDownloadFileWindows = "libwebp-{version}-windows-x64-no-wic.zip"
+)
+
+func ensureLibwebpHome(t *testing.T) (to string) {
+	from := libwebpDownloadUrl(t)
+	to = toPath(from)
+
+	if _, err := os.Stat(to); os.IsNotExist(err) {
+		t.Logf("%s does not exist; downloading it...", to)
+	} else if err != nil {
+		fatalfWithEnvironment(t, "cannot check of existing of %s: %v", to, err)
+	} else {
+		return
+	}
+
+	archive := downloadLibwebpArchive(t, from)
+	defer func() { _ = os.Remove(archive) }()
+	unpackArchive(t, archive, from, to)
+
+	return
+}
+
+func unpackArchive(t *testing.T, from, sourceUrl, to string) {
+	fromF, err := os.Open(from)
+	if err != nil {
+		fatalfWithEnvironment(t, "cannot open libwebp archive %s: %v", from, err)
+	}
+	defer func() { _ = fromF.Close() }()
+
+	var unpack func(from *os.File, to string) error
+	if strings.HasSuffix(sourceUrl, ".tar.gz") {
+		unpack = unpackTarGzArchive
+	} else if strings.HasSuffix(sourceUrl, ".zip") {
+		unpack = unpackZipArchive
+	} else {
+		t.Fatalf("unsupported libwebp archive type: %s", sourceUrl)
+	}
+
+	if err := unpack(fromF, to); err != nil {
+		fatalfWithEnvironment(t, "cannot unpack libwebp archive %s: %v", from, err)
+	}
+
+	return
+}
+
+func unpackTarGzArchive(from *os.File, to string) error {
+	gr, err := gzip.NewReader(from)
+	if err != nil {
+		return err
+	}
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		p := filepath.Join(to, withoutFirstDirectory(hdr.Name))
+		fi := hdr.FileInfo()
+		if fi.IsDir() {
+			if err := os.MkdirAll(p, fi.Mode()); err != nil {
+				return fmt.Errorf("cannot create directory %s: %v", p, err)
+			}
+		} else {
+			if err := writeFile(tr, p, fi.Mode()); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func unpackZipArchive(from *os.File, to string) error {
+	fi, err := from.Stat()
+	if err != nil {
+		return err
+	}
+	zr, err := zip.NewReader(from, fi.Size())
+	if err != nil {
+		return err
+	}
+	for _, file := range zr.File {
+		p := filepath.Join(to, withoutFirstDirectory(file.Name))
+		fi := file.FileInfo()
+		if fi.IsDir() {
+			if err := os.MkdirAll(p, fi.Mode()); err != nil {
+				return fmt.Errorf("cannot create directory %s: %v", p, err)
+			}
+		} else if err := writeZipFile(file, to); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func withoutFirstDirectory(in string) (out string) {
+	out = in
+	index := strings.Index(out, "/")
+	if index > 0 {
+		out = out[index:]
+	}
+	return
+}
+
+func writeZipFile(file *zip.File, to string) error {
+	fr, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = fr.Close() }()
+	p := filepath.Join(to, withoutFirstDirectory(file.Name))
+	return writeFile(fr, p, file.Mode())
+}
+
+func writeFile(r io.Reader, path string, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("cannot create parents of %s: %v", path, err)
+	}
+	out, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return fmt.Errorf("cannot create output %s: %v", path, err)
+	}
+	defer func() { _ = out.Close() }()
+	if _, err := io.Copy(out, r); err != nil {
+		return fmt.Errorf("cannot write output %s: %v", path, err)
+	}
+	return nil
+}
+
+func downloadLibwebpArchive(t *testing.T, url string) (file string) {
+	f, err := ioutil.TempFile("", "libwebp-download")
+	if err != nil {
+		fatalfWithEnvironment(t, "cannot download libwebp from %s, because cannot get temporary file: %v", url, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("cannot download libwebp from %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		t.Fatalf("cannot download libwebp from %s: %d %s", url, resp.StatusCode, resp.Status)
+	}
+
+	_, err = io.Copy(f, resp.Body)
+	if err != nil {
+		t.Fatalf("cannot download libwebp from %s: %v", url, err)
+	}
+
+	return f.Name()
+}
+
+func libwebpDownloadUrl(t *testing.T) (result string) {
+	result = libwebpDownloadBase
+	switch runtime.GOOS {
+	case "linux":
+		result += libwebpDownloadFileLinux
+	case "darwin":
+		result += libwebpDownloadFileMacOs
+	case "windows":
+		result += libwebpDownloadFileWindows
+	default:
+		skipBecauseLibwebpUnavailable(t)
+	}
+
+	return strings.ReplaceAll(result, "{version}", libwebpVersion)
+}
+
+func toPath(from string) (result string) {
+	result = path.Base(from)
+	result = strings.ReplaceAll(result, ".tar.gz", "")
+	result = strings.ReplaceAll(result, ".zip", "")
+	result = filepath.Join(os.TempDir(), result)
+	return
+}
+
+func skipBecauseLibwebpUnavailable(t *testing.T) {
+	t.Skip("There is no libwebp available on this platform." +
+		" Execution of this test is not possible." +
+		" It will be skipped.")
+}

--- a/resources/images/webp/common_test.go
+++ b/resources/images/webp/common_test.go
@@ -1,0 +1,193 @@
+package webp
+
+import (
+	"fmt"
+	"golang.org/x/image/webp"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"io"
+	"os"
+	"os/exec"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	colorTolerance = 20
+)
+
+func setEnvironmentVariable(t *testing.T, name, to string) func() {
+	oldHome := os.Getenv(name)
+	if err := os.Setenv(name, to); err != nil {
+		fatalfWithEnvironment(t, "cannot set environment %s variable: %v", name, err)
+	}
+	return func() {
+		if oldHome == "" {
+			if err := os.Unsetenv(name); err != nil {
+				fatalfWithEnvironment(t, "cannot unset %s environment variable: %v", name, err)
+			}
+		} else {
+			if err := os.Setenv(name, oldHome); err != nil {
+				fatalfWithEnvironment(t, "cannot reset %s environment variable: %v", name, err)
+			}
+		}
+	}
+}
+
+func setCwd(t *testing.T, to string) func() {
+	oldHome, err := os.Getwd()
+	if err != nil {
+		fatalfWithEnvironment(t, "cannot get cwd: %v", err)
+	}
+	if err := os.Chdir(to); err != nil {
+		fatalfWithEnvironment(t, "cannot set cwd: %v", err)
+	}
+	return func() {
+		if err := os.Chdir(oldHome); err != nil {
+			fatalfWithEnvironment(t, "cannot reset cwd: %v", err)
+		}
+	}
+}
+
+func decodePngFrom(t *testing.T, file string) image.Image {
+	fp, err := os.Open(file)
+	if err != nil {
+		t.Fatalf("cannot open PNG file %s: %v", file, err)
+	}
+	defer func() { _ = fp.Close() }()
+	return decodePng(t, fp, file)
+}
+
+func decodePng(t *testing.T, r io.Reader, name string) image.Image {
+	i, err := png.Decode(r)
+	if err != nil {
+		t.Fatalf("cannot decode PNG file %s: %v", name, err)
+	}
+	return i
+}
+
+func decodeWebp(t *testing.T, r io.Reader, name string) image.Image {
+	i, err := webp.Decode(r)
+	if err != nil {
+		t.Fatalf("cannot decode WEBP file %s: %v", name, err)
+	}
+	return i
+}
+
+func testImage() *image.RGBA {
+	i := image.NewRGBA(image.Rect(0, 0, 100, 100))
+	blue := color.RGBA{R: 0, G: 0, B: 255, A: 255}
+	draw.Draw(i, i.Bounds(), image.NewUniform(blue), image.Point{}, draw.Src)
+	return i
+}
+
+func assertRgbaImageEquals(t *testing.T, expected *image.RGBA, actual image.Image) {
+	actualRgba, actualIsRgba := actual.(*image.RGBA)
+	if !actualIsRgba {
+		t.Fatalf("image is expected to be of type *image.RGBA, but got: %v", reflect.TypeOf(actual))
+	}
+	if expected.Rect != actualRgba.Rect {
+		t.Fatalf("image is expected to have bounds %v, but got: %v", expected.Rect, actualRgba.Rect)
+	}
+	if !reflect.DeepEqual(expected, actualRgba) {
+		t.Fatalf("image is not as expected")
+	}
+}
+
+// This test is not perfect, but we do not test if webp itself works, we just test if webp produces a valid
+// image with the same rect and at least with "similar" pixels. We assume that webp works.
+func assertYCbCrImageEquals(t *testing.T, expected *image.RGBA, actual image.Image) {
+	actualYCbCr, actualIsYCbCr := actual.(*image.YCbCr)
+	if !actualIsYCbCr {
+		t.Fatalf("image is expected to be of type *image.YCbCr, but got: %v", reflect.TypeOf(actual))
+	}
+	if expected.Rect != actualYCbCr.Rect {
+		t.Fatalf("image is expected to have bounds %v, but got: %v", expected.Rect, actualYCbCr.Rect)
+	}
+
+	for y := actualYCbCr.Rect.Min.Y; y < actualYCbCr.Rect.Max.Y; y++ {
+		for x := actualYCbCr.Rect.Min.X; x < actualYCbCr.Rect.Max.X; x++ {
+			expectedColor := expected.RGBAAt(x, y)
+			actualYCbCrColor := actualYCbCr.YCbCrAt(x, y)
+			r, g, b := color.YCbCrToRGB(actualYCbCrColor.Y, actualYCbCrColor.Cb, actualYCbCrColor.Cr)
+			actualColor := color.RGBA{R: r, G: g, B: b, A: 255}
+
+			if !isColorPartSimilarEnough(expectedColor.R, actualColor.R) {
+				t.Fatalf("image's %dx%d pixel's red is expected to be %d, but got: %d", x, y, expectedColor.R, actualColor.R)
+			}
+			if !isColorPartSimilarEnough(expectedColor.G, actualColor.G) {
+				t.Fatalf("image's %dx%d pixel's green is expected to be %d, but got: %d", x, y, expectedColor.G, actualColor.G)
+			}
+			if !isColorPartSimilarEnough(expectedColor.B, actualColor.B) {
+				t.Fatalf("image's %dx%d pixel's blue is expected to be %d, but got: %d", x, y, expectedColor.B, actualColor.B)
+			}
+			if !isColorPartSimilarEnough(expectedColor.A, actualColor.A) {
+				t.Fatalf("image's %dx%d pixel's alpha is expected to be %d, but got: %d", x, y, expectedColor.A, actualColor.A)
+			}
+		}
+	}
+}
+
+func isColorPartSimilarEnough(expected, actual uint8) bool {
+	return expected-colorTolerance < actual || expected+colorTolerance > actual
+}
+
+func fatalfWithEnvironment(t *testing.T, format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	t.Fatalf("%s\nPlatform: %s", message, retrievePlatformInformation())
+}
+
+func retrievePlatformInformation() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return executeAndDump(nil, "sw_vers")
+	case "windows":
+		return executeAndDump(regexp.MustCompile(`^OS (Name|Version):\s+(.+)`), "systeminfo")
+	case "linux":
+		return fmt.Sprintf("KERNEL=%q, %s",
+			executeAndDump(nil, "uname", "-a"),
+			executeAndDump(regexp.MustCompile(`^(NAME|VERSION)\s*=\s*"?([^"]+)"?`), "cat", "/etc/os-release"),
+		)
+	default:
+		return unknownPlatformInformation("unknown operating system")
+	}
+}
+
+func unknownPlatformInformation(reasonFormat string, args ...interface{}) string {
+	return fmt.Sprintf("[%s] %s", runtime.GOOS, fmt.Sprintf(reasonFormat, args...))
+}
+
+func executeAndDump(acceptLinesOnlyIfMatches *regexp.Regexp, cmd string, args ...string) string {
+	executable, err := exec.LookPath(cmd)
+	if err != nil {
+		return unknownPlatformInformation("cannot lookup '%s' in path: %v", cmd, err)
+	}
+	command := exec.Command(executable, args...)
+	stdout, err := command.Output()
+	if err != nil {
+		return unknownPlatformInformation("cannot excute %q: %v", command, err)
+	}
+	result := ""
+	for _, line := range strings.Split(string(stdout), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && (acceptLinesOnlyIfMatches == nil || acceptLinesOnlyIfMatches.MatchString(line)) {
+			if result != "" {
+				result += ", "
+			}
+			if acceptLinesOnlyIfMatches != nil {
+				result += fmt.Sprintf("%s=%q",
+					acceptLinesOnlyIfMatches.ReplaceAllString(line, "$1"),
+					acceptLinesOnlyIfMatches.ReplaceAllString(line, "$2"),
+				)
+			} else {
+				result += line
+			}
+		}
+	}
+	return result
+}

--- a/resources/images/webp/writer.go
+++ b/resources/images/webp/writer.go
@@ -1,0 +1,159 @@
+package webp
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	LibwebpHome = "LIBWEBP_HOME"
+)
+
+var (
+	ErrWebpEncodingNotSupported = errors.New("webp encoding not supported; no valid cwebp binary available;" +
+		" neither by " + LibwebpHome + " environment variable" +
+		" nor in PATH" +
+		" nor in current working directory" +
+		" nor directly configured")
+)
+
+type Options struct {
+	// Quality between 1..100
+	// If not present or out of range 80 will be used as default
+	Quality int
+
+	// Defines the cwebp binary explicitly.
+	// If not present it will looked in the environment.
+	CwebpBinary string
+}
+
+func Encode(w io.Writer, m image.Image, o *Options) (err error) {
+	if o == nil {
+		o = &Options{}
+	}
+	if o.Quality < 1 || o.Quality > 100 {
+		o.Quality = 80
+	}
+
+	input, eErr := encodeToTemp(m)
+	if eErr != nil {
+		err = eErr
+		return
+	}
+	defer func() {
+		if rErr := os.Remove(input); rErr != nil && err == nil {
+			err = fmt.Errorf("cannot remove temporary PNG file (%s) for webp conversion: %v", input, err)
+		}
+	}()
+
+	cwebpBinary, lErr := lookupCwebpBinary(o)
+	if lErr != nil {
+		err = lErr
+		return
+	}
+
+	if eErr := executeCwebp(cwebpBinary, input, w, o); eErr != nil {
+		err = eErr
+		return
+	}
+
+	return
+}
+
+func executeCwebp(binary string, from string, to io.Writer, o *Options) error {
+	cmd := exec.Command(binary,
+		"-q", strconv.FormatInt(int64(o.Quality), 10), // Quality
+		"-quiet",  // Suppress useless output, we just want to see here real errors
+		"-o", "-", // Output to stdout
+		"--", from, // Input from file
+	)
+	var stderr bytes.Buffer
+	cmd.Stdout = to
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cannot encode webp: %v; stderr: %s", err, strings.TrimSpace(stderr.String()))
+	}
+
+	if stderr.Len() > 0 {
+		return fmt.Errorf("encode of webp failed: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	return nil
+}
+
+func encodeToTemp(m image.Image) (filename string, err error) {
+	var f *os.File
+	if f, err = ioutil.TempFile("", "hugo-webp-input-*.png"); err != nil {
+		err = fmt.Errorf("cannot create temporary file for webp conversion: %v", err)
+		return
+	}
+	defer func() {
+		if rErr := f.Close(); rErr != nil {
+			if err == nil {
+				err = fmt.Errorf("cannot close temporary PNG file (%s) for webp conversion: %v", f.Name(), err)
+			}
+		}
+	}()
+	if err = png.Encode(f, m); err != nil {
+		_ = f.Close()
+		err = fmt.Errorf("cannot encode temporary PNG file (%s) for webp conversion: %v", f.Name(), err)
+		return
+	}
+	filename = f.Name()
+	return
+}
+
+func lookupCwebpBinary(o *Options) (string, error) {
+	if o != nil && o.CwebpBinary != "" {
+		if found, err := exec.LookPath(o.CwebpBinary); isExecNotFound(err) {
+			return "", ErrWebpEncodingNotSupported
+		} else {
+			return found, err
+		}
+	}
+
+	if cwd, err := os.Getwd(); err == nil {
+		if found, err := exec.LookPath(filepath.Join(cwd, "cwebp")); err == nil {
+			return found, nil
+		} else if !isExecNotFound(err) {
+			return "", fmt.Errorf("cannot lookup webp executable: %v", err)
+		}
+	}
+
+	if webpHome := os.Getenv(LibwebpHome); webpHome != "" {
+		if found, err := exec.LookPath(filepath.Join(webpHome, "bin", "cwebp")); err == nil {
+			return found, nil
+		} else if !isExecNotFound(err) {
+			return "", fmt.Errorf("cannot lookup webp executable: %v", err)
+		}
+	}
+
+	if found, err := exec.LookPath("cwebp"); err == nil {
+		return found, nil
+	} else if isExecNotFound(err) {
+		return "", ErrWebpEncodingNotSupported
+	} else {
+		return "", fmt.Errorf("cannot lookup webp executable: %v", err)
+	}
+}
+
+func isExecNotFound(err error) bool {
+	if os.IsNotExist(err) {
+		return true
+	}
+	if eErr, ok := err.(*exec.Error); ok {
+		unwrapped := eErr.Unwrap()
+		return unwrapped == exec.ErrNotFound || os.IsNotExist(unwrapped)
+	}
+	return false
+}

--- a/resources/images/webp/writer_test.go
+++ b/resources/images/webp/writer_test.go
@@ -1,0 +1,134 @@
+package webp
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func Test_Encode(t *testing.T) {
+	libwebpHome := ensureLibwebpHome(t)
+
+	givenOptions := Options{CwebpBinary: filepath.Join(libwebpHome, "bin", "cwebp")}
+	givenImage := testImage()
+	expectedImage := givenImage
+
+	actualBuf := new(bytes.Buffer)
+	actualErr := Encode(actualBuf, givenImage, &givenOptions)
+	if actualErr != nil {
+		fatalfWithEnvironment(t, "no error expected, but got: %v", actualErr)
+	}
+
+	actualImage := decodeWebp(t, actualBuf, "buffer")
+
+	assertYCbCrImageEquals(t, expectedImage, actualImage)
+}
+
+func Test_Encode_failsBecauseNoCwebpAvailable(t *testing.T) {
+	givenImage := testImage()
+
+	defer setEnvironmentVariable(t, LibwebpHome, "DOES_NOT_EXIST")()
+	defer setEnvironmentVariable(t, "PATH", "DOES_NOT_EXIST")()
+
+	actualBuf := new(bytes.Buffer)
+	actualErr := Encode(actualBuf, givenImage, nil)
+	if actualErr != ErrWebpEncodingNotSupported {
+		fatalfWithEnvironment(t, "error %v expected, but got: %v", ErrWebpEncodingNotSupported, actualErr)
+	}
+}
+
+func Test_encodeToPng(t *testing.T) {
+	givenImage := testImage()
+	expectedImage := givenImage
+
+	actualFile, actualErr := encodeToTemp(givenImage)
+	if actualErr != nil {
+		fatalfWithEnvironment(t, "no error expected, but got: %v", actualErr)
+	}
+	defer func() { _ = os.Remove(actualFile) }()
+
+	if !strings.HasPrefix(actualFile, os.TempDir()) {
+		fatalfWithEnvironment(t, "expected to start with temporary directory, but got: %v", actualFile)
+	}
+	actualImage := decodePngFrom(t, actualFile)
+
+	assertRgbaImageEquals(t, expectedImage, actualImage)
+}
+
+func Test_lookupCwebpBinary_viaOptions(t *testing.T) {
+	libwebpHome := ensureLibwebpHome(t)
+
+	defer setEnvironmentVariable(t, LibwebpHome, "DOES_NOT_EXIST")()
+	defer setEnvironmentVariable(t, "PATH", "DOES_NOT_EXIST")()
+
+	actual, actualErr := lookupCwebpBinary(&Options{CwebpBinary: filepath.Join(libwebpHome, "bin", "cwebp")})
+
+	if actualErr != nil {
+		fatalfWithEnvironment(t, "no error expected, but got: %v", actualErr)
+	}
+	expected := filepath.Join(libwebpHome, "bin", executableName())
+	if actual != expected {
+		fatalfWithEnvironment(t, "expected '%s', but got: %s", expected, actual)
+	}
+}
+
+func Test_lookupCwebpBinary_viaHomeEnv(t *testing.T) {
+	libwebpHome := ensureLibwebpHome(t)
+
+	defer setEnvironmentVariable(t, LibwebpHome, libwebpHome)()
+	defer setEnvironmentVariable(t, "PATH", "DOES_NOT_EXIST")()
+	actual, actualErr := lookupCwebpBinary(nil)
+
+	if actualErr != nil {
+		fatalfWithEnvironment(t, "no error expected, but got: %v", actualErr)
+	}
+	expected := filepath.Join(libwebpHome, "bin", executableName())
+	if actual != expected {
+		fatalfWithEnvironment(t, "expected '%s', but got: %s", expected, actual)
+	}
+}
+
+func Test_lookupCwebpBinary_viaCwd(t *testing.T) {
+	libwebpHome := ensureLibwebpHome(t)
+
+	defer setEnvironmentVariable(t, LibwebpHome, "DOES_NOT_EXIST")()
+	defer setEnvironmentVariable(t, "PATH", "DOES_NOT_EXIST")()
+	defer setCwd(t, filepath.Join(libwebpHome, "bin"))()
+	actual, actualErr := lookupCwebpBinary(nil)
+
+	if actualErr != nil {
+		fatalfWithEnvironment(t, "no error expected, but got: %v", actualErr)
+	}
+	expected := filepath.Join(libwebpHome, "bin", executableName())
+	if !strings.HasSuffix(actual, expected) {
+		fatalfWithEnvironment(t, "expects to start with '%s', but got: %s", expected, actual)
+	}
+}
+
+func Test_lookupCwebpBinary_viaPath(t *testing.T) {
+	libwebpHome := ensureLibwebpHome(t)
+
+	defer setEnvironmentVariable(t, LibwebpHome, "DOES_NOT_EXIST")()
+	defer setEnvironmentVariable(t, "PATH", filepath.Join(libwebpHome, "bin"))()
+	actual, actualErr := lookupCwebpBinary(nil)
+
+	if actualErr != nil {
+		fatalfWithEnvironment(t, "no error expected, but got: %v", actualErr)
+	}
+	expected := filepath.Join(libwebpHome, "bin", executableName())
+	if actual != expected {
+		fatalfWithEnvironment(t, "expected '%s', but got: %s", expected, actual)
+	}
+}
+
+func executableName() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "cwebp.exe"
+	default:
+		return "cwebp"
+	}
+}


### PR DESCRIPTION
This is based on the `cwebp` binary of the [WebP utilities of Google](https://developers.google.com/speed/webp/download).
If on the system the binary is installed methods like `$image.Resize "600x webp"` are available.

The reason why this is based on the binaries of [WebP utilities of Google](https://developers.google.com/speed/webp/download) because there is currently no golang native WebP implementation available. On the other side using C-bindings to access libraries just make the whole build process of hugo too complicated. To execute binaries is not my favorite but seems under this conditions the best compromise.

Fixes #5924
Supports #4780