### PR TITLE
Move time notification to after rebuild errors

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -162,14 +162,16 @@ Complete documentation is available at http://gohugo.io/.`,
 				return nil
 			}
 
+			// prevent cobra printing error so it can be handled here (before the timeTrack prints)
+			cmd.SilenceErrors = true
+
 			c, err := initializeConfig(true, cc.buildWatch, &cc.hugoBuilderCommon, cc, cfgInit)
 			if err != nil {
+				cmd.PrintErrln("Error:", err.Error())
 				return err
 			}
 			cc.c = c
 
-			// prevent cobra printing error so it can be handled here (before the timeTrack prints)
-			cmd.SilenceErrors = true
 			err = c.build()
 			if err != nil {
 				cmd.PrintErrln("Error:", err.Error())

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -168,7 +168,13 @@ Complete documentation is available at http://gohugo.io/.`,
 			}
 			cc.c = c
 
-			return c.build()
+			// prevent cobra printing error so it can be handled here (before the timeTrack prints)
+			cmd.SilenceErrors = true
+			err = c.build()
+			if err != nil {
+				cmd.PrintErrln("Error:", err.Error())
+			}
+			return err
 		},
 	})
 

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -735,7 +735,6 @@ func (c *commandeer) handleBuildErr(err error, msg string) {
 }
 
 func (c *commandeer) rebuildSites(events []fsnotify.Event) error {
-	defer c.timeTrack(time.Now(), "Total")
 
 	c.buildErr = nil
 	visited := c.visitedURLs.PeekAllSet()
@@ -1112,9 +1111,15 @@ func (c *commandeer) handleEvents(watcher *watcher.Batcher,
 
 		c.printChangeDetected("")
 		c.changeDetector.PrepareNew()
-		if err := c.rebuildSites(dynamicEvents); err != nil {
-			c.handleBuildErr(err, "Rebuild failed")
-		}
+
+		func() {
+			defer c.timeTrack(time.Now(), "Total")
+			if err := c.rebuildSites(dynamicEvents); err != nil {
+				c.handleBuildErr(err, "Rebuild failed")
+			}
+		}()
+		// startTime := time.Now()
+		// c.timeTrack(startTime, "Total")
 
 		if doLiveReload {
 			if len(partitionedEvents.ContentEvents) == 0 && len(partitionedEvents.AssetEvents) > 0 {

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -537,7 +537,6 @@ func (c *commandeer) build() error {
 }
 
 func (c *commandeer) serverBuild() error {
-	defer c.timeTrack(time.Now(), "Built")
 
 	stopProfiling, err := c.initProfiling()
 	if err != nil {
@@ -1118,8 +1117,6 @@ func (c *commandeer) handleEvents(watcher *watcher.Batcher,
 				c.handleBuildErr(err, "Rebuild failed")
 			}
 		}()
-		// startTime := time.Now()
-		// c.timeTrack(startTime, "Total")
 
 		if doLiveReload {
 			if len(partitionedEvents.ContentEvents) == 0 && len(partitionedEvents.AssetEvents) > 0 {

--- a/commands/server.go
+++ b/commands/server.go
@@ -239,7 +239,17 @@ func (sc *serverCmd) server(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := c.serverBuild(); err != nil {
+	// silence errors in cobra so we can handle them here
+	cmd.SilenceErrors = true
+	err = func() error {
+		defer c.timeTrack(time.Now(), "Built")
+		err := c.serverBuild()
+		if err != nil {
+			cmd.PrintErrln("Error:", err.Error())
+		}
+		return err
+	}()
+	if err != nil {
 		return err
 	}
 

--- a/commands/server.go
+++ b/commands/server.go
@@ -234,13 +234,15 @@ func (sc *serverCmd) server(cmd *cobra.Command, args []string) error {
 		jww.WARN.Println("memstats error:", err)
 	}
 
+	// silence errors in cobra so we can handle them here
+	cmd.SilenceErrors = true
+
 	c, err := initializeConfig(true, true, &sc.hugoBuilderCommon, sc, cfgInit)
 	if err != nil {
+		cmd.PrintErrln("Error:", err.Error())
 		return err
 	}
 
-	// silence errors in cobra so we can handle them here
-	cmd.SilenceErrors = true
 	err = func() error {
 		defer c.timeTrack(time.Now(), "Built")
 		err := c.serverBuild()


### PR DESCRIPTION
This allows error parsers (VSCode problem matchers) to use the time notification as bounds for detecting errors

(I've never coded in Go before, so if there is a better way to do this, I'm all ears!)

(partially) closes #8403