### PR TITLE
Use ContentBaseName() as fallback page Title

### DIFF
--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -285,6 +285,9 @@ func (p *pageMeta) Sitemap() config.Sitemap {
 }
 
 func (p *pageMeta) Title() string {
+	if p.title == "" && !p.File().IsZero() {
+		return p.File().ContentBaseName()
+	}
 	return p.title
 }
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1300,7 +1300,7 @@ Content.
 `)
 
 	b.Build(BuildCfg{})
-	b.AssertFileContent("public/index.html", "Title||")
+	b.AssertFileContent("public/index.html", "Title|_index|")
 }
 
 func TestShouldBuild(t *testing.T) {


### PR DESCRIPTION
Closes #7370 
Closes #3805
Related to #6098

The use case is to quickly generate a site from a directory of markdown files without front matter.

It's also possible to parse `ContentBaseName()` and generate a better title, something like a `unslugify()` function.
