### PR TITLE
deps: Update go-org to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/muesli/smartcrop v0.3.0
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/nicksnyder/go-i18n v1.10.0
-	github.com/niklasfasching/go-org v1.1.0
+	github.com/niklasfasching/go-org v1.2.0
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/nicksnyder/go-i18n v1.10.0 h1:5AzlPKvXBH4qBzmZ09Ua9Gipyruv6uApMcrNZdo96+Q=
 github.com/nicksnyder/go-i18n v1.10.0/go.mod h1:HrK7VCrbOvQoUAQ7Vpy7i87N7JZZZ7R2xBGjv0j365Q=
-github.com/niklasfasching/go-org v1.1.0 h1:4EQbzTGLhNoHU/G65ZYHwCYmrfL+W7laAuU+8WNhmIE=
-github.com/niklasfasching/go-org v1.1.0/go.mod h1:AsLD6X7djzRIz4/RFZu8vwRL0VGjUvGZCCH1Nz0VdrU=
+github.com/niklasfasching/go-org v1.2.0 h1:Bx495Vvb/KMdmvhSnbFiTySlG+x9OMMtVFXTjneuTwM=
+github.com/niklasfasching/go-org v1.2.0/go.mod h1:AsLD6X7djzRIz4/RFZu8vwRL0VGjUvGZCCH1Nz0VdrU=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=

--- a/markup/org/convert_test.go
+++ b/markup/org/convert_test.go
@@ -31,5 +31,5 @@ func TestConvert(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	b, err := conv.Convert(converter.RenderContext{Src: []byte("testContent")})
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(b.Bytes()), qt.Equals, "<p>\ntestContent\n</p>\n")
+	c.Assert(string(b.Bytes()), qt.Equals, "<p>testContent</p>\n")
 }


### PR DESCRIPTION
- Add support for #+MACRO
- fix a bug with #+LINK (edge case, should never happen anyways :TM:)
- Make title export optional (add export option)
- Remove cosmetic whitespace added by go-org (for easier visual
  diffing) inside p tags (`<p>\nfoo\n</p>` => `<p>foo</p>`)
  (should make `white-space: pre` on p look more in line with expectations)
- implement table separators via multiple tbodies (the html spec is ok with
  that)