### PR TITLE
hugolib: Add .ProcessedContent page variable

### DIFF
--- a/docs/content/en/variables/page.md
+++ b/docs/content/en/variables/page.md
@@ -120,6 +120,9 @@ See also `.ExpiryDate`, `.Date`, `.PublishDate`, and [`.GitInfo`][gitinfo].
 .PlainWords
 : the Page content stripped of HTML as a `[]string` using Go's [`strings.Fields`](https://golang.org/pkg/strings/#Fields) to split `.Plain` into a slice.
 
+.ProcessedContent
+: the content, before being converted to HTML, but after processing shortcodes.
+
 .Prev
 : Points down to the previous [regular page](/variables/site/#site-pages) (sorted by Hugo's [default sort](/templates/lists#default-weight-date-linktitle-filepath)). Example: `{{if .Prev}}{{.Prev.Permalink}}{{end}}`.  Calling `.Prev` from the last page returns `nil`.
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1755,3 +1755,37 @@ Page1: {{ $p1.Path }}
 
 	b.AssertFileContent("public/index.html", "Lang: no", filepath.FromSlash("Page1: a/B/C/Page1.md"))
 }
+
+func TestProcessedContent(t *testing.T) {
+	t.Parallel()
+
+	b := newTestSitesBuilder(t)
+	b.WithTemplatesAdded("_default/single.html", `
+	ProcessedContent: {{ .ProcessedContent }}
+	`, "shortcodes/t.html", `T-SHORT`, "shortcodes/s.html", `## Code
+	{{ .Inner }}
+	`)
+
+	content := `
++++
+title = "Processed Page"
++++
+
+## Shortcode {{% t %}} in header
+
+{{% s %}}
+Content
+{{% /s %}}
+
+Link with URL as text
+
+[https://google.com](https://google.com)
+`
+
+	b.WithContent("page.md", content)
+
+	b.Build(BuildCfg{})
+
+	b.AssertFileContent("public/page/index.html",
+		`T-SHORT`, `[https://google.com](https://google.com)`, `## Code`)
+}

--- a/resources/page/page.go
+++ b/resources/page/page.go
@@ -77,6 +77,7 @@ type ChildCareProvider interface {
 // ContentProvider provides the content related values for a Page.
 type ContentProvider interface {
 	Content() (interface{}, error)
+	ProcessedContent() (interface{}, error)
 	Plain() string
 	PlainWords() []string
 	Summary() template.HTML

--- a/resources/page/page_nop.go
+++ b/resources/page/page_nop.go
@@ -96,6 +96,10 @@ func (p *nopPage) Content() (interface{}, error) {
 	return "", nil
 }
 
+func (p *nopPage) ProcessedContent() (interface{}, error) {
+	return "", nil
+}
+
 func (p *nopPage) ContentBaseName() string {
 	return ""
 }

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -368,6 +368,10 @@ func (p *testPage) Pages() Pages {
 	panic("not implemented")
 }
 
+func (p *testPage) ProcessedContent() (interface{}, error) {
+	panic("not implemented")
+}
+
 func (p *testPage) RegularPages() Pages {
 	panic("not implemented")
 }


### PR DESCRIPTION
Add a page variable similar to .RawContent which returns the page as if it were a HTML file originally, that is, not passing it through the content converters.

We needed this functionality for rendering Hugo pages in an external SPA frontend with a normal Markdown processor on said frontend, and it suffices for this use case.

While preparing this PR I did stumble across #7297, which proposes a different interface for a similar concern, but which would have additional complexity as the shortcode state seems to be directly tied to the page input currently.