### PR TITLE
jsconfig: Add support for subdirectory mounts

### DIFF
--- a/resources/jsconfig/jsconfig_test.go
+++ b/resources/jsconfig/jsconfig_test.go
@@ -24,12 +24,18 @@ func TestJsConfigBuilder(t *testing.T) {
 	c := qt.New(t)
 
 	b := NewBuilder()
-	b.AddSourceRoot("/c/assets")
-	b.AddSourceRoot("/d/assets")
+	b.AddRoots("/c/assets", "")
+	b.AddRoots("/d/assets", "d")
 
 	conf := b.Build("/a/b")
 	c.Assert(conf.CompilerOptions.BaseURL, qt.Equals, ".")
-	c.Assert(conf.CompilerOptions.Paths["*"], qt.DeepEquals, []string{filepath.FromSlash("../../c/assets/*"), filepath.FromSlash("../../d/assets/*")})
+	c.Assert(
+		conf.CompilerOptions.Paths,
+		qt.DeepEquals,
+		map[string][]string{
+			"*":   {filepath.FromSlash("../../c/assets/*")},
+			"d/*": {filepath.FromSlash("../../d/assets/*")},
+		})
 
 	c.Assert(NewBuilder().Build("/a/b"), qt.IsNil)
 }

--- a/resources/resource_transformers/js/options.go
+++ b/resources/resource_transformers/js/options.go
@@ -217,7 +217,7 @@ func createBuildPlugins(c *Client, opts Options) ([]api.Plugin, error) {
 			// This should be a small number of elements, and when
 			// in server mode, we may get stale entries on renames etc.,
 			// but that shouldn't matter too much.
-			c.rs.JSConfigBuilder.AddSourceRoot(m.SourceRoot())
+			c.rs.JSConfigBuilder.AddRoots(m.SourceRoot(), m.MountRoot())
 			return api.OnResolveResult{Path: m.Filename(), Namespace: nsImportHugo}, nil
 		}
 


### PR DESCRIPTION
This PR add support for modules mounted as subdirectories in `assets`. It aims to solve #8660.