### PR TITLE
Add support for google analytics v4

### DIFF
--- a/docs/content/en/about/hugo-and-gdpr.md
+++ b/docs/content/en/about/hugo-and-gdpr.md
@@ -92,6 +92,9 @@ respectDoNotTrack
 useSessionStorage
 : Enabling this will disable the use of Cookies and use Session Storage to Store the GA Client ID.
 
+{{% warning %}}
+`useSessionStorage` is not supported when using Google Analytics v4 (gtag.js).
+{{% /warning %}}
 ### Instagram
 
 simple

--- a/docs/content/en/templates/internal.md
+++ b/docs/content/en/templates/internal.md
@@ -27,14 +27,20 @@ While the following internal templates are called similar to partials, they do *
 
 ## Google Analytics
 
-Hugo ships with internal templates for Google Analytics tracking, including both synchronous and asynchronous tracking codes.
+Hugo ships with internal templates for Google Analytics tracking, including both synchronous and asynchronous tracking codes. As well as support for both v3 and v4 of Google Analytics.
 
 ### Configure Google Analytics
 
 Provide your tracking id in your configuration file:
 
+**Google Analytics v3 (analytics.js)**
 {{< code-toggle file="config" >}}
-googleAnalytics = "UA-123-45"
+googleAnalytics = "UA-PROPERTY_ID"
+{{</ code-toggle >}}
+
+**Google Analytics v4 (gtag.js)**
+{{< code-toggle file="config" >}}
+googleAnalytics = "G-MEASUREMENT_ID"
 {{</ code-toggle >}}
 
 ### Use the Google Analytics Template
@@ -49,6 +55,8 @@ You can then include the Google Analytics internal template:
 ```
 {{ template "_internal/google_analytics_async.html" . }}
 ```
+
+When using Google Analytics v4 use `_internal/google_analytics.html`.
 
 A `.Site.GoogleAnalytics` variable is also exposed from the config.
 

--- a/hugolib/embedded_templates_test.go
+++ b/hugolib/embedded_templates_test.go
@@ -110,7 +110,7 @@ Disqus:
 	// Gheck GA regular and async
 	b.AssertFileContent("public/index.html",
 		"'anonymizeIp', true",
-		"'script','https://www.google-analytics.com/analytics.js','ga');\n\tga('create', 'ga_id', 'auto')",
+		"'script','https://www.google-analytics.com/analytics.js','ga');\n\tga('create', 'UA-ga_id', 'auto')",
 		"<script async src='https://www.google-analytics.com/analytics.js'>")
 
 	// Disqus

--- a/hugolib/testhelpers_test.go
+++ b/hugolib/testhelpers_test.go
@@ -249,7 +249,7 @@ const commonConfigSections = `
 [services.disqus]
 shortname = "disqus_shortname"
 [services.googleAnalytics]
-id = "ga_id"
+id = "UA-ga_id"
 
 [privacy]
 [privacy.disqus]

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -121,8 +121,19 @@ var EmbeddedTemplates = [][2]string{
 <a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>{{end}}
 {{- end -}}`},
 	{`google_analytics.html`, `{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
-{{- if not $pc.Disable -}}
-{{ with .Site.GoogleAnalytics }}
+{{- if not $pc.Disable }}{{ with .Site.GoogleAnalytics -}}
+{{ if hasPrefix . "G-"}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+<script>
+{{ template "__ga_js_set_doNotTrack" $ }}
+if (!doNotTrack) {
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+	gtag('js', new Date());
+	gtag('config', '{{ . }}', { 'anonymize_ip': {{- $pc.AnonymizeIP -}} });
+}
+</script>
+{{ else if hasPrefix . "UA-" }}
 <script type="application/javascript">
 {{ template "__ga_js_set_doNotTrack" $ }}
 if (!doNotTrack) {
@@ -148,8 +159,9 @@ if (!doNotTrack) {
 	ga('send', 'pageview');
 }
 </script>
-{{ end }}
 {{- end -}}
+{{- end }}{{ end -}}
+
 {{- define "__ga_js_set_doNotTrack" -}}{{/* This is also used in the async version. */}}
 {{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
 {{- if not $pc.RespectDoNotTrack -}}

--- a/tpl/tplimpl/embedded/templates/google_analytics.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics.html
@@ -1,6 +1,17 @@
 {{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
-{{- if not $pc.Disable -}}
-{{ with .Site.GoogleAnalytics }}
+{{- if not $pc.Disable }}{{ with .Site.GoogleAnalytics -}}
+{{ if hasPrefix . "G-"}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+<script>
+{{ template "__ga_js_set_doNotTrack" $ }}
+if (!doNotTrack) {
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+	gtag('js', new Date());
+	gtag('config', '{{ . }}', { 'anonymize_ip': {{- $pc.AnonymizeIP -}} });
+}
+</script>
+{{ else if hasPrefix . "UA-" }}
 <script type="application/javascript">
 {{ template "__ga_js_set_doNotTrack" $ }}
 if (!doNotTrack) {
@@ -26,8 +37,9 @@ if (!doNotTrack) {
 	ga('send', 'pageview');
 }
 </script>
-{{ end }}
 {{- end -}}
+{{- end }}{{ end -}}
+
 {{- define "__ga_js_set_doNotTrack" -}}{{/* This is also used in the async version. */}}
 {{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
 {{- if not $pc.RespectDoNotTrack -}}


### PR DESCRIPTION
Reopen #8264. I should've created a branch for the PR so that when I rebased master it didn't break everything. @coliff 

>The Google analytics template doesn't work with Google Analytics v4 (gtag.js) #7954. v3 analytics.js is not depreciated so we should support both using hasPrefix to tell the difference.

>It should be noted that gtag uses the async attribute. Which is more like google_analytics_async.html. I'm not sure if we should move the changes to that template instead. The naming of the template is also confusing. See #8261.

>Privacy settings anonymizeIP and respectDoNotTrack are supported while useSessionStorage is not. I could only find one document with instructions for session storage but in my testing it still set cookies.