### PR TITLE
hugolib/hugo_sites: Add Unlock before panic

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -987,6 +987,7 @@ func (m *contentChangeMap) add(dirname string, tp bundleDirType) {
 	case bundleLeaf:
 		m.leafBundles.Insert(dirname, true)
 	default:
+		m.mu.Unlock()
 		panic("invalid bundle type")
 	}
 	m.mu.Unlock()


### PR DESCRIPTION
In `func add`, `m.mu.Unlock()` is forgot before panic.
This PR adds Unlock before panic to avoid possible deadlock.