### PR TITLE
Sitemap: exclude "no render" pages

### DIFF
--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -583,11 +583,21 @@ categories = [ "hugo" ]
 +++
 Front Matter with Ordered Pages 4. This is longer content`
 
+var weightedPage5 = `+++
+weight = "5"
+title = "Five"
+
+[_build]
+render = "never"
++++
+Front Matter with Ordered Pages 5`
+
 var weightedSources = [][2]string{
 	{filepath.FromSlash("sect/doc1.md"), weightedPage1},
 	{filepath.FromSlash("sect/doc2.md"), weightedPage2},
 	{filepath.FromSlash("sect/doc3.md"), weightedPage3},
 	{filepath.FromSlash("sect/doc4.md"), weightedPage4},
+	{filepath.FromSlash("sect/doc5.md"), weightedPage5},
 }
 
 func TestOrderedPages(t *testing.T) {
@@ -979,8 +989,8 @@ func TestClassCollector(t *testing.T) {
 
 			b := newTestSitesBuilder(t)
 			b.WithConfigFile("toml", fmt.Sprintf(`
-			
-			
+
+
 minify = %t
 
 [build]
@@ -989,7 +999,7 @@ minify = %t
 `, minify))
 
 			b.WithTemplates("index.html", `
-	
+
 <div id="el1" class="a b c">Foo</div>
 
 Some text.
@@ -1047,7 +1057,7 @@ func TestClassCollectorStress(t *testing.T) {
 
 	b := newTestSitesBuilder(t)
 	b.WithConfigFile("toml", `
-	
+
 disableKinds = ["home", "section", "term", "taxonomy" ]
 
 [languages]

--- a/hugolib/sitemap_test.go
+++ b/hugolib/sitemap_test.go
@@ -25,12 +25,14 @@ import (
 
 const sitemapTemplate = `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {{ range .Data.Pages }}
+    {{- if .Permalink -}}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}
   </url>
+    {{- end -}}
   {{ end }}
 </urlset>`
 
@@ -80,6 +82,7 @@ func doTestSitemapOutput(t *testing.T, internal bool) {
 
 	content := readDestination(th, th.Fs, outputSitemap)
 	c.Assert(content, qt.Not(qt.Contains), "404")
+	c.Assert(content, qt.Not(qt.Contains), "<loc></loc>")
 }
 
 func TestParseSitemap(t *testing.T) {

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -63,6 +63,7 @@ var EmbeddedTemplates = [][2]string{
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
+    {{- if .Permalink -}}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -79,6 +80,7 @@ var EmbeddedTemplates = [][2]string{
                 href="{{ .Permalink }}"
                 />{{ end }}
   </url>
+    {{- end -}}
   {{ end }}
 </urlset>
 `},

--- a/tpl/tplimpl/embedded/templates/_default/sitemap.xml
+++ b/tpl/tplimpl/embedded/templates/_default/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
+    {{- if .Permalink -}}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -18,5 +19,6 @@
                 href="{{ .Permalink }}"
                 />{{ end }}
   </url>
+    {{- end -}}
   {{ end }}
 </urlset>


### PR DESCRIPTION
Currently, pages with `render = "never"` get listed in sitemap.xml, even though they have no permalink, resulting in sitemap entries with empty URL fields (i.e. with `<loc></loc>`). Such pages should be excluded from the sitemap.