### PR TITLE
Add feed preview

### DIFF
--- a/tpl/tplimpl/embedded/templates/_default/rss.xml
+++ b/tpl/tplimpl/embedded/templates/_default/rss.xml
@@ -11,6 +11,7 @@
 {{- $pages = $pages | first $limit -}}
 {{- end -}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+{{- printf "<?xml-stylesheet type=\"text/xsl\" href=\"https://raw.githubusercontent.com/frontaid/feed-ui/main/preview.xsl\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>


### PR DESCRIPTION
Hi. This PR adds a simple preview to the feed template. It does it by using XSLT to restructure the feed to HTML and add a simple styling. Instead of using the generic preview that I added, please feel free to add your own. But please consider a preview as it helps making a difference. See https://github.com/frontaid/feed-ui for more context.

PS: The website of our content management system https://frontaid.io/ is based on Hugo. We are very happy with it. Thank you for your work!