### PR TITLE
pipes: rollup, babel, esbuild

### DIFF
--- a/hugolib/js_test.go
+++ b/hugolib/js_test.go
@@ -109,14 +109,16 @@ document.body.textContent = greeter(user);`
 JS:  {{ template "print" $js }}
 {{ $jsx := resources.Get "js/myjsx.jsx" | js.Build $options }}
 JSX: {{ template "print" $jsx }}
-{{ $ts := resources.Get "js/myts.ts" | js.Build }}
+{{ $ts := resources.Get "js/myts.ts" | js.Build (dict "sourcemap" "inline")}}
 TS: {{ template "print" $ts }}
-
+{{ $ts2 := resources.Get "js/myts.ts" | js.Build (dict "sourcemap" "external" "TargetPath" "js/myts2.js")}}
+TS2: {{ template "print" $ts2 }}
 {{ define "print" }}RelPermalink: {{.RelPermalink}}|MIME: {{ .MediaType }}|Content: {{ .Content | safeJS }}{{ end }}
 
 `)
 
 	jsDir := filepath.Join(workDir, "assets", "js")
+	fmt.Println(workDir)
 	b.Assert(os.MkdirAll(jsDir, 0777), qt.IsNil)
 	b.Assert(os.Chdir(workDir), qt.IsNil)
 	b.WithSourceFile("package.json", packageJSON)
@@ -133,6 +135,8 @@ TS: {{ template "print" $ts }}
 
 	b.Build(BuildCfg{})
 
+	b.AssertFileContent("public/js/myts.js", `//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJz`)
+	b.AssertFileContent("public/js/myts2.js.map", `"version": 3,`)
 	b.AssertFileContent("public/index.html", `
 console.log(&#34;included&#34;);
 if (hasSpace.test(string))

--- a/hugolib/resource_chain_babel_test.go
+++ b/hugolib/resource_chain_babel_test.go
@@ -112,10 +112,10 @@ class Car2 {
 {{ $transpiled := resources.Get "js/main.js" | babel -}}
 Transpiled: {{ $transpiled.Content | safeJS }}
 
-{{ $transpiled := resources.Get "js/main2.js" | babel (dict "sourceMaps" "inline") -}}
+{{ $transpiled := resources.Get "js/main2.js" | babel (dict "sourceMap" "inline") -}}
 Transpiled2: {{ $transpiled.Content | safeJS }}
 
-{{ $transpiled := resources.Get "js/main2.js" | babel (dict "sourceMaps" "external") -}}
+{{ $transpiled := resources.Get "js/main2.js" | babel (dict "sourceMap" "external") -}}
 Transpiled3: {{ $transpiled.Permalink }}
 
 `)

--- a/hugolib/resource_chain_babel_test.go
+++ b/hugolib/resource_chain_babel_test.go
@@ -80,6 +80,15 @@ class Car {
 }
 `
 
+	js2 := `
+/* A Car2 */
+class Car2 {
+  constructor(brand) {
+    this.carname = brand;
+  }
+}
+`
+
 	workDir, clean, err := htesting.CreateTempDir(hugofs.Os, "hugo-test-babel")
 	c.Assert(err, qt.IsNil)
 	defer clean()
@@ -103,11 +112,18 @@ class Car {
 {{ $transpiled := resources.Get "js/main.js" | babel -}}
 Transpiled: {{ $transpiled.Content | safeJS }}
 
+{{ $transpiled := resources.Get "js/main2.js" | babel (dict "sourceMaps" "inline") -}}
+Transpiled2: {{ $transpiled.Content | safeJS }}
+
+{{ $transpiled := resources.Get "js/main2.js" | babel (dict "sourceMaps" "external") -}}
+Transpiled3: {{ $transpiled.Permalink }}
+
 `)
 
 	jsDir := filepath.Join(workDir, "assets", "js")
 	b.Assert(os.MkdirAll(jsDir, 0777), qt.IsNil)
 	b.WithSourceFile("assets/js/main.js", js)
+	b.WithSourceFile("assets/js/main2.js", js2)
 	b.WithSourceFile("package.json", packageJSON)
 	b.WithSourceFile("babel.config.js", babelConfig)
 
@@ -129,4 +145,21 @@ var Car = function Car(brand) {
  this.carname = brand;
 };
 `)
+	b.AssertFileContent("public/index.html", `
+var Car2 = function Car2(brand) {
+ _classCallCheck(this, Car2);
+
+ this.carname = brand;
+};
+`)
+	b.AssertFileContent("public/js/main2.js", `
+var Car2 = function Car2(brand) {
+ _classCallCheck(this, Car2);
+
+ this.carname = brand;
+};
+`)
+	b.AssertFileContent("public/js/main2.js.map", `{"version":3,`)
+	b.AssertFileContent("public/index.html", `
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozL`)
 }

--- a/resources/resource_transformers/babel/babel.go
+++ b/resources/resource_transformers/babel/babel.go
@@ -47,7 +47,7 @@ type Options struct {
 	Compact    *bool
 	Verbose    bool
 	NoBabelrc  bool
-	SourceMaps string
+	SourceMap  string
 }
 
 // DecodeOptions decodes options to and generates command flags
@@ -64,7 +64,7 @@ func (opts Options) toArgs() []string {
 
 	// external is not a known constant on the babel command line
 	// .sourceMaps must be a boolean, "inline", "both", or undefined
-	switch opts.SourceMaps {
+	switch opts.SourceMap {
 	case "external":
 		args = append(args, "--source-maps")
 	case "inline":

--- a/resources/resource_transformers/js/options.go
+++ b/resources/resource_transformers/js/options.go
@@ -338,6 +338,8 @@ func toBuildOptions(opts Options) (buildOptions api.BuildOptions, err error) {
 	switch opts.SourceMap {
 	case "inline":
 		sourceMap = api.SourceMapInline
+	case "external":
+		sourceMap = api.SourceMapExternal
 	case "":
 		sourceMap = api.SourceMapNone
 	default:

--- a/resources/resource_transformers/js/options_test.go
+++ b/resources/resource_transformers/js/options_test.go
@@ -109,4 +109,22 @@ func TestToBuildOptions(t *testing.T) {
 			Loader: api.LoaderJS,
 		},
 	})
+
+	opts, err = toBuildOptions(Options{
+		Target: "es2018", Format: "cjs", Minify: true, mediaType: media.JavascriptType,
+		SourceMap: "external",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(opts, qt.DeepEquals, api.BuildOptions{
+		Bundle:            true,
+		Target:            api.ES2018,
+		Format:            api.FormatCommonJS,
+		MinifyIdentifiers: true,
+		MinifySyntax:      true,
+		MinifyWhitespace:  true,
+		Sourcemap:         api.SourceMapExternal,
+		Stdin: &api.StdinOptions{
+			Loader: api.LoaderJS,
+		},
+	})
 }


### PR DESCRIPTION
WIP
Hopefully there is a way to make a test binary to validate production creation of source maps. In dev it seems to work as expected. Still needs test scripts.

Added rollup for testing.
Added sourceMaps option for babel. Babel can also read sourcemaps from
  the output of an esbuild if they are "inline", it will then
  convert the file and remap the source maps and then re-export them
  but currently not if they are "external".
Added support for sourcemap = "external" for esbuild.

Ref #8132