### PR TITLE
Fix aliases with uglyURLs

### DIFF
--- a/hugolib/alias_test.go
+++ b/hugolib/alias_test.go
@@ -46,12 +46,15 @@ func TestAlias(t *testing.T) {
 	c := qt.New(t)
 
 	tests := []struct {
-		urlPrefix string
-		settings  map[string]interface{}
+		fileSuffix string
+		urlPrefix  string
+		urlSuffix  string
+		settings   map[string]interface{}
 	}{
-		{"http://example.com", map[string]interface{}{"baseURL": "http://example.com"}},
-		{"http://example.com", map[string]interface{}{"baseURL": "http://example.com", "canonifyURLs": true}},
-		{"../..", map[string]interface{}{"relativeURLs": true}},
+		{"/index.html", "http://example.com", "/", map[string]interface{}{"baseURL": "http://example.com"}},
+		{"/index.html", "http://example.com", "/", map[string]interface{}{"baseURL": "http://example.com", "canonifyURLs": true}},
+		{"/index.html", "../..", "/", map[string]interface{}{"relativeURLs": true}},
+		{".html", "", ".html", map[string]interface{}{"uglyURLs": true}},
 	}
 
 	for _, test := range tests {
@@ -63,10 +66,10 @@ func TestAlias(t *testing.T) {
 		c.Assert(len(b.H.Sites[0].RegularPages()), qt.Equals, 1)
 
 		// the real page
-		b.AssertFileContent("public/blog/page/index.html", "For some moments the old man")
+		b.AssertFileContent("public/blog/page"+test.fileSuffix, "For some moments the old man")
 		// the alias redirectors
-		b.AssertFileContent("public/foo/bar/index.html", "<meta http-equiv=\"refresh\" content=\"0; url="+test.urlPrefix+"/blog/page/\" />")
-		b.AssertFileContent("public/blog/rel/index.html", "<meta http-equiv=\"refresh\" content=\"0; url="+test.urlPrefix+"/blog/page/\" />")
+		b.AssertFileContent("public/foo/bar"+test.fileSuffix, "<meta http-equiv=\"refresh\" content=\"0; url="+test.urlPrefix+"/blog/page"+test.urlSuffix+"\" />")
+		b.AssertFileContent("public/blog/rel"+test.fileSuffix, "<meta http-equiv=\"refresh\" content=\"0; url="+test.urlPrefix+"/blog/page"+test.urlSuffix+"\" />")
 	}
 }
 

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -338,17 +338,16 @@ func (s *Site) renderAliases() error {
 				if isRelative {
 					// Make alias relative, where "." will be on the
 					// same directory level as the current page.
-					// TODO(bep) ugly URLs doesn't seem to be supported in
-					// aliases, I'm not sure why not.
-					basePath := of.RelPermalink()
-					if strings.HasSuffix(basePath, "/") {
-						basePath = path.Join(basePath, "..")
-					}
+					basePath := path.Join(of.RelPermalink(), "..")
 					a = path.Join(basePath, a)
 
-				} else if f.Path != "" {
+				} else {
 					// Make sure AMP and similar doesn't clash with regular aliases.
 					a = path.Join(f.Path, a)
+				}
+
+				if s.UglyURLs && !strings.HasSuffix(a, ".html") {
+					a += ".html"
 				}
 
 				lang := p.Language().Lang


### PR DESCRIPTION
For the sake of completeness, I believe this fixes the aliases when using `uglyURLs` without any undesired side effects.

Currently, I get an error like this:
```
Error: Error building site: failed to render pages: open /some/path/public/posts/my-awesome-post.html: is a directory
```

Not sure if there's a better way handle those prefixes and suffixes in the test. In other languages, I'd probably use a lambda, but Go's anonymous functions seem syntactically a bit too heavy for this.