### PR TITLE
docs: create a SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+## Security Policy
+
+### Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities to **[bjorn.erik.pedersen@gmail.com](mailto:bjorn.erik.pedersen@gmail.com)**. You will receive a response from us within 48 hours. If we can confirm the issue, we will release a patch as soon as possible depending on the complexity of the issue but historically within days.


### PR DESCRIPTION
This file is used by Github as a tab on the repos homepage to access information about how to report security issues. The text is kept simple.

Will solve #8074