### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cache/filecache/filecache.go
+++ b/cache/filecache/filecache.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -207,7 +206,7 @@ func (c *Cache) GetOrCreateBytes(id string, create func() ([]byte, error)) (Item
 
 	if r := c.getOrRemove(id); r != nil {
 		defer r.Close()
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		return info, b, err
 	}
 
@@ -242,7 +241,7 @@ func (c *Cache) GetBytes(id string) (ItemInfo, []byte, error) {
 
 	if r := c.getOrRemove(id); r != nil {
 		defer r.Close()
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		return info, b, err
 	}
 
@@ -311,7 +310,7 @@ func (c *Cache) getString(id string) string {
 	}
 	defer f.Close()
 
-	b, _ := ioutil.ReadAll(f)
+	b, _ := io.ReadAll(f)
 	return string(b)
 }
 

--- a/cache/filecache/filecache_test.go
+++ b/cache/filecache/filecache_test.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,11 +43,11 @@ func TestFileCache(t *testing.T) {
 	t.Parallel()
 	c := qt.New(t)
 
-	tempWorkingDir, err := ioutil.TempDir("", "hugo_filecache_test_work")
+	tempWorkingDir, err := os.MkdirTemp("", "hugo_filecache_test_work")
 	c.Assert(err, qt.IsNil)
 	defer os.Remove(tempWorkingDir)
 
-	tempCacheDir, err := ioutil.TempDir("", "hugo_filecache_test_cache")
+	tempCacheDir, err := os.MkdirTemp("", "hugo_filecache_test_cache")
 	c.Assert(err, qt.IsNil)
 	defer os.Remove(tempCacheDir)
 
@@ -123,7 +122,7 @@ dir = ":cacheDir/c"
 					io.Closer
 				}{
 					strings.NewReader(s),
-					ioutil.NopCloser(nil),
+					io.NopCloser(nil),
 				}, nil
 			}
 		}
@@ -138,7 +137,7 @@ dir = ":cacheDir/c"
 				c.Assert(err, qt.IsNil)
 				c.Assert(r, qt.Not(qt.IsNil))
 				c.Assert(info.Name, qt.Equals, "a")
-				b, _ := ioutil.ReadAll(r)
+				b, _ := io.ReadAll(r)
 				r.Close()
 				c.Assert(string(b), qt.Equals, "abc")
 
@@ -154,7 +153,7 @@ dir = ":cacheDir/c"
 
 				_, r, err = ca.GetOrCreate("a", rf("bcd"))
 				c.Assert(err, qt.IsNil)
-				b, _ = ioutil.ReadAll(r)
+				b, _ = io.ReadAll(r)
 				r.Close()
 				c.Assert(string(b), qt.Equals, "abc")
 			}
@@ -173,7 +172,7 @@ dir = ":cacheDir/c"
 		c.Assert(err, qt.IsNil)
 		c.Assert(r, qt.Not(qt.IsNil))
 		c.Assert(info.Name, qt.Equals, "mykey")
-		b, _ := ioutil.ReadAll(r)
+		b, _ := io.ReadAll(r)
 		r.Close()
 		c.Assert(string(b), qt.Equals, "Hugo is great!")
 
@@ -233,7 +232,7 @@ dir = "/cache/c"
 					return hugio.ToReadCloser(strings.NewReader(data)), nil
 				})
 				c.Assert(err, qt.IsNil)
-				b, _ := ioutil.ReadAll(r)
+				b, _ := io.ReadAll(r)
 				r.Close()
 				c.Assert(string(b), qt.Equals, data)
 				// Trigger some expiration.
@@ -260,7 +259,7 @@ func TestFileCacheReadOrCreateErrorInRead(t *testing.T) {
 				return errors.New("fail")
 			}
 
-			b, _ := ioutil.ReadAll(r)
+			b, _ := io.ReadAll(r)
 			result = string(b)
 
 			return nil

--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -16,7 +16,7 @@ package commands
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -167,7 +167,7 @@ func newCommandeer(mustHaveConfigFile, failOnInitErr, running bool, h *hugoBuild
 		rebuildDebouncer = debounce.New(4 * time.Second)
 	}
 
-	out := ioutil.Discard
+	out := io.Discard
 	if !h.quiet {
 		out = os.Stdout
 	}
@@ -187,7 +187,7 @@ func newCommandeer(mustHaveConfigFile, failOnInitErr, running bool, h *hugoBuild
 		running:            running,
 
 		// This will be replaced later, but we need something to log to before the configuration is read.
-		logger: loggers.NewLogger(jww.LevelWarn, jww.LevelError, out, ioutil.Discard, running),
+		logger: loggers.NewLogger(jww.LevelWarn, jww.LevelError, out, io.Discard, running),
 	}
 
 	return c, c.loadConfig()

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -15,7 +15,6 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -390,7 +389,7 @@ Environment: {{ hugo.Environment }}
 
 func writeFile(t *testing.T, filename, content string) {
 	must(t, os.MkdirAll(filepath.Dir(filename), os.FileMode(0755)))
-	must(t, ioutil.WriteFile(filename, []byte(content), os.FileMode(0755)))
+	must(t, os.WriteFile(filename, []byte(content), os.FileMode(0755)))
 }
 
 func must(t *testing.T, err error) {

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -18,7 +18,7 @@ package commands
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -132,10 +132,10 @@ func initializeConfig(mustHaveConfigFile, failOnInitErr, running bool,
 
 func (c *commandeer) createLogger(cfg config.Provider) (loggers.Logger, error) {
 	var (
-		logHandle       = ioutil.Discard
+		logHandle       = io.Discard
 		logThreshold    = jww.LevelWarn
 		logFile         = cfg.GetString("logFile")
-		outHandle       = ioutil.Discard
+		outHandle       = io.Discard
 		stdoutThreshold = jww.LevelWarn
 	)
 
@@ -151,7 +151,7 @@ func (c *commandeer) createLogger(cfg config.Provider) (loggers.Logger, error) {
 				return nil, newSystemError("Failed to open log file:", logFile, err)
 			}
 		} else {
-			logHandle, err = ioutil.TempFile("", "hugo")
+			logHandle, err = os.CreateTemp("", "hugo")
 			if err != nil {
 				return nil, newSystemError(err)
 			}

--- a/commands/import_jekyll.go
+++ b/commands/import_jekyll.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -164,7 +164,7 @@ func (i *importCmd) importFromJekyll(cmd *cobra.Command, args []string) error {
 func (i *importCmd) getJekyllDirInfo(fs afero.Fs, jekyllRoot string) (map[string]bool, bool) {
 	postDirs := make(map[string]bool)
 	hasAnyPost := false
-	if entries, err := ioutil.ReadDir(jekyllRoot); err == nil {
+	if entries, err := os.ReadDir(jekyllRoot); err == nil {
 		for _, entry := range entries {
 			if entry.IsDir() {
 				subDir := filepath.Join(jekyllRoot, entry.Name())
@@ -186,7 +186,7 @@ func (i *importCmd) retrieveJekyllPostDir(fs afero.Fs, dir string) (bool, bool) 
 		return true, !isEmpty
 	}
 
-	if entries, err := ioutil.ReadDir(dir); err == nil {
+	if entries, err := os.ReadDir(dir); err == nil {
 		for _, entry := range entries {
 			if entry.IsDir() {
 				subDir := filepath.Join(dir, entry.Name())
@@ -252,7 +252,7 @@ func (i *importCmd) loadJekyllConfig(fs afero.Fs, jekyllRoot string) map[string]
 
 	defer f.Close()
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil
 	}
@@ -315,7 +315,7 @@ func (i *importCmd) copyJekyllFilesAndFolders(jekyllRoot, dest string, jekyllPos
 	if err != nil {
 		return err
 	}
-	entries, err := ioutil.ReadDir(jekyllRoot)
+	entries, err := os.ReadDir(jekyllRoot)
 	if err != nil {
 		return err
 	}
@@ -391,7 +391,7 @@ func convertJekyllPost(path, relPath, targetDir string, draft bool) error {
 	targetParentDir := filepath.Dir(targetFile)
 	os.MkdirAll(targetParentDir, 0777)
 
-	contentBytes, err := ioutil.ReadFile(path)
+	contentBytes, err := os.ReadFile(path)
 	if err != nil {
 		jww.ERROR.Println("Read file error:", path)
 		return err

--- a/common/herrors/error_locator.go
+++ b/common/herrors/error_locator.go
@@ -16,7 +16,6 @@ package herrors
 
 import (
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 
@@ -207,7 +206,7 @@ func locateError(r io.Reader, le FileError, matches LineMatcherFn) ErrorContext 
 
 	errCtx := ErrorContext{position: text.Position{LineNumber: -1, ColumnNumber: 1, Offset: -1}, LinesPos: -1}
 
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return errCtx
 	}

--- a/common/hugio/copy.go
+++ b/common/hugio/copy.go
@@ -15,7 +15,6 @@ package hugio
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -68,7 +67,7 @@ func CopyDir(fs afero.Fs, from, to string, shouldCopy func(filename string) bool
 		return err
 	}
 
-	entries, _ := ioutil.ReadDir(from)
+	entries, _ := os.ReadDir(from)
 	for _, entry := range entries {
 		fromFilename := filepath.Join(from, entry.Name())
 		toFilename := filepath.Join(to, entry.Name())

--- a/common/hugio/writers.go
+++ b/common/hugio/writers.go
@@ -15,7 +15,6 @@ package hugio
 
 import (
 	"io"
-	"io/ioutil"
 )
 
 type multiWriteCloser struct {
@@ -55,7 +54,7 @@ func ToWriteCloser(w io.Writer) io.WriteCloser {
 		io.Closer
 	}{
 		w,
-		ioutil.NopCloser(nil),
+		io.NopCloser(nil),
 	}
 }
 
@@ -71,6 +70,6 @@ func ToReadCloser(r io.Reader) io.ReadCloser {
 		io.Closer
 	}{
 		r,
-		ioutil.NopCloser(nil),
+		io.NopCloser(nil),
 	}
 }

--- a/common/loggers/loggers.go
+++ b/common/loggers/loggers.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -92,7 +91,7 @@ type logger struct {
 	*jww.Notepad
 
 	// The writer that represents stdout.
-	// Will be ioutil.Discard when in quiet mode.
+	// Will be io.Discard when in quiet mode.
 	out io.Writer
 
 	logCounters *LogCounters
@@ -232,12 +231,12 @@ func NewErrorLogger() Logger {
 
 // NewBasicLogger creates a new basic logger writing to Stdout.
 func NewBasicLogger(t jww.Threshold) Logger {
-	return newLogger(t, jww.LevelError, os.Stdout, ioutil.Discard, false)
+	return newLogger(t, jww.LevelError, os.Stdout, io.Discard, false)
 }
 
 // NewBasicLoggerForWriter creates a new basic logger writing to w.
 func NewBasicLoggerForWriter(t jww.Threshold, w io.Writer) Logger {
-	return newLogger(t, jww.LevelError, w, ioutil.Discard, false)
+	return newLogger(t, jww.LevelError, w, io.Discard, false)
 }
 
 var (
@@ -286,7 +285,7 @@ func InitGlobalLogger(stdoutThreshold, logThreshold jww.Threshold, outHandle, lo
 
 func getLogWriters(outHandle, logHandle io.Writer) (io.Writer, io.Writer) {
 	isTerm := terminal.IsTerminal(os.Stdout)
-	if logHandle != ioutil.Discard && isTerm {
+	if logHandle != io.Discard && isTerm {
 		// Remove any Ansi coloring from log output
 		logHandle = ansiCleaner{w: logHandle}
 	}

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -22,7 +22,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"os"
 	"path/filepath"
@@ -397,7 +396,7 @@ func (lf *localFile) Reader() (io.ReadCloser, error) {
 		// We've got the gzipped contents cached in gzipped.
 		// Note: we can't use lf.gzipped directly as a Reader, since we it discards
 		// data after it is read, and we may read it more than once.
-		return ioutil.NopCloser(bytes.NewReader(lf.gzipped.Bytes())), nil
+		return io.NopCloser(bytes.NewReader(lf.gzipped.Bytes())), nil
 	}
 	// Not expected to fail since we did it successfully earlier in newLocalFile,
 	// but could happen due to changes in the underlying filesystem.

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -406,7 +405,7 @@ func TestLocalFile(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			gotContent, err := ioutil.ReadAll(r)
+			gotContent, err := io.ReadAll(r)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -419,7 +418,7 @@ func TestLocalFile(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			gotContent, err = ioutil.ReadAll(r)
+			gotContent, err = io.ReadAll(r)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -520,11 +519,11 @@ type fsTest struct {
 // 2. A filesystem-based afero.Fs paired with an filesystem-based Go CDK bucket.
 // It returns the pair of tests and a cleanup function.
 func initFsTests() ([]*fsTest, func(), error) {
-	tmpfsdir, err := ioutil.TempDir("", "fs")
+	tmpfsdir, err := os.MkdirTemp("", "fs")
 	if err != nil {
 		return nil, nil, err
 	}
-	tmpbucketdir, err := ioutil.TempDir("", "bucket")
+	tmpbucketdir, err := os.MkdirTemp("", "bucket")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -15,7 +15,6 @@ package helpers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -303,7 +302,7 @@ func TestIsEmpty(t *testing.T) {
 
 func createZeroSizedFileInTempDir() (*os.File, error) {
 	filePrefix := "_path_test_"
-	f, e := ioutil.TempFile("", filePrefix) // dir is os.TempDir()
+	f, e := os.CreateTemp("", filePrefix) // dir is os.TempDir()
 	if e != nil {
 		// if there was an error no file was created.
 		// => no requirement to delete the file
@@ -319,7 +318,7 @@ func createNonZeroSizedFileInTempDir() (*os.File, error) {
 		return nil, err
 	}
 	byteString := []byte("byteString")
-	err = ioutil.WriteFile(f.Name(), byteString, 0644)
+	err = os.WriteFile(f.Name(), byteString, 0644)
 	if err != nil {
 		// delete the file
 		deleteFileInTempDir(f)
@@ -334,7 +333,7 @@ func deleteFileInTempDir(f *os.File) {
 
 func createEmptyTempDir() (string, error) {
 	dirPrefix := "_dir_prefix_"
-	d, e := ioutil.TempDir("", dirPrefix) // will be in os.TempDir()
+	d, e := os.MkdirTemp("", dirPrefix) // will be in os.TempDir()
 	if e != nil {
 		// no directory to delete - it was never created
 		return "", e
@@ -348,7 +347,7 @@ func createTempDirWithZeroLengthFiles() (string, error) {
 		return "", dirErr
 	}
 	filePrefix := "_path_test_"
-	_, fileErr := ioutil.TempFile(d, filePrefix) // dir is os.TempDir()
+	_, fileErr := os.CreateTemp(d, filePrefix) // dir is os.TempDir()
 	if fileErr != nil {
 		// if there was an error no file was created.
 		// but we need to remove the directory to clean-up
@@ -365,7 +364,7 @@ func createTempDirWithNonZeroLengthFiles() (string, error) {
 		return "", dirErr
 	}
 	filePrefix := "_path_test_"
-	f, fileErr := ioutil.TempFile(d, filePrefix) // dir is os.TempDir()
+	f, fileErr := os.CreateTemp(d, filePrefix) // dir is os.TempDir()
 	if fileErr != nil {
 		// if there was an error no file was created.
 		// but we need to remove the directory to clean-up
@@ -374,7 +373,7 @@ func createTempDirWithNonZeroLengthFiles() (string, error) {
 	}
 	byteString := []byte("byteString")
 
-	fileErr = ioutil.WriteFile(f.Name(), byteString, 0644)
+	fileErr = os.WriteFile(f.Name(), byteString, 0644)
 	if fileErr != nil {
 		// delete the file
 		deleteFileInTempDir(f)
@@ -574,7 +573,7 @@ func TestSafeWriteToDisk(t *testing.T) {
 			if d.expectedErr != e {
 				t.Errorf("Test %d failed. Expected %q but got %q", i, d.expectedErr, e)
 			}
-			contents, _ := ioutil.ReadFile(d.filename)
+			contents, _ := os.ReadFile(d.filename)
 			if randomString != string(contents) {
 				t.Errorf("Test %d failed. Expected contents %q but got %q", i, randomString, string(contents))
 			}
@@ -609,7 +608,7 @@ func TestWriteToDisk(t *testing.T) {
 		if d.expectedErr != e {
 			t.Errorf("Test %d failed. WriteToDisk Error Expected %q but got %q", i, d.expectedErr, e)
 		}
-		contents, e := ioutil.ReadFile(d.filename)
+		contents, e := os.ReadFile(d.filename)
 		if e != nil {
 			t.Errorf("Test %d failed. Could not read file %s. Reason: %s\n", i, d.filename, e)
 		}

--- a/hugofs/rootmapping_fs_test.go
+++ b/hugofs/rootmapping_fs_test.go
@@ -15,7 +15,7 @@ package hugofs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -268,7 +268,7 @@ func TestRootMappingFsMount(t *testing.T) {
 	tf, err := testfilem.Open()
 	c.Assert(err, qt.IsNil)
 	defer tf.Close()
-	b, err := ioutil.ReadAll(tf)
+	b, err := io.ReadAll(tf)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(b), qt.Equals, "some no content")
 

--- a/hugolib/resource_chain_test.go
+++ b/hugolib/resource_chain_test.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -181,7 +180,7 @@ moo {
 
 @import "another.css";
 /* foo */
-        
+
 `)
 			} else {
 				// Dart Sass does not follow regular CSS import, but they
@@ -485,7 +484,7 @@ func TestResourceChainPostProcess(t *testing.T) {
 
 	b.WithTemplates(
 		"_default/single.html", `{{ $hello := "<h1>     Hello World!   </h1>" | resources.FromString "hello.html" | minify  | fingerprint "md5" | resources.PostProcess }}
-HELLO: {{ $hello.RelPermalink }}	
+HELLO: {{ $hello.RelPermalink }}
 `,
 		"index.html", `Start.
 {{ $hello := "<h1>     Hello World!   </h1>" | resources.FromString "hello.html" | minify  | fingerprint "md5" | resources.PostProcess }}
@@ -559,7 +558,7 @@ func TestResourceChains(t *testing.T) {
 		switch r.URL.Path {
 		case "/css/styles1.css":
 			w.Header().Set("Content-Type", "text/css")
-			w.Write([]byte(`h1 { 
+			w.Write([]byte(`h1 {
 				font-style: bold;
 			}`))
 			return
@@ -621,7 +620,7 @@ func TestResourceChains(t *testing.T) {
 		case "/post":
 			w.Header().Set("Content-Type", "text/plain")
 			if r.Method == http.MethodPost {
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				if err != nil {
 					http.Error(w, "Internal server error", http.StatusInternalServerError)
 					return
@@ -745,7 +744,7 @@ T2: Content: {{ $combinedText.Content }}|{{ $combinedText.RelPermalink }}
 {{/* https://github.com/gohugoio/hugo/issues/5269 */}}
 {{ $css := "body { color: blue; }" | resources.FromString "styles.css" }}
 {{ $minified := resources.Get "css/styles1.css" | minify }}
-{{ slice $css $minified | resources.Concat "bundle/mixed.css" }} 
+{{ slice $css $minified | resources.Concat "bundle/mixed.css" }}
 {{/* https://github.com/gohugoio/hugo/issues/5403 */}}
 {{ $d := "function D {} // A comment" | resources.FromString "d.js"}}
 {{ $e := "(function E {})" | resources.FromString "e.js"}}
@@ -876,7 +875,7 @@ Publish 2: {{ $cssPublish2.Permalink }}
 
 Slogan: {{ $toml.slogan }}
 CSV1: {{ $csv1 }} {{ len (index $csv1 0)  }}
-CSV2: {{ $csv2 }}		
+CSV2: {{ $csv2 }}
 XML: {{ $xml.body }}
 `)
 		}, func(b *sitesBuilder) {
@@ -947,7 +946,7 @@ document.getElementById("demo").innerHTML = x * 10;
 			b.WithSourceFile(filepath.Join("assets", "mydata", "json1.json"), `
 {
 "employees":[
-    {"firstName":"John", "lastName":"Doe"}, 
+    {"firstName":"John", "lastName":"Doe"},
     {"firstName":"Anna", "lastName":"Smith"},
     {"firstName":"Peter", "lastName":"Jones"}
 ]
@@ -957,7 +956,7 @@ document.getElementById("demo").innerHTML = x * 10;
 			b.WithSourceFile(filepath.Join("assets", "mydata", "svg1.svg"), `
 <svg height="100" width="100">
   <path d="M 100 100 L 300 100 L 200 100 z"/>
-</svg> 
+</svg>
 `)
 
 			b.WithSourceFile(filepath.Join("assets", "mydata", "xml1.xml"), `
@@ -1115,7 +1114,7 @@ module.exports = {
 h1 {
     @apply text-2xl font-bold;
 }
-  
+
 `
 
 	workDir, clean, err := htesting.CreateTempDir(hugofs.Os, "hugo-test-postcss")

--- a/hugolib/site_stats_test.go
+++ b/hugolib/site_stats_test.go
@@ -16,7 +16,7 @@ package hugolib
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/gohugoio/hugo/helpers"
@@ -87,8 +87,8 @@ aliases: [/Ali%d]
 		h.Sites[1].PathSpec.ProcessingStats,
 	}
 
-	stats[0].Table(ioutil.Discard)
-	stats[1].Table(ioutil.Discard)
+	stats[0].Table(io.Discard)
+	stats[1].Table(io.Discard)
 
 	var buff bytes.Buffer
 

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -16,7 +16,6 @@ package hugolib
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1100,7 +1099,7 @@ ABC.
 	b.Build(BuildCfg{})
 
 	contentMem := b.FileContent(statsFilename)
-	cb, err := ioutil.ReadFile(statsFilename)
+	cb, err := os.ReadFile(statsFilename)
 	b.Assert(err, qt.IsNil)
 	contentFile := string(cb)
 

--- a/magefile.go
+++ b/magefile.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -304,7 +303,7 @@ func TestCoverHTML() error {
 		if err := sh.Run(goexe, "test", "-coverprofile="+cover, "-covermode=count", pkg); err != nil {
 			return err
 		}
-		b, err := ioutil.ReadFile(cover)
+		b, err := os.ReadFile(cover)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue

--- a/media/mediaType_test.go
+++ b/media/mediaType_test.go
@@ -15,7 +15,7 @@ package media
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -190,7 +190,7 @@ func TestFromContent(t *testing.T) {
 	for _, filename := range files {
 		name := filepath.Base(filename)
 		c.Run(name, func(c *qt.C) {
-			content, err := ioutil.ReadFile(filename)
+			content, err := os.ReadFile(filename)
 			c.Assert(err, qt.IsNil)
 			ext := strings.TrimPrefix(paths.Ext(filename), ".")
 			var exts []string
@@ -217,7 +217,7 @@ func TestFromContentFakes(t *testing.T) {
 	for _, filename := range files {
 		name := filepath.Base(filename)
 		c.Run(name, func(c *qt.C) {
-			content, err := ioutil.ReadFile(filename)
+			content, err := os.ReadFile(filename)
 			c.Assert(err, qt.IsNil)
 			ext := strings.TrimPrefix(paths.Ext(filename), ".")
 			got := FromContent(mtypes, []string{ext}, content)

--- a/modules/client.go
+++ b/modules/client.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -425,7 +424,7 @@ func (c *Client) Clean(pattern string) error {
 }
 
 func (c *Client) runVerify() error {
-	return c.runGo(context.Background(), ioutil.Discard, "mod", "verify")
+	return c.runGo(context.Background(), io.Discard, "mod", "verify")
 }
 
 func isProbablyModule(path string) bool {
@@ -440,7 +439,7 @@ func (c *Client) listGoMods() (goModules, error) {
 	downloadModules := func(modules ...string) error {
 		args := []string{"mod", "download"}
 		args = append(args, modules...)
-		out := ioutil.Discard
+		out := io.Discard
 		err := c.runGo(context.Background(), out, args...)
 		if err != nil {
 			return errors.Wrap(err, "failed to download modules")

--- a/parser/pageparser/pageparser.go
+++ b/parser/pageparser/pageparser.go
@@ -16,7 +16,6 @@ package pageparser
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/gohugoio/hugo/parser/metadecoders"
 	"github.com/pkg/errors"
@@ -100,7 +99,7 @@ func ParseMain(r io.Reader, cfg Config) (Result, error) {
 }
 
 func parseSection(r io.Reader, cfg Config, start stateFunc) (Result, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read page content")
 	}

--- a/releaser/github.go
+++ b/releaser/github.go
@@ -3,7 +3,7 @@ package releaser
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -124,7 +124,7 @@ func doGitHubRequest(req *http.Request, v interface{}) error {
 	defer resp.Body.Close()
 
 	if isError(resp) {
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("GitHub lookup failed: %s", string(b))
 	}
 

--- a/releaser/releasenotes_writer.go
+++ b/releaser/releasenotes_writer.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -159,13 +158,12 @@ func fetchThemeCount() (int, error) {
 	}
 	defer resp.Body.Close()
 
-	b, _ := ioutil.ReadAll(resp.Body)
+	b, _ := io.ReadAll(resp.Body)
 	return bytes.Count(b, []byte("\n")) - bytes.Count(b, []byte("#")), nil
 }
 
 func getReleaseNotesFilename(version string) string {
 	return filepath.FromSlash(fmt.Sprintf("temp/%s-relnotes-ready.md", version))
-
 }
 
 func (r *ReleaseHandler) writeReleaseNotesToTemp(version string, isPatch bool, infosMain, infosDocs gitInfos) (string, error) {

--- a/releaser/releaser.go
+++ b/releaser/releaser.go
@@ -17,7 +17,6 @@ package releaser
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -275,7 +274,7 @@ func (r *ReleaseHandler) replaceInFile(filename string, oldNew ...string) error 
 		return nil
 	}
 
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
@@ -286,7 +285,7 @@ func (r *ReleaseHandler) replaceInFile(filename string, oldNew ...string) error 
 		newContent = re.ReplaceAllString(newContent, oldNew[i+1])
 	}
 
-	return ioutil.WriteFile(filename, []byte(newContent), fi.Mode())
+	return os.WriteFile(filename, []byte(newContent), fi.Mode())
 }
 
 func isCI() bool {

--- a/resources/image.go
+++ b/resources/image.go
@@ -22,7 +22,6 @@ import (
 	_ "image/gif"
 	_ "image/png"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -88,7 +87,7 @@ func (i *imageResource) getExif() *exif.Exif {
 
 		read := func(info filecache.ItemInfo, r io.ReadSeeker) error {
 			meta := &imageMeta{}
-			data, err := ioutil.ReadAll(r)
+			data, err := io.ReadAll(r)
 			if err != nil {
 				return err
 			}

--- a/resources/image_test.go
+++ b/resources/image_test.go
@@ -16,7 +16,6 @@ package resources
 import (
 	"fmt"
 	"image"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -713,9 +712,9 @@ func TestImageOperationsGolden(t *testing.T) {
 func assetGoldenDirs(c *qt.C, dir1, dir2 string) {
 
 	// The two dirs above should now be the same.
-	dirinfos1, err := ioutil.ReadDir(dir1)
+	dirinfos1, err := os.ReadDir(dir1)
 	c.Assert(err, qt.IsNil)
-	dirinfos2, err := ioutil.ReadDir(dir2)
+	dirinfos2, err := os.ReadDir(dir2)
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(dirinfos1), qt.Equals, len(dirinfos2))
 

--- a/resources/resource.go
+++ b/resources/resource.go
@@ -16,7 +16,6 @@ package resources
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -334,7 +333,7 @@ func (l *genericResource) initContent() error {
 		defer r.Close()
 
 		var b []byte
-		b, err = ioutil.ReadAll(r)
+		b, err = io.ReadAll(r)
 		if err != nil {
 			return
 		}

--- a/resources/resource_factories/create/remote.go
+++ b/resources/resource_factories/create/remote.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/http/httputil"
@@ -98,7 +97,7 @@ func (c *Client) FromRemote(uri string, optionsm map[string]interface{}) (resour
 		return nil, nil
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read remote resource %q", uri)
 	}

--- a/resources/resource_transformers/babel/babel.go
+++ b/resources/resource_transformers/babel/babel.go
@@ -16,7 +16,6 @@ package babel
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -162,7 +161,7 @@ func (t *babelTransformation) Transform(ctx *resources.ResourceTransformationCtx
 	// Create compile into a real temp file:
 	// 1. separate stdout/stderr messages from babel (https://github.com/gohugoio/hugo/issues/8136)
 	// 2. allow generation and retrieval of external source map.
-	compileOutput, err := ioutil.TempFile("", "compileOut-*.js")
+	compileOutput, err := os.CreateTemp("", "compileOut-*.js")
 	if err != nil {
 		return err
 	}
@@ -206,7 +205,7 @@ func (t *babelTransformation) Transform(ctx *resources.ResourceTransformationCtx
 		return errors.Wrap(err, errBuf.String())
 	}
 
-	content, err := ioutil.ReadAll(compileOutput)
+	content, err := io.ReadAll(compileOutput)
 	if err != nil {
 		return err
 	}
@@ -214,7 +213,7 @@ func (t *babelTransformation) Transform(ctx *resources.ResourceTransformationCtx
 	mapFile := compileOutput.Name() + ".map"
 	if _, err := os.Stat(mapFile); err == nil {
 		defer os.Remove(mapFile)
-		sourceMap, err := ioutil.ReadFile(mapFile)
+		sourceMap, err := os.ReadFile(mapFile)
 		if err != nil {
 			return err
 		}

--- a/resources/resource_transformers/js/build.go
+++ b/resources/resource_transformers/js/build.go
@@ -15,7 +15,7 @@ package js
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -76,7 +76,7 @@ func (t *buildTransformation) Transform(ctx *resources.ResourceTransformationCtx
 		ctx.ReplaceOutPathExtension(".js")
 	}
 
-	src, err := ioutil.ReadAll(ctx.From)
+	src, err := io.ReadAll(ctx.From)
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func (t *buildTransformation) Transform(ctx *resources.ResourceTransformationCtx
 	}
 
 	if buildOptions.Sourcemap == api.SourceMapExternal && buildOptions.Outdir == "" {
-		buildOptions.Outdir, err = ioutil.TempDir(os.TempDir(), "compileOutput")
+		buildOptions.Outdir, err = os.MkdirTemp(os.TempDir(), "compileOutput")
 		if err != nil {
 			return err
 		}

--- a/resources/resource_transformers/js/options.go
+++ b/resources/resource_transformers/js/options.go
@@ -16,7 +16,7 @@ package js
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -249,7 +249,7 @@ func createBuildPlugins(c *Client, opts Options) ([]api.Plugin, error) {
 				})
 			build.OnLoad(api.OnLoadOptions{Filter: `.*`, Namespace: nsImportHugo},
 				func(args api.OnLoadArgs) (api.OnLoadResult, error) {
-					b, err := ioutil.ReadFile(args.Path)
+					b, err := os.ReadFile(args.Path)
 					if err != nil {
 						return api.OnLoadResult{}, errors.Wrapf(err, "failed to read %q", args.Path)
 					}

--- a/resources/resource_transformers/postcss/postcss.go
+++ b/resources/resource_transformers/postcss/postcss.go
@@ -18,7 +18,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -333,7 +332,7 @@ func (imp *importResolver) importRecursive(
 func (imp *importResolver) resolve() (io.Reader, error) {
 	const importIdentifier = "@import"
 
-	content, err := ioutil.ReadAll(imp.r)
+	content, err := io.ReadAll(imp.r)
 	if err != nil {
 		return nil, err
 	}

--- a/resources/testhelpers_test.go
+++ b/resources/testhelpers_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"image"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -105,7 +104,7 @@ func newTestResourceOsFs(c *qt.C) (*Spec, string) {
 	cfg := createTestCfg()
 	cfg.Set("baseURL", "https://example.com")
 
-	workDir, err := ioutil.TempDir("", "hugores")
+	workDir, err := os.MkdirTemp("", "hugores")
 	c.Assert(err, qt.IsNil)
 	c.Assert(workDir, qt.Not(qt.Equals), "")
 

--- a/scripts/fork_go_templates/main.go
+++ b/scripts/fork_go_templates/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -187,7 +186,7 @@ func doWithGoFiles(dir string,
 			return nil
 		}
 
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		must(err)
 		f, err := os.Create(path)
 		must(err)

--- a/tpl/data/resources.go
+++ b/tpl/data/resources.go
@@ -15,7 +15,7 @@ package data
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -63,7 +63,7 @@ func (ns *Namespace) getRemote(cache *filecache.Cache, unmarshal func([]byte) (b
 			}
 
 			var b []byte
-			b, err = ioutil.ReadAll(res.Body)
+			b, err = io.ReadAll(res.Body)
 			if err != nil {
 				return nil, err
 			}

--- a/tpl/internal/templatefuncsRegistry.go
+++ b/tpl/internal/templatefuncsRegistry.go
@@ -22,7 +22,6 @@ import (
 	"go/doc"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -135,7 +134,7 @@ func (t goDocFunc) toJSON() ([]byte, error) {
 	}
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf(`%q:
-    { "Description": %q, "Args": %s, "Aliases": %s, "Examples": %s }	
+    { "Description": %q, "Args": %s, "Aliases": %s, "Examples": %s }
 `, t.Name, t.Description, args, aliases, examples))
 
 	return buf.Bytes(), nil
@@ -239,7 +238,7 @@ func getGetTplPackagesGoDoc() map[string]map[string]methodGoDocInfo {
 			basePath = filepath.Join(pwd, "tpl")
 		}
 
-		files, err := ioutil.ReadDir(basePath)
+		files, err := os.ReadDir(basePath)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/tpl/openapi/openapi3/openapi3.go
+++ b/tpl/openapi/openapi3/openapi3.go
@@ -14,7 +14,7 @@
 package openapi3
 
 import (
-	"io/ioutil"
+	"io"
 
 	gyaml "github.com/ghodss/yaml"
 
@@ -66,7 +66,7 @@ func (ns *Namespace) Unmarshal(r resource.UnmarshableResource) (*kopenapi3.T, er
 		}
 		defer reader.Close()
 
-		b, err := ioutil.ReadAll(reader)
+		b, err := io.ReadAll(reader)
 		if err != nil {
 			return nil, err
 		}

--- a/tpl/partials/partials.go
+++ b/tpl/partials/partials.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"strings"
 	"sync"
@@ -128,7 +127,7 @@ func (ns *Namespace) Include(name string, contextList ...interface{}) (interface
 		}
 
 		// We don't care about any template output.
-		w = ioutil.Discard
+		w = io.Discard
 	} else {
 		b := bp.GetBuffer()
 		defer bp.PutBuffer(b)

--- a/tpl/tplimpl/embedded/generate/generate.go
+++ b/tpl/tplimpl/embedded/generate/generate.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -51,7 +50,7 @@ func main() {
 
 		templateName := filepath.ToSlash(strings.TrimPrefix(path, templateFolder+string(os.PathSeparator)))
 
-		templateContent, err := ioutil.ReadFile(path)
+		templateContent, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/tpl/transform/unmarshal.go
+++ b/tpl/transform/unmarshal.go
@@ -14,7 +14,7 @@
 package transform
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/gohugoio/hugo/resources/resource"
@@ -81,7 +81,7 @@ func (ns *Namespace) Unmarshal(args ...interface{}) (interface{}, error) {
 			}
 			defer reader.Close()
 
-			b, err := ioutil.ReadAll(reader)
+			b, err := io.ReadAll(reader)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.