### PR TITLE
commands: add maxReadFileSize command line argument.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -304,6 +304,7 @@ func (cc *hugoBuilderCommon) handleFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&cc.printm, "print-mem", "", false, "print memory usage to screen at intervals")
 	cmd.Flags().StringVarP(&cc.mutexprofile, "profile-mutex", "", "", "write Mutex profile to `file`")
 	cmd.Flags().StringVarP(&cc.traceprofile, "trace", "", "", "write trace to `file` (not useful in general)")
+	cmd.Flags().IntP("maxReadFileSize", "", 1000000, "an upper size limit(in bytes) for readFile.")
 
 	// Hide these for now.
 	cmd.Flags().MarkHidden("profile-cpu")

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -198,6 +198,7 @@ func initializeFlags(cmd *cobra.Command, cfg config.Provider) {
 		"ignoreVendorPaths",
 		"templateMetrics",
 		"templateMetricsHints",
+		"maxReadFileSize",
 
 		// Moved from vars.
 		"baseURL",

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -635,6 +635,7 @@ func loadDefaultSettingsFor(v *viper.Viper) error {
 	v.SetDefault("disableFastRender", false)
 	v.SetDefault("timeout", "30s")
 	v.SetDefault("enableInlineShortcodes", false)
+	v.SetDefault("maxReadFileSize", 1000000)
 
 	return nil
 }

--- a/tpl/os/os_test.go
+++ b/tpl/os/os_test.go
@@ -32,12 +32,14 @@ func TestReadFile(t *testing.T) {
 
 	v := viper.New()
 	v.Set("workingDir", workingDir)
+	v.Set("maxReadFileSize", 16)
 
 	// f := newTestFuncsterWithViper(v)
-	ns := New(&deps.Deps{Fs: hugofs.NewMem(v)})
+	ns := New(&deps.Deps{Fs: hugofs.NewMem(v), Cfg: v})
 
 	afero.WriteFile(ns.deps.Fs.Source, filepath.Join(workingDir, "/f/f1.txt"), []byte("f1-content"), 0755)
 	afero.WriteFile(ns.deps.Fs.Source, filepath.Join("/home", "f2.txt"), []byte("f2-content"), 0755)
+	afero.WriteFile(ns.deps.Fs.Source, filepath.Join(workingDir, "bigFile.txt"), []byte("a-very-big-file-content"), 0755)
 
 	for _, test := range []struct {
 		filename string
@@ -48,6 +50,7 @@ func TestReadFile(t *testing.T) {
 		{filepath.FromSlash("../f2.txt"), false},
 		{"", false},
 		{"b", false},
+		{filepath.FromSlash("bigFile.txt"), false},
 	} {
 
 		result, err := ns.ReadFile(test.filename)


### PR DESCRIPTION
This allows to override the default file size limit for readFile.
More context here: https://discourse.gohugo.io/t/error-calling-readfile-file-is-too-big/25460.