### PR TITLE
fix: Links are not crawlable

### DIFF
--- a/tpl/tplimpl/embedded/templates/pagination.html
+++ b/tpl/tplimpl/embedded/templates/pagination.html
@@ -7,7 +7,7 @@
   </li>
   {{ end -}}
   <li class="page-item{{ if not $pag.HasPrev }} disabled{{ end }}">
-    <a {{ if $pag.HasPrev }}href="{{ $pag.Prev.URL }}"{{ end }} class="page-link" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
+    <a href="{{ if $pag.HasPrev }}{{ $pag.Prev.URL }}{{ else }}#{{ end }}" class="page-link" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
   </li>
   {{- $ellipsed := false -}}
   {{- $shouldEllipse := false -}}
@@ -33,7 +33,7 @@
   {{- end -}}
   {{- end }}
   <li class="page-item{{ if not $pag.HasNext }} disabled{{ end }}">
-    <a {{ if $pag.HasNext }}href="{{ $pag.Next.URL }}"{{ end }} class="page-link" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
+    <a href="{{ if $pag.HasNext }}{{ $pag.Next.URL }}{{ else }}#{{ end }}" class="page-link" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
   </li>
   {{- with $pag.Last }}
   <li class="page-item">


### PR DESCRIPTION
Google Lighthouse

Links are not crawlable 

Search engines may use `href` attributes on links to crawl websites. Ensure that the `href` attribute of anchor elements links to an appropriate destination, so more pages of the site can be discovered.

Uncrawlable Link

```
<a class="page-link" aria-label="Previous">
```
