### PR TITLE
tpl: Fix reflection bug in merge

### DIFF
--- a/tpl/collections/merge.go
+++ b/tpl/collections/merge.go
@@ -106,6 +106,10 @@ func mergeMap(dst, src reflect.Value) reflect.Value {
 			dve := dv.Elem()
 			if dve.Kind() == reflect.Map {
 				sve := sv.Elem()
+				if sve.Kind() != reflect.Map {
+					continue
+				}
+
 				if dve.Type().Key() == sve.Type().Key() {
 					out.SetMapIndex(key, mergeMap(dve, sve))
 				}

--- a/tpl/collections/merge_test.go
+++ b/tpl/collections/merge_test.go
@@ -111,6 +111,15 @@ func TestMerge(t *testing.T) {
 			},
 			maps.Params{"a": 1, "b": maps.Params{"d": 1, "e": 2, "f": 3}, "c": 3}, false,
 		},
+		{
+			// https://github.com/gohugoio/hugo/issues/7899
+			"matching keys with non-map src value",
+			[]interface{}{
+				map[string]interface{}{"k": "v"},
+				map[string]interface{}{"k": map[string]interface{}{"k2": "v2"}},
+			},
+			map[string]interface{}{"k": map[string]interface{}{"k2": "v2"}}, false,
+		},
 		{"src nil", []interface{}{nil, simpleMap}, simpleMap, false},
 		// Error cases.
 		{"dst not a map", []interface{}{nil, "not a map"}, nil, true},


### PR DESCRIPTION
Value.Type().Key() must only be called on map values.

Fixes #7899