### PR TITLE
Escape `&` in livereload injected code

### DIFF
--- a/transform/livereloadinject/livereloadinject.go
+++ b/transform/livereloadinject/livereloadinject.go
@@ -59,7 +59,7 @@ func New(port int) transform.Transformer {
 			return err
 		}
 
-		script := []byte(fmt.Sprintf(`<script src="/livereload.js?port=%d&mindelay=10&v=2" data-no-instant defer></script>`, port))
+		script := []byte(fmt.Sprintf(`<script src="/livereload.js?port=%d&amp;mindelay=10&amp;v=2" data-no-instant defer></script>`, port))
 
 		i := idx
 		if match.appendScript {

--- a/transform/livereloadinject/livereloadinject_test.go
+++ b/transform/livereloadinject/livereloadinject_test.go
@@ -25,7 +25,7 @@ import (
 func TestLiveReloadInject(t *testing.T) {
 	c := qt.New(t)
 
-	expectBase := `<script src="/livereload.js?port=1313&mindelay=10&v=2" data-no-instant defer></script>`
+	expectBase := `<script src="/livereload.js?port=1313&amp;mindelay=10&amp;v=2" data-no-instant defer></script>`
 	apply := func(s string) string {
 		out := new(bytes.Buffer)
 		in := strings.NewReader(s)


### PR DESCRIPTION
Whilst potentially valid for HTML5 under certain conditions, URLs should be encoded properly. This PR changes 
`<script src="/livereload.js?port=%d&mindelay=10&v=2" data-no-instant defer></script>` to 
`<script src="/livereload.js?port=%d&amp;mindelay=10&amp;v=2" data-no-instant defer></script>`
