### PR TITLE
accept a class parameter (slice or string) and append to <ul>

### DIFF
--- a/tpl/tplimpl/embedded/templates/pagination.html
+++ b/tpl/tplimpl/embedded/templates/pagination.html
@@ -5,6 +5,7 @@
 
 {{- $page := . }}
 {{- $format := "default" }}
+{{- $class := slice -}}
 
 {{- if reflect.IsMap . }}
   {{- with .page }}
@@ -15,11 +16,18 @@
   {{- with .format }}
     {{- $format = lower . }}
   {{- end }}
+  {{- with .class -}}
+    {{- if reflect.IsSlice -}}
+      {{- $class = . -}}
+    {{- else -}}
+      {{- $class = slice .class -}}
+    {{- end -}}
+  {{- end -}}
 {{- end }}
 
 {{- if in $validFormats $format }}
   {{- if gt $page.Paginator.TotalPages 1 }}
-    <ul class="pagination pagination-{{ $format }}">
+    <ul class="pagination pagination-{{ $format }} {{ delimit $class " " }}">
       {{- partial (printf "partials/inline/pagination/%s" $format) $page }}
     </ul>
   {{- end }}


### PR DESCRIPTION
This allows css manipulation of pagination block via utility classes. 

By default the pagination block is justify:left and it can only be justified to the center via css (not utility classes, which this template is written with)