### PR TITLE
tpl: Fix substr when length parameter is zero

### DIFF
--- a/tpl/strings/strings.go
+++ b/tpl/strings/strings.go
@@ -327,9 +327,12 @@ func (ns *Namespace) Substr(a interface{}, nums ...interface{}) (string, error) 
 
 	end := rlen
 
-	if length < 0 {
+	switch {
+	case length == 0:
+		return "", nil
+	case length < 0:
 		end += length
-	} else if length > 0 {
+	case length > 0:
 		end = start + length
 	}
 

--- a/tpl/strings/strings_test.go
+++ b/tpl/strings/strings_test.go
@@ -441,6 +441,9 @@ func TestSubstr(t *testing.T) {
 	}{
 		{"abc", 1, 2, "bc"},
 		{"abc", 0, 1, "a"},
+		{"abcdef", 0, 0, ""},
+		{"abcdef", 1, 0, ""},
+		{"abcdef", -1, 0, ""},
 		{"abcdef", -1, 2, "f"},
 		{"abcdef", -3, 3, "def"},
 		{"abcdef", -1, nil, "f"},
@@ -488,7 +491,7 @@ func TestSubstr(t *testing.T) {
 		}
 
 		c.Assert(err, qt.IsNil)
-		c.Assert(result, qt.Equals, test.expect, qt.Commentf("%v", test))
+		c.Check(result, qt.Equals, test.expect, qt.Commentf("%v", test))
 	}
 
 	_, err = ns.Substr("abcdef")


### PR DESCRIPTION
When length parameter is zero, always return an empty string.

Updates #7993