### PR TITLE
Add default user-agent header for getJSON requests

### DIFF
--- a/tpl/data/data.go
+++ b/tpl/data/data.go
@@ -116,6 +116,7 @@ func (ns *Namespace) GetJSON(urlParts ...interface{}) (interface{}, error) {
 	}
 
 	req.Header.Add("Accept", "application/json")
+	req.Header.Add("User-Agent", "Hugo Static Site Generator")
 
 	err = ns.getResource(cache, unmarshal, req)
 	if err != nil {


### PR DESCRIPTION
I would like to add a default user-agent header for getJSON function because many API's would like to read user-agent header. For example, I'm developing a simple Instagram shortcode but always getting an error because getjSON function doesn't send User-Agent header