### PR TITLE
Fix default values when loading from config dir

### DIFF
--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -78,10 +78,6 @@ func LoadConfig(d ConfigSourceDescriptor, doWithConfig ...func(cfg config.Provid
 		}
 	}
 
-	if err := l.applyConfigDefaults(); err != nil {
-		return l.cfg, configFiles, err
-	}
-
 	if d.AbsConfigDir != "" {
 		dcfg, dirnames, err := config.LoadConfigFromDir(l.Fs, d.AbsConfigDir, l.Environment)
 		if err == nil {
@@ -95,6 +91,10 @@ func LoadConfig(d ConfigSourceDescriptor, doWithConfig ...func(cfg config.Provid
 			}
 			return nil, nil, err
 		}
+	}
+
+	if err := l.applyConfigDefaults(); err != nil {
+		return l.cfg, configFiles, err
 	}
 
 	l.cfg.SetDefaultMergeStrategy()


### PR DESCRIPTION
By waiting until we've loaded the config dir config before applying the default values.

Fixes #8763