### PR TITLE
locale tags based on page language code

### DIFF
--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -229,7 +229,12 @@ if (!doNotTrack) {
 {{- end -}}
 
 {{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
-{{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
+<meta property="og:locale" content="{{ .Lang }}">
+{{- if .IsTranslated -}}
+{{- range .Translations }}
+<meta property="og:locale:alternate" content="{{ .Lang }}">
+{{- end -}}
+{{- end -}}
 {{- with .Site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
 {{- with .Params.videos }}{{- range . }}
 <meta property="og:video" content="{{ . | absURL }}" />

--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -24,7 +24,12 @@
 {{- end -}}
 
 {{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
-{{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
+<meta property="og:locale" content="{{ .Lang }}">
+{{- if .IsTranslated -}}
+{{- range .Translations }}
+<meta property="og:locale:alternate" content="{{ .Lang }}">
+{{- end -}}
+{{- end -}}
 {{- with .Site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
 {{- with .Params.videos }}{{- range . }}
 <meta property="og:video" content="{{ . | absURL }}" />


### PR DESCRIPTION
Currently a user has to set the locale for OG in .Params.locale

This PR gets locale from .Lang (set in defaultContentLanguage: in the config file)

If the page has been translated, alternate languages will added