### PR TITLE
add image dithering filter #8598

### DIFF
--- a/resources/images/dither.go
+++ b/resources/images/dither.go
@@ -1,0 +1,179 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package images
+
+import (
+	"image"
+	"image/color"
+	"image/draw"
+	"strings"
+
+	"github.com/disintegration/gift"
+)
+
+var _ gift.Filter = (*ditherFilter)(nil)
+
+var matrixs = map[string][][]float32{
+
+	strings.ToLower("FloydSteinberg"):    {{0, 0, 7.0 / 16.0}, {3.0 / 16.0, 5.0 / 16.0, 1.0 / 16.0}},
+	strings.ToLower("JarvisJudiceNinke"): {{0, 0, 0, 7.0 / 48.0, 5.0 / 48.0}, {3.0 / 48.0, 5.0 / 48.0, 7.0 / 48.0, 5.0 / 48.0, 3.0 / 48.0}, {1.0 / 48.0, 3.0 / 48.0, 5.0 / 48.0, 3.0 / 48.0, 1.0 / 48.0}},
+	strings.ToLower("Stucki"):            {{0, 0, 0, 8.0 / 42.0, 4.0 / 42.0}, {2.0 / 42.0, 4.0 / 42.0, 8.0 / 42.0, 4.0 / 42.0, 2.0 / 42.0}, {1.0 / 42.0, 2.0 / 42.0, 4.0 / 42.0, 2.0 / 42.0, 1.0 / 42.0}},
+	strings.ToLower("Atkinson"):          {{0, 0, 1.0 / 8.0, 1.0 / 8.0}, {1.0 / 8.0, 1.0 / 8.0, 1.0 / 8.0, 0}, {0, 1.0 / 8.0, 0, 0}},
+	strings.ToLower("Burkes"):            {{0, 0, 0, 8.0 / 32.0, 4.0 / 32.0}, {2.0 / 32.0, 4.0 / 32.0, 8.0 / 32.0, 4.0 / 32.0, 2.0 / 32.0}},
+	strings.ToLower("Sierra"):            {{0, 0, 0, 5.0 / 32.0, 3.0 / 32.0}, {2.0 / 32.0, 4.0 / 32.0, 5.0 / 32.0, 4.0 / 32.0, 2.0 / 32.0}, {0, 2.0 / 32.0, 3.0 / 32.0, 2.0 / 32.0, 0}},
+	strings.ToLower("TwoRowSierra"):      {{0, 0, 0, 4.0 / 16.0, 3.0 / 16.0}, {1.0 / 32.0, 2.0 / 32.0, 3.0 / 32.0, 2.0 / 32.0, 1.0 / 32.0}},
+	strings.ToLower("SierraLite"):        {{0, 0, 2.0 / 4.0}, {1.0 / 4.0, 1.0 / 4.0, 0}},
+}
+
+var (
+	defaultMatrix  = [][]float32{{0, 0, 7.0 / 16.0}, {3.0 / 16.0, 5.0 / 16.0, 1.0 / 16.0}}
+	defaultPalette = color.Palette{color.Black, color.White}
+)
+
+type ditherFilter struct {
+	config string
+}
+
+func (f ditherFilter) Draw(dst draw.Image, src image.Image, options *gift.Options) {
+	var (
+		palette []color.Color
+		matrix  [][]float32
+	)
+	parts := strings.Fields(f.config)
+	for _, part := range parts {
+		part = strings.ToLower(part)
+		if m, ok := matrixs[part]; ok {
+			matrix = m
+		} else if part[0] == '#' {
+			p, err := hexStringToColor(part[1:])
+			palette = append(palette, p)
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	// set to default matrix if matrix not found
+	if len(matrix) <= 0 {
+		matrix = defaultMatrix
+	}
+
+	// append palette if only has one color or less 
+	if len(palette) <= 1 {
+		palette = append(palette, defaultPalette...)
+	}
+
+	rect := dst.Bounds()
+	errImg := NewErrorImage(rect)
+	shift := findShift(matrix)
+
+	animation := make(chan draw.Image)
+
+	pixPerFrame := (rect.Dx() * rect.Dy()) / 1
+
+	for y := rect.Min.Y; y < rect.Max.Y; y++ {
+		for x := rect.Min.X; x < rect.Max.X; x++ {
+			// using the closest color
+			r, e, _ := findColor(errImg.PixelErrorAt(x, y), src.At(x, y), palette)
+			dst.Set(x, y, r)
+			errImg.SetPixelError(x, y, e)
+
+			if (y != 0 && x != 0) && (((y*rect.Dy())+x)%pixPerFrame == 0) {
+				animation <- dst
+			}
+
+			// diffusing the error using the diffusion matrix
+			for i, v1 := range matrix {
+				for j, v2 := range v1 {
+					errImg.SetPixelError(x+j+shift, y+i,
+						errImg.PixelErrorAt(x+j+shift, y+i).Add(errImg.PixelErrorAt(x, y).Mul(v2)))
+				}
+			}
+		}
+	}
+}
+
+func (f ditherFilter) Bounds(srcBounds image.Rectangle) (dstBounds image.Rectangle) {
+	dstBounds = image.Rect(0, 0, srcBounds.Dx(), srcBounds.Dy())
+	return
+}
+
+func findShift(matrix [][]float32) int {
+	for _, v1 := range matrix {
+		for j, v2 := range v1 {
+			if v2 > 0.0 {
+				return -j + 1
+			}
+		}
+	}
+	return 0
+}
+
+// findColor determines the closest color in a palette given the pixel color and the error
+//
+// It returns the closest color, the updated error and the distance between the error and the color
+func findColor(err color.Color, pix color.Color, pal color.Palette) (color.RGBA, PixelError, uint16) {
+	var errR, errG, errB,
+		pixR, pixG, pixB,
+		colR, colG, colB int16
+	_errR, _errG, _errB, _ := err.RGBA()
+	_pixR, _pixG, _pixB, _ := pix.RGBA()
+
+	// Low-pass filter
+	errR = int16(float32(int16(_errR)) * 0.75)
+	errG = int16(float32(int16(_errG)) * 0.75)
+	errB = int16(float32(int16(_errB)) * 0.75)
+
+	pixR = int16(uint8(_pixR)) + errR
+	pixG = int16(uint8(_pixG)) + errG
+	pixB = int16(uint8(_pixB)) + errB
+
+	var index int
+	var minDiff uint16 = 1<<16 - 1
+
+	for i, col := range pal {
+		_colR, _colG, _colB, _ := col.RGBA()
+
+		colR = int16(uint8(_colR))
+		colG = int16(uint8(_colG))
+		colB = int16(uint8(_colB))
+		var distance = abs(pixR-colR) + abs(pixG-colG) + abs(pixB-colB)
+
+		if distance < minDiff {
+			index = i
+			minDiff = distance
+		}
+	}
+
+	_colR, _colG, _colB, _ := pal[index].RGBA()
+
+	colR = int16(uint8(_colR))
+	colG = int16(uint8(_colG))
+	colB = int16(uint8(_colB))
+
+	return color.RGBA{uint8(colR), uint8(colG), uint8(colB), 255},
+		PixelError{float32(pixR - colR),
+			float32(pixG - colG),
+			float32(pixB - colB),
+			1<<16 - 1},
+		minDiff
+}
+
+// abs gives the absolute value of a signed integer
+func abs(x int16) uint16 {
+	if x < 0 {
+		return uint16(-x)
+	}
+	return uint16(x)
+}

--- a/resources/images/filters.go
+++ b/resources/images/filters.go
@@ -25,6 +25,14 @@ const filterAPIVersion = 0
 type Filters struct {
 }
 
+// Dither creates a filter that dither image.
+func (*Filters) Dither(config interface{}) gift.Filter {
+	return filter{
+		Options: newFilterOpts(config),
+		Filter:  ditherFilter{config: cast.ToString(config)},
+	}
+}
+
 // Overlay creates a filter that overlays src at position x y.
 func (*Filters) Overlay(src ImageSource, x, y interface{}) gift.Filter {
 	return filter{

--- a/resources/images/pixelerror.go
+++ b/resources/images/pixelerror.go
@@ -1,0 +1,181 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package images
+
+import (
+	"image"
+	"image/color"
+	"math"
+)
+
+// PixelError represents the error for each canal in the image
+// when dithering an image
+// Errors are floats because they are the result of a division
+type PixelError struct {
+	// TODO(brouxco): the alpha value does not make a lot of sense in a PixelError
+	R, G, B, A float32
+}
+
+// RGBA returns the errors for each canal in the image
+func (c PixelError) RGBA() (r, g, b, a uint32) {
+	return uint32(c.R), uint32(c.G), uint32(c.B), uint32(c.A)
+}
+
+// Add adds two PixelError
+func (c PixelError) Add(c2 PixelError) PixelError {
+	r := c.R + c2.R
+	g := c.G + c2.G
+	b := c.B + c2.B
+	return PixelError{r, g, b, 0}
+}
+
+// Mul multiplies two PixelError
+func (c PixelError) Mul(v float32) PixelError {
+	r := c.R * v
+	g := c.G * v
+	b := c.B * v
+	return PixelError{r, g, b, 0}
+}
+
+func pixelErrorModel(c color.Color) color.Color {
+	if _, ok := c.(PixelError); ok {
+		return c
+	}
+	r, g, b, a := c.RGBA()
+	return PixelError{float32(r), float32(g), float32(b), float32(a)}
+}
+
+// ErrorImage is an in-memory image whose At method returns dithering.PixelError values
+type ErrorImage struct {
+	// Pix holds the image's pixels, in R, G, B, A order. The pixel at
+	// (x, y) starts at Pix[(y-Rect.Min.Y)*Stride + (x-Rect.Min.X)*4].
+	Pix []float32
+	// Stride is the Pix stride between vertically adjacent pixels.
+	Stride int
+	// Rect is the image's bounds.
+	Rect image.Rectangle
+	// Min & Max values in the image
+	Min, Max PixelError
+}
+
+// ColorModel returns the ErrorImage color model
+func (p *ErrorImage) ColorModel() color.Model {
+	return color.ModelFunc(pixelErrorModel)
+}
+
+// Bounds returns the domain for which At can return non-zero color
+func (p *ErrorImage) Bounds() image.Rectangle { return p.Rect }
+
+// At returns the color of the pixel at (x, y)
+func (p *ErrorImage) At(x, y int) color.Color {
+	if !(image.Point{x, y}.In(p.Rect)) {
+		return PixelError{}
+	}
+	i := p.PixOffset(x, y)
+
+	r := (p.Pix[i+0]) + float32(math.Abs(float64(p.Min.R)))/(p.Max.R-p.Min.R)*255
+	g := (p.Pix[i+1]) + float32(math.Abs(float64(p.Min.G)))/(p.Max.G-p.Min.G)*255
+	b := (p.Pix[i+2]) + float32(math.Abs(float64(p.Min.B)))/(p.Max.B-p.Min.B)*255
+
+	return color.RGBA{uint8(r), uint8(g), uint8(b), 255}
+}
+
+// PixelErrorAt returns the pixel error at (x, y)
+func (p *ErrorImage) PixelErrorAt(x, y int) PixelError {
+	if !(image.Point{x, y}.In(p.Rect)) {
+		return PixelError{}
+	}
+	i := p.PixOffset(x, y)
+	r := p.Pix[i+0]
+	g := p.Pix[i+1]
+	b := p.Pix[i+2]
+	a := p.Pix[i+3]
+
+	return PixelError{r, g, b, a}
+}
+
+// PixOffset returns the index of the first element of Pix that corresponds to
+// the pixel at (x, y).
+func (p *ErrorImage) PixOffset(x, y int) int {
+	return (y-p.Rect.Min.Y)*p.Stride + (x-p.Rect.Min.X)*4
+}
+
+// Set sets the error of the pixel at (x, y)
+func (p *ErrorImage) Set(x, y int, c color.Color) {
+	if !(image.Point{x, y}.In(p.Rect)) {
+		return
+	}
+	i := p.PixOffset(x, y)
+	c1 := color.ModelFunc(pixelErrorModel).Convert(c).(PixelError)
+	// TODO(brouxco): use min and max functions maybe ?
+	if c1.R > p.Max.R {
+		p.Max.R = c1.R
+	}
+	if c1.G > p.Max.G {
+		p.Max.G = c1.G
+	}
+	if c1.B > p.Max.B {
+		p.Max.B = c1.B
+	}
+	if c1.R < p.Min.R {
+		p.Min.R = c1.R
+	}
+	if c1.G < p.Min.G {
+		p.Min.G = c1.G
+	}
+	if c1.B < p.Min.B {
+		p.Min.B = c1.B
+	}
+	p.Pix[i+0] = c1.R
+	p.Pix[i+1] = c1.G
+	p.Pix[i+2] = c1.B
+	p.Pix[i+3] = c1.A
+}
+
+// SetPixelError sets the error of the pixel at (x, y)
+func (p *ErrorImage) SetPixelError(x, y int, c PixelError) {
+	if !(image.Point{x, y}.In(p.Rect)) {
+		return
+	}
+	if c.R > p.Max.R {
+		p.Max.R = c.R
+	}
+	if c.G > p.Max.G {
+		p.Max.G = c.G
+	}
+	if c.B > p.Max.B {
+		p.Max.B = c.B
+	}
+	if c.R < p.Min.R {
+		p.Min.R = c.R
+	}
+	if c.G < p.Min.G {
+		p.Min.G = c.G
+	}
+	if c.B < p.Min.B {
+		p.Min.B = c.B
+	}
+	i := p.PixOffset(x, y)
+	p.Pix[i+0] = c.R
+	p.Pix[i+1] = c.G
+	p.Pix[i+2] = c.B
+	p.Pix[i+3] = c.A
+}
+
+// NewErrorImage returns a new ErrorImage image with the given width and height
+func NewErrorImage(r image.Rectangle) *ErrorImage {
+	w, h := r.Dx(), r.Dy()
+	buf := make([]float32, 4*w*h)
+	return &ErrorImage{buf, 4 * w, r, PixelError{}, PixelError{}}
+}


### PR DESCRIPTION
Fix this issue [#8598](https://github.com/gohugoio/hugo/issues/8598)

You can set the dither algorithm and palette colors to use with a 3 or 6 digit hex code starting with #. If you set palettes only one color, it will add Black and White automatically. Use png file for best result. List algorithm :
- FloydSteinberg (default)
- JarvisJudiceNinke
- Stucki
- Atkinson
- Burkes
- Sierra
- TwoRowSierra
- SierraLite

example :
`{{ $img = $img.Filter (images.Dither "Stucki #ffffff #8D1900") }}`
`{{ $img = $img.Filter (images.Dither "FloydSteinberg #ffffff #8D1900 #AD8359 #508A00 #1A6C82") }}`
