### PR TITLE
tpl: Added simple addition to show layout name

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1721,7 +1721,7 @@ func (hr hookRenderer) RenderHeading(w io.Writer, ctx hooks.HeadingContext) erro
 
 func (s *Site) renderForTemplate(name, outputFormat string, d interface{}, w io.Writer, templ tpl.Template) (err error) {
 	if templ == nil {
-		s.logMissingLayout(name, "", outputFormat)
+		s.logMissingLayout(name, "", "", outputFormat)
 		return nil
 	}
 

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -130,7 +130,7 @@ func pageRenderer(
 		}
 
 		if !found {
-			s.logMissingLayout("", p.Kind(), p.f.Name)
+			s.logMissingLayout("", p.Layout(), p.Kind(), p.f.Name)
 			continue
 		}
 
@@ -148,7 +148,7 @@ func pageRenderer(
 	}
 }
 
-func (s *Site) logMissingLayout(name, kind, outputFormat string) {
+func (s *Site) logMissingLayout(name, layout, kind, outputFormat string) {
 	log := s.Log.WARN
 	if name != "" && infoOnMissingLayout[name] {
 		log = s.Log.INFO
@@ -160,6 +160,11 @@ func (s *Site) logMissingLayout(name, kind, outputFormat string) {
 	if outputFormat != "" {
 		msg += " %q"
 		args = append(args, outputFormat)
+	}
+
+	if layout != "" {
+		msg += " for layout %q"
+		args = append(args, layout)
 	}
 
 	if kind != "" {


### PR DESCRIPTION
if the layout name was specified on the page or section then show it as part of the missing template warning.

Ref: #7617
