### PR TITLE
Create robots.txt in the domain root directory

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -49,6 +49,7 @@ import (
 
 	"github.com/gohugoio/hugo/langs/i18n"
 	"github.com/gohugoio/hugo/resources/page"
+	"github.com/gohugoio/hugo/resources/page/pagemeta"
 	"github.com/gohugoio/hugo/tpl"
 	"github.com/gohugoio/hugo/tpl/tplimpl"
 )
@@ -690,7 +691,7 @@ func (cfg *BuildCfg) shouldRender(p *pageState) bool {
 	return false
 }
 
-func (h *HugoSites) renderCrossSitesArtifacts() error {
+func (h *HugoSites) renderCrossSitesSitemap() error {
 
 	if !h.multilingual.enabled() || h.IsMultihost() {
 		return nil
@@ -714,6 +715,38 @@ func (h *HugoSites) renderCrossSitesArtifacts() error {
 
 	return s.renderAndWriteXML(&s.PathSpec.ProcessingStats.Sitemaps, "sitemapindex",
 		s.siteCfg.sitemap.Filename, h.toSiteInfos(), templ)
+}
+
+func (h *HugoSites) renderCrossSitesRobotsTXT() error {
+	if h.multihost {
+		return nil
+	}
+	if !h.Cfg.GetBool("enableRobotsTXT") {
+		return nil
+	}
+
+	s := h.Sites[0]
+
+	p, err := newPageStandalone(&pageMeta{
+		s:    s,
+		kind: kindRobotsTXT,
+		urlPaths: pagemeta.URLPath{
+			URL: "robots.txt",
+		},
+	},
+		output.RobotsTxtFormat)
+
+	if err != nil {
+		return err
+	}
+
+	if !p.render {
+		return nil
+	}
+
+	templ := s.lookupLayouts("robots.txt", "_default/robots.txt", "_internal/_default/robots.txt")
+
+	return s.renderAndWritePage(&s.PathSpec.ProcessingStats.Pages, "Robots Txt", "robots.txt", p, templ)
 }
 
 func (h *HugoSites) removePageByFilename(filename string) {

--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -334,7 +334,10 @@ func (h *HugoSites) render(config *BuildCfg) error {
 	}
 
 	if !config.SkipRender {
-		if err := h.renderCrossSitesArtifacts(); err != nil {
+		if err := h.renderCrossSitesSitemap(); err != nil {
+			return err
+		}
+		if err := h.renderCrossSitesRobotsTXT(); err != nil {
 			return err
 		}
 	}

--- a/hugolib/hugo_sites_build_test.go
+++ b/hugolib/hugo_sites_build_test.go
@@ -255,8 +255,10 @@ func doTestMultiSitesBuild(t *testing.T, configTemplate, configSuffix string) {
 	b.AssertFileContent("public/fr/404.html", "404|fr|404 Page not found")
 
 	// Check robots.txt
-	b.AssertFileContent("public/en/robots.txt", "robots|en|")
-	b.AssertFileContent("public/nn/robots.txt", "robots|nn|")
+	// the domain root is the public directory, so the robots.txt has to be created there and not in the language directories
+	b.AssertFileContent("public/robots.txt", "robots")
+	b.AssertFileDoesNotExist("public/en/robots.txt")
+	b.AssertFileDoesNotExist("public/nn/robots.txt")
 
 	b.AssertFileContent("public/en/sect/doc1-slug/index.html", "Permalink: http://example.com/blog/en/sect/doc1-slug/")
 	b.AssertFileContent("public/en/sect/doc2/index.html", "Permalink: http://example.com/blog/en/sect/doc2/")

--- a/hugolib/hugo_sites_multihost_test.go
+++ b/hugolib/hugo_sites_multihost_test.go
@@ -19,6 +19,7 @@ disablePathToLower = true
 defaultContentLanguage = "fr"
 defaultContentLanguageInSubdir = false
 staticDir = ["s1", "s2"]
+enableRobotsTXT = true
 
 [permalinks]
 other = "/somewhere/else/:filename"
@@ -72,6 +73,12 @@ languageName = "Nynorsk"
 	c.Assert(pageWithURLInFrontMatter, qt.Not(qt.IsNil))
 	c.Assert(pageWithURLInFrontMatter.RelPermalink(), qt.Equals, "/docs/superbob/")
 	b.AssertFileContent("public/en/superbob/index.html", "doc3|Hello|en")
+
+	// the domain root is the language directory for each language, so the robots.txt is created in the language directories
+	b.AssertFileContent("public/en/robots.txt", "robots|en")
+	b.AssertFileContent("public/fr/robots.txt", "robots|fr")
+	b.AssertFileContent("public/nn/robots.txt", "robots|nn")
+	b.AssertFileDoesNotExist("public/robots.txt")
 
 	// check alias:
 	b.AssertFileContent("public/en/al/alias1/index.html", `content="0; url=https://example.com/docs/superbob/"`)

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1209,8 +1209,10 @@ func (s *Site) render(ctx *siteRenderContext) (err error) {
 			return
 		}
 
-		if err = s.renderRobotsTXT(); err != nil {
-			return
+		if ctx.multihost {
+			if err = s.renderRobotsTXT(); err != nil {
+				return
+			}
 		}
 
 		if err = s.render404(); err != nil {

--- a/hugolib/testhelpers_test.go
+++ b/hugolib/testhelpers_test.go
@@ -726,6 +726,12 @@ func (s *sitesBuilder) AssertFileContent(filename string, matches ...string) {
 	}
 }
 
+func (s *sitesBuilder) AssertFileDoesNotExist(filename string) {
+	if s.CheckExists(filename) {
+		s.Fatalf("File %q exists but must not exist.", filename)
+	}
+}
+
 func (s *sitesBuilder) AssertImage(width, height int, filename string) {
 	filename = filepath.Join(s.workingDir, filename)
 	f, err := s.Fs.Destination.Open(filename)


### PR DESCRIPTION
Before this change a robots.txt is created in every Site. So in public/robots.txt if there are no languages (was correct). But if there are multiple languages in every language directory, too (was wrong). If defaultContentLanguageInSubdir is true, no language is created into the root directory, so no robots.txt is in the root directory (was wrong). If multihosts are configured for each language, that is the only case where one robots.txt must be created in each language directory (was correct).

I've changed the behaviour, that only in the multihost case the robots.txt is created in the language directories. In any other case it is created in public/robots.txt. I've also added tests that files are not created in the wrong directories.

Fixes #5160
See also #4193