### PR TITLE
added info on running hugo after build by go

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ If you want to compile with Sass/SCSS support use `--tags extended` and make sur
 CGO_ENABLED=1 go install --tags extended
 ```
 
+#### Run Hugo
+By default, go will put the compiled program into the `bin` subdirectory of `$GOPATH`, which on a Unix/Linux system is generally `$HOME/go/bin`. Hugo can then be run right from that directory, or can be copied or moved elsewhere.
+
 ## The Hugo Documentation
 
 The Hugo documentation now lives in its own repository, see https://github.com/gohugoio/hugoDocs. But we do keep a version of that documentation as a `git subtree` in this repository. To build the sub folder `/docs` as a Hugo site, you need to clone this repo:


### PR DESCRIPTION
See issue for more details.
Added a short paragraph to README.md detailing where to find the hugo executable after building with `go install`.