### PR TITLE
tpl: Add indexIn function into templates

### DIFF
--- a/tpl/internal/go_templates/texttemplate/funcs.go
+++ b/tpl/internal/go_templates/texttemplate/funcs.go
@@ -211,6 +211,12 @@ func indexIn(item reflect.Value, indexSlice reflect.Value) (reflect.Value, error
 	}
 	indexes := make([]reflect.Value, 0)
 	switch indexSlice.Kind() {
+	case reflect.String:
+		str := indexSlice.String()
+		slice := strings.Split(str, ".")
+		for _, arg := range slice {
+			indexes = append(indexes, reflect.ValueOf(arg))
+		}
 	case reflect.Array, reflect.Slice:
 		intf := indexSlice.Interface()
 		slice, ok := intf.([]interface{})


### PR DESCRIPTION
The indexIn function is similar to index, but uses a slice
as the last arg to supply the path within the document.
Ref #7618