### PR TITLE
remove unneeded meta tag from blog example

### DIFF
--- a/examples/blog/layouts/partials/meta.html
+++ b/examples/blog/layouts/partials/meta.html
@@ -1,6 +1,5 @@
 
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{{ .Description }}">
     <meta name="author" content="A Hugo User"> <!-- This should be modified to be your name, if you want to include this information -->


### PR DESCRIPTION
```html
    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
```
This was only needed for IE10 and lower (which are no longer supported) and chromeframe which was a Google plugin for IE8 and lower and was discontinued many years ago. So this meta tag can be safely removed.