### PR TITLE
chore: more explicit support link to discourse

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-    - name: Support
+    - name: SUPPORT, ISSUES and TROUBLESHOOTING
       url: https://discourse.gohugo.io/
-      about: Please do not use Github for support requests. Visit https://discourse.gohugo.io for support!
+      about: Please DO NOT use Github for support requests. Please visit https://discourse.gohugo.io for support! You will be helped much faster there. If you ignore this request your issue might be closed with a discourse label.


### PR DESCRIPTION
Changed the description for the discourse link to a little more forceful wording. I also suggest to create a `discourse` label that has some description with a link to the discourse to  brush off people to the discourse.