### PR TITLE
Allow setting the delimiter used for setting config via OS env, e.g. HUGO_

### DIFF
--- a/common/maps/params.go
+++ b/common/maps/params.go
@@ -84,7 +84,7 @@ func GetNestedParam(keyStr, separator string, candidates ...Params) (interface{}
 }
 
 func GetNestedParamFn(keyStr, separator string, lookupFn func(key string) interface{}) (interface{}, string, map[string]interface{}, error) {
-	keySegments := strings.Split(strings.ToLower(keyStr), separator)
+	keySegments := strings.Split(keyStr, separator)
 	if len(keySegments) == 0 {
 		return nil, "", nil, nil
 	}

--- a/docs/content/en/getting-started/configuration.md
+++ b/docs/content/en/getting-started/configuration.md
@@ -427,6 +427,8 @@ Names must be prefixed with `HUGO_` and the configuration key must be set in upp
 To set config params, prefix the name with `HUGO_PARAMS_`
 {{% /note %}}
 
+{{< new-in "0.79.0" >}} If you are using snake_cased variable names, the above will not work, so since Hugo 0.79.0 Hugo determines the delimiter to use by the first character after `HUGO`. This allows you to define environment variables on the form `HUGOxPARAMSxAPI_KEY=abcdefgh`, using any [allowed](https://stackoverflow.com/questions/2821043/allowed-characters-in-linux-environment-variable-names#:~:text=So%20names%20may%20contain%20any,not%20begin%20with%20a%20digit.) delimiter.
+
 {{< todo >}}
 Test and document setting params via JSON env var.
 {{< /todo >}}

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -492,6 +492,11 @@ intSlice = [5,7,9]
 floatSlice = [3.14, 5.19]
 stringSlice = ["a", "b"]
 
+[params]
+[params.api_config]
+api_key="default_key"
+another_key="default another_key"
+
 [imaging]
 anchor = "smart"
 quality = 75 
@@ -508,6 +513,10 @@ quality = 75
 		"HUGO_STRINGSLICE", `["c", "d"]`,
 		"HUGO_INTSLICE", `[5, 8, 9]`,
 		"HUGO_FLOATSLICE", `[5.32]`,
+		// https://github.com/gohugoio/hugo/issues/7829
+		"HUGOxPARAMSxAPI_CONFIGxAPI_KEY", "new_key",
+		// Delimiters are case sensitive.
+		"HUGOxPARAMSxAPI_CONFIGXANOTHER_KEY", "another_key",
 	)
 
 	b.Build(BuildCfg{})
@@ -523,5 +532,7 @@ quality = 75
 	c.Assert(cfg.Get("stringSlice"), qt.DeepEquals, []interface{}{"c", "d"})
 	c.Assert(cfg.Get("floatSlice"), qt.DeepEquals, []interface{}{5.32})
 	c.Assert(cfg.Get("intSlice"), qt.DeepEquals, []interface{}{5, 8, 9})
+	c.Assert(cfg.Get("params.api_config.api_key"), qt.Equals, "new_key")
+	c.Assert(cfg.Get("params.api_config.another_key"), qt.Equals, "default another_key")
 
 }


### PR DESCRIPTION
Fixes #7829