### PR TITLE
config: Set HUGO_ENABLEGITINFO=false override in Set_in_string

### DIFF
--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -742,6 +742,7 @@ theme_param="themevalue2"
 		b := newB(c)
 
 		b.WithEnviron(
+			"HUGO_ENABLEGITINFO", "false",
 			// imaging.anchor is a string, and it's not possible
 			// to set a child attribute.
 			"HUGO_IMAGING_ANCHOR_FOO", "top",


### PR DESCRIPTION
This allows TestLoadConfigWithOsEnvOverrides/Set_in_string to PASS
even if there is no .git directory, e.g. during Debian package build.

To reproduce the error that I encountered before applying this PR:

```
$ mv .git .git~ ; go test -v ./hugolib -run TestLoadConfigWithOsEnvOverrides ; mv .git~ .git
=== RUN   TestLoadConfigWithOsEnvOverrides
=== RUN   TestLoadConfigWithOsEnvOverrides/Variations
=== RUN   TestLoadConfigWithOsEnvOverrides/Set_in_string
ERROR 2021/10/22 04:52:43 Failed to read Git log: fatal: not a git repository (or any of the parent directories): .git
    config_test.go:750: Build failed: logged 1 error(s)
--- FAIL: TestLoadConfigWithOsEnvOverrides (0.10s)
    --- PASS: TestLoadConfigWithOsEnvOverrides/Variations (0.05s)
    --- FAIL: TestLoadConfigWithOsEnvOverrides/Set_in_string (0.06s)
FAIL
FAIL	github.com/gohugoio/hugo/hugolib	0.141s
FAIL
```

TestLoadConfigWithOsEnvOverrides/Set_in_string was introduced in commit 49fedbc as fix for #8709.

Many thanks!