### PR TITLE
implement and test a render-document capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /hugo
 docs/public*
 /.idea
+/.vscode
 hugo.exe
 *.test
 *.prof

--- a/docs/content/en/getting-started/configuration-markup.md
+++ b/docs/content/en/getting-started/configuration-markup.md
@@ -132,6 +132,7 @@ The features currently supported are:
 * `image`
 * `link`
 * `heading` {{< new-in "0.71.0" >}}
+* `document` {{< new-in "0.89.0" >}}
 
 You can define [Output-Format-](/templates/output-formats) and [language-](/content-management/multilingual/)specific templates if needed. Your `layouts` folder may look like this:
 
@@ -141,7 +142,9 @@ layouts
     └── _markup
         ├── render-image.html
         ├── render-image.rss.xml
-        └── render-link.html
+        ├── render-link.html
+        ├── render-heading.html
+        └── render-document.html
 ```
 
 Some use cases for the above:
@@ -152,6 +155,7 @@ Some use cases for the above:
 * Add [header links](https://remysharp.com/2014/08/08/automatic-permalinks-for-blog-posts).
 
 ### Render Hook Templates
+#### render-link and render-image
 
 The `render-link` and `render-image` templates will receive this context:
 
@@ -170,6 +174,8 @@ Text
 PlainText
 : The plain variant of the above.
 
+#### render-heading
+
 The `render-heading` template will receive this context:
 
 Page
@@ -186,6 +192,21 @@ Text
 
 PlainText
 : The plain variant of the above.
+
+Attributes (map) {{< new-in "0.82.0" >}}
+: A map of attributes (e.g. `id`, `class`)
+
+#### render-document {{< new-in "0.89.0" >}}
+
+The `render-document` template is invoked twice: once before processing of the markdown starts; and once when processing of the markdown ends.
+The `render-document` template will receive this context:
+
+Page
+: The [Page] being rendered.
+
+Entering
+: true - processing of the markdown about to start
+: false - processing of the markdown has completed
 
 Attributes (map) {{< new-in "0.82.0" >}}
 : A map of attributes (e.g. `id`, `class`)
@@ -235,3 +256,41 @@ The rendered html will be
 ```html
 <h3 id="section-a">Section A <a href="#section-a">¶</a></h3>
 ```
+
+#### render-document example
+
+`render-document` may be used to modify the generated html.
+Given this template file
+
+{{< code file="layouts/_default/_markup/render-document.html" >}}
+{{ if .Entering }}<div class="markup" data-title="{{- .Page.Title -}}">{{ else }}</div>{{ end }}
+{{< /code >}}
+
+And this markdown
+
+```md
+---
+title: "render-document"
+---
+# Heading 1
+```
+
+The rendered html will be
+
+```html
+<div class="markup" data-title="render-document"><h1 id="heading-1">Heading 1</h1>
+</div>
+```
+
+`render-document` may establish some initial conditions, which persist for the processing of the markdown
+and which may be retrieved by some other markdown render hook, for example, the `render-heading` template.
+Given this template file
+
+{{< code file="layouts/_default/_markup/render-document.html" >}}
+{{ if .Entering }} {{ .Page.Scratch.Set "todayMsg" "Choices have consequences" }} {{ end }}
+{{< /code >}}
+
+`render-heading` template can retrieve `todayMsg` with the following snippet:
+{{< code file="layouts/_default/_markup/render-heading.html" >}}
+{{ .Page.Scratch.Get "todayMsg" }}
+{{< /code >}}

--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -459,6 +459,28 @@ RSTART:Hook Heading: 2:REND
 `)
 }
 
+func TestRenderDocumentHook(t *testing.T) {
+	b := newTestSitesBuilder(t)
+
+	b.WithTemplatesAdded(
+		"index.html", `
+{{ .Content }}
+`, "_default/_markup/render-document.html", `{{ if .Entering }}<div class="markup" data-title=" {{- .Page.Title -}}">{{ else }}</div>{{ end }}`,
+	)
+
+	b.WithContent("_index.md", `---
+title: "render-document"
+---
+# Heading 1
+`)
+
+	b.Build(BuildCfg{})
+
+	b.AssertFileContent("public/index.html", `<div class="markup" data-title="render-document"><h1 id="heading-1">Heading 1</h1>
+</div>`,
+	)
+}
+
 // https://github.com/gohugoio/hugo/issues/6882
 func TestRenderStringOnListPage(t *testing.T) {
 	renderStringTempl := `

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -436,6 +436,18 @@ func (p *pageState) createRenderHooks(f output.Format) (hooks.Renderers, error) 
 			templ:           templ,
 		}
 	}
+	layoutDescriptor.Kind = "render-document"
+	templ, templFound, err = p.s.Tmpl().LookupLayout(layoutDescriptor, f)
+	if err != nil {
+		return renderers, err
+	}
+	if templFound {
+		renderers.DocumentRenderer = hookRenderer{
+			templateHandler: p.s.Tmpl(),
+			SearchProvider:  templ.(identity.SearchProvider),
+			templ:           templ,
+		}
+	}
 
 	return renderers, nil
 }

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1766,6 +1766,10 @@ func (hr hookRenderer) RenderHeading(w io.Writer, ctx hooks.HeadingContext) erro
 	return hr.templateHandler.Execute(hr.templ, w, ctx)
 }
 
+func (hr hookRenderer) RenderDocument(w io.Writer, ctx hooks.DocumentContext) error {
+	return hr.templateHandler.Execute(hr.templ, w, ctx)
+}
+
 func (s *Site) renderForTemplate(name, outputFormat string, d interface{}, w io.Writer, templ tpl.Template) (err error) {
 	if templ == nil {
 		s.logMissingLayout(name, "", "", outputFormat)

--- a/markup/converter/hooks/hooks.go
+++ b/markup/converter/hooks/hooks.go
@@ -63,10 +63,30 @@ type HeadingRenderer interface {
 	identity.Provider
 }
 
+// DocumentContext contains accessors to all attributes that a DocumentRenderer
+// can use at the opening or closing of rendering the document
+type DocumentContext interface {
+	// Page is the page
+	Page() interface{}
+	// Entering is true if opening, false if closing the rendering of the document.
+	Entering() bool
+
+	// Attributes (e.g. CSS classes)
+	AttributesProvider
+}
+
+// DocumentRenderer describes a uniquely identifiable rendering hook.
+type DocumentRenderer interface {
+	// Render writes the rendered content to w using the data in w.
+	RenderDocument(w io.Writer, ctx DocumentContext) error
+	identity.Provider
+}
+
 type Renderers struct {
-	LinkRenderer    LinkRenderer
-	ImageRenderer   LinkRenderer
-	HeadingRenderer HeadingRenderer
+	LinkRenderer     LinkRenderer
+	ImageRenderer    LinkRenderer
+	HeadingRenderer  HeadingRenderer
+	DocumentRenderer DocumentRenderer
 }
 
 func (r Renderers) Eq(other interface{}) bool {
@@ -104,11 +124,19 @@ func (r Renderers) Eq(other interface{}) bool {
 		return false
 	}
 
+	b1, b2 = r.DocumentRenderer == nil, ro.DocumentRenderer == nil
+	if (b1 || b2) && (b1 != b2) {
+		return false
+	}
+	if !b1 && r.DocumentRenderer.GetIdentity() != ro.DocumentRenderer.GetIdentity() {
+		return false
+	}
+
 	return true
 }
 
 func (r Renderers) IsZero() bool {
-	return r.HeadingRenderer == nil && r.LinkRenderer == nil && r.ImageRenderer == nil
+	return r.HeadingRenderer == nil && r.LinkRenderer == nil && r.ImageRenderer == nil && r.DocumentRenderer == nil
 }
 
 func (r Renderers) String() string {


### PR DESCRIPTION
First time using go. First time contributing to any project on GitHub. Please feel free to inform if I'm not following process.

The proposed code adds the capability to create a markdown hook in layout/_default/_markup/render-document.html that hooks into goldmark render-document. The hook gets invoked twice: just before markdown processing starts; and just after markdown processing finishes. A boolean parameter indicates the reason for invocation.

I found this useful to set up some initial conditions before processing start, and to clean up when processing has completed. 
