### PR TITLE
Deploy invalidate specific paths

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -268,7 +268,7 @@ func (d *Deployer) Deploy(ctx context.Context) error {
 				}
 			} else {
 				jww.FEEDBACK.Println("Invalidating CloudFront CDN...")
-				if err := InvalidateCloudFront(ctx, d.target.CloudFrontDistributionID); err != nil {
+				if err := InvalidateCloudFront(ctx, d.target.CloudFrontDistributionID, d.target.InvalidatePaths); err != nil {
 					jww.FEEDBACK.Printf("Failed to invalidate CloudFront CDN: %v\n", err)
 					return err
 				}
@@ -281,7 +281,7 @@ func (d *Deployer) Deploy(ctx context.Context) error {
 				}
 			} else {
 				jww.FEEDBACK.Println("Invalidating Google Cloud CDN...")
-				if err := InvalidateGoogleCloudCDN(ctx, d.target.GoogleCloudCDNOrigin); err != nil {
+				if err := InvalidateGoogleCloudCDN(ctx, d.target.GoogleCloudCDNOrigin, d.target.InvalidatePaths); err != nil {
 					jww.FEEDBACK.Printf("Failed to invalidate Google Cloud CDN: %v\n", err)
 					return err
 				}

--- a/deploy/deployConfig.go
+++ b/deploy/deployConfig.go
@@ -48,6 +48,9 @@ type target struct {
 	// invalidate when deploying this target.  It is specified as <project>/<origin>.
 	GoogleCloudCDNOrigin string
 
+	// Optional paths to invalidate, defaults to all e.g /*
+	InvalidatePaths []string
+
 	// Optional patterns of files to include/exclude for this target.
 	// Parsed using github.com/gobwas/glob.
 	Include string

--- a/deploy/google.go
+++ b/deploy/google.go
@@ -24,8 +24,11 @@ import (
 )
 
 // Invalidate all of the content in a Google Cloud CDN distribution.
-func InvalidateGoogleCloudCDN(ctx context.Context, origin string) error {
+func InvalidateGoogleCloudCDN(ctx context.Context, origin string, invalidatePaths []string) error {
 	parts := strings.Split(origin, "/")
+	if invalidatePaths == nil {
+		invalidatePaths = append(invalidatePaths, "/*")
+	}
 	if len(parts) != 2 {
 		return fmt.Errorf("origin must be <project>/<origin>")
 	}
@@ -33,7 +36,8 @@ func InvalidateGoogleCloudCDN(ctx context.Context, origin string) error {
 	if err != nil {
 		return err
 	}
-	rule := &compute.CacheInvalidationRule{Path: "/*"}
-	_, err = service.UrlMaps.InvalidateCache(parts[0], parts[1], rule).Context(ctx).Do()
+	for _, iPath := range invalidatePaths {
+		_, err = service.UrlMaps.InvalidateCache(parts[0], parts[1], &compute.CacheInvalidationRule{Path: iPath}).Context(ctx).Do()
+	}
 	return err
 }

--- a/docs/content/en/hosting-and-deployment/hugo-deploy.md
+++ b/docs/content/en/hosting-and-deployment/hugo-deploy.md
@@ -82,6 +82,10 @@ name = "mydeployment"
 # If you are using a CloudFront CDN, deploy will invalidate the cache as needed.
 cloudFrontDistributionID = <ID>
 
+# Target specific paths to invalidate when using cloudFrontDistributionID or GoogleCloudCDNOrigin
+# Leaving unspecified defaults to invalidating the entire cache e.g  /*
+# InvalidatePaths = [ "/foo.html", "/bar.html" ]
+
 # Optionally, you can include or exclude specific files.
 # See https://godoc.org/github.com/gobwas/glob#Glob for the glob pattern syntax.
 # If non-empty, the pattern is matched against the local path.


### PR DESCRIPTION
**Problem:** Hugo deploy will run a cache invalidation when we set the cloudfront distributionid which is great. However this clears everything and we want to be able to target specific paths.

**Solution:** This PR adds an `invalidatePaths` deployment configuration option.  When undefined the current functionality should remain clearing `/*`. However if you specify this option then the invalidation will run with your supplied paths.

**Notes:** I've tested this as successfully working on my aws s3/cloudfront setup both with default and specified paths. I haven't got a gcp setup handy to test on.

