### PR TITLE
media: correctly detect webmanifest mimetypes

### DIFF
--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -166,7 +166,7 @@ var (
 	TSXType        = newMediaType("text", "tsx", []string{"tsx"})
 	JSXType        = newMediaType("text", "jsx", []string{"jsx"})
 
-	JSONType = newMediaType("application", "json", []string{"json"})
+	JSONType = newMediaType("application", "json", []string{"json", "webmanifest"})
 	RSSType  = newMediaTypeWithMimeSuffix("application", "rss", "xml", []string{"xml"})
 	XMLType  = newMediaType("application", "xml", []string{"xml"})
 	SVGType  = newMediaTypeWithMimeSuffix("image", "svg", "xml", []string{"svg"})


### PR DESCRIPTION
The standard file extension for Web App Manifest files is
".webmanifest". This commit allows Hugo to process .webmanifest files as
JSON, simplifiying tasks such as minification.

The .webmanifest file extension is recommended in the w3c spec to
simplify media type registration:
https://www.w3.org/TR/appmanifest/#media-type-registration

Webhint docs are also relevant:
https://webhint.io/docs/user-guide/hints/hint-manifest-file-extension/