### PR TITLE
fix(config):env string split

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -41,7 +41,7 @@ func SetEnvVars(oldVars *[]string, keyValues ...string) {
 }
 
 func SplitEnvVar(v string) (string, string) {
-	parts := strings.Split(v, "=")
+	parts := strings.SplitN(v, "=", 2)
 	return parts[0], parts[1]
 }
 

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -528,6 +528,8 @@ theme_param="themevalue2"
 		// Issue #8346
 		"HUGOxPARAMSxMYTHEME_SECTIONxTHEME_PARAM", "themevalue_changed",
 		"HUGOxPARAMSxMYTHEME_SECTION2xTHEME_PARAM", "themevalue2_changed",
+		"HUGO_PARAMS_EMPTY", ``,
+		"HUGO_PARAMS_HTML", `<a target="_blank" />`,
 	)
 
 	b.Build(BuildCfg{})
@@ -547,4 +549,6 @@ theme_param="themevalue2"
 	c.Assert(cfg.Get("params.api_config.another_key"), qt.Equals, "default another_key")
 	c.Assert(cfg.Get("params.mytheme_section.theme_param"), qt.Equals, "themevalue_changed")
 	c.Assert(cfg.Get("params.mytheme_section2.theme_param"), qt.Equals, "themevalue2_changed")
+	c.Assert(cfg.Get("params.empty"), qt.Equals, ``)
+	c.Assert(cfg.Get("params.html"), qt.Equals, `<a target="_blank" />`)
 }


### PR DESCRIPTION
replace strings.Split with strings.SplitN in config.SplitEnvVar, to keep html.

Environment Variable with html could be cut by '=' in original config.SplitEnvVar.

thanks.

fix issure #8589