### PR TITLE
tpl: Added configuration options to influence 'TableOfContents' generation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,3 +3,5 @@
 ### Reporting a Vulnerability
 
 Please report (suspected) security vulnerabilities to **[bjorn.erik.pedersen@gmail.com](mailto:bjorn.erik.pedersen@gmail.com)**. You will receive a response from us within 48 hours. If we can confirm the issue, we will release a patch as soon as possible depending on the complexity of the issue but historically within days.
+
+Also see [Hugo's Security Model](https://gohugo.io/about/security-model/).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+## Security Policy
+
+### Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities to **[bjorn.erik.pedersen@gmail.com](mailto:bjorn.erik.pedersen@gmail.com)**. You will receive a response from us within 48 hours. If we can confirm the issue, we will release a patch as soon as possible depending on the complexity of the issue but historically within days.

--- a/common/hexec/safeCommand.go
+++ b/common/hexec/safeCommand.go
@@ -1,0 +1,45 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hexec
+
+import (
+	"context"
+
+	"os/exec"
+
+	"github.com/cli/safeexec"
+)
+
+// SafeCommand is a wrapper around os/exec Command which uses a LookPath
+// implementation that does not search in current directory before looking in PATH.
+// See https://github.com/cli/safeexec and the linked issues.
+func SafeCommand(name string, arg ...string) (*exec.Cmd, error) {
+	bin, err := safeexec.LookPath(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return exec.Command(bin, arg...), nil
+}
+
+// SafeCommandContext wraps CommandContext
+// See SafeCommand for more context.
+func SafeCommandContext(ctx context.Context, name string, arg ...string) (*exec.Cmd, error) {
+	bin, err := safeexec.LookPath(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return exec.CommandContext(ctx, bin, arg...), nil
+}

--- a/common/para/para_test.go
+++ b/common/para/para_test.go
@@ -81,6 +81,9 @@ func TestPara(t *testing.T) {
 
 		c.Assert(r.Wait(), qt.IsNil)
 		c.Assert(counter, qt.Equals, int64(n))
-		c.Assert(time.Since(start) < n/2*time.Millisecond, qt.Equals, true)
+
+		since := time.Since(start)
+		limit := n / 2 * time.Millisecond
+		c.Assert(since < limit, qt.Equals, true, qt.Commentf("%s >= %s", since, limit))
 	})
 }

--- a/create/content.go
+++ b/create/content.go
@@ -18,12 +18,12 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
 
+	"github.com/gohugoio/hugo/common/hexec"
 	"github.com/gohugoio/hugo/hugofs/files"
 
 	"github.com/gohugoio/hugo/hugofs"
@@ -105,7 +105,10 @@ func NewContent(
 		jww.FEEDBACK.Printf("Editing %s with %q ...\n", targetPath, editor)
 
 		editorCmd := append(strings.Fields(editor), contentPath)
-		cmd := exec.Command(editorCmd[0], editorCmd[1:]...)
+		cmd, err := hexec.SafeCommand(editorCmd[0], editorCmd[1:]...)
+		if err != nil {
+			return err
+		}
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/docs/content/en/content-management/page-resources.md
+++ b/docs/content/en/content-management/page-resources.md
@@ -21,7 +21,9 @@ the lowest page they are bundled with, and simple which names does not contain `
 ## Properties
 
 ResourceType
-: The main type of the resource. For example, a file of MIME type `image/jpeg` has the ResourceType `image`.
+: The main type of the resource's [Media Type](/templates/output-formats/#media-types). For example, a file of MIME type `image/jpeg` has the ResourceType `image`. A `Page` will have `ResourceType` with value `page`.
+
+{{< new-in "0.80.0" >}} Note that we in Hugo `v0.80.0` fixed a bug where non-image resources (e.g. video) would return the MIME sub type, e.g. `json`.
 
 Name
 : Default value is the filename (relative to the owning page). Can be set in front matter.

--- a/docs/content/en/getting-started/configuration-markup.md
+++ b/docs/content/en/getting-started/configuration-markup.md
@@ -80,6 +80,18 @@ endLevel
 ordered
 : Whether or not to generate an ordered list instead of an unordered list.
 
+writeLevels
+: If enabled the list elements `<ul>, <ol>` will receive an attribute `data-level` with the corresponding level value.
+
+wrapperElement
+: By default `<nav>` is used. This option allows to specify an alternative such as `<div>`.
+
+wrapperId
+: By default `TableOfContents` is used. This option allows to specify an alternate ID.
+
+wrapperClass
+: If set this CSS class will be applied to the _wrapperElement_.
+
 
 ## Markdown Render Hooks
 

--- a/docs/content/en/news/0.79.1-relnotes/index.md
+++ b/docs/content/en/news/0.79.1-relnotes/index.md
@@ -1,0 +1,19 @@
+
+---
+date: 2020-12-19
+title: "Hugo 0.79.1: A couple of Bug Fixes"
+description: "This version fixes a couple of bugs introduced in 0.79.0."
+categories: ["Releases"]
+images:
+- images/blog/hugo-bug-poster.png
+
+---
+
+	
+
+This is a bug-fix release with one important fix.
+
+* Improve LookPath [4a8267d6](https://github.com/gohugoio/hugo/commit/4a8267d64a40564aced0695bca05249da17b0eab) [@bep](https://github.com/bep) 
+
+
+

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/bep/gitmap v1.1.2
 	github.com/bep/golibsass v0.7.0
 	github.com/bep/tmc v0.5.1
+	github.com/cli/safeexec v1.0.0
 	github.com/disintegration/gift v1.2.1
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgk
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=
+github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=

--- a/hugolib/content_map_test.go
+++ b/hugolib/content_map_test.go
@@ -423,9 +423,9 @@ Draft5: {{ if (.Site.GetPage "blog/draftsection/sub/page") }}FOUND{{ end }}|
         
       Home: Hugo Home|/|2019-06-08|Current Section: |Resources: 
         Blog Section: Blogs|/blog/|2019-06-08|Current Section: blog|Resources: 
-        Blog Sub Section: Page 3|/blog/subsection/|2019-06-03|Current Section: blog/subsection|Resources: json: /blog/subsection/subdata.json|
+        Blog Sub Section: Page 3|/blog/subsection/|2019-06-03|Current Section: blog/subsection|Resources: application: /blog/subsection/subdata.json|
         Page: Page 1|/blog/page1/|2019-06-01|Current Section: blog|Resources: 
-        Bundle: Page 12|/blog/bundle/|0001-01-01|Current Section: blog|Resources: json: /blog/bundle/data.json|page: |
+        Bundle: Page 12|/blog/bundle/|0001-01-01|Current Section: blog|Resources: application: /blog/bundle/data.json|page: |
         IsDescendant: true: true true: true true: true true: true true: true true: true false: false
         IsAncestor: true: true true: true true: true true: true true: true true: true true: true false: false false: false  false: false
         IsDescendant overlap1: false: false

--- a/hugolib/js_test.go
+++ b/hugolib/js_test.go
@@ -16,10 +16,11 @@ package hugolib
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/gohugoio/hugo/common/hexec"
 
 	"github.com/gohugoio/hugo/htesting"
 
@@ -125,7 +126,9 @@ TS: {{ template "print" $ts }}
 
 	b.WithSourceFile("assets/js/included.js", includedJS)
 
-	out, err := exec.Command("npm", "install").CombinedOutput()
+	cmd, err := hexec.SafeCommand("npm", "install")
+	b.Assert(err, qt.IsNil)
+	out, err := cmd.CombinedOutput()
 	b.Assert(err, qt.IsNil, qt.Commentf(string(out)))
 
 	b.Build(BuildCfg{})
@@ -193,7 +196,8 @@ require github.com/gohugoio/hugoTestProjectJSModImports v0.5.0 // indirect
 }`)
 
 	b.Assert(os.Chdir(workDir), qt.IsNil)
-	_, err = exec.Command("npm", "install").CombinedOutput()
+	cmd, _ := hexec.SafeCommand("npm", "install")
+	_, err = cmd.CombinedOutput()
 	b.Assert(err, qt.IsNil)
 
 	b.Build(BuildCfg{})

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -137,6 +137,10 @@ func newPageContentOutput(p *pageState, po *pageOutput) (*pageContentOutput, err
 						cfg.TableOfContents.StartLevel,
 						cfg.TableOfContents.EndLevel,
 						cfg.TableOfContents.Ordered,
+						cfg.TableOfContents.WriteLevels,
+						cfg.TableOfContents.WrapperElement,
+						cfg.TableOfContents.WrapperId,
+						cfg.TableOfContents.WrapperClass,
 					),
 				)
 			} else {

--- a/hugolib/pagebundler_test.go
+++ b/hugolib/pagebundler_test.go
@@ -707,7 +707,7 @@ func newTestBundleSources(t testing.TB) (*hugofs.Fs, *viper.Viper) {
 	cfg.Set("contentDir", "base")
 	cfg.Set("baseURL", "https://example.com")
 	cfg.Set("mediaTypes", map[string]interface{}{
-		"text/bepsays": map[string]interface{}{
+		"bepsays/bep": map[string]interface{}{
 			"suffixes": []string{"bep"},
 		},
 	})
@@ -1234,7 +1234,7 @@ title: %q
 	b.Build(BuildCfg{})
 
 	b.AssertFileContent("public/bundle/index.html", `
-        json|sub/data.json|
+        application|sub/data.json|
         page|bundle p1|
         page|bundle sub index|
         page|bundle sub p2|

--- a/hugolib/resource_chain_babel_test.go
+++ b/hugolib/resource_chain_babel_test.go
@@ -16,10 +16,11 @@ package hugolib
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/gohugoio/hugo/common/hexec"
 
 	jww "github.com/spf13/jwalterweatherman"
 
@@ -111,7 +112,8 @@ Transpiled: {{ $transpiled.Content | safeJS }}
 	b.WithSourceFile("babel.config.js", babelConfig)
 
 	b.Assert(os.Chdir(workDir), qt.IsNil)
-	_, err = exec.Command("npm", "install").CombinedOutput()
+	cmd, _ := hexec.SafeCommand("npm", "install")
+	_, err = cmd.CombinedOutput()
 	b.Assert(err, qt.IsNil)
 
 	b.Build(BuildCfg{})

--- a/hugolib/resource_chain_test.go
+++ b/hugolib/resource_chain_test.go
@@ -19,12 +19,14 @@ import (
 	"io"
 	"math/rand"
 	"os"
-	"os/exec"
+
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gohugoio/hugo/common/hexec"
 
 	jww "github.com/spf13/jwalterweatherman"
 
@@ -930,7 +932,8 @@ class-in-b {
 	b.WithSourceFile("postcss.config.js", postcssConfig)
 
 	b.Assert(os.Chdir(workDir), qt.IsNil)
-	_, err = exec.Command("npm", "install").CombinedOutput()
+	cmd, err := hexec.SafeCommand("npm", "install")
+	_, err = cmd.CombinedOutput()
 	b.Assert(err, qt.IsNil)
 	b.Build(BuildCfg{})
 

--- a/hugolib/resource_chain_test.go
+++ b/hugolib/resource_chain_test.go
@@ -383,7 +383,7 @@ End.`)
 	b.AssertFileContent("public/index.html",
 		`Start.
 HELLO: /hello.min.a2d1cb24f24b322a7dad520414c523e9.html|Integrity: md5-otHLJPJLMip9rVIEFMUj6Q==|MediaType: text/html
-HELLO2: Name: hello.html|Content: <h1>Hello World!</h1>|Title: hello.html|ResourceType: html
+HELLO2: Name: hello.html|Content: <h1>Hello World!</h1>|Title: hello.html|ResourceType: text
 End.`)
 
 	b.AssertFileContent("public/page1/index.html", `HELLO: /hello.min.a2d1cb24f24b322a7dad520414c523e9.html`)

--- a/markup/asciidocext/convert.go
+++ b/markup/asciidocext/convert.go
@@ -18,8 +18,9 @@ package asciidocext
 
 import (
 	"bytes"
-	"os/exec"
 	"path/filepath"
+
+	"github.com/cli/safeexec"
 
 	"github.com/gohugoio/hugo/identity"
 	"github.com/gohugoio/hugo/markup/asciidocext/asciidocext_config"
@@ -193,7 +194,7 @@ func (a *asciidocConverter) appendArg(args []string, option, value, defaultValue
 }
 
 func getAsciidoctorExecPath() string {
-	path, err := exec.LookPath("asciidoctor")
+	path, err := safeexec.LookPath("asciidoctor")
 	if err != nil {
 		return ""
 	}

--- a/markup/goldmark/convert_test.go
+++ b/markup/goldmark/convert_test.go
@@ -160,7 +160,7 @@ description
 
 	toc, ok := b.(converter.TableOfContentsProvider)
 	c.Assert(ok, qt.Equals, true)
-	tocHTML := toc.TableOfContents().ToHTML(1, 2, false)
+	tocHTML := toc.TableOfContents().ToHTML(1, 2, false, false, "", "", "")
 	c.Assert(tocHTML, qt.Contains, "TableOfContents")
 }
 

--- a/markup/goldmark/toc_test.go
+++ b/markup/goldmark/toc_test.go
@@ -60,7 +60,7 @@ And then some.
 	c.Assert(err, qt.IsNil)
 	b, err := conv.Convert(converter.RenderContext{Src: []byte(content), RenderTOC: true})
 	c.Assert(err, qt.IsNil)
-	got := b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(2, 3, false)
+	got := b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(2, 3, false, false, "", "", "")
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#first-h2---now-with-typography">First h2&mdash;now with typography!</a>
@@ -110,7 +110,7 @@ func TestEscapeToc(t *testing.T) {
 	// content := ""
 	b, err := safeConv.Convert(converter.RenderContext{Src: []byte(content), RenderTOC: true})
 	c.Assert(err, qt.IsNil)
-	got := b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(1, 2, false)
+	got := b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(1, 2, false, false, "", "", "")
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#a--b--c--d">A &lt; B &amp; C &gt; D</a></li>
@@ -122,7 +122,7 @@ func TestEscapeToc(t *testing.T) {
 
 	b, err = unsafeConv.Convert(converter.RenderContext{Src: []byte(content), RenderTOC: true})
 	c.Assert(err, qt.IsNil)
-	got = b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(1, 2, false)
+	got = b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(1, 2, false, false, "", "", "")
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#a--b--c--d">A &lt; B &amp; C &gt; D</a></li>

--- a/markup/pandoc/convert.go
+++ b/markup/pandoc/convert.go
@@ -15,8 +15,7 @@
 package pandoc
 
 import (
-	"os/exec"
-
+	"github.com/cli/safeexec"
 	"github.com/gohugoio/hugo/identity"
 	"github.com/gohugoio/hugo/markup/internal"
 
@@ -65,7 +64,7 @@ func (c *pandocConverter) getPandocContent(src []byte, ctx converter.DocumentCon
 }
 
 func getPandocExecPath() string {
-	path, err := exec.LookPath("pandoc")
+	path, err := safeexec.LookPath("pandoc")
 	if err != nil {
 		return ""
 	}

--- a/markup/rst/convert.go
+++ b/markup/rst/convert.go
@@ -16,8 +16,9 @@ package rst
 
 import (
 	"bytes"
-	"os/exec"
 	"runtime"
+
+	"github.com/cli/safeexec"
 
 	"github.com/gohugoio/hugo/identity"
 	"github.com/gohugoio/hugo/markup/internal"
@@ -96,9 +97,9 @@ func (c *rstConverter) getRstContent(src []byte, ctx converter.DocumentContext) 
 }
 
 func getRstExecPath() string {
-	path, err := exec.LookPath("rst2html")
+	path, err := safeexec.LookPath("rst2html")
 	if err != nil {
-		path, err = exec.LookPath("rst2html.py")
+		path, err = safeexec.LookPath("rst2html.py")
 		if err != nil {
 			return ""
 		}

--- a/markup/tableofcontents/tableofcontents.go
+++ b/markup/tableofcontents/tableofcontents.go
@@ -14,8 +14,8 @@
 package tableofcontents
 
 import (
-	"strings"
 	"strconv"
+	"strings"
 )
 
 // Headers holds the top level (h1) headers.
@@ -90,13 +90,13 @@ type tocBuilder struct {
 	s strings.Builder
 	h Headers
 
-	startLevel      int
-	stopLevel       int
-	ordered         bool
-	writeLevels     bool
-	wrapperElement  string
-	wrapperId       string
-	wrapperClass	string
+	startLevel     int
+	stopLevel      int
+	ordered        bool
+	writeLevels    bool
+	wrapperElement string
+	wrapperId      string
+	wrapperClass   string
 }
 
 func (b *tocBuilder) Build() {
@@ -108,7 +108,7 @@ func (b *tocBuilder) writeNav(h Headers) {
 	if len(b.wrapperClass) > 0 {
 		wrapperClass = " class=\"" + b.wrapperClass + "\""
 	}
-	b.s.WriteString("<" + b.wrapperElement + wrapperClass + " id=\"" + b.wrapperId +"\">")
+	b.s.WriteString("<" + b.wrapperElement + wrapperClass + " id=\"" + b.wrapperId + "\">")
 	b.writeHeaders(1, 0, b.h)
 	b.s.WriteString("</" + b.wrapperElement + ">")
 }
@@ -132,7 +132,7 @@ func (b *tocBuilder) writeHeaders(level, indent int, h Headers) {
 		b.indent(indent + 1)
 		levelAttr := ""
 		if b.writeLevels {
-			levelAttr = " data-level=\"" + strconv.Itoa(level) + "\"";
+			levelAttr = " data-level=\"" + strconv.Itoa(level) + "\""
 		}
 		if b.ordered {
 			b.s.WriteString("<ol" + levelAttr + ">\n")
@@ -175,13 +175,13 @@ func (b *tocBuilder) indent(n int) {
 
 // DefaultConfig is the default ToC configuration.
 var DefaultConfig = Config{
-	StartLevel:      2,
-	EndLevel:        3,
-	Ordered:         false,
-	WriteLevels:     false,
-	WrapperElement:  "nav",
-	WrapperId:       "TableOfContents",
-	WrapperClass:    "",
+	StartLevel:     2,
+	EndLevel:       3,
+	Ordered:        false,
+	WriteLevels:    false,
+	WrapperElement: "nav",
+	WrapperId:      "TableOfContents",
+	WrapperClass:   "",
 }
 
 type Config struct {
@@ -196,7 +196,7 @@ type Config struct {
 	// Whether to produce a ordered list or not.
 	Ordered bool
 
-	// If set to true each <ul> element will provide an attribute 'data-level' 
+	// If set to true each <ul> element will provide an attribute 'data-level'
 	// with the corresponding level (eg. h2 -> 2, h3 -> 3, ...)
 	WriteLevels bool
 
@@ -208,5 +208,4 @@ type Config struct {
 
 	// CSS class which will be applied to the wrapper
 	WrapperClass string
-
 }

--- a/markup/tableofcontents/tableofcontents_test.go
+++ b/markup/tableofcontents/tableofcontents_test.go
@@ -154,7 +154,6 @@ func TestTocMissingParent(t *testing.T) {
 </nav>`, qt.Commentf(got))
 }
 
-
 func TestTocWriteLevels(t *testing.T) {
 	c := qt.New(t)
 

--- a/markup/tableofcontents/tableofcontents_test.go
+++ b/markup/tableofcontents/tableofcontents_test.go
@@ -30,7 +30,7 @@ func TestToc(t *testing.T) {
 	toc.AddAt(Header{Text: "1-H3-1", ID: "1-h2-2"}, 0, 2)
 	toc.AddAt(Header{Text: "Header 2", ID: "h1-2"}, 1, 0)
 
-	got := toc.ToHTML(1, -1, false)
+	got := toc.ToHTML(1, -1, false, false, "", "", "")
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#h1-1">Header 1</a>
@@ -47,7 +47,7 @@ func TestToc(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(1, 1, false)
+	got = toc.ToHTML(1, 1, false, false, "", "", "")
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#h1-1">Header 1</a></li>
@@ -55,7 +55,7 @@ func TestToc(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(1, 2, false)
+	got = toc.ToHTML(1, 2, false, false, "", "", "")
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#h1-1">Header 1</a>
@@ -68,7 +68,7 @@ func TestToc(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(2, 2, false)
+	got = toc.ToHTML(2, 2, false, false, "", "", "")
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#1-h2-1">1-H2-1</a></li>
@@ -76,7 +76,7 @@ func TestToc(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(1, -1, true)
+	got = toc.ToHTML(1, -1, true, false, "", "", "")
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ol>
     <li><a href="#h1-1">Header 1</a>
@@ -103,7 +103,7 @@ func TestTocMissingParent(t *testing.T) {
 	toc.AddAt(Header{Text: "H3", ID: "h3"}, 1, 2)
 	toc.AddAt(Header{Text: "H3", ID: "h3"}, 1, 2)
 
-	got := toc.ToHTML(1, -1, false)
+	got := toc.ToHTML(1, -1, false, false, "", "", "")
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li>
@@ -124,7 +124,7 @@ func TestTocMissingParent(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(3, 3, false)
+	got = toc.ToHTML(3, 3, false, false, "", "", "")
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#h3">H3</a></li>
@@ -132,7 +132,7 @@ func TestTocMissingParent(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(1, -1, true)
+	got = toc.ToHTML(1, -1, true, false, "", "", "")
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ol>
     <li>
@@ -152,4 +152,155 @@ func TestTocMissingParent(t *testing.T) {
     </li>
   </ol>
 </nav>`, qt.Commentf(got))
+}
+
+
+func TestTocWriteLevels(t *testing.T) {
+	c := qt.New(t)
+
+	toc := &Root{}
+
+	toc.AddAt(Header{Text: "Header 1", ID: "h1-1"}, 0, 0)
+	toc.AddAt(Header{Text: "1-H2-1", ID: "1-h2-1"}, 0, 1)
+	toc.AddAt(Header{Text: "1-H2-2", ID: "1-h2-2"}, 0, 1)
+	toc.AddAt(Header{Text: "1-H3-1", ID: "1-h2-2"}, 0, 2)
+	toc.AddAt(Header{Text: "Header 2", ID: "h1-2"}, 1, 0)
+
+	got := toc.ToHTML(1, -1, false, true, "", "", "")
+	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
+  <ul data-level="1">
+    <li><a href="#h1-1">Header 1</a>
+      <ul data-level="2">
+        <li><a href="#1-h2-1">1-H2-1</a></li>
+        <li><a href="#1-h2-2">1-H2-2</a>
+          <ul data-level="3">
+            <li><a href="#1-h2-2">1-H3-1</a></li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li><a href="#h1-2">Header 2</a></li>
+  </ul>
+</nav>`, qt.Commentf(got))
+
+}
+
+func TestTocAlternateWrapperElement(t *testing.T) {
+	c := qt.New(t)
+
+	toc := &Root{}
+
+	toc.AddAt(Header{Text: "Header 1", ID: "h1-1"}, 0, 0)
+	toc.AddAt(Header{Text: "1-H2-1", ID: "1-h2-1"}, 0, 1)
+	toc.AddAt(Header{Text: "1-H2-2", ID: "1-h2-2"}, 0, 1)
+	toc.AddAt(Header{Text: "1-H3-1", ID: "1-h2-2"}, 0, 2)
+	toc.AddAt(Header{Text: "Header 2", ID: "h1-2"}, 1, 0)
+
+	got := toc.ToHTML(1, -1, false, false, "div", "", "")
+	c.Assert(got, qt.Equals, `<div id="TableOfContents">
+  <ul>
+    <li><a href="#h1-1">Header 1</a>
+      <ul>
+        <li><a href="#1-h2-1">1-H2-1</a></li>
+        <li><a href="#1-h2-2">1-H2-2</a>
+          <ul>
+            <li><a href="#1-h2-2">1-H3-1</a></li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li><a href="#h1-2">Header 2</a></li>
+  </ul>
+</div>`, qt.Commentf(got))
+
+}
+
+func TestTocAlternateWrapperId(t *testing.T) {
+	c := qt.New(t)
+
+	toc := &Root{}
+
+	toc.AddAt(Header{Text: "Header 1", ID: "h1-1"}, 0, 0)
+	toc.AddAt(Header{Text: "1-H2-1", ID: "1-h2-1"}, 0, 1)
+	toc.AddAt(Header{Text: "1-H2-2", ID: "1-h2-2"}, 0, 1)
+	toc.AddAt(Header{Text: "1-H3-1", ID: "1-h2-2"}, 0, 2)
+	toc.AddAt(Header{Text: "Header 2", ID: "h1-2"}, 1, 0)
+
+	got := toc.ToHTML(1, -1, false, false, "", "bronco", "")
+	c.Assert(got, qt.Equals, `<nav id="bronco">
+  <ul>
+    <li><a href="#h1-1">Header 1</a>
+      <ul>
+        <li><a href="#1-h2-1">1-H2-1</a></li>
+        <li><a href="#1-h2-2">1-H2-2</a>
+          <ul>
+            <li><a href="#1-h2-2">1-H3-1</a></li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li><a href="#h1-2">Header 2</a></li>
+  </ul>
+</nav>`, qt.Commentf(got))
+
+}
+
+func TestTocWithWrapperClass(t *testing.T) {
+	c := qt.New(t)
+
+	toc := &Root{}
+
+	toc.AddAt(Header{Text: "Header 1", ID: "h1-1"}, 0, 0)
+	toc.AddAt(Header{Text: "1-H2-1", ID: "1-h2-1"}, 0, 1)
+	toc.AddAt(Header{Text: "1-H2-2", ID: "1-h2-2"}, 0, 1)
+	toc.AddAt(Header{Text: "1-H3-1", ID: "1-h2-2"}, 0, 2)
+	toc.AddAt(Header{Text: "Header 2", ID: "h1-2"}, 1, 0)
+
+	got := toc.ToHTML(1, -1, false, false, "", "", "my-toc")
+	c.Assert(got, qt.Equals, `<nav class="my-toc" id="TableOfContents">
+  <ul>
+    <li><a href="#h1-1">Header 1</a>
+      <ul>
+        <li><a href="#1-h2-1">1-H2-1</a></li>
+        <li><a href="#1-h2-2">1-H2-2</a>
+          <ul>
+            <li><a href="#1-h2-2">1-H3-1</a></li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li><a href="#h1-2">Header 2</a></li>
+  </ul>
+</nav>`, qt.Commentf(got))
+
+}
+
+func TestTocWithLevelsAndAlternateWrapperElementAndAlternateWrapperIdAndWrapperClass(t *testing.T) {
+	c := qt.New(t)
+
+	toc := &Root{}
+
+	toc.AddAt(Header{Text: "Header 1", ID: "h1-1"}, 0, 0)
+	toc.AddAt(Header{Text: "1-H2-1", ID: "1-h2-1"}, 0, 1)
+	toc.AddAt(Header{Text: "1-H2-2", ID: "1-h2-2"}, 0, 1)
+	toc.AddAt(Header{Text: "1-H3-1", ID: "1-h2-2"}, 0, 2)
+	toc.AddAt(Header{Text: "Header 2", ID: "h1-2"}, 1, 0)
+
+	got := toc.ToHTML(1, -1, false, true, "div", "bibo", "my-toc")
+	c.Assert(got, qt.Equals, `<div class="my-toc" id="bibo">
+  <ul data-level="1">
+    <li><a href="#h1-1">Header 1</a>
+      <ul data-level="2">
+        <li><a href="#1-h2-1">1-H2-1</a></li>
+        <li><a href="#1-h2-2">1-H2-2</a>
+          <ul data-level="3">
+            <li><a href="#1-h2-2">1-H3-1</a></li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li><a href="#h1-2">Header 2</a></li>
+  </ul>
+</div>`, qt.Commentf(got))
+
 }

--- a/modules/client.go
+++ b/modules/client.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gohugoio/hugo/common/hexec"
+
 	hglob "github.com/gohugoio/hugo/hugofs/glob"
 
 	"github.com/gobwas/glob"
@@ -537,7 +539,10 @@ func (c *Client) runGo(
 	}
 
 	stderr := new(bytes.Buffer)
-	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd, err := hexec.SafeCommandContext(ctx, "go", args...)
+	if err != nil {
+		return err
+	}
 
 	cmd.Env = c.environ
 	cmd.Dir = c.ccfg.WorkingDir

--- a/releaser/git.go
+++ b/releaser/git.go
@@ -15,11 +15,12 @@ package releaser
 
 import (
 	"fmt"
-	"os/exec"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/gohugoio/hugo/common/hexec"
 )
 
 var issueRe = regexp.MustCompile(`(?i)[Updates?|Closes?|Fix.*|See] #(\d+)`)
@@ -148,7 +149,7 @@ func extractIssues(body string) []int {
 type gitInfos []gitInfo
 
 func git(args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+	cmd, _ := hexec.SafeCommand("git", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git failed: %q: %q (%q)", err, out, args)

--- a/releaser/releaser.go
+++ b/releaser/releaser.go
@@ -20,10 +20,11 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/gohugoio/hugo/common/hexec"
 
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/pkg/errors"
@@ -266,7 +267,7 @@ func (r *ReleaseHandler) release(releaseNotesFile string) error {
 		args = append(args, "--skip-publish")
 	}
 
-	cmd := exec.Command("goreleaser", args...)
+	cmd, _ := hexec.SafeCommand("goreleaser", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()

--- a/resources/resource_spec.go
+++ b/resources/resource_spec.go
@@ -208,12 +208,7 @@ func (r *Spec) newGenericResourceWithBase(
 	baseFilename = helpers.ToSlashTrimLeading(baseFilename)
 	fpath, fname := path.Split(baseFilename)
 
-	var resourceType string
-	if mediaType.MainType == "image" {
-		resourceType = mediaType.MainType
-	} else {
-		resourceType = mediaType.SubType
-	}
+	resourceType := mediaType.MainType
 
 	pathDescriptor := &resourcePathDescriptor{
 		baseTargetPathDirs: helpers.UniqueStringsReuse(targetPathBaseDirs),

--- a/resources/resource_test.go
+++ b/resources/resource_test.go
@@ -38,7 +38,7 @@ func TestGenericResource(t *testing.T) {
 
 	c.Assert(r.Permalink(), qt.Equals, "https://example.com/foo.css")
 	c.Assert(r.RelPermalink(), qt.Equals, "/foo.css")
-	c.Assert(r.ResourceType(), qt.Equals, "css")
+	c.Assert(r.ResourceType(), qt.Equals, "text")
 }
 
 func TestGenericResourceWithLinkFactory(t *testing.T) {
@@ -52,7 +52,7 @@ func TestGenericResourceWithLinkFactory(t *testing.T) {
 	c.Assert(r.Permalink(), qt.Equals, "https://example.com/foo/foo.css")
 	c.Assert(r.RelPermalink(), qt.Equals, "/foo/foo.css")
 	c.Assert(r.Key(), qt.Equals, "/foo/foo.css")
-	c.Assert(r.ResourceType(), qt.Equals, "css")
+	c.Assert(r.ResourceType(), qt.Equals, "text")
 }
 
 func TestNewResourceFromFilename(t *testing.T) {
@@ -76,7 +76,7 @@ func TestNewResourceFromFilename(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(r, qt.Not(qt.IsNil))
-	c.Assert(r.ResourceType(), qt.Equals, "json")
+	c.Assert(r.ResourceType(), qt.Equals, "application")
 }
 
 func TestNewResourceFromFilenameSubPathInBaseURL(t *testing.T) {
@@ -108,7 +108,7 @@ func TestResourcesByType(t *testing.T) {
 		spec.newGenericResource(nil, nil, nil, "/a/foo3.css", "foo3.css", media.CSSType),
 	}
 
-	c.Assert(len(resources.ByType("css")), qt.Equals, 3)
+	c.Assert(len(resources.ByType("text")), qt.Equals, 3)
 	c.Assert(len(resources.ByType("image")), qt.Equals, 1)
 }
 

--- a/resources/resource_transformers/babel/babel.go
+++ b/resources/resource_transformers/babel/babel.go
@@ -16,10 +16,11 @@ package babel
 import (
 	"bytes"
 	"io"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 
+	"github.com/cli/safeexec"
+	"github.com/gohugoio/hugo/common/hexec"
 	"github.com/gohugoio/hugo/common/loggers"
 
 	"github.com/gohugoio/hugo/common/hugo"
@@ -108,10 +109,10 @@ func (t *babelTransformation) Transform(ctx *resources.ResourceTransformationCtx
 
 	binary := csiBinPath
 
-	if _, err := exec.LookPath(binary); err != nil {
+	if _, err := safeexec.LookPath(binary); err != nil {
 		// Try PATH
 		binary = binaryName
-		if _, err := exec.LookPath(binary); err != nil {
+		if _, err := safeexec.LookPath(binary); err != nil {
 			// This may be on a CI server etc. Will fall back to pre-built assets.
 			return herrors.ErrFeatureNotAvailable
 		}
@@ -152,7 +153,10 @@ func (t *babelTransformation) Transform(ctx *resources.ResourceTransformationCtx
 	}
 	cmdArgs = append(cmdArgs, "--filename="+ctx.SourcePath)
 
-	cmd := exec.Command(binary, cmdArgs...)
+	cmd, err := hexec.SafeCommand(binary, cmdArgs...)
+	if err != nil {
+		return err
+	}
 
 	cmd.Stdout = ctx.To
 	cmd.Stderr = io.MultiWriter(infoW, &errBuf)

--- a/scripts/fork_go_templates/main.go
+++ b/scripts/fork_go_templates/main.go
@@ -5,10 +5,11 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/gohugoio/hugo/common/hexec"
 
 	"github.com/gohugoio/hugo/common/hugio"
 
@@ -203,7 +204,7 @@ func removeAll(expression, content string) string {
 }
 
 func rewrite(filename, rule string) {
-	cmf := exec.Command("gofmt", "-w", "-r", rule, filename)
+	cmf, _ := hexec.SafeCommand("gofmt", "-w", "-r", rule, filename)
 	out, err := cmf.CombinedOutput()
 	if err != nil {
 		log.Fatal("gofmt failed:", string(out))
@@ -211,7 +212,7 @@ func rewrite(filename, rule string) {
 }
 
 func goimports(dir string) {
-	cmf := exec.Command("goimports", "-w", dir)
+	cmf, _ := hexec.SafeCommand("goimports", "-w", dir)
 	out, err := cmf.CombinedOutput()
 	if err != nil {
 		log.Fatal("goimports failed:", string(out))
@@ -219,7 +220,7 @@ func goimports(dir string) {
 }
 
 func gofmt(dir string) {
-	cmf := exec.Command("gofmt", "-w", dir)
+	cmf, _ := hexec.SafeCommand("gofmt", "-w", dir)
 	out, err := cmf.CombinedOutput()
 	if err != nil {
 		log.Fatal("gofmt failed:", string(out))

--- a/tpl/internal/go_templates/testenv/testenv.go
+++ b/tpl/internal/go_templates/testenv/testenv.go
@@ -13,7 +13,6 @@ package testenv
 import (
 	"errors"
 	"flag"
-	"github.com/gohugoio/hugo/tpl/internal/go_templates/cfg"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,6 +21,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/cli/safeexec"
+	"github.com/gohugoio/hugo/tpl/internal/go_templates/cfg"
 )
 
 // Builder reports the name of the builder running this test
@@ -111,7 +113,7 @@ func GoTool() (string, error) {
 	if _, err := os.Stat(path); err == nil {
 		return path, nil
 	}
-	goBin, err := exec.LookPath("go" + exeSuffix)
+	goBin, err := safeexec.LookPath("go" + exeSuffix)
 	if err != nil {
 		return "", errors.New("cannot find go tool: " + err.Error())
 	}
@@ -162,7 +164,7 @@ func MustHaveExecPath(t testing.TB, path string) {
 
 	err, found := execPaths.Load(path)
 	if !found {
-		_, err = exec.LookPath(path)
+		_, err = safeexec.LookPath(path)
 		err, _ = execPaths.LoadOrStore(path, err)
 	}
 	if err != nil {


### PR DESCRIPTION
This commit adds the following options to control the outcome of the 'TableOfContents' rendering:

* writeLevels: Add 'data-level' attributes to '<ul/ol>' elements which allows better control for the styling.
* wrapperElement: Allows to use alternative elements rather than '<nav>'
* wrapperId: Allows to use an alternative ID rather than 'TableOfContents'
* wrapperClass: Allows to attach a CSS class to the wrapperElement

The default behavior remains unchanged, so if none of these attributes is being used nothing will be changed.