### PR TITLE
Updated installation instruction about Sass/SCSS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ go install
 ```
 
 **If you are a Windows user, substitute the `$HOME` environment variable above with `%USERPROFILE%`.**
-	
+
+If you want to compile with Sass/SCSS support use `--tags extended` and make sure `CGO_ENABLED=1` is set in your go environment. If you don't want to have CGO enabled, you may use the following command to temporarily enable CGO only for hugo compilation:
+
+```bash
+CGO_ENABLED=1 go install --tags extended
+```
+
 ## The Hugo Documentation
 
 The Hugo documentation now lives in its own repository, see https://github.com/gohugoio/hugoDocs. But we do keep a version of that documentation as a `git subtree` in this repository. To build the sub folder `/docs` as a Hugo site, you need to clone this repo:


### PR DESCRIPTION
The goal of this PR is to update installation instruction about `--tags extended` when `CGO_ENABLED=0` as it shows such no straightforward error:

```bash
$ go install --tags extended
../../go/gopath/pkg/mod/github.com/bep/golibsass@v0.6.0/libsass/transpiler.go:15:2: build constraints exclude all Go files in /home/mateusz/go/gopath/pkg/mod/github.com/bep/golibsass@v0.6.0/internal/libsass
```

This is because `CGO_ENABLED=0` on my linux machine (`go1.14.2 linux/adm64` - but previous versions of `go` and `hugo` had this problem as well)

I don't know if this is related to this issue as I haven't tested on ARM: https://github.com/gohugoio/hugo/issues/6991