### PR TITLE
resources: Preserve url set in frontmatter without sanitizing

### DIFF
--- a/resources/page/page_paths.go
+++ b/resources/page/page_paths.go
@@ -308,12 +308,16 @@ func CreateTargetPaths(d TargetPathDescriptor) (tp TargetPaths) {
 
 	linkDir = strings.TrimSuffix(path.Join(slash, linkDir), slash)
 
-	// Note: MakePathSanitized will lower case the path if
-	// disablePathToLower isn't set.
-	pagePath = d.PathSpec.MakePathSanitized(pagePath)
-	pagePathDir = d.PathSpec.MakePathSanitized(pagePathDir)
-	link = d.PathSpec.MakePathSanitized(link)
-	linkDir = d.PathSpec.MakePathSanitized(linkDir)
+	// if page URL is explicitly set in frontmatter,
+	// preserve its value without sanitization
+	if d.Kind != KindPage || d.URL == "" {
+		// Note: MakePathSanitized will lower case the path if
+		// disablePathToLower isn't set.
+		pagePath = d.PathSpec.MakePathSanitized(pagePath)
+		pagePathDir = d.PathSpec.MakePathSanitized(pagePathDir)
+		link = d.PathSpec.MakePathSanitized(link)
+		linkDir = d.PathSpec.MakePathSanitized(linkDir)
+	}
 
 	tp.TargetFilename = filepath.FromSlash(pagePath)
 	tp.SubResourceBaseTarget = filepath.FromSlash(pagePathDir)

--- a/resources/page/page_paths_test.go
+++ b/resources/page/page_paths_test.go
@@ -130,6 +130,13 @@ func TestPageTargetPath(t *testing.T) {
 							URL:      "/some/other/path",
 							Type:     output.HTMLFormat}, TargetPaths{TargetFilename: "/some/other/path/index.html", SubResourceBaseTarget: "/some/other/path", Link: "/some/other/path/"}},
 					{
+						"HTML page with URL containing double hyphen", TargetPathDescriptor{
+							Kind:     KindPage,
+							Dir:      "/sect/",
+							BaseName: "mypage",
+							URL:      "/some/other--url/",
+							Type:     output.HTMLFormat}, TargetPaths{TargetFilename: "/some/other--url/index.html", SubResourceBaseTarget: "/some/other--url", Link: "/some/other--url/"}},
+					{
 						"HTML page with expanded permalink", TargetPathDescriptor{
 							Kind:              KindPage,
 							Dir:               "/a/b",


### PR DESCRIPTION
For now, `url` set in frontmatter is sanitized.
This PR tweak the behavior to preserve user-defined `url` value, skipping sanitization.
This is consistent with `aliases`' manner.

#### in my case
I am maintaining a site, where hugo's version is relatively old.
The site has some contents, of which urls are containing "double dash" like `foo--1.md`.
I need any workaround to keep these urls with latest version of hugo.


related #6007 (already closed)