### PR TITLE
Fix it so disableKinds etc. does not get merged in from theme

### DIFF
--- a/common/maps/params.go
+++ b/common/maps/params.go
@@ -76,6 +76,14 @@ func (p Params) Merge(pp Params) {
 	p.merge("", pp)
 }
 
+// MergeRoot transfers values from pp to p for new keys where p is the
+// root of the tree.
+// This is done recursively.
+func (p Params) MergeRoot(pp Params) {
+	ms, _ := p.GetMergeStrategy()
+	p.merge(ms, pp)
+}
+
 func (p Params) merge(ps ParamsMergeStrategy, pp Params) {
 	ns, found := p.GetMergeStrategy()
 

--- a/config/defaultConfigProvider.go
+++ b/config/defaultConfigProvider.go
@@ -275,7 +275,7 @@ func (c *defaultConfigProvider) Merge(k string, v interface{}) {
 				}
 			}
 			// Merge the rest.
-			c.root.Merge(p)
+			c.root.MergeRoot(p)
 			for _, k := range keysToDelete {
 				delete(c.root, k)
 			}

--- a/config/defaultConfigProvider_test.go
+++ b/config/defaultConfigProvider_test.go
@@ -172,7 +172,6 @@ func TestDefaultConfigProvider(t *testing.T) {
 
 		c.Assert(cfg.Get(""), qt.DeepEquals, maps.Params{
 			"a": "av",
-			"b": "bv2",
 		})
 	})
 

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -153,6 +153,9 @@ name = "menu-top-main"
 baseURL = "http://bep.is/"
 
 # Can not be set in theme.
+disableKinds = ["taxonomy", "term"]
+
+# Can not be set in theme.
 [frontmatter]
 expiryDate = ["date"]
 
@@ -227,6 +230,9 @@ name = "menu-theme"
 		b := buildForStrategy(c, "")
 
 		got := b.Cfg.Get("").(maps.Params)
+
+		// Issue #8866
+		b.Assert(b.Cfg.Get("disableKinds"), qt.IsNil)
 
 		b.Assert(got["params"], qt.DeepEquals, maps.Params{
 			"b": maps.Params{


### PR DESCRIPTION
Unless the merge strategy is set up to do so.

For `disableKinds` the current workaround is to make sure the project config has an entry, even if is empty:

```
disableKinds = []
```

Note that this issue only touches root, non-map config-values that either is not set in project config or in Hugo's defaults.

Fixes #8866