### PR TITLE
Fix locale format in internal opengraph template

### DIFF
--- a/docs/content/en/content-management/multilingual.md
+++ b/docs/content/en/content-management/multilingual.md
@@ -37,12 +37,14 @@ help  = "Help"
 [languages.en]
 title = "My blog"
 weight = 1
+locale = "en_US"
 [languages.en.params]
 linkedin = "https://linkedin.com/whoever"
 
 [languages.fr]
 title = "Mon blogue"
 weight = 2
+locale = "fr_FR"
 [languages.fr.params]
 linkedin = "https://linkedin.com/fr/whoever"
 [languages.fr.params.navigation]

--- a/langs/config.go
+++ b/langs/config.go
@@ -184,6 +184,8 @@ func toSortedLanguages(cfg config.Provider, l map[string]interface{}) (Languages
 				language.LanguageName = cast.ToString(v)
 			case "languagedirection":
 				language.LanguageDirection = cast.ToString(v)
+			case "locale":
+				language.Locale = cast.ToString(v)
 			case "weight":
 				language.Weight = cast.ToInt(v)
 			case "contentdir":

--- a/langs/language.go
+++ b/langs/language.go
@@ -44,6 +44,7 @@ type Language struct {
 	Lang              string
 	LanguageName      string
 	LanguageDirection string
+	Locale            string
 	Title             string
 	Weight            int
 

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -236,9 +236,14 @@ if (!doNotTrack) {
 {{- end -}}
 {{- end -}}
 
-{{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
-{{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
 {{- with .Site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
+
+{{- with or .Params.locale .Language.Locale }}<meta property="og:locale" content="{{ . }}" />{{ end -}}
+{{- range .Translations }}{{ with or .Params.locale .Language.Locale -}}
+<meta property="og:locale:alternate" content="{{ . }}" />
+{{- end }}{{ end -}}
+
+{{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
 {{- with .Params.videos }}{{- range . }}
 <meta property="og:video" content="{{ . | absURL }}" />
 {{ end }}{{ end }}

--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -31,9 +31,14 @@
 {{- end -}}
 {{- end -}}
 
-{{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
-{{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
 {{- with .Site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
+
+{{- with or .Params.locale .Language.Locale }}<meta property="og:locale" content="{{ . }}" />{{ end -}}
+{{- range .Translations }}{{ with or .Params.locale .Language.Locale -}}
+<meta property="og:locale:alternate" content="{{ . }}" />
+{{- end }}{{ end -}}
+
+{{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
 {{- with .Params.videos }}{{- range . }}
 <meta property="og:video" content="{{ . | absURL }}" />
 {{ end }}{{ end }}


### PR DESCRIPTION
In response to #8296. This PR updates the internal opengraph template and allows you set the locale for an entire translation in the site config. You can still override the language locale in your front matter.

Set your language locale in your site config:
```toml
# config.toml
defaultContentLanguage = "en"

[languages]
    [languages.en]
        locale = "en_US"
```

Generates:
```html
<meta property="og:locale" content="en_US">
```

But you can override the locale in your content file:
```md
---
locale: en_GB
---
```

Generates:
```html
<meta property="og:locale" content="en_GB">
```

I've also added the `og:locale:alternate` meta property. So if you have the same page in multiple languages it will also generate like this:
```html
<meta property="og:locale:alternate" content="es_ES" />
<meta property="og:locale:alternate" content="fr_FR" />
```