### PR TITLE
Upgrade golang version for current Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Twitter:      https://twitter.com/gohugoio
 # Website:      https://gohugo.io/
 
-FROM golang:1.15-alpine AS build
+FROM golang:1.16-alpine AS build
 
 # Optionally set HUGO_BUILD_TAGS to "extended" or "nodeploy" when building like so:
 #   docker build --build-arg HUGO_BUILD_TAGS=extended .


### PR DESCRIPTION
As mentioned in  https://github.com/gohugoio/hugo/issues/8210
Hugo version 0.81.0 only compiles on golang > 1.16

This PR fixes the build error in the current Dockerfile

relates to: #8210