### PR TITLE
Fix default value of timeout in site configuration

### DIFF
--- a/docs/content/en/getting-started/configuration.md
+++ b/docs/content/en/getting-started/configuration.md
@@ -381,9 +381,9 @@ The directory where Hugo reads the themes from.
 
 ### timeout 
 
-**Default value:** 10000
+**Default value:** 30000
 
-Timeout for generating page contents, in milliseconds (defaults to 10&nbsp;seconds). *Note:* this is used to bail out of recursive content generation, if your pages are slow to generate (e.g., because they require large image processing or depend on remote contents) you might need to raise this limit.
+Timeout for generating page contents, in milliseconds (defaults to 30&nbsp;seconds). *Note:*&nbsp;this is used to bail out of recursive content generation. You might need to raise this limit if your pages are slow to generate (e.g., because they require large image processing or depend on remote contents).
 
 ### timeZone 
 

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -290,7 +290,7 @@ func (l configLoader) applyConfigDefaults() error {
 		"disableAliases":                       false,
 		"debug":                                false,
 		"disableFastRender":                    false,
-		"timeout":                              "30s",
+		"timeout":                              30000,
 		"enableInlineShortcodes":               false,
 	}
 


### PR DESCRIPTION
- The existing default value is a string: 30s
- cfg.Language.GetInt() in deps/deps.go cannot cast this to a string,
  discards the error, and returns 0
- Then, also in deps/deps.go, timeoutms <= 0 is true so the default
  timeout value is set to 3000ms (3s)