### PR TITLE
Added page resources to figure shortcode

### DIFF
--- a/tpl/tplimpl/embedded/templates/shortcodes/figure.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/figure.html
@@ -1,8 +1,9 @@
+{{ $src := (.Page.Resources.GetMatch (printf "**%s*" (.Get "src"))) }}
 <figure{{ with .Get "class" }} class="{{ . }}"{{ end }}>
     {{- if .Get "link" -}}
         <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
     {{- end -}}
-    <img src="{{ .Get "src" }}"
+    <img src="{{ if $src }} {{ $src.RelPermalink }} {{ else }} {{ .Get "src" }} {{ end }}"
          {{- if or (.Get "alt") (.Get "caption") }}
          alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
          {{- end -}}


### PR DESCRIPTION
I've adopted the official shortcode figure.html to be able to use page resources and also the original src path.
In my case it works like expected. Maybe this is useful for others too.