### PR TITLE
Use the same logic for og:video as og:image

### DIFF
--- a/docs/content/en/templates/internal.md
+++ b/docs/content/en/templates/internal.md
@@ -152,7 +152,7 @@ tags = []
 
 Hugo uses the page title and description for the title and description metadata.
 The first 6 URLs from the `images` array are used for image metadata.
-If [page bundles](/content-management/page-bundles/) are used and the `images` array is empty or undefined, images with filenames matching `*feature*` or `*cover*,*thumbnail*` are used for image metadata.
+If [page bundles](/content-management/page-bundles/) are used and the `images` or `videos` arrays are empty or undefined, images and videos with filenames matching `*feature*` or `*cover*,*thumbnail*` are used for image and video metadata.
 
 Various optional metadata can also be set:
 

--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -26,9 +26,16 @@
 {{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
 {{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
 {{- with .Site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
-{{- with .Params.videos }}{{- range . }}
-<meta property="og:video" content="{{ . | absURL }}" />
-{{ end }}{{ end }}
+
+{{- with .Params.videos -}}
+{{- range first 6 . }}<meta property="og:video" content="{{ . | absURL }}" />{{ end -}}
+{{- else -}}
+{{- $videos := $.Resources.ByType "video" -}}
+{{- $featured_video := $videos.GetMatch "*feature*" -}}
+{{- if not $featured_video }}{{ $featured_video = $videos.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
+{{- with $featured_video -}}
+<meta property="og:video" content="{{ $featured_video.Permalink | absURL }}" />
+{{- end -}}
 
 {{- /* If it is part of a series, link to related articles */}}
 {{- $permalink := .Permalink }}


### PR DESCRIPTION
When populating the `og:video` fields, if the `videos` array isn't set in the front matter, Hugo should look for any page resources of type video that have a name containing `feature`, `cover`, or `thumbnail`. This is the same behavior as `og:image`.