### PR TITLE
use environment variable `HUGO_ASCIIDOCTOR_ARGS` to override the default arguments

### DIFF
--- a/docs/content/en/content-management/formats.md
+++ b/docs/content/en/content-management/formats.md
@@ -47,7 +47,7 @@ Some of the formats in the table above needs external helpers installed on your 
 
 Hugo passes reasonable default arguments to these external helpers by default:
 
-- `asciidoc`: `--no-header-footer --safe -`
+- `asciidoc`: `--no-header-footer --safe -` use environment variable **HUGO_ASCIIDOCTOR_ARGS** to override the default arguments.
 - `asciidoctor`: `--no-header-footer --safe --trace -`
 - `rst2html`: `--leave-comments --initial-header-level=2`
 - `pandoc`: `--mathjax`

--- a/markup/asciidoc/convert.go
+++ b/markup/asciidoc/convert.go
@@ -16,7 +16,9 @@
 package asciidoc
 
 import (
+	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/gohugoio/hugo/identity"
 	"github.com/gohugoio/hugo/markup/internal"
@@ -75,6 +77,14 @@ func (a *asciidocConverter) getAsciidocContent(src []byte, ctx converter.Documen
 		args = append(args, "--trace")
 	}
 	args = append(args, "-")
+	if asciidoctorArgs := os.Getenv("HUGO_ASCIIDOCTOR_ARGS"); asciidoctorArgs != "" {
+		args = args[:0]
+		for _, str := range strings.Split(asciidoctorArgs, " ") {
+			if str != "" {
+				args = append(args, str)
+			}
+		}
+	}
 	return internal.ExternallyRenderContent(a.cfg, ctx, src, path, args)
 }
 


### PR DESCRIPTION
fixed #5842