### PR TITLE
site_renderer: add pprof profiler labels

### DIFF
--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -70,7 +70,7 @@ func (s *Site) renderPages(ctx *siteRenderContext) error {
 
 	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)
-		go pageRenderer(ctx, s, pages, results, wg)
+		go pageRenderer(s, pages, results, wg)
 	}
 
 	cfg := ctx.cfg
@@ -101,7 +101,6 @@ func (s *Site) renderPages(ctx *siteRenderContext) error {
 }
 
 func pageRenderer(
-	ctx *siteRenderContext,
 	s *Site,
 	pages <-chan *pageState,
 	results chan<- error,


### PR DESCRIPTION
When pprof CPU profiling, I just see a big stacktrace full of
'texttemplate' functions that are hard to relate back to my templates and
site layout.

My intention here is to be able to attribute CPU cycles and work done to
specific causes, and be able to slice the profile by a few dimensions.
I'm hoping this will make it easier to tell where Hugo is spending time.

This took inspiration from https://rakyll.org/profiler-labels/.

Here's an example, building Graphviz's docs,
using the interactive pprof tool, showing the time spent in each tag:

```
$ hugo --profile-cpu /tmp/pprof
$ go tool pprof /tmp/pprof
Type: cpu
Time: Aug 29, 2021 at 6:29pm (AEST)
Duration: 15.61s, Total samples = 24.82s (158.96%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) tags
 format: Total 17.5s
           17.2s (98.34%): HTML
         290.0ms ( 1.66%): print

 kind: Total 17.5s
         16.6s (94.96%): page
       790.0ms ( 4.52%): section
        90.0ms ( 0.52%): home

 section: Total 17.0s
            15.9s (93.40%): docs
          730.0ms ( 4.30%): Gallery
          170.0ms ( 1.00%): Misc
          120.0ms ( 0.71%): download
           80.0ms ( 0.47%): build
           20.0ms ( 0.12%): _pages

 target_filename: Total 17.5s
                  130.0ms ( 0.74%): /docs/outputs/cmap/index.html
                  120.0ms ( 0.69%): /docs/attrs/pencolor/index.html
                  110.0ms ( 0.63%): /docs/attr-types/string/index.html
                  110.0ms ( 0.63%): /docs/attrs/id/index.html
                  [...]

 template: Total 17.4s
             10.2s (58.67%): attrs/single.html
              2.2s (12.85%): output/single.html
              2.0s (11.76%): attr-types/single.html
              1.6s ( 8.93%): docs/single.html
              [...]
```

You can also use pprof's `--tagFocus` argument, like this:

```
(pprof) tagfocus=template=attrs/single.html
(pprof) top
Active filters:
   tagfocus=template=attrs/single.html
Showing nodes accounting for 3.83s, 15.43% of 24.82s total
Dropped 220 nodes (cum <= 0.12s)
Showing top 10 nodes out of 129
      flat  flat%   sum%        cum   cum%
     0.77s  3.10%  3.10%      2.17s  8.74%  runtime.mallocgc
     0.60s  2.42%  5.52%      7.96s 32.07%  reflect.Value.call
     0.56s  2.26%  7.78%      0.70s  2.82%  runtime.heapBitsSetType
     0.46s  1.85%  9.63%      0.46s  1.85%  reflect.name.name
     0.41s  1.65% 11.28%      2.39s  9.63%  reflect.(*rtype).MethodByName
     0.25s  1.01% 12.29%      0.25s  1.01%  reflect.(*rtype).Kind (partial-inline)
     0.24s  0.97% 13.26%      0.24s  0.97%  runtime.nextFreeFast (inline)
     0.21s  0.85% 14.10%      9.92s 39.97%  github.com/gohugoio/hugo/tpl/internal/go_templates/texttemplate.(*state).evalCall
     0.18s  0.73% 14.83%      0.18s  0.73%  runtime.resolveNameOff
     0.15s   0.6% 15.43%     10.16s 40.93%  github.com/gohugoio/hugo/tpl/internal/go_templates/texttemplate.(*state).evalPipeline
```

My hope is that you'll find this as useful as I have for tracing the cause of slowdowns.

Considerations:
- I haven't thought too much about what tags/labels are most useful -- it's possible I'm missing some, or I might have too many.
- I could also break out a subfunction for `renderPage`, as the indentation is getting fairly deep here.
- I haven't documented this, just like the --profile-cpu flag is undocumented
- I'm using `context.Background()` -- perhaps this should be `context.TODO()` until the `main` function passes a Context? It probably doesn't matter too much as this is a command line tool without RPC deadlines.
- Some parts of the hugo pipeline aren't within this `renderPages` function -- perhaps they could get tags too? But for my runs, most of the CPU time is within `renderPages`.
- the 'template' is the top-level template, but the top-level template can include other templates. I haven't captured that here.