### PR TITLE
Fix typo in multilingual.md

### DIFF
--- a/docs/content/en/content-management/multilingual.md
+++ b/docs/content/en/content-management/multilingual.md
@@ -389,7 +389,7 @@ Assume `.ReadingTime.Count` in the context has value of 525600. The result will 
 If `.ReadingTime.Count` in the context has value is 1. The result is:
 
 ```
-One minutes to read
+One minute to read
 ```
 
 In case you need to pass custom data: (`(dict "Count" 25)` is minimum requirement)


### PR DESCRIPTION
While going through the docs, I realized that the wrong text was being printed.

I believe it was supposed to be printed without the `s`