### PR TITLE
Adds automatic configuration of Tor and I2P Services to `hugo serve`

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -555,7 +555,6 @@ func (c *commandeer) serve(s *serverCmd) error {
 					os.Exit(1)
 				}
 				defer torendpoint.Close()
-				fmt.Printf("Open Tor browser and navigate to http://%v.onion\n", torendpoint.ID)
 				err = http.Serve(torendpoint, mu)
 				if err != nil {
 					c.logger.Errorf("Error: %s\n", err.Error())
@@ -590,14 +589,14 @@ func (c *commandeer) torlistener(addr string, keysDir string) (*tor.OnionService
 		os.Exit(1)
 	}
 	var keys *ed25519.KeyPair
-	if _, err := os.Stat(keysDir + addr + ".tor.private"); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(keysDir, addr) + ".tor.private"); os.IsNotExist(err) {
 		tkeys, err := ed25519.GenerateKey(nil)
 		if err != nil {
 			c.logger.Errorf("Error: %s\n", err.Error())
 			os.Exit(1)
 		}
 		keys = &tkeys
-		f, err := os.Create(keysDir + ".tor.private")
+		f, err := os.Create(filepath.Join(keysDir, addr) + ".tor.private")
 		if err != nil {
 			c.logger.Errorf("Error: %s\n", err.Error())
 			os.Exit(1)
@@ -609,7 +608,7 @@ func (c *commandeer) torlistener(addr string, keysDir string) (*tor.OnionService
 			os.Exit(1)
 		}
 	} else if err == nil {
-		tkeys, err := ioutil.ReadFile(keysDir + ".tor.private")
+		tkeys, err := ioutil.ReadFile(filepath.Join(keysDir, addr) + ".tor.private")
 		if err != nil {
 			c.logger.Errorf("Error: %s\n", err.Error())
 			os.Exit(1)
@@ -635,7 +634,7 @@ func (c *commandeer) torlistener(addr string, keysDir string) (*tor.OnionService
 		os.Exit(1)
 	}
 	//	torconfig.Onion = listener.ID + ".onion"
-	err = ioutil.WriteFile(keysDir+addr+".tor.public.txt", []byte(listener.ID+".onion"), 0644)
+	err = ioutil.WriteFile(filepath.Join(keysDir, addr)+".tor.public.txt", []byte(listener.ID+".onion"), 0644)
 	if err != nil {
 		c.logger.Errorf("Error: %s\n", err.Error())
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,12 @@ require (
 	github.com/bep/golibsass v0.7.0
 	github.com/bep/tmc v0.5.1
 	github.com/cli/safeexec v1.0.0
+	github.com/cretz/bine v0.1.0 // indirect
 	github.com/disintegration/gift v1.2.1
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evanw/esbuild v0.11.0
+	github.com/eyedeekay/sam3 v0.32.32 // indirect
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/frankban/quicktest v1.11.3
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cretz/bine v0.1.0 h1:1/fvhLE+fk0bPzjdO5Ci+0ComYxEMuB1JhM4X5skT3g=
+github.com/cretz/bine v0.1.0/go.mod h1:6PF6fWAvYtwjRGkAuDEJeWNOv3a2hUouSP/yRYXmvHw=
 github.com/daaku/go.zipexe v1.0.0 h1:VSOgZtH418pH9L16hC/JrgSNJbbAL26pj7lmD1+CGdY=
 github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
 github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
@@ -239,6 +241,8 @@ github.com/evanw/esbuild v0.9.6 h1:w7NbUL9q5U1H7QGJDZQsiqWqSkMOZk/Wuu2QE3tw5aA=
 github.com/evanw/esbuild v0.9.6/go.mod h1:y2AFBAGVelPqPodpdtxWWqe6n2jYf5FrsJbligmRmuw=
 github.com/evanw/esbuild v0.11.0 h1:dEsfxfHUZcioNld/wzESxCLM+pigjiRSD9EaRmVSQxg=
 github.com/evanw/esbuild v0.11.0/go.mod h1:y2AFBAGVelPqPodpdtxWWqe6n2jYf5FrsJbligmRmuw=
+github.com/eyedeekay/sam3 v0.32.32 h1:9Ea1Ere5O8Clx8zYxKnvhrWy7R96Q4FvxlPskYf8VW0=
+github.com/eyedeekay/sam3 v0.32.32/go.mod h1:qRA9KIIVxbrHlkj+ZB+OoxFGFgdKeGp1vSgPw26eOVU=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=


### PR DESCRIPTION
This adds three flags, 2 booleans(--i2p and --tor) and a string(--keysdir), which allow a Hugo server to automatically configure itself to listen at a Tor Onion Service address and as an I2P Site. It handles every step of the setup process including key generation and connection setup. It can also listen on multiple addresses simultaneously. When the keys required to host the hidden service are generated they are stored in the directory indicated by the keysdir flag.