### PR TITLE
Fix aliases with relativeURLs

### DIFF
--- a/hugolib/alias.go
+++ b/hugolib/alias.go
@@ -99,8 +99,11 @@ func (s *Site) publishDestAlias(allowRoot bool, path, permalink string, outputFo
 		OutputFormat: outputFormat,
 	}
 
-	return s.publisher.Publish(pd)
+	if s.Info.relativeURLs || s.Info.canonifyURLs {
+		pd.AbsURLPath = s.absURLPath(targetPath)
+	}
 
+	return s.publisher.Publish(pd)
 }
 
 func (a aliasHandler) targetPathAlias(src string) (string, error) {

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -383,7 +383,7 @@ func (s *Site) renderMainLanguageRedirect() error {
 	if found {
 		mainLang := s.h.multilingual.DefaultLang
 		if s.Info.defaultContentLanguageInSubdir {
-			mainLangURL := s.PathSpec.AbsURL(mainLang.Lang, false)
+			mainLangURL := s.PathSpec.AbsURL(mainLang.Lang+"/", false)
 			s.Log.DEBUG.Printf("Write redirect to main language %s: %s", mainLang, mainLangURL)
 			if err := s.publishDestAlias(true, "/", mainLangURL, html, nil); err != nil {
 				return err

--- a/hugolib/testhelpers_test.go
+++ b/hugolib/testhelpers_test.go
@@ -277,9 +277,14 @@ func (s *sitesBuilder) WithSimpleConfigFile() *sitesBuilder {
 
 func (s *sitesBuilder) WithSimpleConfigFileAndBaseURL(baseURL string) *sitesBuilder {
 	s.T.Helper()
-	config := fmt.Sprintf("baseURL = %q", baseURL)
+	return s.WithSimpleConfigFileAndSettings(map[string]interface{}{"baseURL": baseURL})
+}
 
-	config = config + commonConfigSections
+func (s *sitesBuilder) WithSimpleConfigFileAndSettings(settings interface{}) *sitesBuilder {
+	s.T.Helper()
+	var buf bytes.Buffer
+	parser.InterfaceToConfig(settings, metadecoders.TOML, &buf)
+	config := buf.String() + commonConfigSections
 	return s.WithConfigFile("toml", config)
 }
 

--- a/transform/urlreplacers/absurlreplacer.go
+++ b/transform/urlreplacers/absurlreplacer.go
@@ -69,6 +69,7 @@ func newPrefixState() []*prefix {
 	return []*prefix{
 		{b: []byte("src="), f: checkCandidateBase},
 		{b: []byte("href="), f: checkCandidateBase},
+		{b: []byte("url="), f: checkCandidateBase},
 		{b: []byte("action="), f: checkCandidateBase},
 		{b: []byte("srcset="), f: checkCandidateSrcset},
 	}

--- a/transform/urlreplacers/absurlreplacer_test.go
+++ b/transform/urlreplacers/absurlreplacer_test.go
@@ -88,8 +88,8 @@ schemaless: &lt;img srcset=&#39;//img.jpg&#39; src=&#39;//basic.jpg&#39;&gt;
 schemaless2: &lt;img srcset=&quot;//img.jpg&quot; src=&quot;//basic.jpg2&gt; POST
 `
 
-	relPathVariations        = `PRE. a href="/img/small.jpg" input action="/foo.html" POST.`
-	relPathVariationsCorrect = `PRE. a href="../../img/small.jpg" input action="../../foo.html" POST.`
+	relPathVariations        = `PRE. a href="/img/small.jpg" input action="/foo.html" meta url=/redirect/to/page/ POST.`
+	relPathVariationsCorrect = `PRE. a href="../../img/small.jpg" input action="../../foo.html" meta url=../../redirect/to/page/ POST.`
 
 	testBaseURL = "http://base/"
 )


### PR DESCRIPTION
This PR fixes alias' redirect URLs when using the `relativeURLs` setting. This applies to both aliases explicitly defined in the page front matter and aliases implicitly created for the default language (e.g. `/` -> `/en`).

Taking the language redirect as an example, when setting `relativeURLs` to `true`, currently, the redirect portion of `/index.html` file looks like this:
```
<meta http-equiv="refresh" content="0; url=/en" />
```

While the correct should be (the last `/` is not strictly necessary, but I added it to be consistent with other URLs generated by Hugo):
```
<meta http-equiv="refresh" content="0; url=./en/" />
```

Using the [example from Hugo's documentation](https://gohugo.io/content-management/urls/#example-aliases), it currently generates two "redirect" files like this:
* `/posts/my-original-url/index.html` -> `/posts/my-awesome-post/`
* `/2010/01/01/even-earlier-url.html` -> `/posts/my-awesome-post/`

After this change:
* `/posts/my-original-url/index.html` -> `../../posts/my-awesome-post/`
* `/2010/01/01/even-earlier-url.html` -> `../../../posts/my-awesome-post/`

(These are my first lines of go in a real project, so let me know if I'm doing things in a non-idiomatic way.)