### PR TITLE
Attributes for code fences should be placed after the lang indicator only

### DIFF
--- a/docs/content/en/getting-started/configuration-markup.md
+++ b/docs/content/en/getting-started/configuration-markup.md
@@ -68,6 +68,14 @@ There are some current limitations: For tables you can currently only apply it t
 {.list}
 ```
 
+Note that attributes in [code fences](/content-management/syntax-highlighting/#highlighting-in-code-fences) must come after the opening tag, with any other highlighting processing instruction, e.g.:
+
+````
+```go {.myclass linenos=table,hl_lines=[8,"15-17"],linenostart=199}
+// ... code
+```
+````
+
 autoHeadingIDType ("github") {{< new-in "0.62.2" >}}
 : The strategy used for creating auto IDs (anchor names). Available types are `github`, `github-ascii` and `blackfriday`. `github` produces GitHub-compatible IDs, `github-ascii` will drop any non-Ascii characters after accent normalization, and `blackfriday` will make the IDs work as with [Blackfriday](#blackfriday), the default Markdown engine before Hugo 0.60. Note that if Goldmark is your default Markdown engine, this is also the strategy used in the [anchorize](/functions/anchorize/) template func.
 

--- a/markup/goldmark/convert_test.go
+++ b/markup/goldmark/convert_test.go
@@ -242,8 +242,18 @@ func TestConvertAttributes(t *testing.T) {
 				withBlockAttributes(conf)
 				conf.Highlight.CodeFences = true
 			},
-			"```bash\necho 'foo';\n````\n{.myclass id=\"myid\"}",
+			"```bash {.myclass id=\"myid\"}\necho 'foo';\n````\n",
 			"<div class=\"highlight myclass\" id=\"myid\"><pre style",
+		},
+		{
+			"Code block, CodeFences=true,linenos=table",
+			func(conf *markup_config.Config) {
+				withBlockAttributes(conf)
+				conf.Highlight.CodeFences = true
+			},
+			"```bash {linenos=table .myclass id=\"myid\"}\necho 'foo';\n````\n{ .adfadf }",
+			[]string{"div class=\"highlight myclass\" id=\"myid\"><div s",
+				"table style"},
 		},
 		{
 			"Paragraph",

--- a/markup/goldmark/internal/extensions/attributes/attributes.go
+++ b/markup/goldmark/internal/extensions/attributes/attributes.go
@@ -97,10 +97,16 @@ type transformer struct{}
 func (a *transformer) Transform(node *ast.Document, reader text.Reader, pc parser.Context) {
 	var attributes = make([]ast.Node, 0, 500)
 	ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
-		if entering && node.Kind() == kindAttributesBlock && !node.HasBlankPreviousLines() {
-			attributes = append(attributes, node)
-			return ast.WalkSkipChildren, nil
+		if entering && node.Kind() == kindAttributesBlock {
+			// Attributes for fenced code blocks are handled in their own extension,
+			// but note that we currently only support code block attributes when
+			// CodeFences=true.
+			if node.PreviousSibling().Kind() != ast.KindFencedCodeBlock && !node.HasBlankPreviousLines() {
+				attributes = append(attributes, node)
+				return ast.WalkSkipChildren, nil
+			}
 		}
+
 		return ast.WalkContinue, nil
 	})
 


### PR DESCRIPTION
Fixes #8313