### PR TITLE
tpl: change <a> to <div> for non-link elements in pagination internal template

### DIFF
--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -265,7 +265,11 @@ if (!doNotTrack) {
   </li>
   {{ end -}}
   <li class="page-item{{ if not $pag.HasPrev }} disabled{{ end }}">
-    <a {{ if $pag.HasPrev }}href="{{ $pag.Prev.URL }}"{{ end }} class="page-link" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
+    {{- if $pag.HasPrev -}}
+    <a href="{{ $pag.Prev.URL }}" class="page-link" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
+    {{- else -}}
+    <div class="page-link" aria-label="Previous"><span aria-hidden="true">&laquo;</span></div>
+    {{- end -}}
   </li>
   {{- $ellipsed := false -}}
   {{- $shouldEllipse := false -}}
@@ -292,7 +296,11 @@ if (!doNotTrack) {
   {{- end -}}
   {{- end }}
   <li class="page-item{{ if not $pag.HasNext }} disabled{{ end }}">
-    <a {{ if $pag.HasNext }}href="{{ $pag.Next.URL }}"{{ end }} class="page-link" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
+    {{- if $pag.HasNext -}}
+    <a href="{{ $pag.Next.URL }}" class="page-link" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
+    {{- else -}}
+    <div class="page-link" aria-label="Next"><span aria-hidden="true">&raquo;</span></div>
+    {{- end -}}
   </li>
   {{- with $pag.Last }}
   <li class="page-item">

--- a/tpl/tplimpl/embedded/templates/pagination.html
+++ b/tpl/tplimpl/embedded/templates/pagination.html
@@ -7,7 +7,11 @@
   </li>
   {{ end -}}
   <li class="page-item{{ if not $pag.HasPrev }} disabled{{ end }}">
-    <a {{ if $pag.HasPrev }}href="{{ $pag.Prev.URL }}"{{ end }} class="page-link" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
+    {{- if $pag.HasPrev -}}
+    <a href="{{ $pag.Prev.URL }}" class="page-link" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
+    {{- else -}}
+    <div class="page-link" aria-label="Previous"><span aria-hidden="true">&laquo;</span></div>
+    {{- end -}}
   </li>
   {{- $ellipsed := false -}}
   {{- $shouldEllipse := false -}}
@@ -34,7 +38,11 @@
   {{- end -}}
   {{- end }}
   <li class="page-item{{ if not $pag.HasNext }} disabled{{ end }}">
-    <a {{ if $pag.HasNext }}href="{{ $pag.Next.URL }}"{{ end }} class="page-link" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
+    {{- if $pag.HasNext -}}
+    <a href="{{ $pag.Next.URL }}" class="page-link" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
+    {{- else -}}
+    <div class="page-link" aria-label="Next"><span aria-hidden="true">&raquo;</span></div>
+    {{- end -}}
   </li>
   {{- with $pag.Last }}
   <li class="page-item">


### PR DESCRIPTION
When on the first or last page, the previous/next link would be disabled and no href would be generated. This impacts the SEO score in LightHouse. The modification changes `<a>` tags to `<div>` elements.

`mage check` returned no errors. The [Contribution Guide](https://github.com/gohugoio/hugo/blob/master/CONTRIBUTING.md) mentioned having test cases for the new code, but I'm not sure how this modification can be tested.