### PR TITLE
exif: Log warning for metadata decode error

### DIFF
--- a/resources/image.go
+++ b/resources/image.go
@@ -112,8 +112,8 @@ func (i *imageResource) getExif() *exif.Exif {
 
 			x, err := i.getSpec().imaging.DecodeExif(f)
 			if err != nil {
-				i.metaInitErr = err
-				return
+				i.getSpec().Logger.Warnf("Unable to decode Exif metadata from image: %s", i.Key())
+				return nil
 			}
 
 			i.meta = &imageMeta{Exif: x}


### PR DESCRIPTION
The error is logged as a WARNING and nil is returned.

see #8519