### PR TITLE
js: Let ESBuild handle all impports from node_modules

### DIFF
--- a/commands/static_syncer.go
+++ b/commands/static_syncer.go
@@ -79,9 +79,9 @@ func (s *staticSyncer) syncsStaticEvents(staticEvents []fsnotify.Event) error {
 
 			fromPath := ev.Name
 
-			relPath := sourceFs.MakePathRelative(fromPath)
+			relPath, found := sourceFs.MakePathRelative(fromPath)
 
-			if relPath == "" {
+			if !found {
 				// Not member of this virtual host.
 				continue
 			}

--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -267,7 +267,7 @@ func (s SourceFilesystems) IsI18n(filename string) bool {
 // It will return an empty string if the filename is not a member of a static filesystem.
 func (s SourceFilesystems) MakeStaticPathRelative(filename string) string {
 	for _, staticFs := range s.Static {
-		rel := staticFs.MakePathRelative(filename)
+		rel, _ := staticFs.MakePathRelative(filename)
 		if rel != "" {
 			return rel
 		}
@@ -276,8 +276,7 @@ func (s SourceFilesystems) MakeStaticPathRelative(filename string) string {
 }
 
 // MakePathRelative creates a relative path from the given filename.
-// It will return an empty string if the filename is not a member of this filesystem.
-func (d *SourceFilesystem) MakePathRelative(filename string) string {
+func (d *SourceFilesystem) MakePathRelative(filename string) (string, bool) {
 
 	for _, dir := range d.Dirs {
 		meta := dir.(hugofs.FileMetaInfo).Meta()
@@ -288,10 +287,10 @@ func (d *SourceFilesystem) MakePathRelative(filename string) string {
 			if mp := meta.Path(); mp != "" {
 				rel = filepath.Join(mp, rel)
 			}
-			return strings.TrimPrefix(rel, filePathSeparator)
+			return strings.TrimPrefix(rel, filePathSeparator), true
 		}
 	}
-	return ""
+	return "", false
 }
 
 func (d *SourceFilesystem) RealFilename(rel string) string {

--- a/hugolib/filesystems/basefs_test.go
+++ b/hugolib/filesystems/basefs_test.go
@@ -394,9 +394,14 @@ func TestMakePathRelative(t *testing.T) {
 	sfs := bfs.Static[""]
 	c.Assert(sfs, qt.Not(qt.IsNil))
 
-	c.Assert(sfs.MakePathRelative(filepath.Join(workDir, "dist", "d1", "foo.txt")), qt.Equals, filepath.FromSlash("mydist/d1/foo.txt"))
-	c.Assert(sfs.MakePathRelative(filepath.Join(workDir, "static", "d2", "foo.txt")), qt.Equals, filepath.FromSlash("d2/foo.txt"))
-	c.Assert(sfs.MakePathRelative(filepath.Join(workDir, "dust", "d3", "foo.txt")), qt.Equals, filepath.FromSlash("foo/bar/d3/foo.txt"))
+	makeRel := func(s string) string {
+		r, _ := sfs.MakePathRelative(s)
+		return r
+	}
+
+	c.Assert(makeRel(filepath.Join(workDir, "dist", "d1", "foo.txt")), qt.Equals, filepath.FromSlash("mydist/d1/foo.txt"))
+	c.Assert(makeRel(filepath.Join(workDir, "static", "d2", "foo.txt")), qt.Equals, filepath.FromSlash("d2/foo.txt"))
+	c.Assert(makeRel(filepath.Join(workDir, "dust", "d3", "foo.txt")), qt.Equals, filepath.FromSlash("foo/bar/d3/foo.txt"))
 
 }
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1047,7 +1047,7 @@ func (s *Site) processPartial(config *BuildCfg, init func(config *BuildCfg) erro
 	)
 
 	for _, ev := range events {
-		if assetsFilename := s.BaseFs.Assets.MakePathRelative(ev.Name); assetsFilename != "" {
+		if assetsFilename, _ := s.BaseFs.Assets.MakePathRelative(ev.Name); assetsFilename != "" {
 			cachePartitions = append(cachePartitions, resources.ResourceKeyPartitions(assetsFilename)...)
 			if evictCSSRe == nil {
 				if cssFileRe.MatchString(assetsFilename) || cssConfigRe.MatchString(assetsFilename) {

--- a/resources/resource_transformers/tocss/scss/tocss.go
+++ b/resources/resource_transformers/tocss/scss/tocss.go
@@ -76,7 +76,7 @@ func (t *toCSSTransformation) Transform(ctx *resources.ResourceTransformationCtx
 		if prev == "stdin" {
 			prevDir = baseDir
 		} else {
-			prevDir = t.c.sfs.MakePathRelative(filepath.Dir(prev))
+			prevDir, _ = t.c.sfs.MakePathRelative(filepath.Dir(prev))
 
 			if prevDir == "" {
 				// Not a member of this filesystem. Let LibSASS handle it.


### PR DESCRIPTION
This commit fixes some issues where modules in /assets share the same name as in node_modules.

This was not intended, and with this commit the node_modules-components should be isolated. If you want to redefine something inside node_modules, use the `defines` option.

Fixes #7948