### PR TITLE
SafeURL: considerer  "tel:" URI sheme as safe

### DIFF
--- a/docs/content/en/functions/safeURL.md
+++ b/docs/content/en/functions/safeURL.md
@@ -20,7 +20,7 @@ aliases: []
 
 `safeURL` declares the provided string as a "safe" URL or URL substring (see [RFC 3986][]). A URL like `javascript:checkThatFormNotEditedBeforeLeavingPage()` from a trusted source should go in the page, but by default dynamic `javascript:` URLs are filtered out since they are a frequently exploited injection vector.
 
-Without `safeURL`, only the URI schemes `http:`, `https:` and `mailto:` are considered safe by Go templates. If any other URI schemes (e.g., `irc:` and `javascript:`) are detected, the whole URL will be replaced with `#ZgotmplZ`. This is to "defang" any potential attack in the URL by rendering it useless.
+Without `safeURL`, only the URI schemes `http:`, `https:`, `mailto:` and `tel:` are considered safe by Go templates. If any other URI schemes (e.g., `irc:` and `javascript:`) are detected, the whole URL will be replaced with `#ZgotmplZ`. This is to "defang" any potential attack in the URL by rendering it useless.
 
 The following examples use a [site `config.toml`][configuration] with the following [menu entry][menus]:
 

--- a/tpl/internal/go_templates/htmltemplate/url.go
+++ b/tpl/internal/go_templates/htmltemplate/url.go
@@ -28,6 +28,10 @@ import (
 //    * mailto: Opens an email program and starts a new draft. This side effect
 //              is not irreversible until the user explicitly clicks send; it
 //              can be undone by closing the email program.
+//    * tel:    Opens an call program to start a new phone call. This side effect
+//              use to be reversible as call programms use to wait for confirmation
+//              before starting the call ; and can be undone by closing the call or
+//              the call program.
 //
 // To allow URLs containing other schemes to bypass this filter, developers must
 // explicitly indicate that such a URL is expected and safe by encapsulating it
@@ -49,7 +53,8 @@ func isSafeURL(s string) bool {
 	if i := strings.IndexRune(s, ':'); i >= 0 && !strings.ContainsRune(s[:i], '/') {
 
 		protocol := s[:i]
-		if !strings.EqualFold(protocol, "http") && !strings.EqualFold(protocol, "https") && !strings.EqualFold(protocol, "mailto") {
+		if !strings.EqualFold(protocol, "http") && !strings.EqualFold(protocol, "https") &&
+		!strings.EqualFold(protocol, "mailto") && !strings.EqualFold(protocol, "tel") {
 			return false
 		}
 	}


### PR DESCRIPTION
Since "mailto:" is considered as safe, then also should be "tel:".
BTW, the existence of this function does not make me very comfortable.