### PR TITLE
Add diagnostic hints to init timeout message

### DIFF
--- a/lazy/init.go
+++ b/lazy/init.go
@@ -185,7 +185,7 @@ func (ini *Init) withTimeout(timeout time.Duration, f func(ctx context.Context) 
 
 	select {
 	case <-ctx.Done():
-		return nil, errors.New("timed out initializing value. This is most likely a circular loop in a shortcode")
+		return nil, errors.New("timed out initializing value. You may have a circular loop in a shortcode, or your site may have resources that take longer to build than the `timeout` limit in your Hugo config file.")
 	case ve := <-c:
 		return ve.v, ve.err
 	}


### PR DESCRIPTION
Expand the text in the init timeout message to give the reader more hints as to what may be causing the issue.

The current error sent me on a wild goose chase trying to debug my shortcodes, but it turned out that the issue was just that I wasn't caching my resources/ directory on my build server. Once I found this blog post, I solved the issue in minutes:

https://www.henriksommerfeld.se/hugo-timeout-not-a-circular-loop-in-shortcode/

Googling the error message yields several additional posts from users who focus on loops in their shortcode when the problem seems to be overly-expensive builds.