### PR TITLE
markup: Add tabindex="0" to default <pre> wrapper.

### DIFF
--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -89,13 +89,13 @@ func TestShortcodeHighlight(t *testing.T) {
 			`{{< highlight java >}}
 void do();
 {{< /highlight >}}`,
-			`(?s)<div class="highlight"><pre style="background-color:#fff;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java"`,
+			`(?s)<div class="highlight"><pre tabindex="0" style="background-color:#fff;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java"`,
 		},
 		{
 			`{{< highlight java "style=friendly" >}}
 void do();
 {{< /highlight >}}`,
-			`(?s)<div class="highlight"><pre style="background-color:#f0f0f0;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java" data-lang="java">`,
+			`(?s)<div class="highlight"><pre tabindex="0" style="background-color:#f0f0f0;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java" data-lang="java">`,
 		},
 	} {
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1732,12 +1732,12 @@ $$$
 
 	// Blackfriday does not support this extended attribute syntax.
 	b.AssertFileContent("public/page1/index.html",
-		`<pre><code class="language-bash {hl_lines=[1]}" data-lang="bash {hl_lines=[1]}">SHORT</code></pre>`,
-		`<pre><code class="language-bash {hl_lines=[1]}" data-lang="bash {hl_lines=[1]}">MARKDOWN`,
+		`<pre tabindex="0"><code class="language-bash {hl_lines=[1]}" data-lang="bash {hl_lines=[1]}">SHORT</code></pre>`,
+		`<pre tabindex="0"><code class="language-bash {hl_lines=[1]}" data-lang="bash {hl_lines=[1]}">MARKDOWN`,
 	)
 
 	b.AssertFileContent("public/page2/index.html",
-		`<pre><code class="language-bash {hl_lines=[1]}" data-lang="bash {hl_lines=[1]}">SHORT`,
+		`<pre tabindex="0"><code class="language-bash {hl_lines=[1]}" data-lang="bash {hl_lines=[1]}">SHORT`,
 	)
 }
 

--- a/markup/goldmark/convert_test.go
+++ b/markup/goldmark/convert_test.go
@@ -143,7 +143,7 @@ description
 	c.Assert(got, qt.Contains, `<h2 id="神真美好-2">神真美好</h2>`, qt.Commentf(got))
 
 	// Code fences
-	c.Assert(got, qt.Contains, "<div class=\"highlight\"><pre class=\"chroma\"><code class=\"language-bash\" data-lang=\"bash\">LINE1\n</code></pre></div>")
+	c.Assert(got, qt.Contains, "<div class=\"highlight\"><pre tabindex=\"0\" class=\"chroma\"><code class=\"language-bash\" data-lang=\"bash\">LINE1\n</code></pre></div>")
 	c.Assert(got, qt.Contains, "Code Fences No Lexer</h2>\n<pre><code class=\"language-moo\" data-lang=\"moo\">LINE1\n</code></pre>")
 
 	// Extensions
@@ -378,7 +378,7 @@ LINE5
 
 		result := convertForConfig(c, cfg, `echo "Hugo Rocks!"`, "bash")
 		// TODO(bep) there is a whitespace mismatch (\n) between this and the highlight template func.
-		c.Assert(result, qt.Equals, `<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash"><span class="nb">echo</span> <span class="s2">&#34;Hugo Rocks!&#34;</span>
+		c.Assert(result, qt.Equals, `<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="nb">echo</span> <span class="s2">&#34;Hugo Rocks!&#34;</span>
 </code></pre></div>`)
 		result = convertForConfig(c, cfg, `echo "Hugo Rocks!"`, "unknown")
 		c.Assert(result, qt.Equals, "<pre><code class=\"language-unknown\" data-lang=\"unknown\">echo &quot;Hugo Rocks!&quot;\n</code></pre>")
@@ -389,7 +389,7 @@ LINE5
 		cfg.NoClasses = false
 
 		result := convertForConfig(c, cfg, lines, `bash {linenos=table,hl_lines=[2 "4-5"],linenostart=3}`)
-		c.Assert(result, qt.Contains, "<div class=\"highlight\"><div class=\"chroma\">\n<table class=\"lntable\"><tr><td class=\"lntd\">\n<pre class=\"chroma\"><code><span class")
+		c.Assert(result, qt.Contains, "<div class=\"highlight\"><div class=\"chroma\">\n<table class=\"lntable\"><tr><td class=\"lntd\">\n<pre tabindex=\"0\" class=\"chroma\"><code><span class")
 		c.Assert(result, qt.Contains, "<span class=\"hl\"><span class=\"lnt\">4")
 
 		result = convertForConfig(c, cfg, lines, "bash {linenos=inline,hl_lines=[2]}")

--- a/markup/highlight/highlight.go
+++ b/markup/highlight/highlight.go
@@ -123,7 +123,7 @@ type preWrapper struct {
 
 func (p preWrapper) Start(code bool, styleAttr string) string {
 	w := &strings.Builder{}
-	fmt.Fprintf(w, "<pre%s>", styleAttr)
+	fmt.Fprintf(w, `<pre tabindex="0"%s>`, styleAttr)
 	var language string
 	if code {
 		language = p.language

--- a/markup/highlight/highlight_test.go
+++ b/markup/highlight/highlight_test.go
@@ -43,9 +43,9 @@ User-Agent: foo
 		h := New(cfg)
 
 		result, _ := h.Highlight(`echo "Hugo Rocks!"`, "bash", "")
-		c.Assert(result, qt.Equals, `<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash"><span class="nb">echo</span> <span class="s2">&#34;Hugo Rocks!&#34;</span></code></pre></div>`)
+		c.Assert(result, qt.Equals, `<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="nb">echo</span> <span class="s2">&#34;Hugo Rocks!&#34;</span></code></pre></div>`)
 		result, _ = h.Highlight(`echo "Hugo Rocks!"`, "unknown", "")
-		c.Assert(result, qt.Equals, `<pre><code class="language-unknown" data-lang="unknown">echo &#34;Hugo Rocks!&#34;</code></pre>`)
+		c.Assert(result, qt.Equals, `<pre tabindex="0"><code class="language-unknown" data-lang="unknown">echo &#34;Hugo Rocks!&#34;</code></pre>`)
 	})
 
 	c.Run("Highlight lines, default config", func(c *qt.C) {
@@ -54,7 +54,7 @@ User-Agent: foo
 		h := New(cfg)
 
 		result, _ := h.Highlight(lines, "bash", "linenos=table,hl_lines=2 4-5,linenostart=3")
-		c.Assert(result, qt.Contains, "<div class=\"highlight\"><div class=\"chroma\">\n<table class=\"lntable\"><tr><td class=\"lntd\">\n<pre class=\"chroma\"><code><span class")
+		c.Assert(result, qt.Contains, "<div class=\"highlight\"><div class=\"chroma\">\n<table class=\"lntable\"><tr><td class=\"lntd\">\n<pre tabindex=\"0\" class=\"chroma\"><code><span class")
 		c.Assert(result, qt.Contains, "<span class=\"hl\"><span class=\"lnt\">4")
 
 		result, _ = h.Highlight(lines, "bash", "linenos=inline,hl_lines=2")
@@ -113,7 +113,7 @@ User-Agent: foo
 		h := New(cfg)
 
 		result, _ := h.Highlight(lines, "", "")
-		c.Assert(result, qt.Equals, "<pre><code>LINE1\nLINE2\nLINE3\nLINE4\nLINE5\n</code></pre>")
+		c.Assert(result, qt.Equals, "<pre tabindex=\"0\"><code>LINE1\nLINE2\nLINE3\nLINE4\nLINE5\n</code></pre>")
 	})
 
 	c.Run("No language, guess syntax", func(c *qt.C) {


### PR DESCRIPTION
Currently the generated `<pre>` element isn't fully accessible as it can't be focused by keyboard users.

An example of syntax highlighting and how the [aXe devTools extension](https://www.deque.com/axe/browser-extensions/) detects this issue:

<img width="1789" alt="Screenshot 2021-05-23 at 10 35 27 PM" src="https://user-images.githubusercontent.com/146201/119275887-ec520500-bc17-11eb-8ad4-545c35138fb9.png">

Additional info:

- [Deque University: Ensure that scrollable region has keyboard access](https://dequeuniversity.com/rules/axe/4.2/scrollable-region-focusable):

> The key to getting a scrollable region to be accessible with the keyboard is to ensure that a keyboard-only user can focus the scrollable region itself or a static text item within the scrollable region.

- [Accessibility insights: scrollable-region-focusable](https://accessibilityinsights.io/info-examples/web/scrollable-region-focusable/)

> Thus, scrollable content is keyboard accessible only if the scrollable element is focusable or contains a focusable element.

To make this fully accessible, the attribute `tabindex="0"` should be added to the `<pre>` tag.

According to [MDN's page on tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) the attribute can have 3 values:

- `-1`, which means "skip it using sequential tabbing"
- `0`, focusable with sequential keyboard navigation (what we want in this case)
- something over 0, which changes the priority of tabbing inside the page

Closes #7194

See also https://github.com/alecthomas/chroma/issues/514 