### PR TITLE
Added nodesource apt repository to snap package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,13 @@ base: core20
 confinement: strict
 grade: devel # "devel" or "stable"
 
+package-repositories:
+  - type: apt
+    components: [main]
+    suites: [focal]
+    key-id: 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280
+    url: https://deb.nodesource.com/node_16.x
+
 apps:
   hugo:
     command: bin/hugo


### PR DESCRIPTION
This fixes #9028.

When running the Snap distribution of Hugo, the NodeJS version inside the container is v10.19.0 (the default and outdated version of node) this PR add the nodesource apt repository to allow the latest node version to be installed instead.
