### PR TITLE
helpers: Make UniqueStringsReuse allocation free

### DIFF
--- a/helpers/general.go
+++ b/helpers/general.go
@@ -85,11 +85,16 @@ func FirstUpper(s string) string {
 // UniqueStrings returns a new slice with any duplicates removed.
 func UniqueStrings(s []string) []string {
 	unique := make([]string, 0, len(s))
-	set := map[string]interface{}{}
-	for _, val := range s {
-		if _, ok := set[val]; !ok {
+	for i, val := range s {
+		var seen bool
+		for j := 0; j < i; j++ {
+			if s[j] == val {
+				seen = true
+				break
+			}
+		}
+		if !seen {
 			unique = append(unique, val)
-			set[val] = val
 		}
 	}
 	return unique
@@ -98,12 +103,19 @@ func UniqueStrings(s []string) []string {
 // UniqueStringsReuse returns a slice with any duplicates removed.
 // It will modify the input slice.
 func UniqueStringsReuse(s []string) []string {
-	set := map[string]interface{}{}
 	result := s[:0]
-	for _, val := range s {
-		if _, ok := set[val]; !ok {
+	for i, val := range s {
+		var seen bool
+
+		for j := 0; j < i; j++ {
+			if s[j] == val {
+				seen = true
+				break
+			}
+		}
+
+		if !seen {
 			result = append(result, val)
-			set[val] = val
 		}
 	}
 	return result


### PR DESCRIPTION
This should be faster for all of our use cases (small string slices), but more important, it makes UniqueStringsReuse allocation free.

```bash
name                                 old time/op    new time/op    delta
UniqueStrings/Safe-16                   776ns ± 0%     305ns ± 0%   -60.68%  (p=0.029 n=4+4)
UniqueStrings/Reuse_slice-16            621ns ± 3%     174ns ± 0%   -72.01%  (p=0.029 n=4+4)
UniqueStrings/Reuse_slice_sorted-16     319ns ± 4%     313ns ± 0%    -2.01%  (p=0.029 n=4+4)

name                                 old alloc/op   new alloc/op   delta
UniqueStrings/Safe-16                    224B ± 0%      128B ± 0%   -42.86%  (p=0.029 n=4+4)
UniqueStrings/Reuse_slice-16            96.0B ± 0%      0.0B       -100.00%  (p=0.029 n=4+4)
UniqueStrings/Reuse_slice_sorted-16     24.0B ± 0%     24.0B ± 0%      ~     (all equal)

name                                 old allocs/op  new allocs/op  delta
UniqueStrings/Safe-16                    7.00 ± 0%      1.00 ± 0%   -85.71%  (p=0.029 n=4+4)
UniqueStrings/Reuse_slice-16             6.00 ± 0%      0.00       -100.00%  (p=0.029 n=4+4)
UniqueStrings/Reuse_slice_sorted-16      1.00 ± 0%      1.00 ± 0%      ~     (all equal)
```