### PR TITLE
Fix invalid timestamp of the "public" folder

### DIFF
--- a/hugofs/fileinfo.go
+++ b/hugofs/fileinfo.go
@@ -280,7 +280,7 @@ func (fi *dirNameOnlyFileInfo) Mode() os.FileMode {
 }
 
 func (fi *dirNameOnlyFileInfo) ModTime() time.Time {
-	return time.Time{}
+	return time.Now()
 }
 
 func (fi *dirNameOnlyFileInfo) IsDir() bool {


### PR DESCRIPTION
Special thanks to both Richard Mortimer (@oldelvet) and
Joshua M. Clulow (@jclulow) for their analysis and suggested fix:

 * https://github.com/gohugoio/hugo/issues/6161#issuecomment-574336088
 * https://github.com/gohugoio/hugo/issues/6161#issuecomment-596805273

Fixes #6161

---

I am satisfied with the behaviour I see after applying this patch.  The timestamp of `public` folder itself gets updated to "now" for each `hugo` run; the timestamps of the contents inside the public folder look good.  `hugo server` LiveReload still works as expected, whether rendered to memory or to disk.