### PR TITLE
Add support for native Org dates in frontmatter

### DIFF
--- a/parser/metadecoders/decoder.go
+++ b/parser/metadecoders/decoder.go
@@ -18,6 +18,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/gohugoio/hugo/common/herrors"
@@ -203,6 +204,14 @@ func (d Decoder) unmarshalCSV(data []byte, v interface{}) error {
 
 }
 
+func parseORGDate(s string) string {
+	r := regexp.MustCompile(`[<\[](\d{4}-\d{2}-\d{2}) .*[>\]]`)
+	if m := r.FindStringSubmatch(s); m != nil {
+		return m[1]
+	}
+	return s
+}
+
 func (d Decoder) unmarshalORG(data []byte, v interface{}) error {
 	config := org.New()
 	config.Log = jww.WARN
@@ -218,6 +227,8 @@ func (d Decoder) unmarshalORG(data []byte, v interface{}) error {
 		} else if k == "tags" || k == "categories" || k == "aliases" {
 			jww.WARN.Printf("Please use '#+%s[]:' notation, automatic conversion is deprecated.", k)
 			frontMatter[k] = strings.Fields(v)
+		} else if k == "date" {
+			frontMatter[k] = parseORGDate(v)
 		} else {
 			frontMatter[k] = v
 		}

--- a/parser/metadecoders/decoder_test.go
+++ b/parser/metadecoders/decoder_test.go
@@ -69,6 +69,7 @@ func TestUnmarshalToInterface(t *testing.T) {
 		{`[ "Brecker", "Blake", "Redman" ]`, JSON, []interface{}{"Brecker", "Blake", "Redman"}},
 		{`{ "a": "b" }`, JSON, expect},
 		{`#+a: b`, ORG, expect},
+		{`#+DATE: <2020-06-26 Fri>`, ORG, map[string]interface{}{"date": "2020-06-26"}},
 		{`a = "b"`, TOML, expect},
 		{`a: "b"`, YAML, expect},
 		{`a,b,c`, CSV, [][]string{{"a", "b", "c"}}},


### PR DESCRIPTION
When using Org mode with Hugo, it would be nice to have support for [Org timestamps](https://orgmode.org/manual/Timestamps.html) for the `DATE` header.

At the moment (hugo v0.72.0), `DATE` only supports Hugo's native syntax in Org files, therefore this is parsed correctly:
```
#+DATE: 2020-06-10
```

While this is not:
```
#+DATE: <2020-06-10 Wed>
```

### Expected result

Using the following template to format a page's `Date` attribute should produce the correct date:
```
{{ dateFormat "January 2, 2006" .Date }}
```

### Actual result
Output for `#+DATE: 2020-06-10`:
```
June 10, 2020
```

Output for `#+DATE: <2020-06-10 Wed>`:
```
January 1, 0001
```

Since Org mode defaults to the latter syntax, it would be great to have support for that in Hugo. Discussing this issue with @niklasfasching, he explained that this would fit better into Hugo than into go-org because of how Org frontmatter is handled by Hugo.

This pull request adds a simple parseORGDate function that does not touch the date value if it does not match an Org timestamp regexp, so that users who are currently using Hugo's native syntax do not experience any breakage.