### PR TITLE
Fix IsAncestor and IsDescendant when the same page is passed

### DIFF
--- a/hugolib/content_map_test.go
+++ b/hugolib/content_map_test.go
@@ -395,8 +395,8 @@ Blog Section: {{ template "print-page" $blog }}
 Blog Sub Section: {{ template "print-page" $blogSub }}
 Page: {{ template "print-page" $page }}
 Bundle: {{ template "print-page" $bundle }}
-IsDescendant: true: {{ $page.IsDescendant $blog }} true: {{ $blogSub.IsDescendant $blog }} true: {{ $bundle.IsDescendant $blog }} true: {{ $page4.IsDescendant $blog }} true: {{ $blog.IsDescendant $home }} false: {{ $home.IsDescendant $blog }}
-IsAncestor: true: {{ $blog.IsAncestor $page }} true: {{ $home.IsAncestor $blog }} true: {{ $blog.IsAncestor $blogSub }} true: {{ $blog.IsAncestor $bundle }} true: {{ $blog.IsAncestor $page4 }} true: {{ $home.IsAncestor $page }} false: {{ $page.IsAncestor $blog }} false: {{ $blog.IsAncestor $home }}  false: {{ $blogSub.IsAncestor $blog }}
+IsDescendant: true: {{ $page.IsDescendant $blog }} true: {{ $blogSub.IsDescendant $blog }} true: {{ $bundle.IsDescendant $blog }} true: {{ $page4.IsDescendant $blog }} true: {{ $blog.IsDescendant $home }} true: {{ $blog.IsDescendant $blog }} false: {{ $home.IsDescendant $blog }}
+IsAncestor: true: {{ $blog.IsAncestor $page }} true: {{ $home.IsAncestor $blog }} true: {{ $blog.IsAncestor $blogSub }} true: {{ $blog.IsAncestor $bundle }} true: {{ $blog.IsAncestor $page4 }} true: {{ $home.IsAncestor $page }} true: {{ $blog.IsAncestor $blog }} false: {{ $page.IsAncestor $blog }} false: {{ $blog.IsAncestor $home }}  false: {{ $blogSub.IsAncestor $blog }}
 IsDescendant overlap1: false: {{ $overlap1.IsDescendant $overlap2 }}
 IsDescendant overlap2: false: {{ $overlap2.IsDescendant $overlap1 }}
 IsAncestor overlap1: false: {{ $overlap1.IsAncestor $overlap2 }}
@@ -438,8 +438,8 @@ Draft5: {{ if (.Site.GetPage "blog/draftsection/sub/page") }}FOUND{{ end }}|
         Blog Sub Section: Page 3|/blog/subsection/|2019-06-03|Current Section: blog/subsection|Resources: json: /blog/subsection/subdata.json|
         Page: Page 1|/blog/page1/|2019-06-01|Current Section: blog|Resources: 
         Bundle: Page 12|/blog/bundle/|0001-01-01|Current Section: blog|Resources: json: /blog/bundle/data.json|page: |
-        IsDescendant: true: true true: true true: true true: true true: true false: false
-        IsAncestor: true: true true: true true: true true: true true: true true: true false: false false: false  false: false
+        IsDescendant: true: true true: true true: true true: true true: true true: true false: false
+        IsAncestor: true: true true: true true: true true: true true: true true: true true: true false: false false: false  false: false
         IsDescendant overlap1: false: false
         IsDescendant overlap2: false: false
         IsAncestor overlap1: false: false

--- a/hugolib/page__tree.go
+++ b/hugolib/page__tree.go
@@ -54,6 +54,10 @@ func (pt pageTree) IsAncestor(other interface{}) (bool, error) {
 		return false, nil
 	}
 
+	if ref1.key == ref2.key {
+		return true, nil
+	}
+
 	if strings.HasPrefix(ref2.key, ref1.key+"/") {
 		return true, nil
 	}
@@ -99,6 +103,10 @@ func (pt pageTree) IsDescendant(other interface{}) (bool, error) {
 
 	if !ref2.isSection() {
 		return false, nil
+	}
+
+	if ref1.key == ref2.key {
+		return true, nil
 	}
 
 	if strings.HasPrefix(ref1.key, ref2.key+"/") {


### PR DESCRIPTION
IsAncestor and IsDescendant returned true if the same page is passed until the changes of https://github.com/gohugoio/hugo/pull/7097 .

```
{{ $blog.IsAncestor $blog }} -> true
```

Some themes (e.g., docsy) depend on this behavior.
This PR changes IsAncestor and IsDescendant to the old behavior.