### PR TITLE
Add: Google Analytics documentation for GDPR consent

### DIFF
--- a/docs/content/en/about/hugo-and-gdpr.md
+++ b/docs/content/en/about/hugo-and-gdpr.md
@@ -83,6 +83,19 @@ disable = true
 
 ### GoogleAnalytics
 
+Implement GDPR consent support with some custom JavaScript.
+```html
+<script>
+if (localStorage.getItem("doNotTrack") === null) {
+    // default value before any choice has been made
+    localStorage.setItem("doNotTrack", "1")
+}
+var doNotTrack = localStorage.getItem("doNotTrack");
+</script>
+{{ template "_internal/google_analytics.html" . }}
+```
+After consent, set the localStorage `doNotTrack` value to `"0"` and reload the page.
+
 anonymizeIP
 : Enabling this will make it so the users' IP addresses are anonymized within Google Analytics.
 


### PR DESCRIPTION
As per issue #8262. I've updated the Google Analytics GDPR documentation to explain implementing user consent.