### PR TITLE
Fix order of GetTerms

### DIFF
--- a/common/collections/order.go
+++ b/common/collections/order.go
@@ -1,0 +1,20 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collections
+
+type Order interface {
+	// Ordinal is a zero-based ordinal that represents the order of an object
+	// in a collection.
+	Ordinal() int
+}

--- a/hugolib/content_map.go
+++ b/hugolib/content_map.go
@@ -264,6 +264,7 @@ func (b *cmInsertKeyBuilder) newTopLevel() {
 }
 
 type contentBundleViewInfo struct {
+	ordinal    int
 	name       viewName
 	termKey    string
 	termOrigin string

--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -579,7 +579,6 @@ func (m *pageMap) attachPageToViews(s string, b *contentNode) {
 		if vals == nil {
 			continue
 		}
-
 		w := getParamToLower(b.p, viewName.plural+"_weight")
 		weight, err := cast.ToIntE(w)
 		if err != nil {
@@ -587,11 +586,12 @@ func (m *pageMap) attachPageToViews(s string, b *contentNode) {
 			// weight will equal zero, so let the flow continue
 		}
 
-		for _, v := range vals {
+		for i, v := range vals {
 			termKey := m.s.getTaxonomyKey(v)
 
 			bv := &contentNode{
 				viewInfo: &contentBundleViewInfo{
+					ordinal:    i,
 					name:       viewName,
 					termKey:    termKey,
 					termOrigin: v,

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -132,6 +132,7 @@ func (p *pageState) GitInfo() *gitmap.GitInfo {
 }
 
 // GetTerms gets the terms defined on this page in the given taxonomy.
+// The pages returned will be ordered according to the front matter.
 func (p *pageState) GetTerms(taxonomy string) page.Pages {
 	if p.treeRef == nil {
 		return nil
@@ -147,8 +148,9 @@ func (p *pageState) GetTerms(taxonomy string) page.Pages {
 
 	m.taxonomies.WalkQuery(pageMapQuery{Prefix: prefix}, func(s string, n *contentNode) bool {
 		key := s + self
-		if _, found := m.taxonomyEntries.Get(key); found {
-			pas = append(pas, n.p)
+		if tn, found := m.taxonomyEntries.Get(key); found {
+			vi := tn.(*contentNode).viewInfo
+			pas = append(pas, pageWithOrdinal{pageState: n.p, ordinal: vi.ordinal})
 		}
 		return false
 	})
@@ -1005,4 +1007,23 @@ func (s *Site) sectionsFromFile(fi source.File) []string {
 	}
 
 	return parts
+}
+
+var (
+	_ page.Page         = (*pageWithOrdinal)(nil)
+	_ collections.Order = (*pageWithOrdinal)(nil)
+	_ pageWrapper       = (*pageWithOrdinal)(nil)
+)
+
+type pageWithOrdinal struct {
+	ordinal int
+	*pageState
+}
+
+func (p pageWithOrdinal) Ordinal() int {
+	return p.ordinal
+}
+
+func (p pageWithOrdinal) page() page.Page {
+	return p.pageState
 }

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -644,12 +644,12 @@ Cats Paginator {{ range $cats.Paginator.Pages }}{{ .RelPermalink }}|{{ end }}:EN
 Categories Pages: /categories/birds/|/categories/cats/|/categories/dogs/|/categories/funny/|/categories/gorillas/|:END
 Funny Pages: /section/p1/|/section/p2/|:END
 Cats Pages: /section/p1/|/section/|:END
-P1 Terms: /categories/cats/|/categories/funny/|:END
-Section Terms: /categories/birds/|/categories/cats/|/categories/dogs/|:END
+P1 Terms: /categories/funny/|/categories/cats/|:END
+Section Terms: /categories/cats/|/categories/dogs/|/categories/birds/|:END
 Home Terms: /categories/dogs/|/categories/gorillas/|:END
 Cats Paginator /section/p1/|/section/|:END
-Category Paginator /categories/birds/|/categories/cats/|/categories/dogs/|/categories/funny/|/categories/gorillas/|:END
-`)
+Category Paginator /categories/birds/|/categories/cats/|/categories/dogs/|/categories/funny/|/categories/gorillas/|:END`,
+	)
 	b.AssertFileContent("public/404.html", "\n404 Terms: :END\n\t")
 	b.AssertFileContent("public/categories/funny/index.xml", `<link>http://example.com/section/p1/</link>`)
 	b.AssertFileContent("public/categories/index.xml", `<link>http://example.com/categories/funny/</link>`)


### PR DESCRIPTION
Preserve the order from front matter, which would be behaviour when doing this manually (before GetTerms).

Fixes #7213