### PR TITLE
Add ability to generate nginx 30X configuration

### DIFF
--- a/config/commonConfig.go
+++ b/config/commonConfig.go
@@ -30,6 +30,7 @@ import (
 var DefaultBuild = Build{
 	UseResourceCacheWhen: "fallback",
 	WriteStats:           false,
+	NginxAliases:         false,
 }
 
 // Build holds some build related condfiguration.
@@ -39,6 +40,7 @@ type Build struct {
 	// When enabled, will collect and write a hugo_stats.json with some build
 	// related aggregated data (e.g. CSS class names).
 	WriteStats bool
+	NginxAliases bool
 }
 
 func (b Build) UseResourceCache(err error) bool {

--- a/docs/content/en/getting-started/configuration.md
+++ b/docs/content/en/getting-started/configuration.md
@@ -309,6 +309,12 @@ useResourceCacheWhen="fallback"
 useResourceCacheWhen
 : When to use the cached resources in `/resources/_gen` for PostCSS and ToCSS. Valid values are `never`, `always` and `fallback`. The last value means that the cache will be tried if PostCSS/extended version is not available.
 
+{{< new-in "-dev" >}}
+nginxAliases
+: If set to true a `nginx.conf` file will be generated in the root
+project containing all configurated aliases as nginx redirection configuration.
+This file can be include in you nginx virtual host configuration.
+
 ## Configure Server
 
 {{< new-in "0.67.0" >}}

--- a/publisher/aliasElements.go
+++ b/publisher/aliasElements.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publisher
+
+import (
+  "fmt"
+)
+
+type AliasElement struct {
+  source string
+  destination string
+  redirectionType string
+}
+
+type ServerAliases struct {
+  // array of aliases
+  AliasElements []AliasElement
+}
+
+// Convert the slice of AliasElement stored as current ServerAliases
+// as valide http server configuration.
+//
+// First arg is the target http server type
+func (p *ServerAliases) Format(format string) []byte {
+  if (format == "nginx") {
+    var result string
+    for _, alias := range p.AliasElements {
+
+      // Geneate redirection type
+      var redirectionType string = "permanent"
+      if alias.redirectionType == "302" {
+        redirectionType = "redirect"
+      }
+
+      // Compute nginx configuration line and append to result
+      result = result + fmt.Sprintf("rewrite ^%s$ %s %s;\n", alias.source, alias.destination, redirectionType)
+    }
+    return []byte(result)
+  }
+  return []byte{}
+}
+

--- a/publisher/aliasElements_test.go
+++ b/publisher/aliasElements_test.go
@@ -1,0 +1,79 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publisher
+
+import (
+	"testing"
+  "strings"
+	qt "github.com/frankban/quicktest"
+)
+
+func TestClassServerAliases(t *testing.T) {
+	c := qt.New((t))
+
+  // Geneator of aliases elements
+  //
+  // Usage :
+  //
+  //   generateAliases([]string{"/src,/dest,301","/src2,/dest2,302"})
+  //
+  generateAliases := func(elms []string) []AliasElement {
+    var aliases []AliasElement
+    for _,e := range elms {
+      var elm = strings.Split(e, ",")
+      var alias = AliasElement{
+        source: elm[0],
+        destination: elm[1],
+        redirectionType: elm[2],
+      }
+      aliases = append(aliases, alias)
+    }
+
+    return aliases
+  }
+
+  t.Run("no-alias", func(t *testing.T) {
+    var aliases ServerAliases = ServerAliases{}
+    c.Assert(aliases.Format("nginx"), qt.DeepEquals, []byte(""))
+  })
+
+  t.Run("bad-server", func(t *testing.T) {
+    var aliases ServerAliases = ServerAliases{}
+    c.Assert(aliases.Format("dummy"), qt.DeepEquals, []byte(""))
+  })
+
+  t.Run("simple-301-nginx", func(t *testing.T) {
+    var aliases ServerAliases = ServerAliases{}
+    aliases.AliasElements = generateAliases([]string{"/src,/dest,301"})
+    c.Assert(string(aliases.Format("nginx")), qt.DeepEquals, "rewrite ^/src$ /dest permanent;\n")
+  })
+
+  t.Run("simple-302-nginx", func(t *testing.T) {
+    var aliases ServerAliases = ServerAliases{}
+    aliases.AliasElements = generateAliases([]string{"/src,/dest,302"})
+    c.Assert(string(aliases.Format("nginx")), qt.DeepEquals, "rewrite ^/src$ /dest redirect;\n")
+  })
+
+  t.Run("many-301-nginx", func(t *testing.T) {
+    var aliases ServerAliases = ServerAliases{}
+    aliases.AliasElements = generateAliases([]string{"/src,/dest,301","/src2,/dest2,301"})
+    c.Assert(string(aliases.Format("nginx")), qt.DeepEquals, "rewrite ^/src$ /dest permanent;\nrewrite ^/src2$ /dest2 permanent;\n")
+  })
+
+  t.Run("many-mixed-status-nginx", func(t *testing.T) {
+    var aliases ServerAliases = ServerAliases{}
+    aliases.AliasElements = generateAliases([]string{"/src,/dest,302","/src2,/dest2,301"})
+    c.Assert(string(aliases.Format("nginx")), qt.DeepEquals, "rewrite ^/src$ /dest redirect;\nrewrite ^/src2$ /dest2 permanent;\n")
+  })
+}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 
 	"github.com/gohugoio/hugo/resources"
+	"github.com/gohugoio/hugo/resources/page"
 
 	"github.com/gohugoio/hugo/media"
 
@@ -140,6 +141,23 @@ func (p DestinationPublisher) PublishStats() PublishStats {
 	}
 }
 
+// Return a ServerAliases struct
+func (p DestinationPublisher) GeneateServerAliases(page page.Page) ServerAliases {
+	var aliases []AliasElement
+
+	for _, alias := range page.Aliases() {
+		aliases = append(aliases, AliasElement{
+			source: alias,
+			destination: page.RelPermalink(),
+			redirectionType: "302",
+		})
+	}
+
+	return ServerAliases{
+		AliasElements: aliases,
+	}
+}
+
 type PublishStats struct {
 	HTMLElements HTMLElements `json:"htmlElements"`
 }
@@ -148,6 +166,7 @@ type PublishStats struct {
 type Publisher interface {
 	Publish(d Descriptor) error
 	PublishStats() PublishStats
+	GeneateServerAliases(page page.Page) ServerAliases 
 }
 
 // XML transformer := transform.New(urlreplacers.NewAbsURLInXMLTransformer(path))


### PR DESCRIPTION
Hi

This PR add the ability to generate an nginx configuration in order to handle aliases as real 30X HTTP response.

Details:
Add the ability to set a new build option `nginxAliases`. If set to true
when building a new `nginx.conf` file will be generated in the project's
root directory. This file will be filled with all configurated aliases
and can be directly include in website nginx configuration.

The main objective of this feature is to prevent the http page loading
(HTTP status of 200) containing only a meta refresh html tag, but
directly serving a 30X HTTP status reponse. This is mainly SEO related.


Note: I'm not a Go developer, maybe not a developer at all, so fell free to consider this PR as a POC and don't hesitate to criticize :).