### PR TITLE
rfac: use consistent log on building/rebuilding

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -789,7 +789,7 @@ func (c *commandeer) fullRebuild(changeType string) {
 			time.Sleep(2 * time.Second)
 		}()
 
-		defer c.timeTrack(time.Now(), "Rebuilt")
+		defer c.timeTrack(time.Now(), "Total")
 
 		c.commandeerHugoState = newCommandeerHugoState()
 		err := c.loadConfig(true, true)


### PR DESCRIPTION
Closes #8403 

This refactors the log after a successful rebuilt to "Total in..." as mentioned in #8403 replacing the earlier version of "Rebuilt in..."