### PR TITLE
update to golang 1.15 and alpine 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Twitter:      https://twitter.com/gohugoio
 # Website:      https://gohugo.io/
 
-FROM golang:1.13-alpine AS build
+FROM golang:1.15-alpine AS build
 
 # Optionally set HUGO_BUILD_TAGS to "extended" when building like so:
 #   docker build --build-arg HUGO_BUILD_TAGS=extended .
@@ -26,7 +26,7 @@ RUN mage hugo && mage install
 
 # ---
 
-FROM alpine:3.11
+FROM alpine:3.12
 
 COPY --from=build /go/bin/hugo /usr/bin/hugo
 


### PR DESCRIPTION
Golang 1.13 used for build is now EOL, updated to latest 1.15. Updated main image to alpine 3.12 to match alpine used in build.