### PR TITLE
Partial fix for fatal crash on use of so-called "paired shortcodes"

### DIFF
--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -502,12 +502,7 @@ Loop:
 
 		case currItem.IsShortcodeClose():
 			next := pt.Peek()
-			if !sc.isInline && !sc.info.ParseInfo().IsInner {
-				if next.IsError() {
-					// return that error, more specific
-					continue
-				}
-
+			if !sc.isInline && !sc.info.ParseInfo().IsInner && next.IsError() {
 				return sc, fail(_errors.Errorf("shortcode %q has no .Inner, yet a closing tag was provided", next.Val), next)
 			}
 			if next.IsRightShortcodeDelim() {


### PR DESCRIPTION
See #7329.

Here is my particular use case of "paired shortcodes":

```
{{< section >}}

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam efficitur luctus hendrerit. Nullam nunc massa, placerat non pharetra sit amet, facilisis sed est. Proin convallis arcu eget blandit accumsan.

Etiam eu metus nec est consectetur efficitur a sed eros. Proin nec fermentum metus. Ut vulputate erat ante, a egestas purus mollis eu. Donec porttitor lacus elementum, laoreet odio in, mollis odio. Proin dui libero, bibendum eu dapibus in, lobortis a sapien.

Nulla condimentum turpis nibh, sit amet rhoncus dui sodales sit amet. Vestibulum tincidunt tempor magna, in pellentesque quam rhoncus eu. Nam gravida metus et elit mollis, at posuere mauris venenatis.

{{< section />}}
```

This is a partial fix, because there is a catch. (There is always a catch.) Two, in fact.

**I)**

```
{{% mdshortcode %}}Stuff to `process` in the *center*.{{% /mdshortcode %}}
```

Shortcodes defined with `%` may "escape" some of the closing HTML tags in one or more templates. Don't ask me how this happens — I don't know.

**II)**

From:

```
{{< highlight go >}} A bunch of code here {{< /highlight >}}
```

To:

```
{{< highlight go >}} A bunch of code here {{< highlight />}}
```

The closing slash must be moved from before `highlight` (as described in the documentation) to before the right angle bracket. To leave the slash where it is may cause precisely the same fatal error as before.

The reasons for these strange phenomena are not clear to me, as I have no prior experience with Go in any capacity whatsoever.

You are welcome to do whatever you want with this code, @bep, but don't tell me that my problems don't real.