### PR TITLE
output: Remove irregular layout lookups

### DIFF
--- a/output/layout.go
+++ b/output/layout.go
@@ -208,9 +208,11 @@ func resolvePageTemplate(d LayoutDescriptor, f Format) []string {
 }
 
 func (l *layoutBuilder) resolveVariations() []string {
-	var layouts []string
+	var (
+		layouts    []string
+		variations []string
+	)
 
-	var variations []string
 	name := strings.ToLower(l.f.Name)
 
 	if l.d.Lang != "" {
@@ -222,14 +224,23 @@ func (l *layoutBuilder) resolveVariations() []string {
 
 	variations = append(variations, "")
 
-	for _, typeVar := range l.typeVariations {
+	for _, typ := range l.typeVariations {
 		for _, variation := range variations {
-			for _, layoutVar := range l.layoutVariations {
-				if variation == "" && layoutVar == "" {
+			for _, layout := range l.layoutVariations {
+				if variation == "" && layout == "" {
 					continue
 				}
 
-				s := constructLayoutPath(typeVar, layoutVar, variation, l.f.MediaType.Suffix())
+				var s string
+
+				// Avoid stuttering lookups such as index.html.html.
+				// Second condition checks for lang variation such as "fr.html".
+				if variation == l.f.MediaType.Suffix() || strings.HasSuffix(variation, "."+l.f.MediaType.Suffix()) {
+					s = constructLayoutPath(typ, layout, variation, "")
+				} else {
+					s = constructLayoutPath(typ, layout, variation, l.f.MediaType.Suffix())
+				}
+
 				if s != "" {
 					layouts = append(layouts, s)
 				}

--- a/output/layout_test.go
+++ b/output/layout_test.go
@@ -104,17 +104,10 @@ func TestLayout(t *testing.T) {
 		},
 		{
 			"Home, HTML", LayoutDescriptor{Kind: "home"}, "", htmlFormat,
-			// We will eventually get to index.html. This looks stuttery, but makes the lookup logic easy to understand.
 			[]string{
-				"index.html.html",
-				"home.html.html",
-				"list.html.html",
 				"index.html",
 				"home.html",
 				"list.html",
-				"_default/index.html.html",
-				"_default/home.html.html",
-				"_default/list.html.html",
 				"_default/index.html",
 				"_default/home.html",
 				"_default/list.html",
@@ -123,18 +116,31 @@ func TestLayout(t *testing.T) {
 		{
 			"Home, HTML, baseof", LayoutDescriptor{Kind: "home", Baseof: true}, "", htmlFormat,
 			[]string{
-				"index-baseof.html.html",
-				"home-baseof.html.html",
-				"list-baseof.html.html",
-				"baseof.html.html",
 				"index-baseof.html",
 				"home-baseof.html",
 				"list-baseof.html",
 				"baseof.html",
-				"_default/index-baseof.html.html",
-				"_default/home-baseof.html.html",
-				"_default/list-baseof.html.html",
-				"_default/baseof.html.html",
+				"_default/index-baseof.html",
+				"_default/home-baseof.html",
+				"_default/list-baseof.html",
+				"_default/baseof.html",
+			},
+		},
+		{
+			"Home, HTML, baseof, french", LayoutDescriptor{Kind: "home", Baseof: true, Lang: "fr"}, "", htmlFormat,
+			[]string{
+				"index-baseof.fr.html",
+				"home-baseof.fr.html",
+				"list-baseof.fr.html",
+				"baseof.fr.html",
+				"index-baseof.html",
+				"home-baseof.html",
+				"list-baseof.html",
+				"baseof.html",
+				"_default/index-baseof.fr.html",
+				"_default/home-baseof.fr.html",
+				"_default/list-baseof.fr.html",
+				"_default/baseof.fr.html",
 				"_default/index-baseof.html",
 				"_default/home-baseof.html",
 				"_default/list-baseof.html",
@@ -552,15 +558,9 @@ func TestLayout(t *testing.T) {
 		{
 			"Home plain text", LayoutDescriptor{Kind: "home"}, "", JSONFormat,
 			[]string{
-				"index.json.json",
-				"home.json.json",
-				"list.json.json",
 				"index.json",
 				"home.json",
 				"list.json",
-				"_default/index.json.json",
-				"_default/home.json.json",
-				"_default/list.json.json",
 				"_default/index.json",
 				"_default/home.json",
 				"_default/list.json",
@@ -569,7 +569,6 @@ func TestLayout(t *testing.T) {
 		{
 			"Page plain text", LayoutDescriptor{Kind: "page"}, "", JSONFormat,
 			[]string{
-				"_default/single.json.json",
 				"_default/single.json",
 			},
 		},
@@ -611,19 +610,14 @@ func TestLayout(t *testing.T) {
 		{
 			"404, HTML", LayoutDescriptor{Kind: "404"}, "", htmlFormat,
 			[]string{
-				"404.html.html",
 				"404.html",
 			},
 		},
 		{
 			"404, HTML baseof", LayoutDescriptor{Kind: "404", Baseof: true}, "", htmlFormat,
 			[]string{
-				"404-baseof.html.html",
-				"baseof.html.html",
 				"404-baseof.html",
 				"baseof.html",
-				"_default/404-baseof.html.html",
-				"_default/baseof.html.html",
 				"_default/404-baseof.html",
 				"_default/baseof.html",
 			},


### PR DESCRIPTION
Avoid adding "stuttering" lookup variations such as `index.html.html`.