### PR TITLE
[minifiers] Uncomment KeepQuotes

### DIFF
--- a/minifiers/config.go
+++ b/minifiers/config.go
@@ -35,7 +35,7 @@ var defaultTdewolffConfig = tdewolffConfig{
 		KeepEndTags:             true,
 		KeepDefaultAttrVals:     true,
 		KeepWhitespace:          false,
-		// KeepQuotes:              false, >= v2.6.2
+		KeepQuotes:              false,
 	},
 	CSS: css.Minifier{
 		Decimals: -1, // will be deprecated


### PR DESCRIPTION
ref: #6699

minify's  `KeepQuotes` is set false as default value.
You need to enable it in the hugo's config
(cc @pperzyna)