### PR TITLE
Add 'linktitle' option to figure shortcode

### DIFF
--- a/tpl/tplimpl/embedded/templates/shortcodes/figure.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/figure.html
@@ -1,6 +1,6 @@
 <figure{{ with .Get "class" }} class="{{ . }}"{{ end }}>
     {{- if .Get "link" -}}
-        <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
+        <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "linktitle" }} title="{{ . }}"{{end}}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
     {{- end }}
     <img src="{{ .Get "src" }}"
          {{- if or (.Get "alt") (.Get "caption") }}


### PR DESCRIPTION
If a link is included and the user wants to include the `title` attribute on the anchor, this will parse it into the `<a>` element.