### PR TITLE
Make isset warning message more actionable

### DIFF
--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -380,7 +380,7 @@ func (ns *Namespace) IsSet(a interface{}, key interface{}) (bool, error) {
 			return av.MapIndex(kv).IsValid(), nil
 		}
 	default:
-		helpers.DistinctErrorLog.Printf("WARNING: calling IsSet with unsupported type %q (%T) will always return false.\n", av.Kind(), a)
+		helpers.DistinctErrorLog.Printf("WARNING: calling (isset %q %q) with unsupported collection type %q (%T) will always return false.\n", a, key, av.Kind(), a)
 	}
 
 	return false, nil


### PR DESCRIPTION
- Refer to the way that most users will call this: using the `isset` template
- Log the key used as well -- this helps narrow down callers.

Before:

```
WARNING: calling IsSet with unsupported type "invalid" (<nil>) will always return false.
```

After:

```
WARNING: calling (isset %!q(<nil>) "taxonomycloud") with unsupported collection type "invalid" (<nil>) will always return false.
```

Addresses #8667