### PR TITLE
Remove trailing hyphen from auto heading ID

### DIFF
--- a/markup/goldmark/autoid.go
+++ b/markup/goldmark/autoid.go
@@ -54,6 +54,8 @@ func sanitizeAnchorNameWithHook(b []byte, idType string, hook func(buf *bytes.Bu
 			b = text.RemoveAccents(b)
 		}
 
+		b = bytes.TrimSpace(b)
+
 		for len(b) > 0 {
 			r, size := utf8.DecodeRune(b)
 			switch {

--- a/markup/goldmark/autoid_test.go
+++ b/markup/goldmark/autoid_test.go
@@ -66,6 +66,9 @@ tabspace
 
 	testlines, expectlines := strings.Split(tests, "\n"), strings.Split(expect, "\n")
 
+	testlines = append(testlines, "Trailing Space ")
+	expectlines = append(expectlines, "trailing-space")
+
 	if len(testlines) != len(expectlines) {
 		panic("test setup failed")
 	}


### PR DESCRIPTION
Applicable when autoHeadingIDType is either `github` or `github-ascii`.

When autoHeadingIDType is `blackfriday`, the existing code removes
trailing whitespace while iterating through the characters, using
a boolean "futureDash" mechanism.

Fixes #6798