### PR TITLE
Work In Progress: Resolve JS imports in /content

### DIFF
--- a/hugofs/fileinfo.go
+++ b/hugofs/fileinfo.go
@@ -66,6 +66,7 @@ type FileMeta struct {
 	IsRootFile bool
 	Watch      bool
 
+	Component  string
 	Classifier files.ContentClass
 
 	SkipDir bool

--- a/resources/resource_transformers/js/options_test.go
+++ b/resources/resource_transformers/js/options_test.go
@@ -165,7 +165,7 @@ func TestResolveComponentInAssets(t *testing.T) {
 
 			bfs := hugofs.DecorateBasePathFs(afero.NewBasePathFs(mfs, baseDir).(*afero.BasePathFs))
 
-			got := resolveComponentInAssets(bfs, test.impPath)
+			got := resolveComponentInFs(bfs, test.impPath)
 
 			gotPath := ""
 			if got != nil {

--- a/resources/transform.go
+++ b/resources/transform.go
@@ -19,6 +19,7 @@ import (
 	"image"
 	"io"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -96,6 +97,12 @@ type ResourceTransformationCtx struct {
 
 	// This is the relative target path to the resource. Unix styled slashes.
 	InPath string
+
+	// The component type (e.g. "content") if the source is a file.
+	Component string
+
+	// The base directory inside Component if the source is a file.
+	ComponentBase string
 
 	// The relative target path to the transformed resource. Unix styled slashes.
 	OutPath string
@@ -371,6 +378,13 @@ func (r *resourceAdapter) transform(publish, setContent bool) error {
 
 	tctx.InPath = r.target.TargetPath()
 	tctx.SourcePath = tctx.InPath
+
+	if r.target.getFileInfo() != nil {
+		meta := r.target.getFileInfo().Meta()
+		mp := filepath.FromSlash(meta.Path)
+		tctx.Component = meta.Component
+		tctx.ComponentBase = strings.TrimSuffix(strings.TrimSuffix(mp, tctx.SourcePath), "/")
+	}
 
 	counter := 0
 	writeToFileCache := false


### PR DESCRIPTION
This commit allows JS files in content bundles to resolve imports inside /content relative to the bundle:

* It's not possible to navigate upwards in the content tree, but that is the only restriction.
* That means that JS files loaded from `site.Home.Resources` can import everything.
* The import resolver will fall back to `/assets` and then `node_modules`

Fixes #9125