### PR TITLE
Fix broken fragment identifier on the Taxonomy Templates docs page

### DIFF
--- a/docs/content/en/templates/taxonomy-templates.md
+++ b/docs/content/en/templates/taxonomy-templates.md
@@ -25,7 +25,7 @@ Hugo includes support for user-defined groupings of content called **taxonomies*
 
 Hugo provides multiple ways to use taxonomies throughout your project templates:
 
-* Order the way content associated with a taxonomy term is displayed in a [taxonomy list template](#taxonomy-list-template)
+* Order the way content associated with a taxonomy term is displayed in a [taxonomy list template](#taxonomy-list-templates)
 * Order the way the terms for a taxonomy are displayed in a [taxonomy terms template](#taxonomy-terms-template)
 * List a single content's taxonomy terms within a [single page template][]
 


### PR DESCRIPTION
Small typo in docs caused a broken link to the "Taxonomy List Templates" section.

On https://gohugo.io/templates/taxonomy-templates/ the following text contains a broken link using a singular fragment identifier -- it should be plural: 

`Order the way content associated with a taxonomy term is displayed in a taxonomy list template` 
