### PR TITLE
Prepare next DEV release on master branch

### DIFF
--- a/releaser/releaser.go
+++ b/releaser/releaser.go
@@ -225,6 +225,12 @@ func (r *ReleaseHandler) Run() error {
 		}
 	}
 
+	// switch back to the "master" branch
+	if _, err := r.git("checkout", "master"); err != nil {
+		return err
+	}
+
+    // prepare repo for next release
 	if err := r.release(releaseNotesFile); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes the issue where the releaser would do the preparation
for the next DEV-release on the current release branch.

![image](https://user-images.githubusercontent.com/11457729/109423056-60e12300-79de-11eb-945e-01778af142d4.png)

The preparation (bump version number, add _DEV_ version, etc.)
is now done on the master branch.

related to: https://github.com/gohugoio/hugo/pull/8289#issuecomment-787452692

I tested locally by executing:
```
go run -tags release main.go release --rel 1.2.3 --try=false --skip-publish true
```