### PR TITLE
List headless pages

### DIFF
--- a/hugolib/content_map.go
+++ b/hugolib/content_map.go
@@ -815,6 +815,13 @@ var (
 		return n.p.m.noListAlways()
 	}
 
+	contentTreeNoListNeverFilter = func(s string, n *contentNode) bool {
+		if n.p == nil {
+			return true
+		}
+		return n.p.m.noListNever()
+	}
+
 	contentTreeNoRenderFilter = func(s string, n *contentNode) bool {
 		if n.p == nil {
 			return true

--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -300,14 +300,16 @@ func (m *pageMap) createSiteTaxonomies() error {
 	return walkErr
 }
 
-func (m *pageMap) createListAllPages() page.Pages {
+type contentNodeFilter func(s string, n *contentNode) bool
+
+func (m *pageMap) createListPages(cnf contentNodeFilter) page.Pages {
 	pages := make(page.Pages, 0)
 
 	m.contentMap.pageTrees.Walk(func(s string, n *contentNode) bool {
 		if n.p == nil {
 			panic(fmt.Sprintf("BUG: page not set for %q", s))
 		}
-		if contentTreeNoListAlwaysFilter(s, n) {
+		if cnf(s, n) {
 			return false
 		}
 		pages = append(pages, n.p)
@@ -316,6 +318,14 @@ func (m *pageMap) createListAllPages() page.Pages {
 
 	page.SortByDefault(pages)
 	return pages
+}
+
+func (m *pageMap) createListAllPages() page.Pages {
+	return m.createListPages(contentTreeNoListAlwaysFilter)
+}
+
+func (m *pageMap) createListHeadlessPages() page.Pages {
+	return m.createListPages(contentTreeNoListNeverFilter)
 }
 
 func (m *pageMap) assemblePages() error {

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -656,6 +656,10 @@ func (p *pageMeta) noListAlways() bool {
 	return p.buildConfig.List != pagemeta.Always
 }
 
+func (p *pageMeta) noListNever() bool {
+	return p.buildConfig.List != pagemeta.Never
+}
+
 func (p *pageMeta) getListFilter(local bool) contentTreeNodeCallback {
 	return newContentTreeFilter(func(n *contentNode) bool {
 		if n == nil {

--- a/hugolib/pagecollections.go
+++ b/hugolib/pagecollections.go
@@ -34,6 +34,7 @@ type PageCollections struct {
 	// Lazy initialized page collections
 	pages           *lazyPagesFactory
 	regularPages    *lazyPagesFactory
+	headlessPages   *lazyPagesFactory
 	allPages        *lazyPagesFactory
 	allRegularPages *lazyPagesFactory
 }
@@ -48,6 +49,12 @@ func (c *PageCollections) Pages() page.Pages {
 // This is for the current language only.
 func (c *PageCollections) RegularPages() page.Pages {
 	return c.regularPages.get()
+}
+
+// HeadlessPages returns all the headless pages.
+// This is for the current language only.
+func (c *PageCollections) HeadlessPages() page.Pages {
+	return c.headlessPages.get()
 }
 
 // AllPages returns all pages for all languages.
@@ -91,6 +98,10 @@ func newPageCollections(m *pageMap) *PageCollections {
 
 	c.regularPages = newLazyPagesFactory(func() page.Pages {
 		return c.findPagesByKindIn(page.KindPage, c.pages.get())
+	})
+
+	c.headlessPages = newLazyPagesFactory(func() page.Pages {
+		return m.createListHeadlessPages()
 	})
 
 	return c


### PR DESCRIPTION
Expose a `HeadlessPages` collection, so that it's possible to to list headless pages, filter them, count them, paginate them, etc, without any template hackery needed.