### PR TITLE
markup: Allow arbitrary Asciidoc extension in unsafe mode

### DIFF
--- a/docs/content/en/content-management/formats.md
+++ b/docs/content/en/content-management/formats.md
@@ -100,6 +100,8 @@ Below are all the AsciiDoc related settings in Hugo with their default values:
 
 {{< code-toggle config="markup.asciidocExt" />}}
 
+Notice that for security concerns only extensions that do not have path separators (either `\`, `/` or `.`) are allowed. That means that extensions can only be invoked if they are in one's ruby's `$LOAD_PATH` (ie. most likely, the extension has been installed by the user). Any extension declared relative to the website's path will not be accepted.
+
 Example of how to set extensions and attributes:
 
 ```

--- a/markup/asciidocext/asciidocext_config/config.go
+++ b/markup/asciidocext/asciidocext_config/config.go
@@ -37,18 +37,6 @@ var (
 		FailureLevel: "fatal",
 	}
 
-	AllowedExtensions = map[string]bool{
-		"asciidoctor-html5s":           true,
-		"asciidoctor-bibtex":           true,
-		"asciidoctor-diagram":          true,
-		"asciidoctor-interdoc-reftext": true,
-		"asciidoctor-katex":            true,
-		"asciidoctor-latex":            true,
-		"asciidoctor-mathematical":     true,
-		"asciidoctor-question":         true,
-		"asciidoctor-rouge":            true,
-	}
-
 	AllowedSafeMode = map[string]bool{
 		"unsafe": true,
 		"safe":   true,

--- a/markup/asciidocext/convert.go
+++ b/markup/asciidocext/convert.go
@@ -19,6 +19,7 @@ package asciidocext
 import (
 	"bytes"
 	"path/filepath"
+	"strings"
 
 	"github.com/gohugoio/hugo/htesting"
 
@@ -105,11 +106,10 @@ func (a *asciidocConverter) parseArgs(ctx converter.DocumentContext) []string {
 	args = a.appendArg(args, "-b", cfg.Backend, asciidocext_config.CliDefault.Backend, asciidocext_config.AllowedBackend)
 
 	for _, extension := range cfg.Extensions {
-		if !asciidocext_config.AllowedExtensions[extension] {
-			a.cfg.Logger.Errorln("Unsupported asciidoctor extension was passed in. Extension `" + extension + "` ignored.")
+		if strings.LastIndexAny(extension, `\/.`) > -1 {
+			a.cfg.Logger.Errorln("Unsupported asciidoctor extension was passed in. Extension `" + extension + "` ignored. Only installed asciidoctor extensions are allowed.")
 			continue
 		}
-
 		args = append(args, "-r", extension)
 	}
 


### PR DESCRIPTION
This PR implements proposal #7698 which allows for arbitrary Asciidoc extensions in unsafe mode expanding the range of possibilities when using this markup language. 

The proposal allows for arbitrary extension when [`SafeMode`](https://docs.asciidoctor.org/asciidoctor/latest/safe-modes/) option is set to `unsafe`.  Any stricter mode would prevent arbitrary extensions and only those listed in the [configuration](https://github.com/gohugoio/hugo/blob/master/markup/asciidocext/asciidocext_config/config.go#L40) would be allowed.