### PR TITLE
Added check to skip loading 0 byte json files from data directory

### DIFF
--- a/hugolib/datafiles_test.go
+++ b/hugolib/datafiles_test.go
@@ -410,3 +410,17 @@ Slogan from shortcode: {{< d >}}
 	c.Assert(content, qt.Contains, "Slogan from template: Hugo Rocks!")
 	c.Assert(content, qt.Contains, "Slogan from shortcode: Hugo Rocks!")
 }
+
+func TestDataDirEmpty(t *testing.T) {
+	t.Parallel()
+	equivDataDirs := make([]dataDir, 3)
+	equivDataDirs[0].addSource("data/test/a.json", ``)
+	equivDataDirs[1].addSource("data/test/a.yaml", "")
+	equivDataDirs[2].addSource("data/test/a.toml", "")
+	expected := map[string]interface{}{
+		"test": map[string]interface{}{
+			"a": map[string]interface{}{},
+		},
+	}
+	doTestEquivalentDataDirs(t, equivDataDirs, expected)
+}

--- a/parser/metadecoders/decoder.go
+++ b/parser/metadecoders/decoder.go
@@ -112,7 +112,7 @@ func (d Decoder) UnmarshalStringTo(data string, typ interface{}) (interface{}, e
 // Unmarshal will unmarshall data in format f into an interface{}.
 // This is what's needed for Hugo's /data handling.
 func (d Decoder) Unmarshal(data []byte, f Format) (interface{}, error) {
-	if data == nil {
+	if len(data) == 0 {
 		switch f {
 		case CSV:
 			return make([][]string, 0), nil


### PR DESCRIPTION
Made following change to [hugo_sites.go](https://github.com/gohugoio/hugo/blob/master/hugolib/hugo_sites.go#L825) file. 

```diff
- if err := h.handleDataFile(r); err != nil {;
+ if err := h.handleDataFile(r); r.FileInfo().Size() != 0 && err != nil {;
```
This way, a 0 byte JSON file which is not referenced in the project's template is not loaded.

Expected Behaviour :
* You use valid JSON files in your data directory which are referenced : `no errors`
* You add a new 0 byte JSON file / files which are **not** referenced : `no errors`
* You add a new 0 byte JSON file / files which are referenced : `error - unexpected end of JSON input`
* You change any of the JSON file  / files to 0 bytes : `error - unexpected end of JSON input`