### PR TITLE
Fix aliases with path in baseURL

### DIFF
--- a/hugolib/alias_test.go
+++ b/hugolib/alias_test.go
@@ -52,6 +52,7 @@ func TestAlias(t *testing.T) {
 		settings   map[string]interface{}
 	}{
 		{"/index.html", "http://example.com", "/", map[string]interface{}{"baseURL": "http://example.com"}},
+		{"/index.html", "http://example.com/some/path", "/", map[string]interface{}{"baseURL": "http://example.com/some/path"}},
 		{"/index.html", "http://example.com", "/", map[string]interface{}{"baseURL": "http://example.com", "canonifyURLs": true}},
 		{"/index.html", "../..", "/", map[string]interface{}{"relativeURLs": true}},
 		{".html", "", ".html", map[string]interface{}{"uglyURLs": true}},

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -338,7 +338,7 @@ func (s *Site) renderAliases() error {
 				if isRelative {
 					// Make alias relative, where "." will be on the
 					// same directory level as the current page.
-					basePath := path.Join(of.RelPermalink(), "..")
+					basePath := path.Join(p.targetPaths().SubResourceBaseLink, "..")
 					a = path.Join(basePath, a)
 
 				} else {


### PR DESCRIPTION
Currently, running the example from the alias unit test with `baseURL = "http://example.com/some/path"` generates a tree structure like this (where the path in the baseURL is prepended to the relative alias output path):

```
public/
├── blog/
│   └── page/
│       └── index.html
├── foo/
│   └── bar/
│       └── index.html
└── some/
    └── path/
        └── blog/
            └── rel/
                └── index.html
```

With this PR, it will look like this:

```
public/
├── blog/
│   ├── page/
│   │   └── index.html
│   └── rel/
│       └── index.html
└── foo/
    └── bar/
        └── index.html
```

Not sure if there's any special case where replacing `of.RelPermalink()` by `p.targetPaths().SubResourceBaseLink` could cause issues, but it worked correctly in all examples I tried.