### PR TITLE
Fix Resource.ResourceType so it always returns MIME's main type

### DIFF
--- a/docs/content/en/content-management/page-resources.md
+++ b/docs/content/en/content-management/page-resources.md
@@ -21,7 +21,9 @@ the lowest page they are bundled with, and simple which names does not contain `
 ## Properties
 
 ResourceType
-: The main type of the resource. For example, a file of MIME type `image/jpeg` has the ResourceType `image`.
+: The main type of the resource's [Media Type](/templates/output-formats/#media-types). For example, a file of MIME type `image/jpeg` has the ResourceType `image`. A `Page` will have `ResourceType` with value `page`.
+
+{{< new-in "0.80.0" >}} Note that we in Hugo `v0.80.0` fixed a bug where non-image resources (e.g. video) would return the MIME sub type, e.g. `json`.
 
 Name
 : Default value is the filename (relative to the owning page). Can be set in front matter.

--- a/hugolib/content_map_test.go
+++ b/hugolib/content_map_test.go
@@ -423,9 +423,9 @@ Draft5: {{ if (.Site.GetPage "blog/draftsection/sub/page") }}FOUND{{ end }}|
         
       Home: Hugo Home|/|2019-06-08|Current Section: |Resources: 
         Blog Section: Blogs|/blog/|2019-06-08|Current Section: blog|Resources: 
-        Blog Sub Section: Page 3|/blog/subsection/|2019-06-03|Current Section: blog/subsection|Resources: json: /blog/subsection/subdata.json|
+        Blog Sub Section: Page 3|/blog/subsection/|2019-06-03|Current Section: blog/subsection|Resources: application: /blog/subsection/subdata.json|
         Page: Page 1|/blog/page1/|2019-06-01|Current Section: blog|Resources: 
-        Bundle: Page 12|/blog/bundle/|0001-01-01|Current Section: blog|Resources: json: /blog/bundle/data.json|page: |
+        Bundle: Page 12|/blog/bundle/|0001-01-01|Current Section: blog|Resources: application: /blog/bundle/data.json|page: |
         IsDescendant: true: true true: true true: true true: true true: true true: true false: false
         IsAncestor: true: true true: true true: true true: true true: true true: true true: true false: false false: false  false: false
         IsDescendant overlap1: false: false

--- a/hugolib/pagebundler_test.go
+++ b/hugolib/pagebundler_test.go
@@ -707,7 +707,7 @@ func newTestBundleSources(t testing.TB) (*hugofs.Fs, *viper.Viper) {
 	cfg.Set("contentDir", "base")
 	cfg.Set("baseURL", "https://example.com")
 	cfg.Set("mediaTypes", map[string]interface{}{
-		"text/bepsays": map[string]interface{}{
+		"bepsays/bep": map[string]interface{}{
 			"suffixes": []string{"bep"},
 		},
 	})
@@ -1234,7 +1234,7 @@ title: %q
 	b.Build(BuildCfg{})
 
 	b.AssertFileContent("public/bundle/index.html", `
-        json|sub/data.json|
+        application|sub/data.json|
         page|bundle p1|
         page|bundle sub index|
         page|bundle sub p2|

--- a/hugolib/resource_chain_test.go
+++ b/hugolib/resource_chain_test.go
@@ -383,7 +383,7 @@ End.`)
 	b.AssertFileContent("public/index.html",
 		`Start.
 HELLO: /hello.min.a2d1cb24f24b322a7dad520414c523e9.html|Integrity: md5-otHLJPJLMip9rVIEFMUj6Q==|MediaType: text/html
-HELLO2: Name: hello.html|Content: <h1>Hello World!</h1>|Title: hello.html|ResourceType: html
+HELLO2: Name: hello.html|Content: <h1>Hello World!</h1>|Title: hello.html|ResourceType: text
 End.`)
 
 	b.AssertFileContent("public/page1/index.html", `HELLO: /hello.min.a2d1cb24f24b322a7dad520414c523e9.html`)

--- a/resources/resource_spec.go
+++ b/resources/resource_spec.go
@@ -208,12 +208,7 @@ func (r *Spec) newGenericResourceWithBase(
 	baseFilename = helpers.ToSlashTrimLeading(baseFilename)
 	fpath, fname := path.Split(baseFilename)
 
-	var resourceType string
-	if mediaType.MainType == "image" {
-		resourceType = mediaType.MainType
-	} else {
-		resourceType = mediaType.SubType
-	}
+	resourceType := mediaType.MainType
 
 	pathDescriptor := &resourcePathDescriptor{
 		baseTargetPathDirs: helpers.UniqueStringsReuse(targetPathBaseDirs),

--- a/resources/resource_test.go
+++ b/resources/resource_test.go
@@ -38,7 +38,7 @@ func TestGenericResource(t *testing.T) {
 
 	c.Assert(r.Permalink(), qt.Equals, "https://example.com/foo.css")
 	c.Assert(r.RelPermalink(), qt.Equals, "/foo.css")
-	c.Assert(r.ResourceType(), qt.Equals, "css")
+	c.Assert(r.ResourceType(), qt.Equals, "text")
 }
 
 func TestGenericResourceWithLinkFactory(t *testing.T) {
@@ -52,7 +52,7 @@ func TestGenericResourceWithLinkFactory(t *testing.T) {
 	c.Assert(r.Permalink(), qt.Equals, "https://example.com/foo/foo.css")
 	c.Assert(r.RelPermalink(), qt.Equals, "/foo/foo.css")
 	c.Assert(r.Key(), qt.Equals, "/foo/foo.css")
-	c.Assert(r.ResourceType(), qt.Equals, "css")
+	c.Assert(r.ResourceType(), qt.Equals, "text")
 }
 
 func TestNewResourceFromFilename(t *testing.T) {
@@ -76,7 +76,7 @@ func TestNewResourceFromFilename(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(r, qt.Not(qt.IsNil))
-	c.Assert(r.ResourceType(), qt.Equals, "json")
+	c.Assert(r.ResourceType(), qt.Equals, "application")
 }
 
 func TestNewResourceFromFilenameSubPathInBaseURL(t *testing.T) {
@@ -108,7 +108,7 @@ func TestResourcesByType(t *testing.T) {
 		spec.newGenericResource(nil, nil, nil, "/a/foo3.css", "foo3.css", media.CSSType),
 	}
 
-	c.Assert(len(resources.ByType("css")), qt.Equals, 3)
+	c.Assert(len(resources.ByType("text")), qt.Equals, 3)
 	c.Assert(len(resources.ByType("image")), qt.Equals, 1)
 }
 


### PR DESCRIPTION
The one exception being for the Page, which does not have a MIME type, in which you will get the value `page`.

Fixes #8052