### PR TITLE
tpl: Added Google Analytics GTM (gtag.js) internal template

### DIFF
--- a/config/privacy/privacyConfig.go
+++ b/config/privacy/privacyConfig.go
@@ -53,6 +53,15 @@ type GoogleAnalytics struct {
 
 	// Enabling this will make it so the users' IP addresses are anonymized within Google Analytics.
 	AnonymizeIP bool
+
+	// Enabling this will disable all advertising, reporting, and remarketing features, and override any property settings established in the Google Analytics user interface (gtag only).
+	DisableGtagAdGoogleSignals bool
+
+	// Enabling this will disable Google advertising personalization features (gtag only).
+	DisableGtagAdPersonalizationSignals bool
+
+	// Enabling this will make it so extra page information is not sent to Google Analytics (gtag only).
+	DisableGtagEnhancedData bool
 }
 
 // Instagram holds the privacy configuration settings related to the Instagram shortcode.

--- a/config/privacy/privacyConfig_test.go
+++ b/config/privacy/privacyConfig_test.go
@@ -36,6 +36,9 @@ disable = true
 respectDoNotTrack = true
 anonymizeIP = true
 useSessionStorage = true
+disableGtagAdGoogleSignals = true
+disableGtagAdPersonalizationSignals = true
+disableGtagEnhancedData = true
 [privacy.instagram]
 disable = true
 simple = true
@@ -62,7 +65,9 @@ simple = true
 	got := []bool{
 		pc.Disqus.Disable, pc.GoogleAnalytics.Disable,
 		pc.GoogleAnalytics.RespectDoNotTrack, pc.GoogleAnalytics.AnonymizeIP,
-		pc.GoogleAnalytics.UseSessionStorage, pc.Instagram.Disable,
+		pc.GoogleAnalytics.UseSessionStorage, pc.GoogleAnalytics.DisableGtagAdGoogleSignals,
+		pc.GoogleAnalytics.DisableGtagAdPersonalizationSignals,
+		pc.GoogleAnalytics.DisableGtagEnhancedData, pc.Instagram.Disable,
 		pc.Instagram.Simple, pc.Twitter.Disable, pc.Twitter.EnableDNT,
 		pc.Twitter.Simple, pc.Vimeo.Disable, pc.Vimeo.EnableDNT, pc.Vimeo.Simple,
 		pc.YouTube.PrivacyEnhanced, pc.YouTube.Disable,

--- a/docs/content/en/about/hugo-and-gdpr.md
+++ b/docs/content/en/about/hugo-and-gdpr.md
@@ -42,6 +42,9 @@ disable = false
 respectDoNotTrack = false
 anonymizeIP = false
 useSessionStorage = false
+disableGtagAdGoogleSignals = false
+disableGtagAdPersonalizationSignals = false
+disableGtagEnhancedData = false
 [privacy.instagram]
 disable = false
 simple = false
@@ -91,6 +94,15 @@ respectDoNotTrack
 
 useSessionStorage
 : Enabling this will disable the use of Cookies and use Session Storage to Store the GA Client ID.
+
+disableGtagAdGoogleSignals
+: Enabling this will disable all advertising, reporting, and remarketing features, and override any property settings established in the Google Analytics user interface (gtag only).
+
+disableGtagAdPersonalizationSignals
+: Enabling this will disable Google advertising personalization features (gtag only).
+	
+disableGtagEnhancedData
+: Enabling this will make it so extra page information is not sent to Google Analytics (gtag only).
 
 ### Instagram
 

--- a/docs/content/en/templates/internal.md
+++ b/docs/content/en/templates/internal.md
@@ -27,7 +27,7 @@ While the following internal templates are called similar to partials, they do *
 
 ## Google Analytics
 
-Hugo ships with internal templates for Google Analytics tracking, including both synchronous and asynchronous tracking codes.
+Hugo ships with internal templates for Google Analytics tracking, including synchronous, asynchronous, and gtag tracking codes.
 
 ### Configure Google Analytics
 
@@ -48,6 +48,11 @@ You can then include the Google Analytics internal template:
 
 ```
 {{ template "_internal/google_analytics_async.html" . }}
+```
+
+
+```
+{{ template "_internal/google_analytics_gtag.html" . }}
 ```
 
 A `.Site.GoogleAnalytics` variable is also exposed from the config.

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -188,6 +188,68 @@ if (!doNotTrack) {
 {{ end }}
 {{- end -}}
 `},
+	{`google_analytics_gtag.html`, `{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.Disable -}}
+{{ with .Site.GoogleAnalytics }}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+<script type="application/javascript">
+{{ template "__ga_js_set_doNotTrack" $ }}
+if (!doNotTrack) {
+  var config = { 'send_page_view': true };
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+
+  {{ if $pc.UseSessionStorage -}}
+  var GA_STORAGE_KEY = 'ga:clientId';
+  if (window.sessionStorage && sessionStorage.getItem(GA_STORAGE_KEY)) {
+    sessionStorage.setItem(GA_STORAGE_KEY);
+  }
+  config['client_storage'] = 'none';
+  config['client_id'] = sessionStorage.getItem(GA_STORAGE_KEY);
+  {{ end -}}
+
+  {{ if $pc.AnonymizeIP }}
+  config['anonymize_ip'] = true;
+  {{ end -}}
+
+  {{ if $pc.DisableGtagAdGoogleSignals }}
+  config['allow_google_signals'] = false;
+  {{ end -}}
+
+  {{ if $pc.DisableGtagAdPersonalizationSignals }}
+  config['allow_ad_personalization_signals'] = false;
+  {{ end -}}
+
+  {{ if not $pc.DisableGtagEnhancedData -}}
+  gtag('title', '{{ $.Title }}');
+  gtag('permalink', '{{ $.Permalink }}');
+  gtag('published_date', '{{ $.Date.Format "2006-01-22" }}');
+  gtag('modified_date', '{{ $.Lastmod.Format "2006-01-22" }}');
+  gtag('language', '{{ $.Language }}');
+  gtag('kind', '{{ $.Kind }}');
+  gtag('type', '{{ $.Type }}');
+  gtag('tags', {{ $.Params.tags }});
+  gtag('categories', {{ $.Params.categories }});
+  {{ end -}}
+
+  gtag('js', new Date());
+  gtag('config', '{{ . }}', config);
+}
+else {
+  window['ga-disable-{{ . }}'] = true;
+}
+</script>
+{{ end -}}
+{{- end -}}
+{{- define "__ga_js_set_doNotTrack" -}}{{/* This is also used in the async version. */}}
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.RespectDoNotTrack -}}
+var doNotTrack = false;
+{{- else -}}
+var dnt = (navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack);
+var doNotTrack = (dnt == "1" || dnt == "yes");
+{{- end -}}
+{{- end -}}`},
 	{`google_news.html`, `{{ if .IsPage }}{{ with .Params.news_keywords }}
   <meta name="news_keywords" content="{{ range $i, $kw := first 10 . }}{{ if $i }},{{ end }}{{ $kw }}{{ end }}" />
 {{ end }}{{ end }}`},

--- a/tpl/tplimpl/embedded/templates/google_analytics_gtag.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics_gtag.html
@@ -1,0 +1,62 @@
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.Disable -}}
+{{ with .Site.GoogleAnalytics }}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+<script type="application/javascript">
+{{ template "__ga_js_set_doNotTrack" $ }}
+if (!doNotTrack) {
+  var config = { 'send_page_view': true };
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+
+  {{ if $pc.UseSessionStorage -}}
+  var GA_STORAGE_KEY = 'ga:clientId';
+  if (window.sessionStorage && sessionStorage.getItem(GA_STORAGE_KEY)) {
+    sessionStorage.setItem(GA_STORAGE_KEY);
+  }
+  config['client_storage'] = 'none';
+  config['client_id'] = sessionStorage.getItem(GA_STORAGE_KEY);
+  {{ end -}}
+
+  {{ if $pc.AnonymizeIP }}
+  config['anonymize_ip'] = true;
+  {{ end -}}
+
+  {{ if $pc.DisableGtagAdGoogleSignals }}
+  config['allow_google_signals'] = false;
+  {{ end -}}
+
+  {{ if $pc.DisableGtagAdPersonalizationSignals }}
+  config['allow_ad_personalization_signals'] = false;
+  {{ end -}}
+
+  {{ if not $pc.DisableGtagEnhancedData -}}
+  gtag('title', '{{ $.Title }}');
+  gtag('permalink', '{{ $.Permalink }}');
+  gtag('published_date', '{{ $.Date.Format "2006-01-22" }}');
+  gtag('modified_date', '{{ $.Lastmod.Format "2006-01-22" }}');
+  gtag('language', '{{ $.Language }}');
+  gtag('kind', '{{ $.Kind }}');
+  gtag('type', '{{ $.Type }}');
+  gtag('tags', {{ $.Params.tags }});
+  gtag('categories', {{ $.Params.categories }});
+  {{ end -}}
+
+  gtag('js', new Date());
+  gtag('config', '{{ . }}', config);
+}
+else {
+  window['ga-disable-{{ . }}'] = true;
+}
+</script>
+{{ end -}}
+{{- end -}}
+{{- define "__ga_js_set_doNotTrack" -}}{{/* This is also used in the async version. */}}
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.RespectDoNotTrack -}}
+var doNotTrack = false;
+{{- else -}}
+var dnt = (navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack);
+var doNotTrack = (dnt == "1" || dnt == "yes");
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
Added an internal template that uses the new Google Tag Manager (gtag.js).
Added basic page data to be sent with the new Google Analytics call.
Added additional privacy flags to disable  google ad signals, good ad personalization signals, and sending enhanced page data to google.

Fixes #4327, Fixes #4479