### PR TITLE
Add extra handling for .Page.Title using the file/folder name

### DIFF
--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -283,6 +283,11 @@ func (p *pageMeta) Sitemap() config.Sitemap {
 }
 
 func (p *pageMeta) Title() string {
+	if p.title == "" {
+		if p.File() != nil {
+			return p.File().TranslationBaseName()
+		}
+	}
 	return p.title
 }
 

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -285,7 +285,11 @@ func (p *pageMeta) Sitemap() config.Sitemap {
 func (p *pageMeta) Title() string {
 	if p.title == "" {
 		if p.File() != nil {
-			return p.File().TranslationBaseName()
+			filename := p.File().TranslationBaseName()
+			if filename != "_index" {
+				return filename
+			}
+			return path.Base(p.File().Dir())
 		}
 	}
 	return p.title


### PR DESCRIPTION
By default if you do not specify title on the frontmatter it just outputs an empty title.

With this alteration it gets the title from the file name if there is no title specified.

This is especially useful for Obsidian vault migrations, it's very bureaucratic to change a filename AND the title frontmatter. This does not happen automatically so it breaks the flow. If the note title uses illegal filenames like the ones with `/` or `:` you can always fallback to the title frontmatter.

I expect that I changed the right file xD

Playground to check the behavior: https://github.com/lucasew/hugo-barebones