### PR TITLE
Fix: wrong space for humanize func in some case

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/getkin/kin-openapi v0.32.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/gobuffalo/flect v0.2.2
 	github.com/gobwas/glob v0.2.3
 	github.com/gohugoio/testmodBuilder/mods v0.0.0-20190520184928-c56af20f2e95
 	github.com/google/go-cmp v0.5.3
@@ -32,7 +33,6 @@ require (
 	github.com/kylelemons/godebug v1.1.0
 	github.com/kyokomi/emoji/v2 v2.2.7
 	github.com/magefile/mage v1.10.0
-	github.com/markbates/inflect v1.0.4
 	github.com/mattn/go-isatty v0.0.12
 	github.com/miekg/mmark v1.3.6
 	github.com/mitchellh/hashstructure v1.0.0
@@ -68,7 +68,5 @@ require (
 	gopkg.in/ini.v1 v1.51.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 )
-
-replace github.com/markbates/inflect => github.com/markbates/inflect v0.0.0-20171215194931-a12c3aec81a6
 
 go 1.12

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gobuffalo/flect v0.2.2 h1:PAVD7sp0KOdfswjAw9BpLCU9hXo7wFSzgpQ+zNeks/A=
+github.com/gobuffalo/flect v0.2.2/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -349,8 +351,6 @@ github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
 github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/markbates/inflect v0.0.0-20171215194931-a12c3aec81a6 h1:LZhVjIISSbj8qLf2qDPP0D8z0uvOWAW5C85ly5mJW6c=
-github.com/markbates/inflect v0.0.0-20171215194931-a12c3aec81a6/go.mod h1:oTeZL2KHA7CUX6X+fovmK9OvIOFuqu0TwdQrZjLTh88=
 github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2/go.mod h1:0KeJpeMD6o+O4hW7qJOT7vyQPKrWmj26uf5wMc/IiIs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gobuffalo/flect"
 	"github.com/gohugoio/hugo/markup/converter"
 
 	"github.com/gohugoio/hugo/hugofs/files"
@@ -31,7 +32,6 @@ import (
 	"github.com/gohugoio/hugo/related"
 
 	"github.com/gohugoio/hugo/source"
-	"github.com/markbates/inflect"
 	"github.com/pkg/errors"
 
 	"github.com/gohugoio/hugo/common/maps"
@@ -717,7 +717,7 @@ func (p *pageMeta) applyDefaultValues(n *contentNode) error {
 
 			sectionName = helpers.FirstUpper(sectionName)
 			if p.s.Cfg.GetBool("pluralizeListTitles") {
-				p.title = inflect.Pluralize(sectionName)
+				p.title = flect.Pluralize(sectionName)
 			} else {
 				p.title = sectionName
 			}

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -22,11 +22,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gobuffalo/flect"
 	"github.com/gohugoio/hugo/publisher"
 
 	"github.com/spf13/viper"
-
-	"github.com/markbates/inflect"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/gohugoio/hugo/deps"
@@ -487,7 +486,7 @@ func doTestSectionNaming(t *testing.T, canonify, uglify, pluralize bool) {
 	for _, test := range tests {
 
 		if test.pluralAware && pluralize {
-			test.expected = inflect.Pluralize(test.expected)
+			test.expected = flect.Pluralize(test.expected)
 		}
 
 		th.assertFileContent(filepath.Join("public", test.doc), test.expected)

--- a/tpl/inflect/inflect.go
+++ b/tpl/inflect/inflect.go
@@ -16,8 +16,9 @@ package inflect
 
 import (
 	"strconv"
+	"strings"
 
-	_inflect "github.com/markbates/inflect"
+	_inflect "github.com/gobuffalo/flect"
 	"github.com/spf13/cast"
 )
 
@@ -53,7 +54,8 @@ func (ns *Namespace) Humanize(in interface{}) (string, error) {
 		return _inflect.Ordinalize(word), nil
 	}
 
-	return _inflect.Humanize(word), nil
+	str := _inflect.Humanize(word)
+	return _inflect.Humanize(strings.ToLower(str)), nil
 }
 
 // Pluralize returns the plural form of a single word.

--- a/tpl/inflect/inflect_test.go
+++ b/tpl/inflect/inflect_test.go
@@ -26,6 +26,8 @@ func TestInflect(t *testing.T) {
 		{ns.Humanize, int64(92), "92nd"},
 		{ns.Humanize, "5.5", "5.5"},
 		{ns.Humanize, t, false},
+		{ns.Humanize, "this is a TEST", "This is a test"},
+		{ns.Humanize, "my-first-Post", "My first post"},
 		{ns.Pluralize, "cat", "cats"},
 		{ns.Pluralize, "", ""},
 		{ns.Pluralize, t, false},


### PR DESCRIPTION
Close #7912 

This issue was caused by [`markbates/inflect`](https://github.com/markbates/inflect) which is deprecated now. use [github.com/gobuffalo/flect](https://github.com/gobuffalo/flect) instead which is recommended solve this issue and won't break `hugo`.