### PR TITLE
tpl: Add functions for hex encoding and secretbox encryption

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/yuin/goldmark-highlighting v0.0.0-20200307114337-60d527fdb691
 	go.opencensus.io v0.22.0 // indirect
 	gocloud.dev v0.15.0
+	golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd
 	golang.org/x/image v0.0.0-20191214001246-9130b4cfad52
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
 	golang.org/x/oauth2 v0.0.0-20190523182746-aaccbc9213b0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -426,6 +426,7 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd h1:sMHc2rZHuzQmrbVoSpt9HgerkXPyIeCSO6k0zUMGfFk=
 golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/image v0.0.0-20191214001246-9130b4cfad52 h1:2fktqPPvDiVEEVT/vSTeoUPXfmRxRaGy6GU8jypvEn0=

--- a/tpl/crypto/crypto.go
+++ b/tpl/crypto/crypto.go
@@ -69,7 +69,7 @@ func (ns *Namespace) SHA256(in interface{}) (string, error) {
 }
 
 // HMAC returns a cryptographic hash that uses a key to sign a message.
-func (ns *Namespace) HMAC(h interface{}, k interface{}, m interface{}) (string, error) {
+func (ns *Namespace) HMAC(h, k, m interface{}) (string, error) {
 	ha, err := cast.ToStringE(h)
 	if err != nil {
 		return "", err
@@ -105,5 +105,5 @@ func (ns *Namespace) HMAC(h interface{}, k interface{}, m interface{}) (string, 
 		return "", err
 	}
 
-	return hex.EncodeToString(mac.Sum(nil)[:]), nil
+	return hex.EncodeToString(mac.Sum(nil)), nil
 }

--- a/tpl/crypto/secretbox/init.go
+++ b/tpl/crypto/secretbox/init.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Hugo Authors. All rights reserved.
+// Copyright 2020 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,14 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crypto
+package secretbox
 
 import (
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/tpl/internal"
 )
 
-const name = "crypto"
+const name = "secretbox"
 
 func init() {
 	f := func(d *deps.Deps) *internal.TemplateFuncsNamespace {
@@ -29,32 +29,23 @@ func init() {
 			Context: func(args ...interface{}) interface{} { return ctx },
 		}
 
-		ns.AddMethodMapping(ctx.MD5,
-			[]string{"md5"},
+		ns.AddMethodMapping(ctx.Open,
+			nil,
 			[][2]string{
-				{`{{ md5 "Hello world, gophers!" }}`, `b3029f756f98f79e7f1b7f1d1f0dd53b`},
-				{`{{ crypto.MD5 "Hello world, gophers!" }}`, `b3029f756f98f79e7f1b7f1d1f0dd53b`},
+				{
+					`{{ secretbox.Open "KEY" (hexDecode "444f4e27542053454e442041204e4f4e434500000000000036f13ebda2c8537738c4958c367744f3c1b949c9872bb59e5f53706fd6ad") }}`,
+					`Secret Message`,
+				},
 			},
 		)
 
-		ns.AddMethodMapping(ctx.SHA1,
-			[]string{"sha1"},
+		ns.AddMethodMapping(ctx.Seal,
+			nil,
 			[][2]string{
-				{`{{ sha1 "Hello world, gophers!" }}`, `c8b5b0e33d408246e30f53e32b8f7627a7a649d4`},
-			},
-		)
-
-		ns.AddMethodMapping(ctx.SHA256,
-			[]string{"sha256"},
-			[][2]string{
-				{`{{ sha256 "Hello world, gophers!" }}`, `6ec43b78da9669f50e4e422575c54bf87536954ccd58280219c393f2ce352b46`},
-			},
-		)
-
-		ns.AddMethodMapping(ctx.HMAC,
-			[]string{"hmac"},
-			[][2]string{
-				{`{{ hmac "sha256" "Secret key" "Hello world, gophers!" }}`, `b6d11b6c53830b9d87036272ca9fe9d19306b8f9d8aa07b15da27d89e6e34f40`},
+				{
+					`{{ secretbox.Seal "KEY" "Secret Message" "DON'T SEND A NONCE" | hexEncode }}`,
+					`444f4e27542053454e442041204e4f4e434500000000000036f13ebda2c8537738c4958c367744f3c1b949c9872bb59e5f53706fd6ad`,
+				},
 			},
 		)
 

--- a/tpl/crypto/secretbox/init_test.go
+++ b/tpl/crypto/secretbox/init_test.go
@@ -1,0 +1,41 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretbox
+
+import (
+	"testing"
+
+	"github.com/gohugoio/hugo/deps"
+	"github.com/gohugoio/hugo/htesting/hqt"
+	"github.com/gohugoio/hugo/tpl/internal"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestInit(t *testing.T) {
+	c := qt.New(t)
+	var found bool
+	var ns *internal.TemplateFuncsNamespace
+
+	for _, nsf := range internal.TemplateFuncsNamespaceRegistry {
+		ns = nsf(&deps.Deps{})
+		if ns.Name == name {
+			found = true
+			break
+		}
+	}
+
+	c.Assert(found, qt.Equals, true)
+	c.Assert(ns.Context(), hqt.IsSameType, &Namespace{})
+}

--- a/tpl/crypto/secretbox/secretbox.go
+++ b/tpl/crypto/secretbox/secretbox.go
@@ -1,0 +1,111 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package secretbox provides template functions for NaCl secretbox operations.
+package secretbox
+
+import (
+	"crypto/rand"
+	"errors"
+	"io"
+
+	"github.com/spf13/cast"
+	"golang.org/x/crypto/nacl/secretbox"
+)
+
+// New returns a new instance of the secretbox-namespaced template functions.
+func New() *Namespace {
+	return &Namespace{}
+}
+
+// Namespace provides template functions for the "secretbox" namespace.
+type Namespace struct{}
+
+// Seal encrypts small messages using the NaCl secretbox framework.  The key and
+// message parameters are required.  The 24-byte nonce is prepended to the
+// resulting output.
+//
+// In normal use, the optional nonce parameter should not be used so that a
+// random 24-byte nonce will be generated for each encryption.
+func (ns *Namespace) Seal(key, message interface{}, nonce ...interface{}) (string, error) {
+	// Key
+	keyString, err := cast.ToStringE(key)
+	if err != nil {
+		return "", err
+	}
+
+	var secretKey [32]byte
+	copy(secretKey[:], keyString)
+
+	// Message
+	messageString, err := cast.ToStringE(message)
+	if err != nil {
+		return "", err
+	}
+
+	// Nonce - must be unique for each call
+	var nonceBytes [24]byte
+	if len(nonce) == 0 {
+		if _, err = io.ReadFull(rand.Reader, nonceBytes[:]); err != nil {
+			return "", err
+		}
+	} else {
+		// Message
+		var nonceString string
+
+		nonceString, err = cast.ToStringE(nonce[0])
+		if err != nil {
+			return "", err
+		}
+
+		copy(nonceBytes[:], nonceString)
+	}
+
+	res, err := secretbox.Seal(nonceBytes[:], []byte(messageString), &nonceBytes, &secretKey), nil
+	return string(res), err
+}
+
+// Open decrypts and authenticates small messages using the NaCl secretbox
+// framework. This implementation expects to find the 24-byte nonce at the
+// beginning of the box content.
+func (ns *Namespace) Open(key, box interface{}) (string, error) {
+	// Key
+	keyString, err := cast.ToStringE(key)
+	if err != nil {
+		return "", err
+	}
+
+	var secretKey [32]byte
+	copy(secretKey[:], keyString)
+
+	// Box
+	boxString, err := cast.ToStringE(box)
+	if err != nil {
+		return "", err
+	}
+
+	if len(boxString) < 32 {
+		return "", errors.New("invalid box parameter to secretbox.Open")
+	}
+
+	// Nonce - prepended to the encrypted payload
+	var nonce [24]byte
+	copy(nonce[:], boxString[:24])
+
+	decrypted, ok := secretbox.Open(nil, []byte(boxString[24:]), &nonce, &secretKey)
+	if !ok {
+		return "", nil
+	}
+
+	return string(decrypted), nil
+}

--- a/tpl/crypto/secretbox/secretbox_test.go
+++ b/tpl/crypto/secretbox/secretbox_test.go
@@ -1,0 +1,87 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretbox
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestSecretBox is a smoketest adapted from the upstream Go implementation to
+// confirm that our implementation matches the Go and C NaCl implementations.
+func TestSecretBox(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	var (
+		key     [32]byte
+		nonce   [24]byte
+		message [64]byte
+	)
+	for i := range key[:] {
+		key[i] = 1
+	}
+	for i := range nonce[:] {
+		nonce[i] = 2
+	}
+	for i := range message[:] {
+		message[i] = 3
+	}
+
+	box, err := ns.Seal(key[:], message[:], nonce[:])
+	c.Assert(err, qt.IsNil)
+
+	// expected was generated using the C implementation of NaCl.
+	expected, _ := hex.DecodeString("8442bc313f4626f1359e3b50122b6ce6fe66ddfe7d39d14e637eb4fd5b45beadab55198df6ab5368439792a23c87db70acb6156dc5ef957ac04f6276cf6093b84be77ff0849cc33e34b7254d5a8f65ad")
+
+	c.Check(box[len(nonce):], qt.Equals, string(expected))
+}
+
+func TestSecretBoxSealOpen(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	for i, test := range []struct {
+		key     interface{}
+		message interface{}
+		isErr   bool // use hex encoding
+	}{
+		{strings.Repeat("1", 32), strings.Repeat("1234567890", 4), false},
+		{[]byte{154, 211, 108, 22, 133, 234, 137, 218, 38, 238, 17, 2, 161, 77, 180, 178}, strings.Repeat("0987654321", 5), false},
+		// Errors
+		{"foo", t, true},
+	} {
+		errMsg := qt.Commentf("[%d] %v", i, test.key)
+
+		result, err := ns.Seal(test.key, test.message)
+
+		if test.isErr {
+			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			continue
+		}
+
+		c.Assert(err, qt.IsNil, errMsg)
+
+		dec, err := ns.Open(test.key, result)
+		c.Assert(err, qt.IsNil, errMsg)
+		c.Check(dec, qt.Equals, test.message, errMsg)
+	}
+}

--- a/tpl/encoding/encoding.go
+++ b/tpl/encoding/encoding.go
@@ -16,6 +16,7 @@ package encoding
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"html/template"
@@ -50,6 +51,27 @@ func (ns *Namespace) Base64Encode(content interface{}) (string, error) {
 	}
 
 	return base64.StdEncoding.EncodeToString([]byte(conv)), nil
+}
+
+// HexDecode returns the hex decoding of the given content.
+func (ns *Namespace) HexDecode(content interface{}) (string, error) {
+	conv, err := cast.ToStringE(content)
+	if err != nil {
+		return "", err
+	}
+
+	dec, err := hex.DecodeString(conv)
+	return string(dec), err
+}
+
+// HexEncode returns the hex encoding of the given content.
+func (ns *Namespace) HexEncode(content interface{}) (string, error) {
+	conv, err := cast.ToStringE(content)
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString([]byte(conv)), nil
 }
 
 // Jsonify encodes a given object to JSON.  To pretty print the JSON, pass a map

--- a/tpl/encoding/encoding_test.go
+++ b/tpl/encoding/encoding_test.go
@@ -37,7 +37,6 @@ func TestBase64Decode(t *testing.T) {
 		// errors
 		{t, false},
 	} {
-
 		result, err := ns.Base64Decode(test.v)
 
 		if b, ok := test.expect.(bool); ok && !b {
@@ -64,8 +63,59 @@ func TestBase64Encode(t *testing.T) {
 		// errors
 		{t, false},
 	} {
-
 		result, err := ns.Base64Encode(test.v)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}
+
+func TestHexDecode(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	for _, test := range []struct {
+		v      interface{}
+		expect interface{}
+	}{
+		{"616263313233213f242a262829272d3d407e", "abc123!?$*&()'-=@~"},
+		// errors
+		{t, false},
+	} {
+		result, err := ns.HexDecode(test.v)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}
+
+func TestHexEncode(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	for _, test := range []struct {
+		v      interface{}
+		expect interface{}
+	}{
+		{"YWJjMTIzIT8kKiYoKSctPUB+", "59574a6a4d54497a4954386b4b69596f4b5363745055422b"},
+		// errors
+		{t, false},
+	} {
+		result, err := ns.HexEncode(test.v)
 
 		if b, ok := test.expect.(bool); ok && !b {
 			c.Assert(err, qt.Not(qt.IsNil))

--- a/tpl/encoding/init.go
+++ b/tpl/encoding/init.go
@@ -44,6 +44,21 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.HexDecode,
+			[]string{"hexDecode"},
+			[][2]string{
+				{`{{ "48656c6c6f20776f726c64" | hexDecode }}`, `Hello world`},
+				{`{{ 42 | hexEncode | hexDecode }}`, `42`},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.HexEncode,
+			[]string{"hexEncode"},
+			[][2]string{
+				{`{{ "Hello world" | hexEncode }}`, `48656c6c6f20776f726c64`},
+			},
+		)
+
 		ns.AddMethodMapping(ctx.Jsonify,
 			[]string{"jsonify"},
 			[][2]string{

--- a/tpl/tplimpl/template_funcs.go
+++ b/tpl/tplimpl/template_funcs.go
@@ -19,22 +19,19 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/gohugoio/hugo/tpl"
-
 	"github.com/gohugoio/hugo/common/maps"
-
+	"github.com/gohugoio/hugo/deps"
+	"github.com/gohugoio/hugo/tpl"
+	"github.com/gohugoio/hugo/tpl/internal"
 	template "github.com/gohugoio/hugo/tpl/internal/go_templates/htmltemplate"
 	texttemplate "github.com/gohugoio/hugo/tpl/internal/go_templates/texttemplate"
-
-	"github.com/gohugoio/hugo/deps"
-
-	"github.com/gohugoio/hugo/tpl/internal"
 
 	// Init the namespaces
 	_ "github.com/gohugoio/hugo/tpl/cast"
 	_ "github.com/gohugoio/hugo/tpl/collections"
 	_ "github.com/gohugoio/hugo/tpl/compare"
 	_ "github.com/gohugoio/hugo/tpl/crypto"
+	_ "github.com/gohugoio/hugo/tpl/crypto/secretbox"
 	_ "github.com/gohugoio/hugo/tpl/data"
 	_ "github.com/gohugoio/hugo/tpl/debug"
 	_ "github.com/gohugoio/hugo/tpl/encoding"
@@ -90,7 +87,7 @@ func (t *templateExecHelper) GetMapValue(tmpl texttemplate.Preparer, receiver, k
 	return v, v.IsValid()
 }
 
-func (t *templateExecHelper) GetMethod(tmpl texttemplate.Preparer, receiver reflect.Value, name string) (method reflect.Value, firstArg reflect.Value) {
+func (t *templateExecHelper) GetMethod(tmpl texttemplate.Preparer, receiver reflect.Value, name string) (method, firstArg reflect.Value) {
 	// This is a hot path and receiver.MethodByName really shows up in the benchmarks.
 	// Page.Render is the only method with a WithTemplateInfo as of now, so let's just
 	// check that for now.
@@ -142,7 +139,6 @@ func newTemplateExecuter(d *deps.Deps) (texttemplate.Executer, map[string]reflec
 }
 
 func createFuncMap(d *deps.Deps) map[string]interface{} {
-
 	funcMap := template.FuncMap{}
 
 	// Merge the namespace funcs
@@ -169,5 +165,4 @@ func createFuncMap(d *deps.Deps) map[string]interface{} {
 	}
 
 	return funcMap
-
 }


### PR DESCRIPTION
Add a new hexEncode and hexDecode to the encoding namespace.

Add a new secretbox namespace (under crypto) for nacl secretbox
operations, Seal and Open.

Updates #7547