### PR TITLE
build: allow optional "nodeploy" tag to exclude deploy command from bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM golang:1.15-alpine AS build
 
-# Optionally set HUGO_BUILD_TAGS to "extended" when building like so:
+# Optionally set HUGO_BUILD_TAGS to "extended" or "nodeploy" when building like so:
 #   docker build --build-arg HUGO_BUILD_TAGS=extended .
 ARG HUGO_BUILD_TAGS
 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nodeploy
+
 package commands
 
 import (

--- a/commands/nodeploy.go
+++ b/commands/nodeploy.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build nodeploy
+
+package commands
+
+import (
+	"errors"
+	"github.com/spf13/cobra"
+)
+
+var _ cmder = (*deployCmd)(nil)
+
+// deployCmd supports deploying sites to Cloud providers.
+type deployCmd struct {
+	*baseBuilderCmd
+}
+
+func (b *commandsBuilder) newDeployCmd() *deployCmd {
+	cc := &deployCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "deploy",
+		Short: "Deploy your site to a Cloud provider.",
+		Long: `Deploy your site to a Cloud provider.
+
+See https://gohugo.io/hosting-and-deployment/hugo-deploy/ for detailed
+documentation.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("build without HUGO_BUILD_TAGS=nodeploy to use this command")
+		},
+	}
+
+	cc.baseBuilderCmd = b.newBuilderBasicCmd(cmd)
+
+	return cc
+}

--- a/deploy/cloudfront.go
+++ b/deploy/cloudfront.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nodeploy
+
 package deploy
 
 import (

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nodeploy
+
 package deploy
 
 import (

--- a/deploy/deployConfig.go
+++ b/deploy/deployConfig.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nodeploy
+
 package deploy
 
 import (

--- a/deploy/deployConfig_test.go
+++ b/deploy/deployConfig_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nodeploy
+
 package deploy
 
 import (

--- a/deploy/deploy_azure.go
+++ b/deploy/deploy_azure.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !solaris
+// +build !solaris,!nodeploy
 
 package deploy
 

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nodeploy
+
 package deploy
 
 import (

--- a/deploy/google.go
+++ b/deploy/google.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nodeploy
+
 package deploy
 
 import (

--- a/magefile.go
+++ b/magefile.go
@@ -354,6 +354,7 @@ func buildFlags() []string {
 func buildTags() string {
 	// To build the extended Hugo SCSS/SASS enabled version, build with
 	// HUGO_BUILD_TAGS=extended mage install etc.
+	// To build without `hugo deploy` for smaller binary, use HUGO_BUILD_TAGS=nodeploy
 	if envtags := os.Getenv("HUGO_BUILD_TAGS"); envtags != "" {
 		return envtags
 	}


### PR DESCRIPTION
Fixes https://github.com/gohugoio/hugo/issues/7826

You can run `HUGO_BUILD_TAGS=nodeploy mage install` or `go install --tags nodeploy` to build `hugo` without the `deploy` command which will make the binary smaller and prevent crashes on certain systems https://github.com/gohugoio/hugo/issues/6324

I kept the command in there by creating `nodeploy.go` that simply returns an error if the user tries to call `hugo deploy`.

```
eric@eric-manjaro-ml ~/p/hugo (feature/build-without-deploy)> hugo deploy
Error: build without HUGO_BUILD_TAGS=nodeploy to use this command
```

Please let me know if you'd like me to remove the `deploy` command all together or keep it like this to warn the user.