### PR TITLE
markup/asciidocext: Fix AsciiDoc TOC with code

### DIFF
--- a/docs/content/en/content-management/formats.md
+++ b/docs/content/en/content-management/formats.md
@@ -49,7 +49,7 @@ tool on your machine to be able to use these formats.
 
 Hugo passes reasonable default arguments to these external helpers by default:
 
-- `asciidoctor`: `--no-header-footer --trace -`
+- `asciidoctor`: `--no-header-footer -`
 - `rst2html`: `--leave-comments --initial-header-level=2`
 - `pandoc`: `--mathjax`
 
@@ -81,7 +81,7 @@ noheaderorfooter | true | Output an embeddable document, which excludes the head
 safemode | `unsafe` | Safe mode level `unsafe`, `safe`, `server` or `secure`. Don't change this unless you know what you are doing.
 sectionnumbers | `false` | Auto-number section titles.
 verbose | `false` | Verbosely print processing information and configuration file checks to stderr.
-trace | `true` | Include backtrace information on errors.
+trace | `false` | Include backtrace information on errors.
 failurelevel | `fatal` | The minimum logging level that triggers a non-zero exit code (failure).
 workingfoldercurrent | `false` | Set the working folder to the rendered `adoc` file, so [include](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files) will work with relative paths. This setting uses the `asciidoctor` cli parameter `--base-dir` and attribute `outdir=`. For rendering [asciidoctor-diagram](https://asciidoctor.org/docs/asciidoctor-diagram/)  `workingfoldercurrent` must be set to `true`.
 

--- a/docs/content/en/content-management/toc.md
+++ b/docs/content/en/content-management/toc.md
@@ -92,11 +92,11 @@ The following is a [partial template][partials] that adds slightly more logic fo
 With the preceding example, even pages with > 400 words *and* `toc` not set to `false` will not render a table of contents if there are no headings in the page for the `{{.TableOfContents}}` variable to pull from.
 {{% /note %}}
 
-## Usage with asciidoc
+## Usage with AsciiDoc
 
-Hugo supports table of contents with Asciidoc content format.
+Hugo supports table of contents with AsciiDoc content format.
 
-In the header of your content file, specify the Asciidoc TOC directives, by using the macro style:
+In the header of your content file, specify the AsciiDoc TOC directives, by using the macro or auto style:
 
 ```asciidoc
 // <!-- Your front matter up here -->
@@ -117,7 +117,7 @@ He lay on his armour-like back, and if he lifted his head a little he could see 
 
 A collection of textile samples lay spread out on the table - Samsa was a travelling salesman - and above it there hung a picture that he had recently cut out of an illustrated magazine and housed in a nice, gilded frame. It showed a lady fitted out with a fur hat and fur boa who sat upright, raising a heavy fur muff that covered the whole of her lower arm towards the viewer. Gregor then turned to look out the window at the dull weather. Drops
 ```
-Hugo will take this Asciddoc and create a table of contents store it in the page variable `.TableOfContents`, in the same as described for Markdown.
+Hugo will take this AsciiDoc and create a table of contents store it in the page variable `.TableOfContents`, in the same as described for Markdown.
 
 [conditionals]: /templates/introduction/#conditionals
 [front matter]: /content-management/front-matter/

--- a/markup/tableofcontents/tableofcontents.go
+++ b/markup/tableofcontents/tableofcontents.go
@@ -40,19 +40,19 @@ type Root struct {
 }
 
 // AddAt adds the header into the given location.
-func (toc *Root) AddAt(h Header, y, x int) {
-	for i := len(toc.Headers); i <= y; i++ {
+func (toc *Root) AddAt(h Header, row, level int) {
+	for i := len(toc.Headers); i <= row; i++ {
 		toc.Headers = append(toc.Headers, Header{})
 	}
 
-	if x == 0 {
-		toc.Headers[y] = h
+	if level == 0 {
+		toc.Headers[row] = h
 		return
 	}
 
-	header := &toc.Headers[y]
+	header := &toc.Headers[row]
 
-	for i := 1; i < x; i++ {
+	for i := 1; i < level; i++ {
 		if len(header.Headers) == 0 {
 			header.Headers = append(header.Headers, Header{})
 		}


### PR DESCRIPTION
Running this adoc (https://asciidoctor.org/docs/install-toolchain/) through Hugo with Hugo Learn Theme, currently produces:

![old_toc](https://user-images.githubusercontent.com/2981969/92661566-cc321e00-f2f4-11ea-8c28-60fb7bcf1b05.png)

With this PR:

![new_toc](https://user-images.githubusercontent.com/2981969/92661576-d05e3b80-f2f4-11ea-956a-c38bd4464a8d.png)

Fixes #7649