### PR TITLE
fix: Add ability for plainify to remove <style> and <script>

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -119,6 +119,38 @@ func StripHTML(s string) string {
 	}
 	s = stripHTMLReplacer.Replace(s)
 
+	for _, value := range []string{"script", "style"} {
+		startTag := "<" + value
+		endTag := "</" + value + ">"
+
+		start := strings.Index(s, startTag)
+		if start >= 0 {
+
+			result := make([]byte, start, len(s))
+			copy(result, s)
+
+			for {
+				end := strings.Index(s[start+len(startTag):], endTag)
+				if end < 0 {
+					result = append(result, s[start:]...)
+					break
+				}
+				end += (start + len(startTag)) + len(endTag)
+
+				start = strings.Index(s[end:], startTag)
+				if start < 0 {
+					result = append(result, s[end:]...)
+					break
+				}
+				start += end
+
+				result = append(result, s[end:start]...)
+			}
+
+			s = string(result)
+		}
+	}
+
 	// Walk through the string removing all tags
 	b := bp.GetBuffer()
 	defer bp.PutBuffer(b)
@@ -146,44 +178,6 @@ func StripHTML(s string) string {
 
 	}
 	return b.String()
-}
-
-// StripTag accepts a string, strips out the given tag and all of its contents and returns a string.
-func StripTag(in string, tag string) string {
-	if len(tag) == 0 {
-		return in
-	}
-
-	startTag := "<" + tag
-	endTag := "</" + tag + ">"
-
-	start := strings.Index(in, startTag)
-	if start < 0 {
-		return in
-	}
-
-	result := make([]byte, start, len(in))
-	copy(result, in)
-
-	for {
-		end := strings.Index(in[start+len(startTag):], endTag)
-		if end < 0 {
-			result = append(result, in[start:]...)
-			break
-		}
-		end += (start + len(startTag)) + len(endTag)
-
-		start = strings.Index(in[end:], startTag)
-		if start < 0 {
-			result = append(result, in[end:]...)
-			break
-		}
-		start += end
-
-		result = append(result, in[end:start]...)
-	}
-
-	return string(result)
 }
 
 // stripEmptyNav strips out empty <nav> tags from content.

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -148,6 +148,44 @@ func StripHTML(s string) string {
 	return b.String()
 }
 
+// StripTag accepts a string, strips out the given tag and all of its contents and returns a string.
+func StripTag(in string, tag string) string {
+	if len(tag) == 0 {
+		return in
+	}
+
+	startTag := "<" + tag
+	endTag := "</" + tag + ">"
+
+	start := strings.Index(in, startTag)
+	if start < 0 {
+		return in
+	}
+
+	result := make([]byte, start, len(in))
+	copy(result, in)
+
+	for {
+		end := strings.Index(in[start+len(startTag):], endTag)
+		if end < 0 {
+			result = append(result, in[start:]...)
+			break
+		}
+		end += (start + len(startTag)) + len(endTag)
+
+		start = strings.Index(in[end:], startTag)
+		if start < 0 {
+			result = append(result, in[end:]...)
+			break
+		}
+		start += end
+
+		result = append(result, in[end:start]...)
+	}
+
+	return string(result)
+}
+
 // stripEmptyNav strips out empty <nav> tags from content.
 func stripEmptyNav(in []byte) []byte {
 	return bytes.Replace(in, []byte("<nav>\n</nav>\n\n"), []byte(``), -1)

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -28,7 +28,7 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
-const tstHTMLContent = "<!DOCTYPE html><html><head><script src=\"http://two/foobar.js\"></script></head><body><nav><ul><li hugo-nav=\"section_0\"></li><li hugo-nav=\"section_1\"></li></ul></nav><article>content <a href=\"http://two/foobar\">foobar</a>. Follow up</article><p>This is some text.<br>And some more.</p></body></html>"
+const tstHTMLContent = "<!DOCTYPE html><html><head><script src=\"http://two/foobar.js\"></script><style>p { color:#ff000; }</style></head><body><nav><ul><li hugo-nav=\"section_0\"></li><li hugo-nav=\"section_1\"></li></ul></nav><article>content <a href=\"http://two/foobar\">foobar</a>. Follow up</article><p>This is some text.<br>And some more.</p><script>alert('test');</script></body></html>"
 
 func TestTrimShortHTML(t *testing.T) {
 	tests := []struct {
@@ -63,6 +63,9 @@ func TestStripHTML(t *testing.T) {
 		{"</br> strip br<br>", " strip br\n"},
 		{"</br> strip br2<br />", " strip br2\n"},
 		{"This <strong>is</strong> a\nnewline", "This is a newline"},
+		{"Test one <script>alert('test');</script>here", "Test one here"},
+		{"Test two <style>p { color:#ff000; }</style>here", "Test two here"},
+		{"Test strip script and style <script>alert('test');</script><style>p { color:#ff000; }</style>here", "Test strip script and style here"},
 		{"No Tags", "No Tags"},
 		{`<p>Summary Next Line.
 <figure >
@@ -88,32 +91,6 @@ func BenchmarkStripHTML(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		StripHTML(tstHTMLContent)
-	}
-}
-
-func TestStripTag(t *testing.T) {
-	type test struct {
-		input, expected, tag string
-	}
-	data := []test{
-		{"Test one <script>alert('test');</script>here", "Test one here", "script"},
-		{"Test two <style>p { color:#ff000; }</style>here", "Test two here", "style"},
-		{"Test strip script not style <script>alert('test');</script><style>p { color:#ff000; }</style>here", "Test strip script not style <style>p { color:#ff000; }</style>here", "script"},
-		{"No Tags", "No Tags", "script"},
-	}
-
-	for i, d := range data {
-		output := StripTag(d.input, d.tag)
-		if d.expected != output {
-			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
-		}
-	}
-}
-
-func BenchmarkStripTag(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		StripTag(tstHTMLContent, "script")
 	}
 }
 

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -91,6 +91,32 @@ func BenchmarkStripHTML(b *testing.B) {
 	}
 }
 
+func TestStripTag(t *testing.T) {
+	type test struct {
+		input, expected, tag string
+	}
+	data := []test{
+		{"Test one <script>alert('test');</script>here", "Test one here", "script"},
+		{"Test two <style>p { color:#ff000; }</style>here", "Test two here", "style"},
+		{"Test strip script not style <script>alert('test');</script><style>p { color:#ff000; }</style>here", "Test strip script not style <style>p { color:#ff000; }</style>here", "script"},
+		{"No Tags", "No Tags", "script"},
+	}
+
+	for i, d := range data {
+		output := StripTag(d.input, d.tag)
+		if d.expected != output {
+			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
+		}
+	}
+}
+
+func BenchmarkStripTag(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		StripTag(tstHTMLContent, "script")
+	}
+}
+
 func TestStripEmptyNav(t *testing.T) {
 	c := qt.New(t)
 	cleaned := stripEmptyNav([]byte("do<nav>\n</nav>\n\nbedobedo"))

--- a/resources/page/page_marshaljson.autogen.go
+++ b/resources/page/page_marshaljson.autogen.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/hugofs/files"
+	"github.com/gohugoio/hugo/identity"
 	"github.com/gohugoio/hugo/langs"
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/navigation"
@@ -87,6 +88,7 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 	isTranslated := p.IsTranslated()
 	allTranslations := p.AllTranslations()
 	translations := p.Translations()
+	getIdentity := p.GetIdentity()
 
 	s := struct {
 		Content                  interface{}
@@ -143,6 +145,7 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 		IsTranslated             bool
 		AllTranslations          Pages
 		Translations             Pages
+		GetIdentity              identity.Identity
 	}{
 		Content:                  content,
 		Plain:                    plain,
@@ -198,6 +201,7 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 		IsTranslated:             isTranslated,
 		AllTranslations:          allTranslations,
 		Translations:             translations,
+		GetIdentity:              getIdentity,
 	}
 
 	return json.Marshal(&s)

--- a/tpl/transform/transform.go
+++ b/tpl/transform/transform.go
@@ -116,5 +116,8 @@ func (ns *Namespace) Plainify(s interface{}) (string, error) {
 		return "", err
 	}
 
+	ss = helpers.StripTag(ss, "script")
+	ss = helpers.StripTag(ss, "style")
+
 	return helpers.StripHTML(ss), nil
 }

--- a/tpl/transform/transform.go
+++ b/tpl/transform/transform.go
@@ -116,8 +116,5 @@ func (ns *Namespace) Plainify(s interface{}) (string, error) {
 		return "", err
 	}
 
-	ss = helpers.StripTag(ss, "script")
-	ss = helpers.StripTag(ss, "style")
-
 	return helpers.StripHTML(ss), nil
 }


### PR DESCRIPTION
Added StripTag helper function to allow the ability to remove any tag and all
of its contents from a string.  Leveraged that new function within the plainify
function to remove <style> and <script> tags and contents.

Fixes #3235