### PR TITLE
Add get-release-notes shortcode to docs site

### DIFF
--- a/docs/layouts/shortcodes/get-release-notes.html
+++ b/docs/layouts/shortcodes/get-release-notes.html
@@ -1,0 +1,9 @@
+{{/* Example: {{< get-release-notes tag="v0.89.2" >}} */}}
+{{ $endpoint := "https://api.github.com/repos/gohugoio/hugo/releases/tags/" }}
+{{ $tag := .Get "tag" }}
+{{ $request := print $endpoint $tag }}
+{{ with getJSON $request }}
+  {{ .body | $.Page.RenderString }}
+{{ else }}
+  {{ errorf "The %q shortcode was unable to retrieve %q. See %s" .Name $request .Position }}
+{{ end }}


### PR DESCRIPTION
To be used in docs/content/en/news/n.n.n-relnotes/index.md. This would
allow us to maintain the release notes in one location (github), and pull
them into the docs site.

Example: {{< get-release-notes tag="v0.89.2" >}}

Related to #9136