### PR TITLE
Change version string format, and add VendorInfo to help with issue triaging

### DIFF
--- a/common/hugo/hugo.go
+++ b/common/hugo/hugo.go
@@ -40,6 +40,9 @@ var (
 
 	// buildDate contains the date of the current build.
 	buildDate string
+
+	// vendorInfo contains vendor notes about the current build.
+	vendorInfo string
 )
 
 // Info contains information about the current Hugo environment

--- a/common/hugo/version.go
+++ b/common/hugo/version.go
@@ -127,14 +127,15 @@ func (v Version) NextPatchLevel(level int) Version {
 // BuildVersionString creates a version string. This is what you see when
 // running "hugo version".
 func BuildVersionString() string {
-	program := "Hugo Static Site Generator"
+	// program := "Hugo Static Site Generator"
+	program := "hugo"
 
 	version := "v" + CurrentVersion.String()
 	if commitHash != "" {
 		version += "-" + strings.ToUpper(commitHash)
 	}
 	if IsExtended {
-		version += "/extended"
+		version += "+extended"
 	}
 
 	osArch := runtime.GOOS + "/" + runtime.GOARCH
@@ -144,7 +145,10 @@ func BuildVersionString() string {
 		date = "unknown"
 	}
 
-	return fmt.Sprintf("%s %s %s BuildDate: %s", program, version, osArch, date)
+	versionString := fmt.Sprintf("%s %s %s BuildDate=%s",
+		program, version, osArch, date)
+
+	return versionString
 }
 
 func version(version float32, patchVersion int, suffix string) string {

--- a/common/hugo/version.go
+++ b/common/hugo/version.go
@@ -148,6 +148,10 @@ func BuildVersionString() string {
 	versionString := fmt.Sprintf("%s %s %s BuildDate=%s",
 		program, version, osArch, date)
 
+	if vendorInfo != "" {
+		versionString += " VendorInfo=" + vendorInfo
+	}
+
 	return versionString
 }
 


### PR DESCRIPTION
This PR is intended to add an optional "vendorInfo" string to help pinpoint the exact origin of a Hugo binary when `hugo version` is reported in a GitHub issue.  For example:

```
Hugo Static Site Generator v0.80.0/extended linux/amd64 BuildDate: 2021-02-09T18:47:48Z (debian 0.80.0-6)
```

which may help determine whether an issue is generic (Hugo upstream) or vendor-specific.

Example snippet from debian/rules:

```
include /etc/os-release
PACKAGE := github.com/gohugoio/hugo
VENDOR_INFO := $(ID) $(shell dpkg-parsechangelog --show-field Version)

all:
	go build -ldflags '-X "$(PACKAGE)/common/hugo.vendorInfo=$(VENDOR_INFO)"'
```

See https://salsa.debian.org/go-team/packages/hugo/-/blob/debian/sid/debian/rules for a full example.

I have just started using this in the hugo 0.80.0-6 Debian package.

Would other package maintainers be interested to add support for this too?  :-)