### PR TITLE
Add support for Goldmark footnote render hooks

### DIFF
--- a/docs/content/en/getting-started/configuration-markup.md
+++ b/docs/content/en/getting-started/configuration-markup.md
@@ -94,6 +94,7 @@ The features currently supported are:
 * `image`
 * `link`
 * `heading` {{< new-in "0.71.0" >}}
+* `footnote-link` and `footnotes`
 
 You can define [Output-Format-](/templates/output-formats) and [language-](/content-management/multilingual/)specific templates if needed.[^hooktemplate] Your `layouts` folder may look like this:
 
@@ -149,6 +150,39 @@ Text
 PlainText
 : The plain variant of the above.
 
+The `render-footnote-link` template will receive this context:
+
+Page
+: The [Page](/variables/page/) being rendered.
+
+Index
+: The footnote numeric index (indicating which number footnote it is in order)
+
+The `render-footnotes` template will receive this context:
+
+Page
+: The [Page](/variables/page/) being rendered.
+
+Footnotes
+: An array of footnote contexts (in ascending order)
+
+Footnote contexts:
+
+Page
+: The [Page](/variables/page/) being rendered.
+
+Ref
+: The internal name used in the markdown file to connect a footnote to it's content
+
+Index
+: The footnote numeric index
+
+Text
+: The rendered (HTML) text.
+
+PlainText
+: The plain variant of the above.
+
 #### Link with title Markdown example:
 
 ```md
@@ -193,6 +227,54 @@ The rendered html will be
 
 ```html
 <h3 id="section-a">Section A <a href="#section-a">¶</a></h3>
+```
+
+#### Footnote example
+
+Given these template files
+
+{{< code file="layouts/_default/_markup/render-footnote-link.html" >}}
+<sup id="fnref:{{ .Page.Title | urlize }}-{{ .Index }}"><a href="#fn:{{ .Page.Title | urlize }}-{{ .Index }}">{{ if (eq 1 .Index) }}*{{ else }}†{{ end }}</a></sup>
+{{< /code >}}
+
+{{< code file="layouts/_default/_markup/render-footnotes.html" >}}
+<ol>
+    {{ range .Footnotes }}
+    <li id="fn:{{ .Page.Title | urlize }}-{{ .Index }}">
+        {{ if (eq 1 .Index) }}*{{ else }}†{{ end }} (ref: {{ .Ref }}) {{ .Text | safeHTML }}
+    </li>
+    {{ end }}
+</ol>
+{{< /code >}}
+
+And this markdown
+
+```md
+---
+title: Example
+---
+This page has footnotes[^1]. Footnotes have been proven to be pretty cool[^cool].
+
+[^1]: A footnote is an aside that appears out of flow.
+
+    They can have multiple paragraphs too!
+
+[^cool]: _Anmerkung et al._ (1967)
+```
+
+The rendered html will be
+
+```html
+<p>This page has footnotes<sup id="fnref:example-1"><a href="#fn:example-1">*</a></sup>. Footnotes have been proven to be pretty cool<sup id="fnref:example-2"><a href="#fn:example-2">†</a></sup>.</p>
+
+<ol>
+    <li id="fn:example-1">
+        * (ref: 1) <p>A footnote is an aside that appears out of flow.</p><p>They can have multiple paragraphs too!</p>
+    </li>
+    <li id="fn:example-2">
+        † (ref: cool) <p><em>_Anmerkung et al.</em> (1967)</p>
+    </li>
+</ol>
 ```
 
 [^hooktemplate]: It's currently only possible to have one set of render hook templates, e.g. not per `Type` or `Section`. We may consider that in a future version.

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -423,6 +423,32 @@ func (p *pageState) createRenderHooks(f output.Format) (*hooks.Renderers, error)
 		}
 	}
 
+	layoutDescriptor.Kind = "render-footnote-link"
+	templ, templFound, err = p.s.Tmpl().LookupLayout(layoutDescriptor, f)
+	if err != nil {
+		return nil, err
+	}
+	if templFound {
+		renderers.FootnoteLinkRenderer = hookRenderer{
+			templateHandler: p.s.Tmpl(),
+			Provider:        templ.(tpl.Info),
+			templ:           templ,
+		}
+	}
+
+	layoutDescriptor.Kind = "render-footnotes"
+	templ, templFound, err = p.s.Tmpl().LookupLayout(layoutDescriptor, f)
+	if err != nil {
+		return nil, err
+	}
+	if templFound {
+		renderers.FootnotesRenderer = hookRenderer{
+			templateHandler: p.s.Tmpl(),
+			Provider:        templ.(tpl.Info),
+			templ:           templ,
+		}
+	}
+
 	return &renderers, nil
 }
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1706,6 +1706,14 @@ func (hr hookRenderer) RenderHeading(w io.Writer, ctx hooks.HeadingContext) erro
 	return hr.templateHandler.Execute(hr.templ, w, ctx)
 }
 
+func (hr hookRenderer) RenderFootnoteLink(w io.Writer, ctx hooks.FootnoteLinkContext) error {
+	return hr.templateHandler.Execute(hr.templ, w, ctx)
+}
+
+func (hr hookRenderer) RenderFootnotes(w io.Writer, ctx hooks.FootnotesContext) error {
+	return hr.templateHandler.Execute(hr.templ, w, ctx)
+}
+
 func (s *Site) renderForTemplate(name, outputFormat string, d interface{}, w io.Writer, templ tpl.Template) (err error) {
 	if templ == nil {
 		s.logMissingLayout(name, "", outputFormat)

--- a/markup/converter/hooks/hooks.go
+++ b/markup/converter/hooks/hooks.go
@@ -54,10 +54,40 @@ type HeadingRenderer interface {
 	identity.Provider
 }
 
+type FootnoteLinkContext interface {
+	Page() interface{}
+	Index() int
+}
+
+type FootnoteLinkRenderer interface {
+	RenderFootnoteLink(w io.Writer, ctx FootnoteLinkContext) error
+	identity.Provider
+}
+
+type FootnotesContext interface {
+	Page() interface{}
+	Footnotes() []FootnoteContext
+}
+
+type FootnoteContext interface {
+	Page() interface{}
+	Ref() string
+	Index() int
+	Text() string
+	PlainText() string
+}
+
+type FootnotesRenderer interface {
+	RenderFootnotes(w io.Writer, ctx FootnotesContext) error
+	identity.Provider
+}
+
 type Renderers struct {
-	LinkRenderer    LinkRenderer
-	ImageRenderer   LinkRenderer
-	HeadingRenderer HeadingRenderer
+	LinkRenderer         LinkRenderer
+	ImageRenderer        LinkRenderer
+	HeadingRenderer      HeadingRenderer
+	FootnoteLinkRenderer FootnoteLinkRenderer
+	FootnotesRenderer    FootnotesRenderer
 }
 
 func (r *Renderers) Eq(other interface{}) bool {

--- a/markup/goldmark/convert.go
+++ b/markup/goldmark/convert.go
@@ -22,6 +22,7 @@ import (
 	"runtime/debug"
 
 	"github.com/gohugoio/hugo/identity"
+	"github.com/gohugoio/hugo/markup/converter/hooks"
 
 	"github.com/pkg/errors"
 
@@ -195,8 +196,29 @@ func (b *bufWriter) Flush() error {
 
 type renderContext struct {
 	*bufWriter
-	pos int
+	pos       []int
+	footnotes []hooks.FootnoteContext
 	renderContextData
+}
+
+func (ctx *renderContext) pushPosition(pos int) {
+	ctx.pos = append(ctx.pos, pos)
+}
+
+func (ctx *renderContext) popPosition() int {
+	popped := ctx.pos[len(ctx.pos)-1]
+	ctx.pos = ctx.pos[:len(ctx.pos)-1]
+	return popped
+}
+
+func (ctx *renderContext) pushFootnote(footnote hooks.FootnoteContext) {
+	ctx.footnotes = append(ctx.footnotes, footnote)
+}
+
+func (ctx *renderContext) flushFootnotes() []hooks.FootnoteContext {
+	footnotes := ctx.footnotes
+	ctx.footnotes = nil
+	return footnotes
 }
 
 type renderContextData interface {


### PR DESCRIPTION
This pull request will allow footnote/endnote customization with Goldmark via the footnote extension render hooks Goldmark provides.

I simplified the Hugo-side render hooks API from what Goldmark exposes and made the way they work for the Hugo end user much more idiomatic in terms of Hugo. There are just two new render templates: footnote-link (the superscript index in flow) and footnotes (all the notes at the bottom, ranged over)

See #7291
See #6807
See #6804 

