### PR TITLE
tpl: Support `start` and `end` parameters in `youtube` shortcode

### DIFF
--- a/docs/content/en/content-management/shortcodes.md
+++ b/docs/content/en/content-management/shortcodes.md
@@ -386,11 +386,19 @@ Copy the YouTube video ID that follows `v=` in the video's URL and pass it to th
 {{</* youtube w7Ft2ymGmfc */>}}
 {{< /code >}}
 
-Furthermore, you can automatically start playback of the embedded video by setting the `autoplay` parameter to `true`. Remember that you can't mix named and unnamed parameters, so you'll need to assign the yet unnamed video id to the parameter `id`:
+#### Additional Playback Options
+
+You can automatically start playback of the embedded video by setting the `autoplay` parameter to `true`. Remember that you can't mix named and unnamed parameters, so you'll need to assign the yet unnamed video id to the parameter `id`:
 
 
 {{< code file="example-youtube-input-with-autoplay.md" >}}
 {{</* youtube id="w7Ft2ymGmfc" autoplay="true" */>}}
+{{< /code >}}
+
+You're also able set the embed's start and end timestamps using the `start` and `end` parameters. Values should be in seconds from the start of the video. In the below example, the embedded video will play from the 90-second mark until the 6-minute mark:
+
+{{< code file="example-youtube-input-with-start-end.md" >}}
+{{</* youtube id="w7Ft2ymGmfc" start=90 end=360 */>}}
 {{< /code >}}
 
 #### Example `youtube` Output
@@ -398,12 +406,12 @@ Furthermore, you can automatically start playback of the embedded video by setti
 Using the preceding `youtube` example, the following HTML will be added to your rendered website's markup:
 
 {{< code file="example-youtube-output.html" >}}
-{{< youtube id="w7Ft2ymGmfc" autoplay="true" >}}
+{{< youtube id="w7Ft2ymGmfc" start=90 end=360 >}}
 {{< /code >}}
 
 #### Example `youtube` Display
 
-Using the preceding `youtube` example (without `autoplay="true"`), the following simulates the displayed experience for visitors to your website. Naturally, the final display will be contingent on your stylesheets and surrounding markup. The video is also include in the [Quick Start of the Hugo documentation][quickstart].
+Using the first `youtube` example above (i.e. without `autoplay="true"`, or `start` and `end` set), the following simulates the displayed experience for visitors to your website. Naturally, the final display will be contingent on your stylesheets and surrounding markup. The video is also include in the [Quick Start of the Hugo documentation][quickstart].
 
 {{< youtube w7Ft2ymGmfc >}}
 

--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -184,6 +184,21 @@ func TestShortcodeYoutube(t *testing.T) {
 			`{{< youtube id="w7Ft2ymGmfc" class="video" autoplay="true" >}}`,
 			"(?s)\n<div class=\"video\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?autoplay=1\".*?allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>",
 		},
+		// set start (using named params, as string)
+		{
+			`{{< youtube id="w7Ft2ymGmfc" start="5" >}}`,
+			"(?s)\n<div style=\".*?\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?start=5\" style=\".*?\" allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>\n",
+		},
+		// set class, start and end (using named params, start and end are ints)
+		{
+			`{{< youtube id="w7Ft2ymGmfc" class="video" start=5 end=10 >}}`,
+			"(?s)\n<div class=\"video\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?start=5&amp;end=10\".*?allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>",
+		},
+		// // set class, start, autoplay, and end (using named params)
+		{
+			`{{< youtube id="w7Ft2ymGmfc" class="video" start=5 end=10 autoplay="true" >}}`,
+			"(?s)\n<div class=\"video\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?autoplay=1&amp;start=5&amp;end=10\".*?allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>",
+		},
 	} {
 		var (
 			cfg, fs = newTestCfg()

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -520,9 +520,19 @@ if (!doNotTrack) {
 {{- if not $pc.Disable -}}
 {{- $ytHost := cond $pc.PrivacyEnhanced  "www.youtube-nocookie.com" "www.youtube.com" -}}
 {{- $id := .Get "id" | default (.Get 0) -}}
-{{- $class := .Get "class" | default (.Get 1) }}
+{{- $class := .Get "class" | default (.Get 1) -}}
+{{- $params := slice -}}
+{{- if eq (.Get "autoplay") "true" -}}
+    {{- $params = $params | append (querify "autoplay" 1) -}}
+{{- end -}}
+{{- with (.Get "start") -}}
+    {{- $params = $params | append (querify "start" (. | int)) -}}
+{{- end -}}
+{{- with (.Get "end") -}}
+    {{- $params = $params | append (querify "end" (. | int)) -}}
+{{- end }}
 <div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
-  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="YouTube Video"></iframe>
+  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with $params }}?{{ delimit $params "&" | safeURL }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="YouTube Video"></iframe>
 </div>
 {{ end -}}
 `},

--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
@@ -2,8 +2,18 @@
 {{- if not $pc.Disable -}}
 {{- $ytHost := cond $pc.PrivacyEnhanced  "www.youtube-nocookie.com" "www.youtube.com" -}}
 {{- $id := .Get "id" | default (.Get 0) -}}
-{{- $class := .Get "class" | default (.Get 1) }}
+{{- $class := .Get "class" | default (.Get 1) -}}
+{{- $params := slice -}}
+{{- if eq (.Get "autoplay") "true" -}}
+    {{- $params = $params | append (querify "autoplay" 1) -}}
+{{- end -}}
+{{- with (.Get "start") -}}
+    {{- $params = $params | append (querify "start" (. | int)) -}}
+{{- end -}}
+{{- with (.Get "end") -}}
+    {{- $params = $params | append (querify "end" (. | int)) -}}
+{{- end }}
 <div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
-  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="YouTube Video"></iframe>
+  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with $params }}?{{ delimit $params "&" | safeURL }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="YouTube Video"></iframe>
 </div>
 {{ end -}}


### PR DESCRIPTION
Adds the `start` and `end` parameters to the `youtube` shortcode so that it's possible to embed shorter snippets of a longer youtube video.

This works both with and without `autoplay="true"`.

See https://github.com/gohugoio/hugo/issues/3694#issuecomment-315802797, which references someone else needing this functionality, and cloning / modifying the existing shortcode for this purpose (though this bug admittedly feels very nebulous!)