### PR TITLE
langs/i18n: Fix for bare TOML keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/nicksnyder/go-i18n/v2 v2.1.1
 	github.com/niklasfasching/go-org v1.3.2
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/pelletier/go-toml v1.6.0 // indirect
+	github.com/pelletier/go-toml v1.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/rogpeppe/go-internal v1.6.2
 	github.com/russross/blackfriday v1.5.3-0.20200218234912-41c5fccfd6f6

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,8 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/langs/i18n/i18n_test.go
+++ b/langs/i18n/i18n_test.go
@@ -199,6 +199,19 @@ other = "{{ .Count }} minuttar lesing"`),
 		expected:     "3 minuttar lesing",
 		expectedFlag: "3 minuttar lesing",
 	},
+	// https://github.com/gohugoio/hugo/issues/7798
+	{
+		name: "known-language-missing-plural",
+		data: map[string][]byte{
+			"oc.toml": []byte(`[oc]
+one =  "abc"`),
+		},
+		args:         1,
+		lang:         "oc",
+		id:           "oc",
+		expected:     "abc",
+		expectedFlag: "abc",
+	},
 	// https://github.com/gohugoio/hugo/issues/7794
 	{
 		name: "dotted-bare-key",
@@ -292,7 +305,7 @@ func TestI18nTranslate(t *testing.T) {
 				} else {
 					expected = test.expected
 				}
-				actual = doTestI18nTranslate(t, test, v)
+				actual = doTestI18nTranslate(c, test, v)
 				c.Assert(actual, qt.Equals, expected)
 			})
 		}

--- a/langs/i18n/i18n_test.go
+++ b/langs/i18n/i18n_test.go
@@ -199,6 +199,20 @@ other = "{{ .Count }} minuttar lesing"`),
 		expected:     "3 minuttar lesing",
 		expectedFlag: "3 minuttar lesing",
 	},
+	// https://github.com/gohugoio/hugo/issues/7794
+	{
+		name: "dotted-bare-key",
+		data: map[string][]byte{
+			"en.toml": []byte(`"shop_nextPage.one" = "Show Me The Money"
+
+`),
+		},
+		args:         nil,
+		lang:         "en",
+		id:           "shop_nextPage.one",
+		expected:     "Show Me The Money",
+		expectedFlag: "Show Me The Money",
+	},
 }
 
 func doTestI18nTranslate(t testing.TB, test i18nTest, cfg config.Provider) string {

--- a/langs/i18n/translationProvider.go
+++ b/langs/i18n/translationProvider.go
@@ -20,9 +20,9 @@ import (
 	"golang.org/x/text/language"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/BurntSushi/toml"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
+	toml "github.com/pelletier/go-toml"
 
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/hugofs"

--- a/langs/i18n/translationProvider.go
+++ b/langs/i18n/translationProvider.go
@@ -15,6 +15,7 @@ package i18n
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/gohugoio/hugo/common/herrors"
 	"golang.org/x/text/language"
@@ -95,6 +96,14 @@ func addTranslationFile(bundle *i18n.Bundle, r source.File) error {
 
 	_, err = bundle.ParseMessageFileBytes(b, name)
 	if err != nil {
+		if strings.Contains(err.Error(), "no plural rule") {
+			// https://github.com/gohugoio/hugo/issues/7798
+			name = artificialLangTagPrefix + name
+			_, err = bundle.ParseMessageFileBytes(b, name)
+			if err == nil {
+				return nil
+			}
+		}
 		return errWithFileContext(_errors.Wrapf(err, "failed to load translations"), r)
 	}
 


### PR DESCRIPTION
Hugo 0.76.0 updated go-i18n from v1 to v2. This allowed us to set the TOML unmarshaler to use, so we set the one we use in other places in Hugo.

But that does not support dotted bare keys, which caused some breakage in the wild.

This commit fixes that by:

* Using go-toml for language files
* Updating go-toml to the latest version