### PR TITLE
highlight: Avoid making unnecessary allocation

### DIFF
--- a/markup/highlight/highlight.go
+++ b/markup/highlight/highlight.go
@@ -37,12 +37,15 @@ type Highlighter struct {
 }
 
 func (h Highlighter) Highlight(code, lang, optsStr string) (string, error) {
-	cfg := h.cfg
-	if optsStr != "" {
-		if err := applyOptionsFromString(optsStr, &cfg); err != nil {
-			return "", err
-		}
+	if optsStr == "" {
+		return highlight(code, lang, h.cfg)
 	}
+
+	cfg := h.cfg
+	if err := applyOptionsFromString(optsStr, &cfg); err != nil {
+		return "", err
+	}
+
 	return highlight(code, lang, cfg)
 }
 


### PR DESCRIPTION
Avoid creating a local copy of the highlight configuration when no
options are passed.

Benchmarks of building the docs site:
```
name        old time/op    new time/op    delta
DocsSite-2     1.94s ± 4%     1.93s ± 4%    ~     (p=0.841 n=5+5)

name        old alloc/op   new alloc/op   delta
DocsSite-2     666MB ± 1%     656MB ± 0%  -1.48%  (p=0.008 n=5+5)

name        old allocs/op  new allocs/op  delta
DocsSite-2     8.85M ± 0%     8.76M ± 0%  -1.04%  (p=0.029 n=4+4)
```