### PR TITLE
tpl/tmplimpl/template: Change defer RLock to RUnlock

### DIFF
--- a/tpl/tplimpl/template.go
+++ b/tpl/tplimpl/template.go
@@ -783,7 +783,7 @@ func (t templateNamespace) Clone(lock bool) *templateNamespace {
 func (t *templateNamespace) Lookup(name string) (tpl.Template, bool) {
 	if t.mu != nil {
 		t.mu.RLock()
-		defer t.mu.RLock()
+		defer t.mu.RUnlock()
 	}
 
 	templ, found := t.templates[name]


### PR DESCRIPTION
In `func Lookup`,
`t.mu.RLock()` is followed by another `t.mu.RLock()`.
This will cause double-lock. There is no RUnlock for the RLock.
This PR changes `t.mu.RLock()` to `t.mu.RUnlock()`.