### PR TITLE
Clean documentation summary on CLI commands page

### DIFF
--- a/docs/layouts/partials/boxes-section-summaries.html
+++ b/docs/layouts/partials/boxes-section-summaries.html
@@ -1,0 +1,38 @@
+<div class="relative {{ .classes }} weight-{{ .context.Weight }}">
+
+  <div class="bg-white mb2 pa3 pa4-l gray">
+    {{ if eq .context.Section "news" }}
+      <date class="f6 db" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
+        {{ .context.Date.Format "January 2, 2006" }}
+      </date>
+    {{ end }}
+
+    <h1 class="near-black f3">
+      <a href="{{ .context.RelPermalink }}" class="link primary-color dim">
+      {{- if eq .context.Section "functions" -}}
+        {{ .context.LinkTitle }}
+      {{- else -}}
+        {{ .context.Title }}
+      {{- end -}}
+      </a>
+    </h1>
+
+    <div class="lh-copy links">
+      {{ if .context.Params.description  }}
+          {{ .context.Params.description | markdownify }}
+        {{ else if eq .context.Section "commands" }}
+          {{ $synopsis := replaceRE "\n" "" .context.RawContent | replaceRE ".*Synopsis" "" | replaceRE "### Options.*" "" }}
+          {{ replaceRE "```.*```" "" $synopsis | markdownify | truncate 200 }}
+        {{ else if .context.Summary }}
+          {{ .context.Summary  }}
+      {{ end }}
+
+        <a href="{{ .context.RelPermalink }}" class="f6 mt2 db link primary-color dim">
+          Read More &raquo;
+        </a>
+
+    </div>
+
+
+  </div>
+</div>


### PR DESCRIPTION
Please evaluate whether hugo/docs is the best location or 
if this should be applied against gohugoioTheme instead. 
I'm still a novice in Hugo.

Lack of 'description' frontmatter generated by spf13/cobra
resulted in ugly summary pages. This commit extracts the
synopsis as replacement for default summary for command
section only. String matching is used to identify the start 
and end of the synopsis section.

fixes 7608