### PR TITLE
Allow asciidoctor-kroki extension

### DIFF
--- a/markup/asciidocext/asciidocext_config/config.go
+++ b/markup/asciidocext/asciidocext_config/config.go
@@ -47,6 +47,7 @@ var (
 		"asciidoctor-mathematical":     true,
 		"asciidoctor-question":         true,
 		"asciidoctor-rouge":            true,
+		"asciidoctor-kroki":			true,
 	}
 
 	AllowedSafeMode = map[string]bool{

--- a/markup/asciidocext/asciidocext_config/config.go
+++ b/markup/asciidocext/asciidocext_config/config.go
@@ -47,7 +47,7 @@ var (
 		"asciidoctor-mathematical":     true,
 		"asciidoctor-question":         true,
 		"asciidoctor-rouge":            true,
-		"asciidoctor-kroki":			true,
+		"asciidoctor-kroki":            true,
 	}
 
 	AllowedSafeMode = map[string]bool{


### PR DESCRIPTION
To allow asciidoctor-kroki extension available for Asciidoctor.

Tested with both kroki.io and self-created kroki server, both workable.