### PR TITLE
langs/i18n: Improve plural handling of floats

### DIFF
--- a/common/types/types.go
+++ b/common/types/types.go
@@ -27,6 +27,12 @@ type RLocker interface {
 	RUnlock()
 }
 
+// KeyValue is a interface{} tuple.
+type KeyValue struct {
+	Key   interface{}
+	Value interface{}
+}
+
 // KeyValueStr is a string tuple.
 type KeyValueStr struct {
 	Key   string


### PR DESCRIPTION
The go-i18n library expects plural counts with floats to be represented as strings.

Fixes #8464