### PR TITLE
Clarify that content folder needs to be created

### DIFF
--- a/docs/content/en/getting-started/quick-start.md
+++ b/docs/content/en/getting-started/quick-start.md
@@ -88,7 +88,7 @@ echo 'theme = "ananke"' >> config.toml
 You can manually create content files (for example as `content/<CATEGORY>/<FILE>.<FORMAT>`) and provide metadata in them, however you can use the `new` command to do a few things for you (like add title and date):
 
 ```
-hugo new posts/my-first-post.md
+hugo new content/posts/my-first-post.md
 ```
 
 {{< asciicast eUojYCfRTZvkEiqc52fUsJRBR >}}


### PR DESCRIPTION
When I first did the quickstart tutorial it wasn't clear to me that the posts belonged in `content/posts`, I think this change will help clarify that.