### PR TITLE
allow asciidoc extensions settings to be configurable

### DIFF
--- a/markup/asciidocext/asciidocext_config/config.go
+++ b/markup/asciidocext/asciidocext_config/config.go
@@ -1,0 +1,65 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package asciidoc_config holds asciidoc related configuration.
+package asciidocext_config
+
+// DefaultConfig holds the default asciidoc configuration.
+var (
+	Default = Config{
+		Backend:          "html5",
+		DocType:          "article",
+		Extensions:       []string{},
+		NoHeaderOrFooter: true,
+		SafeMode:         "safe",
+		SectionNumbers:   false,
+		Verbose:          false,
+	}
+
+	ExtensionsWhitelist = map[string]bool{
+		"asciidoctor-html5s":           true,
+		"asciidoctor-diagram":          true,
+		"asciidoctor-interdoc-reftext": true,
+		"asciidoctor-katex":            true,
+		"asciidoctor-latex":            true,
+		"asciidoctor-question":         true,
+		"asciidoctor-rouge":            true,
+	}
+
+	SafeModeWhitelist = map[string]bool{
+		"unsafe": true,
+		"safe":   true,
+		"server": true,
+		"secure": true,
+	}
+
+	BackendWhitelist = map[string]bool{
+		"html5":     true,
+		"html5s":    true,
+		"xhtml5":    true,
+		"docbook5":  true,
+		"docbook45": true,
+		"manpage":   true,
+	}
+)
+
+// Config configures asciidoc.
+type Config struct {
+	Backend          string
+	DocType          string
+	Extensions       []string
+	NoHeaderOrFooter bool
+	SafeMode         string
+	SectionNumbers   bool
+	Verbose          bool
+}

--- a/markup/asciidocext/convert.go
+++ b/markup/asciidocext/convert.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Hugo Authors. All rights reserved.
+// Copyright 2020 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,24 +11,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package asciidoc converts Asciidoc to HTML using Asciidoc or Asciidoctor
-// external binaries.
-package asciidoc
+// Package asciidocext converts Asciidoc to HTML using Asciidoc or Asciidoctor
+// external binaries. The `asciidoc` module is reserved for a future golang
+// implementation.
+package asciidocext
 
 import (
 	"os/exec"
 
 	"github.com/gohugoio/hugo/identity"
-	"github.com/gohugoio/hugo/markup/internal"
-
+	"github.com/gohugoio/hugo/markup/asciidocext/asciidocext_config"
 	"github.com/gohugoio/hugo/markup/converter"
+	"github.com/gohugoio/hugo/markup/internal"
 )
 
 // Provider is the package entry point.
 var Provider converter.ProviderProvider = provider{}
 
-type provider struct {
-}
+type provider struct{}
 
 func (p provider) New(cfg converter.ProviderConfig) (converter.Provider, error) {
 	return converter.NewProvider("asciidoc", func(ctx converter.DocumentContext) (converter.Converter, error) {
@@ -55,7 +55,7 @@ func (c *asciidocConverter) Supports(feature identity.Identity) bool {
 // getAsciidocContent calls asciidoctor or asciidoc as an external helper
 // to convert AsciiDoc content to HTML.
 func (a *asciidocConverter) getAsciidocContent(src []byte, ctx converter.DocumentContext) []byte {
-	var isAsciidoctor bool
+	isAsciidoctor := false
 	path := getAsciidoctorExecPath()
 	if path == "" {
 		path = getAsciidocExecPath()
@@ -68,14 +68,52 @@ func (a *asciidocConverter) getAsciidocContent(src []byte, ctx converter.Documen
 		isAsciidoctor = true
 	}
 
-	a.cfg.Logger.INFO.Println("Rendering", ctx.DocumentName, "with", path, "...")
-	args := []string{"--no-header-footer", "--safe"}
+	args := a.parseArgs()
+
 	if isAsciidoctor {
-		// asciidoctor-specific arg to show stack traces on errors
 		args = append(args, "--trace")
 	}
+
 	args = append(args, "-")
+
+	a.cfg.Logger.INFO.Println("Rendering", ctx.DocumentName, "with", path, "using asciidoc args", args, "...")
 	return internal.ExternallyRenderContent(a.cfg, ctx, src, path, args)
+}
+
+func (a *asciidocConverter) parseArgs() []string {
+	var cfg = a.cfg.MarkupConfig.AsciidocExt
+	args := []string{}
+
+	if asciidocext_config.BackendWhitelist[cfg.Backend] {
+		args = append(args, "-b", cfg.Backend)
+	}
+
+	for _, extension := range cfg.Extensions {
+		if asciidocext_config.ExtensionsWhitelist[extension] != true {
+			a.cfg.Logger.ERROR.Println("Unsupported asciidoctor extension was passed in.")
+			continue
+		}
+
+		args = append(args, "-r", extension)
+	}
+
+	if cfg.NoHeaderOrFooter {
+		args = append(args, "--no-header-footer")
+	}
+
+	if cfg.SectionNumbers {
+		args = append(args, "--section-numbers")
+	}
+
+	if cfg.Verbose {
+		args = append(args, "-v")
+	}
+
+	if asciidocext_config.SafeModeWhitelist[cfg.SafeMode] {
+		args = append(args, "--safe-mode", cfg.SafeMode)
+	}
+
+	return args
 }
 
 func getAsciidocExecPath() string {

--- a/markup/asciidocext/convert_test.go
+++ b/markup/asciidocext/convert_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Hugo Authors. All rights reserved.
+// Copyright 2020 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package asciidoc
+// Package asciidocext converts Asciidoc to HTML using Asciidoc or Asciidoctor
+// external binaries. The `asciidoc` module is reserved for a future golang
+// implementation.
+
+package asciidocext
 
 import (
 	"testing"

--- a/markup/markup.go
+++ b/markup/markup.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/gohugoio/hugo/markup/org"
 
-	"github.com/gohugoio/hugo/markup/asciidoc"
+	"github.com/gohugoio/hugo/markup/asciidocext"
 	"github.com/gohugoio/hugo/markup/blackfriday"
 	"github.com/gohugoio/hugo/markup/converter"
 	"github.com/gohugoio/hugo/markup/mmark"
@@ -76,7 +76,7 @@ func NewConverterProvider(cfg converter.ProviderConfig) (ConverterProvider, erro
 	if err := add(mmark.Provider); err != nil {
 		return nil, err
 	}
-	if err := add(asciidoc.Provider, "ad", "adoc"); err != nil {
+	if err := add(asciidocext.Provider, "ad", "adoc"); err != nil {
 		return nil, err
 	}
 	if err := add(rst.Provider); err != nil {

--- a/markup/markup_config/config.go
+++ b/markup/markup_config/config.go
@@ -16,6 +16,7 @@ package markup_config
 import (
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/docshelper"
+	"github.com/gohugoio/hugo/markup/asciidocext/asciidocext_config"
 	"github.com/gohugoio/hugo/markup/blackfriday/blackfriday_config"
 	"github.com/gohugoio/hugo/markup/goldmark/goldmark_config"
 	"github.com/gohugoio/hugo/markup/highlight"
@@ -36,6 +37,8 @@ type Config struct {
 	// Content renderers
 	Goldmark    goldmark_config.Config
 	BlackFriday blackfriday_config.Config
+
+	AsciidocExt asciidocext_config.Config
 }
 
 func Decode(cfg config.Provider) (conf Config, err error) {


### PR DESCRIPTION
Following the discussion in #6561, I reworked the asciidoc configuration.

---

* backends, safe-modes, and extensions are now whitelisted to the [popular (ruby) extensions](https://asciidoctor.org/docs/extensions/) and valid values.
* the default for extensions is to not enable any, because they're all external dependencies so the build would break if the user didn't install them beforehand.
* the default backend is `html5` because `html5s` is an external gem dependency.
* the default safe-mode is `safe`, explanations of the modes: https://asciidoctor-docs.netlify.app/asciidoctor/1.5/safe-modes/
* the config is namespaced under `asciidocext_config` and the parser looks at `asciidocext` to allow a future native golang `asciidoc`.

---

example config.toml:

```toml
[markup]
  [markup.asciidocext]
    extensions = ["asciidoctor-html5s"]
    safeMode = "safe"
    backend = "html5s"
    noHeaderOrFooter = true

```
