### PR TITLE
Added support for sort by boolean

### DIFF
--- a/tpl/collections/sort_test.go
+++ b/tpl/collections/sort_test.go
@@ -218,6 +218,9 @@ func TestSort(t *testing.T) {
 				map[interface{}]interface{}{"Title": "Foo", "Weight": 10},
 			},
 		},
+		// test boolean values
+		{[]bool{false, true, false}, "value", "asc", []bool{false, false, true}},
+		{[]bool{false, true, false}, "value", "desc", []bool{true, false, false}},
 		// test error cases
 		{(*[]TstX)(nil), nil, "asc", false},
 		{TstX{A: "a", B: "b"}, nil, "asc", false},

--- a/tpl/compare/compare.go
+++ b/tpl/compare/compare.go
@@ -252,6 +252,11 @@ func (ns *Namespace) compareGet(a interface{}, b interface{}) (float64, float64)
 		case timeType:
 			left = float64(toTimeUnix(av))
 		}
+	case reflect.Bool:
+		left = 0
+		if av.Bool() {
+			left = 1
+		}
 	}
 
 	bv := reflect.ValueOf(b)
@@ -274,6 +279,11 @@ func (ns *Namespace) compareGet(a interface{}, b interface{}) (float64, float64)
 		switch bv.Type() {
 		case timeType:
 			right = float64(toTimeUnix(bv))
+		}
+	case reflect.Bool:
+		right = 0
+		if bv.Bool() {
+			right = 1
 		}
 	}
 


### PR DESCRIPTION
example use case: mark posts as `pinned: true` and be able to sort pages by that property without setting values to all unpinned posts  
sorted by the idea that true = 1 and false = 0  
so default ascending sort will put all false values first and all true values last