### PR TITLE
Add support for Rollup JS asset bundling

### DIFF
--- a/resources/resource_transformers/rollup/rollup.go
+++ b/resources/resource_transformers/rollup/rollup.go
@@ -1,0 +1,163 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rollup
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gohugoio/hugo/common/hugo"
+	"github.com/gohugoio/hugo/resources/internal"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/gohugoio/hugo/common/herrors"
+	"github.com/gohugoio/hugo/hugofs"
+	"github.com/gohugoio/hugo/resources"
+	"github.com/gohugoio/hugo/resources/resource"
+	"github.com/pkg/errors"
+)
+
+// Options from https://rollupjs.io/docs/en/options TODO
+type Options struct {
+	Config string // Custom path to config file
+
+	Verbose bool
+}
+
+func DecodeOptions(m map[string]interface{}) (opts Options, err error) {
+	if m == nil {
+		return
+	}
+	err = mapstructure.WeakDecode(m, &opts)
+	return
+}
+func (opts Options) toArgs() []string {
+	var args []string
+
+	if !opts.Verbose {
+		args = append(args, "--silent")
+	}
+	return args
+}
+
+// Client is the client used to do Rollup transformations.
+type Client struct {
+	rs *resources.Spec
+}
+
+// New creates a new Client with the given specification.
+func New(rs *resources.Spec) *Client {
+	return &Client{rs: rs}
+}
+
+type rollupTransformation struct {
+	options Options
+	rs      *resources.Spec
+}
+
+func (t *rollupTransformation) Key() internal.ResourceTransformationKey {
+	return internal.NewResourceTransformationKey("rollup", t.options)
+}
+
+// Transform shells out to rollup to do the heavy lifting.
+func (t *rollupTransformation) Transform(ctx *resources.ResourceTransformationCtx) error {
+	const localRollupPath = "node_modules/.bin/"
+	const binaryName = "rollup"
+
+	// Try first in the project's node_modules.
+	csiBinPath := filepath.Join(t.rs.WorkingDir, localRollupPath, binaryName)
+
+	binary := csiBinPath
+
+	if _, err := exec.LookPath(binary); err != nil {
+		// Try PATH
+		binary = binaryName
+		if _, err := exec.LookPath(binary); err != nil {
+
+			// This may be on a CI server etc. Will fall back to pre-built assets.
+			return herrors.ErrFeatureNotAvailable
+		}
+	}
+
+	var configFile string
+	logger := t.rs.Logger
+
+	if t.options.Config != "" {
+		configFile = t.options.Config
+	} else {
+		configFile = "rollup.config.js"
+	}
+
+	configFile = filepath.Clean(configFile)
+
+	// We need an abolute filename to the config file.
+	if !filepath.IsAbs(configFile) {
+		// We resolve this against the virtual Work filesystem, to allow
+		// this config file to live in one of the themes if needed.
+		fi, err := t.rs.BaseFs.Work.Stat(configFile)
+		if err != nil {
+			if t.options.Config != "" {
+				// Only fail if the user specificed config file is not found.
+				return errors.Wrapf(err, "rollup config %q not found:", configFile)
+			}
+		} else {
+			configFile = fi.(hugofs.FileMetaInfo).Meta().Filename()
+		}
+	}
+
+	var cmdArgs []string
+
+	if configFile != "" {
+		logger.INFO.Println("rollup: use config file", configFile)
+		cmdArgs = []string{"-c", configFile}
+	}
+
+	if optArgs := t.options.toArgs(); len(optArgs) > 0 {
+		cmdArgs = append(cmdArgs, optArgs...)
+	}
+	cmdArgs = append(cmdArgs, "--input=-")
+
+	cmd := exec.Command(binary, cmdArgs...)
+
+	cmd.Stdout = ctx.To
+	cmd.Stderr = os.Stderr
+	cmd.Env = hugo.GetExecEnviron(t.rs.Cfg)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		defer stdin.Close()
+		io.Copy(stdin, ctx.From)
+	}()
+
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Process transforms the given Resource with the Rollup processor.
+func (c *Client) Process(res resources.ResourceTransformer, options Options) (resource.Resource, error) {
+	return res.Transform(
+		&rollupTransformation{rs: c.rs, options: options},
+	)
+}

--- a/resources/transform.go
+++ b/resources/transform.go
@@ -410,6 +410,8 @@ func (r *resourceAdapter) transform(publish, setContent bool) error {
 					errMsg = ". Check your Hugo installation; you need the extended version to build SCSS/SASS."
 				} else if tr.Key().Name == "babel" {
 					errMsg = ". You need to install Babel, see https://gohugo.io/hugo-pipes/babel/"
+				} else if tr.Key().Name == "rollup" {
+					errMsg = ". You need to install Rollup, see https://gohugo.io/hugo-pipes/rollup/"
 				}
 
 				return errors.New(msg + errMsg)

--- a/tpl/resources/init.go
+++ b/tpl/resources/init.go
@@ -65,6 +65,11 @@ func init() {
 			[][2]string{},
 		)
 
+		ns.AddMethodMapping(ctx.Rollup,
+			[]string{"rollup"},
+			[][2]string{},
+		)
+
 		return ns
 
 	}

--- a/tpl/resources/resources.go
+++ b/tpl/resources/resources.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gohugoio/hugo/resources/resource_transformers/integrity"
 	"github.com/gohugoio/hugo/resources/resource_transformers/minifier"
 	"github.com/gohugoio/hugo/resources/resource_transformers/postcss"
+	"github.com/gohugoio/hugo/resources/resource_transformers/rollup"
 	"github.com/gohugoio/hugo/resources/resource_transformers/templates"
 	"github.com/gohugoio/hugo/resources/resource_transformers/tocss/scss"
 	"github.com/spf13/cast"
@@ -64,6 +65,7 @@ func New(deps *deps.Deps) (*Namespace, error) {
 		postcssClient:   postcss.New(deps.ResourceSpec),
 		templatesClient: templates.New(deps.ResourceSpec, deps),
 		babelClient:     babel.New(deps.ResourceSpec),
+		rollupClient:    rollup.New(deps.ResourceSpec),
 	}, nil
 }
 
@@ -78,6 +80,7 @@ type Namespace struct {
 	minifyClient    *minifier.Client
 	postcssClient   *postcss.Client
 	babelClient     *babel.Client
+	rollupClient    *rollup.Client
 	templatesClient *templates.Client
 }
 
@@ -299,6 +302,25 @@ func (ns *Namespace) Babel(args ...interface{}) (resource.Resource, error) {
 	}
 
 	return ns.babelClient.Process(r, options)
+
+}
+
+// Rollup processes the given Resource with Rollup.
+func (ns *Namespace) Rollup(args ...interface{}) (resource.Resource, error) {
+	r, m, err := ns.resolveArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	var options rollup.Options
+	if m != nil {
+		options, err = rollup.DecodeOptions(m)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ns.rollupClient.Process(r, options)
 
 }
 


### PR DESCRIPTION
**Warning: This patch is not finished yet. The documentation still needs to be written, but submitting to get confirmation that there is interest in finishing this.**

This patch adds support for bundling JavaScript assets with [Rollup](https://rollupjs.org/guide/en/). 

If you want to use JavaScript on your website that uses external dependencies (or that is organized internally into separate files/modules), all the external dependencies need to be bundled into the final `.js` file. This is exactly what Rollup does. 

This plugin is used in the same way as the Babel plugin:

    {{ $script := resources.Get "myscript.js" | rollup | minify | fingerprint }}
    <script src="{{ $script.Permalink }}"></script>

Where `myscript.js` can contain external dependencies, that will be bundled in the final result:

    import $ from "jquery";
   
    $.ajax(....);

Can also be used with Babel earlier in the asset chain:

    {{ $script := resources.Get "myscript.js" | babel | rollup | minify | fingerprint }}
    <script src="{{ $script.Permalink }}"></script>

The implementation is almost exactly the same as the Babel resource processor. 

The current version of the patch works, but the documentation needs to be written. I didn't do this yet because I wasn't sure that there was interest in merging this.