### PR TITLE
Adds ability to sort ByVersion (following semver format)

### DIFF
--- a/docs/content/en/templates/ordering-and-grouping.md
+++ b/docs/content/en/templates/ordering-and-grouping.md
@@ -1,5 +1,5 @@
 ---
-title: Ordere and Grouping Hugo Lists
+title: Order and Grouping Hugo Lists
 linktitle: List Ordering and Grouping
 description: You can group or order your content in both your templating and content front matter.
 date: 2017-02-01
@@ -163,6 +163,17 @@ your list templates:
 {{ range .Pages.ByLinkTitle }}
     <li>
     <a href="{{ .Permalink }}">{{ .LinkTitle }}</a>
+    <div class="meta">{{ .Date.Format "Mon, Jan 2, 2006" }}</div>
+    </li>
+{{ end }}
+{{< /code >}}
+
+### By Version
+
+{{< code file="layouts/partials/by-version.html" >}}
+{{ range .Pages.ByVersion }}
+    <li>
+    <a href="{{ .Permalink }}">{{.Version}} - {{ .LinkTitle }}</a>
     <div class="meta">{{ .Date.Format "Mon, Jan 2, 2006" }}</div>
     </li>
 {{ end }}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/bep/gitmap v1.1.2
 	github.com/bep/golibsass v0.7.0
 	github.com/bep/tmc v0.5.1
+	github.com/coreos/go-semver v0.3.0
 	github.com/disintegration/gift v1.2.1
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,7 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE
 github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=

--- a/resources/page/pages_sort_test.go
+++ b/resources/page/pages_sort_test.go
@@ -229,6 +229,37 @@ func TestPageSortByParamNumeric(t *testing.T) {
 	c.Assert(unsetSortedValue, qt.Equals, unsetValue)
 }
 
+func TestPageSortByVersion(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	var k interface{} = "version"
+
+	var unsorted Pages = createVersionPages()
+
+	got := unsorted.ByVersion()
+
+	wantVersions := []string{
+		"0.0.1",
+		"0.100.1",
+		"1.2.3",
+		"2.2.10",
+		"2.3.1",
+		"2.100.1",
+	}
+
+	c.Assert(len(got), qt.Equals, len(wantVersions))
+	for i, s := range got {
+		v, _ := s.Param(k)
+		c.Assert(v.(string), qt.Equals, wantVersions[i])
+	}
+
+	// pages with empty params will be sorted to the end
+	delete(unsorted[3].Params(), "version")
+	got = unsorted.ByVersion()
+	v, _ := got[5].Param(k)
+	c.Assert(v, qt.Equals, nil)
+}
+
 func BenchmarkSortByWeightAndReverse(b *testing.B) {
 	p := createSortTestPages(300)
 
@@ -286,6 +317,24 @@ func createSortTestPages(num int) Pages {
 		p.description = "initial"
 
 		pages[i] = p
+	}
+
+	return pages
+}
+
+func createVersionPages() Pages {
+	testPages := []*testPage{
+		{params: map[string]interface{}{"version": "2.3.1"}},
+		{params: map[string]interface{}{"version": "1.2.3"}},
+		{params: map[string]interface{}{"version": "2.2.10"}},
+		{params: map[string]interface{}{"version": "2.100.1"}},
+		{params: map[string]interface{}{"version": "0.100.1"}},
+		{params: map[string]interface{}{"version": "0.0.1"}},
+	}
+
+	pages := make(Pages, len(testPages))
+	for i := 0; i < len(testPages); i++ {
+		pages[i] = testPages[i]
 	}
 
 	return pages


### PR DESCRIPTION
User are are able to specify `version` in the frontmatter, following the [semver format](https://semver.org/) for sorting. Pages that don't have `version` will be sorted to the end.