### PR TITLE
tpl: Fix metrics hint tracking

### DIFF
--- a/tpl/partials/partials.go
+++ b/tpl/partials/partials.go
@@ -155,7 +155,7 @@ func (ns *Namespace) Include(name string, contextList ...interface{}) (interface
 	}
 
 	if ns.deps.Metrics != nil {
-		ns.deps.Metrics.TrackValue(n, result)
+		ns.deps.Metrics.TrackValue(templ.Name(), result)
 	}
 
 	return result, nil


### PR DESCRIPTION
When tracking for cache hints, track the same template name as the call
to MeasureSince in Execute.  When referencing a partial "foo", the value
of `n` does not match `templ.Name()` (`partials/foo` versus
`partials/foo.html`).  This was causing hints to go untracked since
there was no existing metric to append the hint to.

Fixes #8125