### PR TITLE
Fix data race in templating code

### DIFF
--- a/tpl/internal/go_templates/texttemplate/exec.go
+++ b/tpl/internal/go_templates/texttemplate/exec.go
@@ -396,7 +396,7 @@ func (s *state) walkRange(dot reflect.Value, r *parse.RangeNode) {
 
 func (s *state) walkTemplate(dot reflect.Value, t *parse.TemplateNode) {
 	s.at(t)
-	tmpl := s.tmpl.tmpl[t.Name]
+	tmpl := s.tmpl.Lookup(t.Name)
 	if tmpl == nil {
 		s.errorf("template %q not defined", t.Name)
 	}

--- a/tpl/internal/go_templates/texttemplate/template.go
+++ b/tpl/internal/go_templates/texttemplate/template.go
@@ -124,6 +124,8 @@ func (t *Template) copy(c *common) *Template {
 // its definition. If it has been defined and already has that name, the existing
 // definition is replaced; otherwise a new template is created, defined, and returned.
 func (t *Template) AddParseTree(name string, tree *parse.Tree) (*Template, error) {
+	t.muFuncs.Lock()
+	defer t.muFuncs.Unlock()
 	t.init()
 	nt := t
 	if name != t.name {
@@ -182,6 +184,8 @@ func (t *Template) Lookup(name string) *Template {
 	if t.common == nil {
 		return nil
 	}
+	t.muFuncs.RLock()
+	defer t.muFuncs.RUnlock()
 	return t.tmpl[name]
 }
 


### PR DESCRIPTION
This should fix the concurrent map access crashes reported in #7293.

Changes:
* Use existing "muFunc" lock in Template.AddParseTree and Template.Lookup
* Call Template.Lookup from outside instead of accessing map directly

The additional lock doesn't appear to impact performance noticeably.