### PR TITLE
add json flag for version command

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -14,31 +14,46 @@
 package commands
 
 import (
-	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/spf13/cobra"
 	jww "github.com/spf13/jwalterweatherman"
+
+	"github.com/gohugoio/hugo/common/hugo"
 )
 
 var _ cmder = (*versionCmd)(nil)
 
 type versionCmd struct {
+	json bool
 	*baseCmd
 }
 
 func newVersionCmd() *versionCmd {
-	return &versionCmd{
-		newBaseCmd(&cobra.Command{
-			Use:   "version",
-			Short: "Print the version number of Hugo",
-			Long:  `All software has versions. This is Hugo's.`,
-			RunE: func(cmd *cobra.Command, args []string) error {
-				printHugoVersion()
+	v := &versionCmd{}
+
+	v.baseCmd = newBaseCmd(&cobra.Command{
+		Use:   "version",
+		Short: "Print the version number of Hugo",
+		Long:  `All software has versions. This is Hugo's.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if v.json {
+				printHugoVersionJson()
 				return nil
-			},
-		}),
-	}
+			}
+			printHugoVersion()
+
+			return nil
+		},
+	})
+
+	v.cmd.Flags().BoolVar(&v.json, "json", false, "print JSON format")
+
+	return v
 }
 
 func printHugoVersion() {
 	jww.FEEDBACK.Println(hugo.BuildVersionString())
+}
+
+func printHugoVersionJson() {
+	jww.FEEDBACK.Println(hugo.BuildVersionJSON())
 }

--- a/common/hugo/version.go
+++ b/common/hugo/version.go
@@ -14,13 +14,15 @@
 package hugo
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"runtime"
 	"strings"
 
-	"github.com/gohugoio/hugo/compare"
 	"github.com/spf13/cast"
+
+	"github.com/gohugoio/hugo/compare"
 )
 
 // Version represents the Hugo build version.
@@ -153,6 +155,53 @@ func BuildVersionString() string {
 	}
 
 	return versionString
+}
+
+// VersionJSON represents the Hugo build version in JSON format.
+type VersionJSON struct {
+	Program        string `json:"program,omitempty"`
+	Version        string `json:"version,omitempty"`
+	Build          string `json:"build,omitempty"`
+	Extended       bool   `json:"extended,omitempty"`
+	BuildDate      string `json:"build_date,omitempty"`
+	VendorInfo     string `json:"vendor_info,omitempty"`
+	OSArchitecture string `json:"os_architecture,omitempty"`
+}
+
+// BuildVersionJSON creates a json version string. This is what you see when
+// running "hugo version --json"
+func BuildVersionJSON() string {
+	v := &VersionJSON{
+		Program: "hugo",
+		Version: "v" + CurrentVersion.String(),
+	}
+
+	if commitHash != "" {
+		v.Build = strings.ToUpper(commitHash)
+	}
+
+	if IsExtended {
+		v.Extended = true
+	} else {
+		v.Extended = false
+	}
+
+	v.OSArchitecture = runtime.GOOS + "/" + runtime.GOARCH
+
+	date := buildDate
+	if date == "" {
+		v.BuildDate = "unknown"
+	} else {
+		v.BuildDate = date
+	}
+
+	if vendorInfo != "" {
+		v.VendorInfo = vendorInfo
+	}
+
+	marshal, _ := json.Marshal(v)
+
+	return string(marshal)
 }
 
 func version(version float32, patchVersion int, suffix string) string {


### PR DESCRIPTION
closes #8717

Adds a JSON flag to version command

```sh
hugo version --json
# {"program":"hugo","version":"v0.85.0-DEV","build_date":"unknown","os_architecture":"darwin/amd64"}
```