### PR TITLE
Make hugo.toml the new default config name

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -120,7 +120,7 @@ func TestExecute(t *testing.T) {
 		siteDir := filepath.Join(dir, "mysite")
 		resp := Execute([]string{"new", "site", siteDir, "-e=staging"})
 		c.Assert(resp.Err, qt.IsNil)
-		config := readFileFrom(c, filepath.Join(siteDir, "config.toml"))
+		config := readFileFrom(c, filepath.Join(siteDir, "hugo.toml"))
 		c.Assert(config, qt.Contains, "baseURL = 'http://example.org/'")
 		checkNewSiteInited(c, siteDir)
 	})
@@ -133,7 +133,7 @@ func checkNewSiteInited(c *qt.C, basepath string) {
 		filepath.Join(basepath, "archetypes"),
 		filepath.Join(basepath, "static"),
 		filepath.Join(basepath, "data"),
-		filepath.Join(basepath, "config.toml"),
+		filepath.Join(basepath, "hugo.toml"),
 	}
 
 	for _, path := range paths {

--- a/commands/new_site.go
+++ b/commands/new_site.go
@@ -139,7 +139,7 @@ func createConfig(fs *hugofs.Fs, inpath string, kind string) (err error) {
 		return err
 	}
 
-	return helpers.WriteToDisk(filepath.Join(inpath, "config."+kind), &buf, fs.Source)
+	return helpers.WriteToDisk(filepath.Join(inpath, "hugo."+kind), &buf, fs.Source)
 }
 
 func nextStepsText() string {

--- a/config/configLoader.go
+++ b/config/configLoader.go
@@ -137,7 +137,7 @@ func LoadConfigFromDir(sourceFs afero.Fs, configDir, environment string) (Provid
 
 			var keyPath []string
 
-			if name != "config" {
+			if name != "hugo" && name != "config" {
 				// Can be params.jp, menus.en etc.
 				name, lang := paths.FileAndExtNoDelimiter(name)
 


### PR DESCRIPTION
Note that the old, e.g. config.toml, still works fine.

See #8979