### PR TITLE
Update date logic of opengraph and schema internal templates

### DIFF
--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -2,51 +2,51 @@
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
-{{ with $.Params.images }}{{ range first 6 . -}}
-<meta property="og:image" content="{{ . | absURL }}" />
-{{ end }}{{ else -}}
+
+{{- with $.Params.images -}}
+{{- range first 6 . }}<meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
+{{- else -}}
 {{- $images := $.Resources.ByType "image" -}}
 {{- $featured := $images.GetMatch "*feature*" -}}
 {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
 {{- with $featured -}}
 <meta property="og:image" content="{{ $featured.Permalink }}"/>
-{{ else -}}
-{{- with $.Site.Params.images -}}
-<meta property="og:image" content="{{ index . 0 | absURL }}"/>
-{{ end }}{{ end }}{{ end }}
+{{- else -}}
+{{- with $.Site.Params.images }}<meta property="og:image" content="{{ index . 0 | absURL }}"/>{{ end -}}
+{{- end -}}
+{{- end -}}
 
-{{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
 {{- if .IsPage }}
+{{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
+<meta property="article:section" content="{{ .Section }}" />
 <meta property="article:published_time" content="{{ .PublishDate.Format $iso8601 }}" />
 <meta property="article:modified_time" content="{{ .Lastmod.Format $iso8601 }}" />
+
+{{- range .Site.Authors }}
+{{ with .Social.facebook }}<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}
+{{ with .Site.Social.facebook }}<meta property="article:publisher" content="https://www.facebook.com/{{ . }}" />{{ end }}
+{{- with .Params.tags }}{{ range first 6 . }}
+<meta property="article:tag" content="{{ . }}" />
+{{- end }}{{ end -}}
+{{- end -}}
 {{- end -}}
 
 {{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
 {{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
 {{- with .Site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
-{{- with .Params.videos }}
-{{- range . }}
+{{- with .Params.videos }}{{- range . }}
 <meta property="og:video" content="{{ . | absURL }}" />
 {{ end }}{{ end }}
 
 {{- /* If it is part of a series, link to related articles */}}
 {{- $permalink := .Permalink }}
-{{- $siteSeries := .Site.Taxonomies.series }}{{ with .Params.series }}
-{{- range $name := . }}
+{{- $siteSeries := .Site.Taxonomies.series }}
+{{ with .Params.series }}{{- range $name := . }}
   {{- $series := index $siteSeries ($name | urlize) }}
   {{- range $page := first 6 $series.Pages }}
     {{- if ne $page.Permalink $permalink }}<meta property="og:see_also" content="{{ $page.Permalink }}" />{{ end }}
   {{- end }}
 {{ end }}{{ end }}
-
-{{- if .IsPage }}
-{{- range .Site.Authors }}{{ with .Social.facebook }}
-<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}{{ with .Site.Social.facebook }}
-<meta property="article:publisher" content="https://www.facebook.com/{{ . }}" />{{ end }}
-<meta property="article:section" content="{{ .Section }}" />
-{{- with .Params.tags }}{{ range first 6 . }}
-<meta property="article:tag" content="{{ . }}" />{{ end }}{{ end }}
-{{- end }}{{ end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
 {{- with .Site.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}

--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -17,14 +17,9 @@
 
 {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
 {{- if .IsPage }}
-{{- if not .PublishDate.IsZero }}<meta property="article:published_time" {{ .PublishDate.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
-{{ else if not .Date.IsZero }}<meta property="article:published_time" {{ .Date.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
-{{ end }}
-{{- if not .Lastmod.IsZero }}<meta property="article:modified_time" {{ .Lastmod.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />{{ end }}
-{{- else }}
-{{- if not .Date.IsZero }}<meta property="og:updated_time" {{ .Lastmod.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
-{{- end }}
-{{- end }}{{/* .IsPage */}}
+<meta property="article:published_time" content="{{ .PublishDate.Format $iso8601 }}" />
+<meta property="article:modified_time" content="{{ .Lastmod.Format $iso8601 }}" />
+{{- end -}}
 
 {{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
 {{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}

--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -19,8 +19,8 @@
 {{- if .IsPage }}
 {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
 <meta property="article:section" content="{{ .Section }}" />
-<meta property="article:published_time" content="{{ .PublishDate.Format $iso8601 }}" />
-<meta property="article:modified_time" content="{{ .Lastmod.Format $iso8601 }}" />
+{{ with .PublishDate }}<meta property="article:published_time" content="{{ .PublishDate.Format $iso8601 }}" />{{ end }}
+{{ with .Lastmod }}<meta property="article:modified_time" content="{{ .Lastmod.Format $iso8601 }}" />{{ end }}
 
 {{- range .Site.Authors }}
 {{ with .Social.facebook }}<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}

--- a/tpl/tplimpl/embedded/templates/schema.html
+++ b/tpl/tplimpl/embedded/templates/schema.html
@@ -5,21 +5,21 @@
 {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
 <meta itemprop="datePublished" content="{{ .PublishDate.Format $iso8601 }}" />
 <meta itemprop="dateModified" content="{{ .Lastmod.Format $iso8601 }}" />
-
 <meta itemprop="wordCount" content="{{ .WordCount }}">
-{{ with $.Params.images }}{{ range first 6 . -}}
-<meta itemprop="image" content="{{ . | absURL }}">
-{{ end }}{{ else -}}
+
+{{- with $.Params.images -}}
+{{- range first 6 . -}}<meta itemprop="image" content="{{ . | absURL }}">{{ end -}}
+{{- else -}}
 {{- $images := $.Resources.ByType "image" -}}
 {{- $featured := $images.GetMatch "*feature*" -}}
 {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
 {{- with $featured -}}
 <meta itemprop="image" content="{{ $featured.Permalink }}">
-{{ else -}}
-{{- with $.Site.Params.images -}}
-<meta itemprop="image" content="{{ index . 0 | absURL }}"/>
-{{ end }}{{ end }}{{ end }}
+{{- else -}}
+{{- with $.Site.Params.images -}}<meta itemprop="image" content="{{ index . 0 | absURL }}"/>{{ end -}}
+{{- end -}}
+{{- end -}}
 
 <!-- Output all taxonomies as schema.org keywords -->
 <meta itemprop="keywords" content="{{ if .IsPage}}{{ range $index, $tag := .Params.tags }}{{ $tag }},{{ end }}{{ else }}{{ range $plural, $terms := .Site.Taxonomies }}{{ range $term, $val := $terms }}{{ printf "%s," $term }}{{ end }}{{ end }}{{ end }}" />
-{{- end }}
+{{- end -}}

--- a/tpl/tplimpl/embedded/templates/schema.html
+++ b/tpl/tplimpl/embedded/templates/schema.html
@@ -3,8 +3,8 @@
 
 {{- if .IsPage -}}
 {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
-<meta itemprop="datePublished" content="{{ .PublishDate.Format $iso8601 }}" />
-<meta itemprop="dateModified" content="{{ .Lastmod.Format $iso8601 }}" />
+{{ with .PublishDate }}<meta itemprop="datePublished" content="{{ .PublishDate.Format $iso8601 }}" />{{ end}}
+{{ with .Lastmod }}<meta itemprop="dateModified" content="{{ .Lastmod.Format $iso8601 }}" />{{ end}}
 <meta itemprop="wordCount" content="{{ .WordCount }}">
 
 {{- with $.Params.images -}}

--- a/tpl/tplimpl/embedded/templates/schema.html
+++ b/tpl/tplimpl/embedded/templates/schema.html
@@ -1,9 +1,11 @@
 <meta itemprop="name" content="{{ .Title }}">
 <meta itemprop="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
 
-{{- if .IsPage }}{{ $ISO8601 := "2006-01-02T15:04:05-07:00" }}{{ if not .PublishDate.IsZero }}
-<meta itemprop="datePublished" {{ .PublishDate.Format $ISO8601 | printf "content=%q" | safeHTMLAttr }} />{{ end }}
-{{ if not .Lastmod.IsZero }}<meta itemprop="dateModified" {{ .Lastmod.Format $ISO8601 | printf "content=%q" | safeHTMLAttr }} />{{ end }}
+{{- if .IsPage -}}
+{{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
+<meta itemprop="datePublished" content="{{ .PublishDate.Format $iso8601 }}" />
+<meta itemprop="dateModified" content="{{ .Lastmod.Format $iso8601 }}" />
+
 <meta itemprop="wordCount" content="{{ .WordCount }}">
 {{ with $.Params.images }}{{ range first 6 . -}}
 <meta itemprop="image" content="{{ . | absURL }}">


### PR DESCRIPTION
This is in response to my previous PR #8186.

* Removed date checking of `PublishDate` and `Lastmod` 
* Merged duplicate `IsPage` blocks in opengraph.html
* Formatted template tags so they're easier to follow. There are a lot of nested blocks and keeping track of what's open and what's closed was extremely tedious. I hope the changes I made makes this easier.

Feel free to cherry pick the date changes and exclude the formatting change.