### PR TITLE
tpl/tplimpl: Add .Site.Title to embedded opengraph template 

### DIFF
--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -230,7 +230,9 @@ if (!doNotTrack) {
 
 {{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
 {{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
+{{- with .Site.Title -}}<meta property="og:site_name" content="{{ . }}" />{{- else -}}
 {{- with .Site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
+{{- end -}}
 {{- with .Params.videos }}{{- range . }}
 <meta property="og:video" content="{{ . | absURL }}" />
 {{ end }}{{ end }}

--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -25,7 +25,9 @@
 
 {{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
 {{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
+{{- with .Site.Title -}}<meta property="og:site_name" content="{{ . }}" />{{- else -}}
 {{- with .Site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
+{{- end -}}
 {{- with .Params.videos }}{{- range . }}
 <meta property="og:video" content="{{ . | absURL }}" />
 {{ end }}{{ end }}


### PR DESCRIPTION
Added .Site.Title, to go alongside the existing .Site.Params.Title lookup for og:site_name.

.Site.Title has been given preference.

.Site.Title is specified in the hugo docs as the place to record the sites name https://gohugo.io/getting-started/configuration/#title

Its also configured by default when running "hugo new site" 

```TOML
# config.toml
baseURL = "http://example.org/"
languageCode = "en-us"
title = "My New Hugo Site"
```