### PR TITLE
First paragraph as summary

### DIFF
--- a/docs/content/en/content-management/summaries.md
+++ b/docs/content/en/content-management/summaries.md
@@ -39,6 +39,10 @@ You can customize how HTML tags in the summary are loaded using functions such a
 The Hugo-defined summaries are set to use word count calculated by splitting the text by one or more consecutive whitespace characters. If you are creating content in a `CJK` language and want to use Hugo's automatic summary splitting, set `hasCJKLanguage` to `true` in your [site configuration](/getting-started/configuration/).
 {{% /note %}}
 
+#### Split after the first paragraph
+
+If you set `summaryByParagraph` configuration to true in the [site configuration](/getting-started/configuration/) then instead of taking the first 70 words, Hugo will take the first paragraph as it's summary.
+
 ### Manual Summary Splitting
 
 Alternatively, you may add the <code>&#60;&#33;&#45;&#45;more&#45;&#45;&#62;</code> summary divider where you want to split the article. 

--- a/docs/content/en/getting-started/configuration.md
+++ b/docs/content/en/getting-started/configuration.md
@@ -258,6 +258,9 @@ sitemap
 staticDir ("static")
 : A directory or a list of directories from where Hugo reads [static files][static-files]. {{% module-mounts-note %}}
 
+summaryByParagraph (false)
+: Enable this to generate summary from the first paragraph if no manual summary or front matter summary set.
+
 summaryLength (70)
 : The length of text in words to show in a [`.Summary`](/content-management/summaries/#hugo-defined-automatic-summary-splitting).
 

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -639,6 +639,7 @@ func loadDefaultSettingsFor(v *viper.Viper) error {
 	v.SetDefault("disablePathToLower", false)
 	v.SetDefault("hasCJKLanguage", false)
 	v.SetDefault("enableEmoji", false)
+	v.SetDefault("summaryByParagraph", false)
 	v.SetDefault("pygmentsCodeFencesGuessSyntax", false)
 	v.SetDefault("defaultContentLanguage", "en")
 	v.SetDefault("defaultContentLanguageInSubdir", false)

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -85,6 +85,8 @@ type pageMeta struct {
 	// whether the content is in a CJK language.
 	isCJKLanguage bool
 
+	summaryByParagraph bool
+
 	layout string
 
 	aliases []string
@@ -437,7 +439,7 @@ func (pm *pageMeta) setMetadata(parentBucket *pagesMapBucket, p *pageState, fron
 
 	var sitemapSet bool
 
-	var draft, published, isCJKLanguage *bool
+	var draft, published, isCJKLanguage, isSummaryByParagraph *bool
 	for k, v := range frontmatter {
 		loki := strings.ToLower(k)
 
@@ -545,6 +547,10 @@ func (pm *pageMeta) setMetadata(parentBucket *pagesMapBucket, p *pageState, fron
 		case "iscjklanguage":
 			isCJKLanguage = new(bool)
 			*isCJKLanguage = cast.ToBool(v)
+
+		case "summarybyparagraph":
+			isSummaryByParagraph = new(bool)
+			*isSummaryByParagraph = cast.ToBool(v)
 		case "translationkey":
 			pm.translationKey = cast.ToString(v)
 			pm.params[loki] = pm.translationKey
@@ -645,6 +651,12 @@ func (pm *pageMeta) setMetadata(parentBucket *pagesMapBucket, p *pageState, fron
 		} else {
 			pm.isCJKLanguage = false
 		}
+	}
+
+	if isSummaryByParagraph != nil {
+		pm.summaryByParagraph = *isSummaryByParagraph
+	} else if p.s.siteCfg.summaryByParagraph {
+		pm.summaryByParagraph = true
 	}
 
 	pm.params["iscjklanguage"] = p.m.isCJKLanguage

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -357,11 +357,14 @@ func (p *pageContentOutput) setAutoSummary() error {
 	var summary string
 	var truncated bool
 
-	if p.p.m.isCJKLanguage {
+	if p.p.m.summaryByParagraph {
+		summary, truncated = p.p.s.ContentSpec.TruncateToParagraph(string(p.content))
+	} else if p.p.m.isCJKLanguage {
 		summary, truncated = p.p.s.ContentSpec.TruncateWordsByRune(p.plainWords)
 	} else {
 		summary, truncated = p.p.s.ContentSpec.TruncateWordsToWholeSentence(p.plain)
 	}
+
 	p.summary = template.HTML(summary)
 
 	p.truncated = truncated

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -188,11 +188,12 @@ func (t taxonomiesConfig) Values() []viewName {
 }
 
 type siteConfigHolder struct {
-	sitemap          config.Sitemap
-	taxonomiesConfig taxonomiesConfig
-	timeout          time.Duration
-	hasCJKLanguage   bool
-	enableEmoji      bool
+	sitemap            config.Sitemap
+	taxonomiesConfig   taxonomiesConfig
+	timeout            time.Duration
+	hasCJKLanguage     bool
+	enableEmoji        bool
+	summaryByParagraph bool
 }
 
 // Lazily loaded site dependencies.
@@ -533,11 +534,12 @@ But this also means that your site configuration may not do what you expect. If 
 	}
 
 	siteConfig := siteConfigHolder{
-		sitemap:          config.DecodeSitemap(config.Sitemap{Priority: -1, Filename: "sitemap.xml"}, cfg.Language.GetStringMap("sitemap")),
-		taxonomiesConfig: taxonomies,
-		timeout:          timeout,
-		hasCJKLanguage:   cfg.Language.GetBool("hasCJKLanguage"),
-		enableEmoji:      cfg.Language.Cfg.GetBool("enableEmoji"),
+		sitemap:            config.DecodeSitemap(config.Sitemap{Priority: -1, Filename: "sitemap.xml"}, cfg.Language.GetStringMap("sitemap")),
+		taxonomiesConfig:   taxonomies,
+		timeout:            timeout,
+		hasCJKLanguage:     cfg.Language.GetBool("hasCJKLanguage"),
+		enableEmoji:        cfg.Language.Cfg.GetBool("enableEmoji"),
+		summaryByParagraph: cfg.Language.GetBool("summaryByParagraph"),
 	}
 
 	s := &Site{


### PR DESCRIPTION
The idea behind this PR is to improve the automatic summary generation.

Instead of defining how many words should be used as summary, use the first paragraph in the document.

The default behavior didn't change, but added a config `summaryByParagraph` which needs to be turned on to activate this feature.

I use the golang.org/x/net/html package to get the first paragraph