### PR TITLE
GroupByParamDate not supporting datetimes

### DIFF
--- a/resources/page/pagegroup.go
+++ b/resources/page/pagegroup.go
@@ -316,7 +316,7 @@ func (p Pages) GroupByParamDate(key string, format string, order ...string) (Pag
 		var r Pages
 
 		for _, p := range pages {
-			param := resource.GetParamToLower(p, key)
+			param := resource.GetParam(p, key)
 			var t time.Time
 
 			if param != nil {

--- a/resources/page/pagegroup_test.go
+++ b/resources/page/pagegroup_test.go
@@ -34,7 +34,8 @@ var pageGroupTestSources = []pageGroupTestObject{
 	{"/section1/testpage2.md", 3, "2012-01-01", "bar"},
 	{"/section1/testpage3.md", 2, "2012-04-06", "foo"},
 	{"/section2/testpage4.md", 1, "2012-03-02", "bar"},
-	{"/section2/testpage5.md", 1, "2012-04-06", "baz"},
+	// date might also be a full datetime:
+	{"/section2/testpage5.md", 1, "2012-04-06T00:00:00Z", "baz"},
 }
 
 func preparePageGroupTestPages(t *testing.T) Pages {


### PR DESCRIPTION
My goal was to sort my readinglist per year. Here I have three date-params:

- date (just the usual page attribute)
- started (when I started reading the book)
- finished (when I finished the book)

Now I wanted the grouping to happen for the `finished` field in a way similar to how GoodReads does it. So I tried the following code:

```go
{{ range .Pages.GroupByParamDate "finished" "2006" }}
```

Sadly, this resulted in only a single group with the key `0001`. This kind of started smelling like an issue with the date format so I went digging.

Turns out that the `Pages.GroupByParamDate` method converts the parameter to a lower-case representation and tries to convert that into a time.Time if it isn't already of that type. That fails for things like RFC3339-formatted dates because the `T` separator is now also a `t` and therefore no longer matches.

This was never an issue simply because before that method didn't support string parameters and therefore never did any actual type conversion before.

This is basically a follow-up to https://github.com/gohugoio/hugo/issues/3983.
