### PR TITLE
Use os.PathError with the file name when reporting error in RootMappi…

### DIFF
--- a/hugofs/rootmapping_fs.go
+++ b/hugofs/rootmapping_fs.go
@@ -493,7 +493,7 @@ func (fs *RootMappingFs) doLstat(name string) ([]FileMetaInfo, error) {
 		// Find any real files or directories with this key.
 		_, roots := fs.getRoots(key)
 		if roots == nil {
-			return nil, os.ErrNotExist
+			return nil, &os.PathError{Op: "LStat", Path: name, Err: os.ErrNotExist}
 		}
 
 		var err error
@@ -512,7 +512,7 @@ func (fs *RootMappingFs) doLstat(name string) ([]FileMetaInfo, error) {
 		}
 
 		if err == nil {
-			err = os.ErrNotExist
+			err = &os.PathError{Op: "LStat", Path: name, Err: err}
 		}
 
 		return nil, err


### PR DESCRIPTION
Use os.PathError with the file name when reporting error in RootMappingFs.doLstat

This change makes RootMappingFs.doLstat behave consistently with most other Stat implementations by returning os.PathError with the file path on error.

If user has a template that takes a path from Params, like below, and they make a typo entering the file path, it will be hard to find the cause of problem, because Stat currently doesn't report the wrong path in the error and Hugo doesn't say which content file caused the error either.

Example template fragment (taken from Zen theme).
```
{{ with .Params.podcast.mp3 }}
    {{ $file_stat := os.Stat (add "/static" . ) }} do stuff
{{ end }}
```

Error as currently reported:
```bash
Error: Error building site: (...) executing "template.xml" at <os.Stat>: error calling Stat: file does not exist
```

Same error after the change:
```bash
Error: Error building site: (...) executing "template.xml" at <os.Stat>: error calling Stat: LStat missing-file-path.mp3: file does not exist
```
