### PR TITLE
tpl: Do not return errors in substr for out-of-bounds cases

### DIFF
--- a/tpl/strings/strings.go
+++ b/tpl/strings/strings.go
@@ -16,7 +16,6 @@ package strings
 
 import (
 	"errors"
-	"fmt"
 	"html/template"
 	"strings"
 	"unicode/utf8"
@@ -322,7 +321,7 @@ func (ns *Namespace) Substr(a interface{}, nums ...interface{}) (string, error) 
 	}
 
 	if start > rlen-1 {
-		return "", fmt.Errorf("start position out of bounds for %d-byte string", rlen)
+		return "", nil
 	}
 
 	end := rlen
@@ -337,7 +336,7 @@ func (ns *Namespace) Substr(a interface{}, nums ...interface{}) (string, error) 
 	}
 
 	if start >= end {
-		return "", fmt.Errorf("calculated start position greater than end position: %d > %d", start, end)
+		return "", nil
 	}
 
 	if end < 0 {

--- a/tpl/strings/strings_test.go
+++ b/tpl/strings/strings_test.go
@@ -453,6 +453,7 @@ func TestSubstr(t *testing.T) {
 		{"abcdef", 2, -1, "cde"},
 		{"abcdef", 4, -4, false},
 		{"abcdef", 7, 1, false},
+		{"abcdef", 6, nil, false},
 		{"abcdef", 1, 100, "bcdef"},
 		{"abcdef", -100, 3, "abc"},
 		{"abcdef", -3, -1, "de"},
@@ -486,7 +487,7 @@ func TestSubstr(t *testing.T) {
 		}
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), qt.Commentf("%v", test))
+			c.Check(err, qt.Not(qt.IsNil), qt.Commentf("%v", test))
 			continue
 		}
 

--- a/tpl/strings/strings_test.go
+++ b/tpl/strings/strings_test.go
@@ -451,9 +451,9 @@ func TestSubstr(t *testing.T) {
 		{"abcdef", -3, 1, "d"},
 		{"abcdef", 0, -1, "abcde"},
 		{"abcdef", 2, -1, "cde"},
-		{"abcdef", 4, -4, false},
-		{"abcdef", 7, 1, false},
-		{"abcdef", 6, nil, false},
+		{"abcdef", 4, -4, ""},
+		{"abcdef", 7, 1, ""},
+		{"abcdef", 6, nil, ""},
 		{"abcdef", 1, 100, "bcdef"},
 		{"abcdef", -100, 3, "abc"},
 		{"abcdef", -3, -1, "de"},
@@ -476,6 +476,7 @@ func TestSubstr(t *testing.T) {
 		{"abcdef", "doo", nil, false},
 		{"abcdef", "doo", "doo", false},
 		{"abcdef", 1, "doo", false},
+		{"", 0, nil, ""},
 	} {
 
 		var result string
@@ -491,7 +492,7 @@ func TestSubstr(t *testing.T) {
 			continue
 		}
 
-		c.Assert(err, qt.IsNil)
+		c.Assert(err, qt.IsNil, qt.Commentf("%v", test))
 		c.Check(result, qt.Equals, test.expect, qt.Commentf("%v", test))
 	}
 


### PR DESCRIPTION
Most other substr implementations don't error out in out-of-bounds cases
but simply return an empty string (or a value that's printed as an empty
string). We'll follow their lead and not exit template execution.  Allow
the user decide what to do with the empty result.

Fixes #8113