### PR TITLE
Add `plainify` to Title - in internal template opengraph.html 

### DIFF
--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -1,4 +1,4 @@
-<meta property="og:title" content="{{ .Title }}" />
+<meta property="og:title" content="{{ .Title | plainify }}" />
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />


### PR DESCRIPTION
Some users can use html tags in the title, for example `<br>`, `<em>` or `<strong>`.

Adding `plainify` to clean up these tags will prevent the title from being rendered inappropriately when sharing a page on Facebook for example.
