### PR TITLE
markup/highlight: Add support to linkable line anchors on Chroma

### DIFF
--- a/docs/content/en/content-management/syntax-highlighting.md
+++ b/docs/content/en/content-management/syntax-highlighting.md
@@ -43,6 +43,8 @@ Options:
 * `linenos`: configure line numbers. Valid values are `true`, `false`, `table`, or `inline`. `false` will turn off line numbers if it's configured to be on in site config. {{< new-in "0.60.0" >}} `table` will give copy-and-paste friendly code blocks.
 * `hl_lines`: lists a set of line numbers or line number ranges to be highlighted.
 * `linenostart=199`: starts the line number count from 199.
+* `anchorlinenos`: Configure anchors on line numbers. Valid values are `true` or `false`;
+* `lineanchors`: Configure a prefix for the anchors on line numbers. Will be suffixed with `-`, so linking to the line number 1 with the option `lineanchors=prefix` adds the anchor `prefix-1` to the page.  
 
 ### Example: Highlight Shortcode
 

--- a/markup/highlight/config.go
+++ b/markup/highlight/config.go
@@ -50,6 +50,10 @@ type Config struct {
 	LineNos            bool
 	LineNumbersInTable bool
 
+	// When set, add links to line numbers
+	AnchorLineNos bool
+	LineAnchors string
+
 	// Start the line numbers from this value (default is 1).
 	LineNoStart int
 
@@ -60,15 +64,21 @@ type Config struct {
 	TabWidth int
 
 	GuessSyntax bool
+
 }
 
 func (cfg Config) ToHTMLOptions() []html.Option {
+	var lineAnchors string
+	if cfg.LineAnchors != "" {
+		lineAnchors = cfg.LineAnchors+"-"
+	}
 	var options = []html.Option{
 		html.TabWidth(cfg.TabWidth),
 		html.WithLineNumbers(cfg.LineNos),
 		html.BaseLineNumber(cfg.LineNoStart),
 		html.LineNumbersInTable(cfg.LineNumbersInTable),
 		html.WithClasses(!cfg.NoClasses),
+		html.LinkableLineNumbers(cfg.AnchorLineNos, lineAnchors),
 	}
 
 	if cfg.Hl_Lines != "" {

--- a/markup/highlight/config.go
+++ b/markup/highlight/config.go
@@ -52,7 +52,7 @@ type Config struct {
 
 	// When set, add links to line numbers
 	AnchorLineNos bool
-	LineAnchors string
+	LineAnchors   string
 
 	// Start the line numbers from this value (default is 1).
 	LineNoStart int
@@ -64,13 +64,12 @@ type Config struct {
 	TabWidth int
 
 	GuessSyntax bool
-
 }
 
 func (cfg Config) ToHTMLOptions() []html.Option {
 	var lineAnchors string
 	if cfg.LineAnchors != "" {
-		lineAnchors = cfg.LineAnchors+"-"
+		lineAnchors = cfg.LineAnchors + "-"
 	}
 	var options = []html.Option{
 		html.TabWidth(cfg.TabWidth),

--- a/markup/highlight/highlight_test.go
+++ b/markup/highlight/highlight_test.go
@@ -79,6 +79,21 @@ User-Agent: foo
 		c.Assert(result, qt.Not(qt.Contains), "class=\"lnt\"")
 	})
 
+	c.Run("Highlight lines, linenumbers default on, anchorlinenumbers default on", func(c *qt.C) {
+		cfg := DefaultConfig
+		cfg.NoClasses = false
+		cfg.LineNos = true
+		cfg.AnchorLineNos = true
+		h := New(cfg)
+
+		result, _ := h.Highlight(lines, "bash", "")
+		c.Assert(result, qt.Contains, "<span class=\"lnt\" id=\"2\">2\n</span>")
+		result, _ = h.Highlight(lines, "bash", "lineanchors=test")
+		c.Assert(result, qt.Contains, "<span class=\"lnt\" id=\"test-2\">2\n</span>")
+		result, _ = h.Highlight(lines, "bash", "anchorlinenos=false,hl_lines=2")
+		c.Assert(result, qt.Not(qt.Contains), "id=\"2\"")
+	})
+
 	c.Run("Highlight lines, linenumbers default on, linenumbers in table default off", func(c *qt.C) {
 		cfg := DefaultConfig
 		cfg.NoClasses = false


### PR DESCRIPTION
Fix #7622 by adding support to the same options that Pygments supported, but now in Chroma. :) 