### PR TITLE
releaser: fix issues regexp in git.go

### DIFF
--- a/releaser/git.go
+++ b/releaser/git.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gohugoio/hugo/common/hexec"
 )
 
-var issueRe = regexp.MustCompile(`(?i)[Updates?|Closes?|Fix.*|See] #(\d+)`)
+var issueRe = regexp.MustCompile(`(?i)(?:Updates?|Closes?|Fix.*|See) #(\d+)`)
 
 const (
 	notesChanges    = "notesChanges"

--- a/releaser/git_test.go
+++ b/releaser/git_test.go
@@ -45,6 +45,16 @@ See #456
 	c.Assert(len(issues), qt.Equals, 4)
 	c.Assert(issues[0], qt.Equals, 123)
 	c.Assert(issues[2], qt.Equals, 543)
+
+	bodyNoIssues := `
+This is a commit message without issue refs.
+
+But it has e #10 to make old regexp confused.
+Streets #20.
+	`
+
+	emptyIssuesList := extractIssues(bodyNoIssues)
+	c.Assert(len(emptyIssuesList), qt.Equals, 0)
 }
 
 func TestGitVersionTagBefore(t *testing.T) {


### PR DESCRIPTION
Original regexp used a char class which caused the regexp to only
check 1 symbol instead of a substring like "See" and "Closes".
So it would match `e #x` instead of `See #x` and many other
weird combinations.

Tests were passing as they never checked against an input that
would confuse that regexp.

Found with go-critic static analyzer, `badRegexp` checker.