### PR TITLE
Fix AsciiDoc alias/extension mismatch

### DIFF
--- a/docs/content/en/content-management/formats.md
+++ b/docs/content/en/content-management/formats.md
@@ -33,7 +33,7 @@ The current list of content formats in Hugo:
 | Blackfriday | blackfriday  |Blackfriday will eventually be deprecated.|
 |MMark|mmark|Mmark is deprecated and will be removed in a future release.|
 |Emacs Org-Mode|org|See [go-org](https://github.com/niklasfasching/go-org).|
-|AsciiDoc|asciidocext, adoc, ad|Needs [Asciidoctor][ascii] installed.|
+|AsciiDoc|asciidocext, asciidoc, adoc, ad|Needs [Asciidoctor][ascii] installed.|
 |RST|rst|Needs [RST](http://docutils.sourceforge.net/rst.html) installed.|
 |Pandoc|pandoc, pdc|Needs [Pandoc](https://www.pandoc.org/) installed.|
 |HTML|html, htm|To be treated as a content file, with layout, shortcodes etc., it must have front matter. If not, it will be copied as-is.|

--- a/hugofs/files/classifier.go
+++ b/hugofs/files/classifier.go
@@ -38,7 +38,7 @@ var (
 	contentFileExtensions = []string{
 		"html", "htm",
 		"mdown", "markdown", "md",
-		"asciidoc", "adoc", "ad",
+		"asciidocext", "asciidoc", "adoc", "ad",
 		"rest", "rst",
 		"mmark",
 		"org",

--- a/markup/markup.go
+++ b/markup/markup.go
@@ -76,7 +76,7 @@ func NewConverterProvider(cfg converter.ProviderConfig) (ConverterProvider, erro
 	if err := add(mmark.Provider); err != nil {
 		return nil, err
 	}
-	if err := add(asciidocext.Provider, "ad", "adoc"); err != nil {
+	if err := add(asciidocext.Provider, "ad", "adoc", "asciidoc"); err != nil {
 		return nil, err
 	}
 	if err := add(rst.Provider); err != nil {


### PR DESCRIPTION
This adds "asciidocext" as a valid file extension, and adds "asciidoc"
as an AsciiDoc provider alias.

Fixes #9074