### PR TITLE
Read sass imports from virtual fs

### DIFF
--- a/resources/resource_transformers/tocss/scss/tocss.go
+++ b/resources/resource_transformers/tocss/scss/tocss.go
@@ -18,6 +18,7 @@ package scss
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"path"
 	"path/filepath"
 	"strings"
@@ -102,10 +103,11 @@ func (t *toCSSTransformation) Transform(ctx *resources.ResourceTransformationCtx
 
 		for _, namePattern := range namePatterns {
 			filenameToCheck := filepath.Join(basePath, fmt.Sprintf(namePattern, name))
-			fi, err := t.c.sfs.Fs.Stat(filenameToCheck)
+			f, err := t.c.sfs.Fs.Open(filenameToCheck)
 			if err == nil {
-				if fim, ok := fi.(hugofs.FileMetaInfo); ok {
-					return fim.Meta().Filename(), "", true
+				body, err := ioutil.ReadAll(f)
+				if err == nil {
+					return "", string(body), true
 				}
 			}
 		}


### PR DESCRIPTION
When experimenting with running Hugo on fully-virtual filesystems (remote, in-mem) i noticed that it is not possible to use `ToCSS` with that setup, since it does not load imports from the hugo filesystem.

This makes sure that sass imports are going through the Hugo filesystem.