### PR TITLE
Avoid too many watch file handles causing the server to fail to start

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -261,6 +261,11 @@ func (sc *serverCmd) server(cmd *cobra.Command, args []string) error {
 		s.RegisterMediaTypes()
 	}
 
+	err = c.serve(sc)
+	if err != nil {
+		return err
+	}
+
 	// Watch runs its own server as part of the routine
 	if sc.serverWatch {
 
@@ -283,7 +288,7 @@ func (sc *serverCmd) server(cmd *cobra.Command, args []string) error {
 
 	}
 
-	return c.serve(sc)
+	return nil
 }
 
 func getRootWatchDirsStr(baseDir string, watchDirs []string) string {


### PR DESCRIPTION
Fixes #8904