### PR TITLE
Added tests to ensure that sorting same value elements will not change their order

### DIFF
--- a/tpl/collections/sort_test.go
+++ b/tpl/collections/sort_test.go
@@ -166,6 +166,31 @@ func TestSort(t *testing.T) {
 			"asc",
 			[]map[string]mid{{"foo": mid{Tst: TstX{A: "a", B: "b"}}}, {"foo": mid{Tst: TstX{A: "c", B: "d"}}}, {"foo": mid{Tst: TstX{A: "e", B: "f"}}}},
 		},
+		// test same value sorting
+		{
+			[]map[string]TstX{{"foo": TstX{A: "a", B: "f"}}, {"foo": TstX{A: "a", B: "b"}}, {"foo": TstX{A: "a", B: "d"}}},
+			"foo.A",
+			"asc",
+			[]map[string]TstX{{"foo": TstX{A: "a", B: "f"}}, {"foo": TstX{A: "a", B: "b"}}, {"foo": TstX{A: "a", B: "d"}}},
+		},
+		{
+			[]map[string]TstX{{"foo": TstX{A: "b", B: "f"}}, {"foo": TstX{A: "a", B: "b"}}, {"foo": TstX{A: "a", B: "d"}}},
+			"foo.A",
+			"asc",
+			[]map[string]TstX{{"foo": TstX{A: "a", B: "b"}}, {"foo": TstX{A: "a", B: "d"}}, {"foo": TstX{A: "b", B: "f"}}},
+		},
+		{
+			[]map[string]TstX{{"foo": TstX{A: "a", B: "f"}}, {"foo": TstX{A: "b", B: "b"}}, {"foo": TstX{A: "a", B: "d"}}},
+			"foo.A",
+			"asc",
+			[]map[string]TstX{{"foo": TstX{A: "a", B: "f"}}, {"foo": TstX{A: "a", B: "d"}}, {"foo": TstX{A: "b", B: "b"}}},
+		},
+		{
+			[]map[string]TstX{{"foo": TstX{A: "a", B: "f"}}, {"foo": TstX{A: "a", B: "b"}}, {"foo": TstX{A: "b", B: "d"}}},
+			"foo.A",
+			"asc",
+			[]map[string]TstX{{"foo": TstX{A: "a", B: "f"}}, {"foo": TstX{A: "a", B: "b"}}, {"foo": TstX{A: "b", B: "d"}}},
+		},
 		// test map sorting by dot chaining key argument
 		{
 			map[string]map[string]TstX{"1": {"foo": TstX{A: "e", B: "f"}}, "2": {"foo": TstX{A: "a", B: "b"}}, "3": {"foo": TstX{A: "c", B: "d"}}},


### PR DESCRIPTION
allows to chain sort operations  
use case: sort pages by both pinned boolean and date  
for example:  
page A:
```yaml
section: "A"
date: 2020-04-27T00:0:0+00:00
```
page B:
```yaml
section: "B"
date: 2020-05-27T00:0:0+00:00
```
page C:
```yaml
section: "A"
date: 2020-06-27T00:0:0+00:00
```
```
{{ sort (sort site.RegularPages "Date") "Params.section" }}
```
will always be ordered like so:  
page C  
page A  
page B  
