### PR TITLE
Update goreleaser.yml

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -146,7 +146,7 @@ nfpms:
     maintainer: "Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>"
     description: "A Fast and Flexible Static Site Generator built with love in GoLang."
     license: "Apache 2.0"
-    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+    file_name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
     replacements:
       amd64: 64bit
       386: 32bit
@@ -169,7 +169,7 @@ nfpms:
     maintainer: "Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>"
     description: "A Fast and Flexible Static Site Generator built with love in GoLang."
     license: "Apache 2.0"
-    name_template: "{{.ProjectName}}_extended_{{.Version}}_{{.Os}}-{{.Arch}}"
+    file_name_template: "{{.ProjectName}}_extended_{{.Version}}_{{.Os}}-{{.Arch}}"
     replacements:
       amd64: 64bit
       386: 32bit


### PR DESCRIPTION
This PR is related to issue #7551. Although the fix is not in this PR, I updated (as I stated in that bug) the file to be compatible with newer `goreleaser` versions.

The issue is that an old version of `goreleaser` has been used to build the releases, and that's what breaks the windows extended build.

This PR updates the `goreleaser.yaml` file to be compatible with the latest current version (v0.144.1), **but to fully fix the bug the person building the release MUST update its copy of `goreleaser`**.

Given that the process to build the release seems somewhat undocumented, I wasn't sure where to document the `goreleaser` required version. Happy to document it if required.