### PR TITLE
Fix: Invalid series detection in opengraph

### DIFF
--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -38,7 +38,7 @@
 {{- $permalink := .Permalink }}
 {{- $siteSeries := .Site.Taxonomies.series }}{{ with .Params.series }}
 {{- range $name := . }}
-  {{- $series := index $siteSeries $name }}
+  {{- $series := index $siteSeries ($name | urlize) }}
   {{- range $page := first 6 $series.Pages }}
     {{- if ne $page.Permalink $permalink }}<meta property="og:see_also" content="{{ $page.Permalink }}" />{{ end }}
   {{- end }}


### PR DESCRIPTION
When inside front matter you specified series with spaces, then the opengraph template wouldn't detect other articles, because in `.Site.Taxonomies.series` they are stored by urlized key.

Example:

```yaml
# in front matter
series:
    - My Series
```

```gohtml
{{/* in a template */}}
{{- $series := index .Site.Taxonomies.series $name }}

{{/* was resolved to */}}
{{- $series := index {'my-series': ...} "My Series" }}
```