### PR TITLE
Allow empty alt (alt="") in img element

### DIFF
--- a/tpl/tplimpl/embedded/templates/shortcodes/figure.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/figure.html
@@ -3,7 +3,7 @@
         <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
     {{- end }}
     <img src="{{ .Get "src" }}"
-         {{- if or (.Get "alt") (.Get "caption") }}
+         {{- if or (isset .Params "alt") (.Get "caption") }}
          alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
          {{- end -}}
          {{- with .Get "width" }} width="{{ . }}"{{ end -}}


### PR DESCRIPTION
It's important to allow an empty alt attribute for img element.
See https://www.w3.org/WAI/tutorials/images/decorative/