### PR TITLE
Add a path.clean function for #8885

### DIFF
--- a/tpl/path/path.go
+++ b/tpl/path/path.go
@@ -144,3 +144,15 @@ func (ns *Namespace) Join(elements ...interface{}) (string, error) {
 	}
 	return _path.Join(pathElements...), nil
 }
+
+// Clean replaces the separators used with standard slashes and then
+// extraneous slashes are removed.
+func (ns *Namespace) Clean(path interface{}) (string, error) {
+	spath, err := cast.ToStringE(path)
+
+	if err != nil {
+		return "", err
+	}
+	spath = filepath.ToSlash(spath)
+	return _path.Clean(spath), nil
+}

--- a/tpl/path/path_test.go
+++ b/tpl/path/path_test.go
@@ -175,3 +175,32 @@ func TestSplit(t *testing.T) {
 		c.Assert(result, qt.Equals, test.expect)
 	}
 }
+
+func TestClean(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	for _, test := range []struct {
+		path   interface{}
+		expect interface{}
+	}{
+		{filepath.FromSlash(`foo/bar.txt`), `foo/bar.txt`},
+		{filepath.FromSlash(`foo/bar/txt`), `foo/bar/txt`},
+		{filepath.FromSlash(`foo/bar`), `foo/bar`},
+		{filepath.FromSlash(`foo/bar.t`), `foo/bar.t`},
+		{``, `.`},
+		// errors
+		{tstNoStringer{}, false},
+	} {
+
+		result, err := ns.Clean(test.path)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}


### PR DESCRIPTION
Add path.clean function as mentioned in #8885.

I'd love to write a more full test suite, but I'm not 100% sure how to emulate windows filepaths effectively. Any tips are appreciated! :D