### PR TITLE
create: Pass editor arguments from newContentEditor correctly

### DIFF
--- a/create/content.go
+++ b/create/content.go
@@ -105,7 +105,8 @@ func NewContent(
 	if editor != "" {
 		jww.FEEDBACK.Printf("Editing %s with %q ...\n", targetPath, editor)
 
-		cmd := exec.Command(editor, contentPath)
+		editorCmd := append(strings.Fields(editor), contentPath)
+		cmd := exec.Command(editorCmd[0], editorCmd[1:]...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
If newContentEditor has editor name with arguments like `emacsclient -n`, it fails with `executable file not found in $PATH`. This change parses the value correctly and passes it to the given editor.