### PR TITLE
media: support application/manifest+json

### DIFF
--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -166,13 +166,14 @@ var (
 	TSXType        = newMediaType("text", "tsx", []string{"tsx"})
 	JSXType        = newMediaType("text", "jsx", []string{"jsx"})
 
-	JSONType = newMediaType("application", "json", []string{"json"})
-	RSSType  = newMediaTypeWithMimeSuffix("application", "rss", "xml", []string{"xml"})
-	XMLType  = newMediaType("application", "xml", []string{"xml"})
-	SVGType  = newMediaTypeWithMimeSuffix("image", "svg", "xml", []string{"svg"})
-	TextType = newMediaType("text", "plain", []string{"txt"})
-	TOMLType = newMediaType("application", "toml", []string{"toml"})
-	YAMLType = newMediaType("application", "yaml", []string{"yaml", "yml"})
+	JSONType           = newMediaType("application", "json", []string{"json"})
+	WebAppManifestType = newMediaTypeWithMimeSuffix("application", "manifest", "json", []string{"webmanifest"})
+	RSSType            = newMediaTypeWithMimeSuffix("application", "rss", "xml", []string{"xml"})
+	XMLType            = newMediaType("application", "xml", []string{"xml"})
+	SVGType            = newMediaTypeWithMimeSuffix("image", "svg", "xml", []string{"svg"})
+	TextType           = newMediaType("text", "plain", []string{"txt"})
+	TOMLType           = newMediaType("application", "toml", []string{"toml"})
+	YAMLType           = newMediaType("application", "yaml", []string{"yaml", "yml"})
 
 	// Common image types
 	PNGType  = newMediaType("image", "png", []string{"png"})
@@ -206,6 +207,7 @@ var DefaultTypes = Types{
 	TSXType,
 	JSXType,
 	JSONType,
+	WebAppManifestType,
 	RSSType,
 	XMLType,
 	SVGType,

--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -167,7 +167,7 @@ var (
 	JSXType        = newMediaType("text", "jsx", []string{"jsx"})
 
 	JSONType           = newMediaType("application", "json", []string{"json"})
-	WebAppManifestType = newMediaTypeWithMimeSuffix("application", "manifest", "json", []string{"webmanifest"})
+	WebAppManifest = newMediaTypeWithMimeSuffix("application", "manifest", "json", []string{"webmanifest"})
 	RSSType            = newMediaTypeWithMimeSuffix("application", "rss", "xml", []string{"xml"})
 	XMLType            = newMediaType("application", "xml", []string{"xml"})
 	SVGType            = newMediaTypeWithMimeSuffix("image", "svg", "xml", []string{"svg"})
@@ -207,7 +207,7 @@ var DefaultTypes = Types{
 	TSXType,
 	JSXType,
 	JSONType,
-	WebAppManifestType,
+	WebAppManifest,
 	RSSType,
 	XMLType,
 	SVGType,

--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -167,7 +167,7 @@ var (
 	JSXType        = newMediaType("text", "jsx", []string{"jsx"})
 
 	JSONType           = newMediaType("application", "json", []string{"json"})
-	WebAppManifest = newMediaTypeWithMimeSuffix("application", "manifest", "json", []string{"webmanifest"})
+	WebAppManifestFormat = newMediaTypeWithMimeSuffix("application", "manifest", "json", []string{"webmanifest"})
 	RSSType            = newMediaTypeWithMimeSuffix("application", "rss", "xml", []string{"xml"})
 	XMLType            = newMediaType("application", "xml", []string{"xml"})
 	SVGType            = newMediaTypeWithMimeSuffix("image", "svg", "xml", []string{"svg"})
@@ -207,7 +207,7 @@ var DefaultTypes = Types{
 	TSXType,
 	JSXType,
 	JSONType,
-	WebAppManifest,
+	WebAppManifestFormat,
 	RSSType,
 	XMLType,
 	SVGType,

--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -167,7 +167,7 @@ var (
 	JSXType        = newMediaType("text", "jsx", []string{"jsx"})
 
 	JSONType           = newMediaType("application", "json", []string{"json"})
-	WebAppManifestFormat = newMediaTypeWithMimeSuffix("application", "manifest", "json", []string{"webmanifest"})
+	WebAppManifestType = newMediaTypeWithMimeSuffix("application", "manifest", "json", []string{"webmanifest"})
 	RSSType            = newMediaTypeWithMimeSuffix("application", "rss", "xml", []string{"xml"})
 	XMLType            = newMediaType("application", "xml", []string{"xml"})
 	SVGType            = newMediaTypeWithMimeSuffix("image", "svg", "xml", []string{"svg"})
@@ -207,7 +207,7 @@ var DefaultTypes = Types{
 	TSXType,
 	JSXType,
 	JSONType,
-	WebAppManifestFormat,
+	WebAppManifestType,
 	RSSType,
 	XMLType,
 	SVGType,

--- a/minifiers/minifiers.go
+++ b/minifiers/minifiers.go
@@ -78,7 +78,7 @@ func New(mediaTypes media.Types, outputFormats output.Formats, cfg config.Provid
 	}
 	if !conf.DisableJSON {
 		addMinifier(m, mediaTypes, "json", &conf.Tdewolff.JSON)
-		m.AddRegexp(regexp.MustCompile(`^(application|text)/(x-|ld\+)?json$`), &conf.Tdewolff.JSON)
+		m.AddRegexp(regexp.MustCompile(`^(application|text)/(x-|(ld|manifest)\+)?json$`), &conf.Tdewolff.JSON)
 	}
 	if !conf.DisableSVG {
 		addMinifier(m, mediaTypes, "svg", &conf.Tdewolff.SVG)

--- a/output/outputFormat.go
+++ b/output/outputFormat.go
@@ -143,6 +143,14 @@ var (
 		Rel:         "alternate",
 	}
 
+	WebAppManifestFormat = Format{
+		Name:        "Web App Manifest",
+		MediaType:   media.WebAppManifestType,
+		BaseName:    "manifest",
+		IsPlainText: true,
+		Rel:         "manifest",
+	}
+
 	RobotsTxtFormat = Format{
 		Name:        "ROBOTS",
 		MediaType:   media.TextType,

--- a/output/outputFormat.go
+++ b/output/outputFormat.go
@@ -145,7 +145,7 @@ var (
 
 	WebAppManifestFormat = Format{
 		Name:        "WebAppManifest",
-		MediaType:   media.WebAppManifestFormat,
+		MediaType:   media.WebAppManifestType,
 		BaseName:    "manifest",
 		IsPlainText: true,
 		Rel:         "manifest",

--- a/output/outputFormat.go
+++ b/output/outputFormat.go
@@ -143,9 +143,9 @@ var (
 		Rel:         "alternate",
 	}
 
-	WebAppManifest = Format{
-		Name:        "Web App Manifest",
-		MediaType:   media.WebAppManifest,
+	WebAppManifestFormat = Format{
+		Name:        "WebAppManifest",
+		MediaType:   media.WebAppManifestFormat,
 		BaseName:    "manifest",
 		IsPlainText: true,
 		Rel:         "manifest",
@@ -184,7 +184,7 @@ var DefaultFormats = Formats{
 	CSVFormat,
 	HTMLFormat,
 	JSONFormat,
-	WebAppManifest,
+	WebAppManifestFormat,
 	RobotsTxtFormat,
 	RSSFormat,
 	SitemapFormat,

--- a/output/outputFormat.go
+++ b/output/outputFormat.go
@@ -143,9 +143,9 @@ var (
 		Rel:         "alternate",
 	}
 
-	WebAppManifestFormat = Format{
+	WebAppManifest = Format{
 		Name:        "Web App Manifest",
-		MediaType:   media.WebAppManifestType,
+		MediaType:   media.WebAppManifest,
 		BaseName:    "manifest",
 		IsPlainText: true,
 		Rel:         "manifest",
@@ -184,6 +184,7 @@ var DefaultFormats = Formats{
 	CSVFormat,
 	HTMLFormat,
 	JSONFormat,
+	WebAppManifest,
 	RobotsTxtFormat,
 	RSSFormat,
 	SitemapFormat,


### PR DESCRIPTION
The standard file extension for Web App Manifest files is
".webmanifest". This commit allows Hugo to recognize .webmanifest files
as "application/manifest+json" files and to minify them using its
JSON minifier.

The .webmanifest file extension is recommended in the w3c spec to
simplify media type registration:
https://www.w3.org/TR/appmanifest/#media-type-registration

Webhint docs are also relevant:
https://webhint.io/docs/user-guide/hints/hint-manifest-file-extension/

Closes #8624