### PR TITLE
Add .Markup page variable

### DIFF
--- a/docs/content/en/content-management/front-matter.md
+++ b/docs/content/en/content-management/front-matter.md
@@ -101,7 +101,8 @@ linkTitle
 : used for creating links to content; if set, Hugo defaults to using the `linktitle` before the `title`. Hugo can also [order lists of content by `linktitle`][bylinktitle].
 
 markup
-: **experimental**; specify `"rst"` for reStructuredText (requires`rst2html`) or `"md"` (default) for Markdown.
+: sets the content format, instead of inferring it from the file extension. See the list of valid markup identifiers in
+[Content Formats](/content-management/formats/#list-of-content-formats).
 
 outputs
 : allows you to specify output formats specific to the content. See [output formats][outputs].

--- a/docs/content/en/variables/page.md
+++ b/docs/content/en/variables/page.md
@@ -98,6 +98,9 @@ See also `.ExpiryDate`, `.Date`, `.PublishDate`, and [`.GitInfo`][gitinfo].
 .LinkTitle
 : access when creating links to the content. If set, Hugo will use the `linktitle` from the front matter before `title`.
 
+.Markup
+: the markup content format. See [Content Formats](/content-management/formats/).
+
 .Next
 : Points up to the next [regular page](/variables/site/#site-pages) (sorted by Hugo's [default sort](/templates/lists#default-weight-date-linktitle-filepath)). Example: `{{with .Next}}{{.Permalink}}{{end}}`. Calling `.Next` from the first page returns `nil`.
 

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -201,6 +201,10 @@ func (p *pageMeta) LinkTitle() string {
 	return p.Title()
 }
 
+func (p *pageMeta) Markup() string {
+	return p.markup
+}
+
 func (p *pageMeta) Name() string {
 	if p.resourcePath != "" {
 		return p.resourcePath
@@ -625,7 +629,13 @@ func (pm *pageMeta) setMetadata(parentBucket *pagesMapBucket, p *pageState, fron
 		pm.sitemap = p.s.siteCfg.sitemap
 	}
 
-	pm.markup = p.s.ContentSpec.ResolveMarkup(pm.markup)
+	if pm.markup != "" {
+		canonicalMarkup := p.s.ContentSpec.ResolveMarkup(pm.markup)
+		if canonicalMarkup == "" {
+			p.m.s.Log.Warnf("page %q has unknown markup %q.", p.File().Filename(), pm.markup)
+		}
+		pm.markup = canonicalMarkup
+	}
 
 	if draft != nil && published != nil {
 		pm.draft = *draft

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -299,6 +299,12 @@ func checkPageTitle(t *testing.T, page page.Page, title string) {
 	}
 }
 
+func checkPageMarkup(t *testing.T, page page.Page, markup string) {
+	if page.Markup() != markup {
+		t.Fatalf("Page markup is: %s.  Expected %s", page.Markup(), markup)
+	}
+}
+
 func checkPageContent(t *testing.T, page page.Page, expected string, msg ...interface{}) {
 	t.Helper()
 	a := normalizeContent(expected)
@@ -571,6 +577,22 @@ func TestCreateNewPage(t *testing.T) {
 	}
 
 	testAllMarkdownEnginesForPages(t, assertFunc, settings, simplePage)
+}
+
+func TestPageMarkup(t *testing.T) {
+	t.Parallel()
+	markupByExt := map[string]string{
+		"md":    "markdown",
+		"mmark": "mmark",
+		"ad":    "asciidocext",
+		"rst":   "rst",
+	}
+	assertFunc := func(t *testing.T, ext string, pages page.Pages) {
+		p := pages[0]
+		checkPageMarkup(t, p, markupByExt[ext])
+	}
+
+	testAllMarkdownEnginesForPages(t, assertFunc, nil, simplePage)
 }
 
 func TestPageSummary(t *testing.T) {

--- a/resources/page/page.go
+++ b/resources/page/page.go
@@ -166,6 +166,9 @@ type PageMetaProvider interface {
 	// The title used for links.
 	LinkTitle() string
 
+	// Markup content format.
+	Markup() string
+
 	// IsNode returns whether this is an item of one of the list types in Hugo,
 	// i.e. not a regular content
 	IsNode() bool

--- a/resources/page/page_nop.go
+++ b/resources/page/page_nop.go
@@ -274,6 +274,10 @@ func (p *nopPage) LogicalName() string {
 	return ""
 }
 
+func (p *nopPage) Markup() string {
+	return ""
+}
+
 func (p *nopPage) MediaType() (m media.Type) {
 	return
 }

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -336,6 +336,10 @@ func (p *testPage) LogicalName() string {
 	panic("not implemented")
 }
 
+func (p *testPage) Markup() string {
+	panic("not implemented")
+}
+
 func (p *testPage) MediaType() media.Type {
 	panic("not implemented")
 }


### PR DESCRIPTION
This PR exposes markup as a page variable. My use case is that I have a theme which has an Asciidoctor-specific stylesheet, so I'd like to load it only when that markup provider was used.