### PR TITLE
Reduce binary size vs locale, update to CLDR v36.1

### DIFF
--- a/common/htime/time.go
+++ b/common/htime/time.go
@@ -21,7 +21,7 @@ import (
 
 	toml "github.com/pelletier/go-toml/v2"
 
-	"github.com/go-playground/locales"
+	"github.com/gohugoio/locales"
 )
 
 var (

--- a/common/htime/time_test.go
+++ b/common/htime/time_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	translators "github.com/bep/gotranslators"
+	translators "github.com/gohugoio/localescompressed"
 	qt "github.com/frankban/quicktest"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/bep/gitmap v1.1.2
 	github.com/bep/godartsass v0.12.0
 	github.com/bep/golibsass v1.0.0
-	github.com/bep/gotranslators v0.2.0
 	github.com/bep/gowebp v0.1.0
 	github.com/bep/tmc v0.5.1
 	github.com/cli/safeexec v1.0.0
@@ -24,10 +23,11 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/getkin/kin-openapi v0.68.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/go-playground/locales v0.13.0
 	github.com/gobuffalo/flect v0.2.3
 	github.com/gobwas/glob v0.2.3
 	github.com/gohugoio/go-i18n/v2 v2.1.3-0.20210430103248-4c28c89f8013
+	github.com/gohugoio/locales v0.14.0
+	github.com/gohugoio/localescompressed v0.14.0
 	github.com/gohugoio/testmodBuilder/mods v0.0.0-20190520184928-c56af20f2e95
 	github.com/google/go-cmp v0.5.6
 	github.com/gorilla/websocket v1.4.2
@@ -70,3 +70,5 @@ require (
 )
 
 go 1.16
+
+replace github.com/bep/gotranslators => /Users/bep/dev/go/bep/gotranslators

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,6 @@ github.com/bep/godartsass v0.12.0 h1:VvGLA4XpXUjKvp53SI05YFLhRFJ78G+Ybnlaz6Oul7E
 github.com/bep/godartsass v0.12.0/go.mod h1:nXQlHHk4H1ghUk6n/JkYKG5RD43yJfcfp5aHRqT/pc4=
 github.com/bep/golibsass v1.0.0 h1:gNguBMSDi5yZEZzVZP70YpuFQE3qogJIGUlrVILTmOw=
 github.com/bep/golibsass v1.0.0/go.mod h1:DL87K8Un/+pWUS75ggYv41bliGiolxzDKWJAq3eJ1MA=
-github.com/bep/gotranslators v0.2.0 h1:GW0mGPivOY4drd4HwWpn44HXBo5zc5iHdDJZj3yWb/k=
-github.com/bep/gotranslators v0.2.0/go.mod h1:fbo6ptvCVYarnHjBm4BvOJX0o18VEvA0slN7xKvqXzc=
 github.com/bep/gowebp v0.1.0 h1:4/iQpfnxHyXs3x/aTxMMdOpLEQQhFmF6G7EieWPTQyo=
 github.com/bep/gowebp v0.1.0/go.mod h1:ZhFodwdiFp8ehGJpF4LdPl6unxZm9lLFjxD3z2h2AgI=
 github.com/bep/tmc v0.5.1 h1:CsQnSC6MsomH64gw0cT5f+EwQDcvZz4AazKunFwTpuI=
@@ -214,8 +212,6 @@ github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUe
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
-github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
-github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/gobuffalo/flect v0.2.3 h1:f/ZukRnSNA/DUpSNDadko7Qc0PhGvsew35p/2tu+CRY=
 github.com/gobuffalo/flect v0.2.3/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
@@ -225,6 +221,10 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gohugoio/go-i18n/v2 v2.1.3-0.20210430103248-4c28c89f8013 h1:Nj29Qbkt0bZ/bJl8eccfxQp3NlU/0IW1v9eyYtQ53XQ=
 github.com/gohugoio/go-i18n/v2 v2.1.3-0.20210430103248-4c28c89f8013/go.mod h1:3Ltoo9Banwq0gOtcOwxuHG6omk+AwsQPADyw2vQYOJQ=
+github.com/gohugoio/locales v0.14.0 h1:Q0gpsZwfv7ATHMbcTNepFd59H7GoykzWJIxi113XGDc=
+github.com/gohugoio/locales v0.14.0/go.mod h1:ip8cCAv/cnmVLzzXtiTpPwgJ4xhKZranqNqtoIu0b/4=
+github.com/gohugoio/localescompressed v0.14.0 h1:gP4zzgfF3NFr2rNzwxReD/tDXz98pAGVmrPy3ZCLRDc=
+github.com/gohugoio/localescompressed v0.14.0/go.mod h1:jBF6q8D7a0vaEmcWPNcAjUZLJaIVNiwvM3WlmTvooB0=
 github.com/gohugoio/testmodBuilder/mods v0.0.0-20190520184928-c56af20f2e95 h1:sgew0XCnZwnzpWxTt3V8LLiCO7OQi3C6dycaE67wfkU=
 github.com/gohugoio/testmodBuilder/mods v0.0.0-20190520184928-c56af20f2e95/go.mod h1:bOlVlCa1/RajcHpXkrUXPSHB/Re1UnlXxD1Qp8SKOd8=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/hugolib/language_test.go
+++ b/hugolib/language_test.go
@@ -126,5 +126,14 @@ NumFmt: -98,765.43
 `,
 	)
 
-	b.AssertFileContent("public/nn/index.html", "FormatNumber: 512,50\nFormatPercent: 512,50\u00a0%\nFormatCurrency: 512,50\u00a0USD\nFormatAccounting: 512,50\u00a0kr")
+	b.AssertFileContent("public/nn/index.html", `
+FormatNumber: 512,50
+FormatPercent: 512,50 %
+FormatCurrency: 512,50 USD
+FormatAccounting: 512,50 kr
+FormatNumberCustom: 12,345.68
+
+# We renamed this to FormatNumberCustom in 0.87.0.
+NumFmt: -98,765.43
+`)
 }

--- a/langs/language.go
+++ b/langs/language.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	translators "github.com/bep/gotranslators"
-	"github.com/go-playground/locales"
+	translators "github.com/gohugoio/localescompressed"
+	"github.com/gohugoio/locales"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/config"
 )

--- a/tpl/lang/lang.go
+++ b/tpl/lang/lang.go
@@ -20,8 +20,8 @@ import (
 	"strconv"
 	"strings"
 
-	translators "github.com/bep/gotranslators"
-	"github.com/go-playground/locales"
+	translators "github.com/gohugoio/localescompressed"
+	"github.com/gohugoio/locales"
 	"github.com/pkg/errors"
 
 	"github.com/gohugoio/hugo/deps"
@@ -186,7 +186,7 @@ func (ns *Namespace) FormatNumberCustom(precision, number interface{}, options .
 	exp := math.Pow(10.0, float64(prec))
 	r := math.Round(n*exp) / exp
 
-	// Logic from MIT Licensed github.com/go-playground/locales/
+	// Logic from MIT Licensed github.com/gohugoio/locales/
 	// Original Copyright (c) 2016 Go Playground
 
 	s := strconv.FormatFloat(math.Abs(r), 'f', prec, 64)

--- a/tpl/lang/lang_test.go
+++ b/tpl/lang/lang_test.go
@@ -3,7 +3,7 @@ package lang
 import (
 	"testing"
 
-	translators "github.com/bep/gotranslators"
+	translators "github.com/gohugoio/localescompressed"
 	qt "github.com/frankban/quicktest"
 	"github.com/gohugoio/hugo/deps"
 )

--- a/tpl/time/time.go
+++ b/tpl/time/time.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/gohugoio/hugo/common/htime"
 
-	"github.com/go-playground/locales"
+	"github.com/gohugoio/locales"
 
 	"github.com/spf13/cast"
 )

--- a/tpl/time/time_test.go
+++ b/tpl/time/time_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	translators "github.com/bep/gotranslators"
+	translators "github.com/gohugoio/localescompressed"
 )
 
 func TestTimeLocation(t *testing.T) {


### PR DESCRIPTION
Test building with `go build -ldflags="-s -w"`

Hugo 0.86.2: 46MB
Before this commit: 77MB
After this commit: 54MB

Fixes #8839
Fixes #8841