### PR TITLE
js.Build: Add SourceMap flag into js.Build opts which can turn on sourcemap.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/jdkato/prose v1.1.1
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/kyokomi/emoji v2.2.1+incompatible
-	github.com/magefile/mage v1.9.0
+	github.com/magefile/mage v1.10.0
 	github.com/markbates/inflect v1.0.0
 	github.com/mattn/go-isatty v0.0.12
 	github.com/miekg/mmark v1.3.6

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,7 @@ github.com/evanw/esbuild v0.6.2 h1:pp33TIPgiHCtKL/gMW/V/PFHWNx/5cDTqbJHqAiy0jg=
 github.com/evanw/esbuild v0.6.2/go.mod h1:mptxmSXIzBIKKCe4jo9A5SToEd1G+AKZ9JmY85dYRJ0=
 github.com/evanw/esbuild v0.6.5 h1:jVUDkQKOX9srwt/mUlvIba0/jmH46+B5wfwh0pWW7BM=
 github.com/evanw/esbuild v0.6.5/go.mod h1:mptxmSXIzBIKKCe4jo9A5SToEd1G+AKZ9JmY85dYRJ0=
+github.com/evanw/esbuild v0.6.28 h1:sTJdvTB8WCSp9N5a+T18Fw3a5So76qHQJHwYNhy0Z/c=
 github.com/fortytw2/leaktest v1.2.0 h1:cj6GCiwJDH7l3tMHLjZDo0QqPtrXJiWSI9JgpeQKw+Q=
 github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
@@ -240,6 +241,8 @@ github.com/kyokomi/emoji v2.2.1+incompatible/go.mod h1:mZ6aGCD7yk8j6QY6KICwnZ2px
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magefile/mage v1.9.0 h1:t3AU2wNwehMCW97vuqQLtw6puppWXHO+O2MHo5a50XE=
 github.com/magefile/mage v1.9.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
+github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=

--- a/resources/resource_transformers/js/build.go
+++ b/resources/resource_transformers/js/build.go
@@ -222,9 +222,9 @@ func toBuildOptions(opts Options) (buildOptions api.BuildOptions, err error) {
 
 	var sourceMap api.SourceMap
 	switch opts.SourceMap {
-	case "inline", "1":
+	case "inline":
 		sourceMap = api.SourceMapInline
-	case "", "0":
+	case "":
 		sourceMap = api.SourceMapNone
 	default:
 		err = fmt.Errorf("unsupported sourcemap type: %q", opts.SourceMap)

--- a/resources/resource_transformers/js/build.go
+++ b/resources/resource_transformers/js/build.go
@@ -42,6 +42,9 @@ type Options struct {
 	// Whether to minify to output.
 	Minify bool
 
+	// Whether to write mapfiles (currently inline only)
+	SourceMap string
+
 	// The language target.
 	// One of: es2015, es2016, es2017, es2018, es2019, es2020 or esnext.
 	// Default is esnext.
@@ -217,12 +220,24 @@ func toBuildOptions(opts Options) (buildOptions api.BuildOptions, err error) {
 		defines = cast.ToStringMapString(opts.Defines)
 	}
 
+	var sourceMap api.SourceMap
+	switch opts.SourceMap {
+	case "inline", "1":
+		sourceMap = api.SourceMapInline
+	case "", "0":
+		sourceMap = api.SourceMapNone
+	default:
+		err = fmt.Errorf("unsupported sourcemap type: %q", opts.SourceMap)
+		return
+	}
+
 	buildOptions = api.BuildOptions{
 		Outfile: "",
 		Bundle:  true,
 
-		Target: target,
-		Format: format,
+		Target:    target,
+		Format:    format,
+		Sourcemap: sourceMap,
 
 		MinifyWhitespace:  opts.Minify,
 		MinifyIdentifiers: opts.Minify,

--- a/resources/resource_transformers/js/build_test.go
+++ b/resources/resource_transformers/js/build_test.go
@@ -63,4 +63,18 @@ func TestToBuildOptions(t *testing.T) {
 		Stdin:             &api.StdinOptions{},
 	})
 
+	opts, err = toBuildOptions(Options{
+		Target: "es2018", Format: "cjs", Minify: true, mediaType: media.JavascriptType,
+		SourceMap: "inline"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(opts, qt.DeepEquals, api.BuildOptions{
+		Bundle:            true,
+		Target:            api.ES2018,
+		Format:            api.FormatCommonJS,
+		MinifyIdentifiers: true,
+		MinifySyntax:      true,
+		MinifyWhitespace:  true,
+		Sourcemap:         api.SourceMapInline,
+		Stdin:             &api.StdinOptions{},
+	})
 }


### PR DESCRIPTION
Added inline source map support to allow debugging during "development".
It's not quite able to send source map into .js.map files but makes debugging a lot easier.
Example:
![image](https://user-images.githubusercontent.com/708186/91708248-11b15700-eb4f-11ea-9556-36dcaa63426b.png)

I didn't want to attach this directly to 7504 because there were additional discussions about code splitting to enable external map files; so I pushed it as the #7607 duplicate.
It's a rather simple addition but would really help to develop javascript since you can use the chrome editor by mapping files.