### PR TITLE
Remove last comma from schema.html template

### DIFF
--- a/tpl/tplimpl/embedded/templates/schema.html
+++ b/tpl/tplimpl/embedded/templates/schema.html
@@ -19,5 +19,5 @@
 {{ end }}{{ end }}{{ end }}
 
 <!-- Output all taxonomies as schema.org keywords -->
-<meta itemprop="keywords" content="{{ if .IsPage}}{{ range $index, $tag := .Params.tags }}{{ $tag }},{{ end }}{{ else }}{{ range $plural, $terms := .Site.Taxonomies }}{{ range $term, $val := $terms }}{{ printf "%s," $term }}{{ end }}{{ end }}{{ end }}" />
+<meta itemprop="keywords" content="{{ if .IsPage}}{{ with .Params.tags }}{{ delimit . "," }}{{ end }}{{ else }}{{ with .Site.Taxonomies }}{{ delimit . "," }}{{ end }}{{ end }}" />
 {{- end }}


### PR DESCRIPTION
With the introduction of delimit in #683 it is possible to use it
instead of range while also removing the last comma in keywords tag.