### PR TITLE
Fix typo in install instructions

### DIFF
--- a/docs/content/en/getting-started/installing.md
+++ b/docs/content/en/getting-started/installing.md
@@ -444,7 +444,7 @@ Directory of C:\hugo\sites\example.com
 
 ### Snap Package
 
-In any of the [Linux distributions that support snaps][snaps], you may install install the "extended" Sass/SCSS version with this command:
+In any of the [Linux distributions that support snaps][snaps], you may install the "extended" Sass/SCSS version with this command:
 
     snap install hugo --channel=extended
 


### PR DESCRIPTION
Fix a minor typo in install instructions for Linux.