### PR TITLE
sitemap: Hide pages from sitemap if `.Sitemap.Hidden` is true

### DIFF
--- a/docs/content/en/templates/sitemap-template.md
+++ b/docs/content/en/templates/sitemap-template.md
@@ -27,6 +27,9 @@ A sitemap is a `Page` and therefore has all the [page variables][pagevars] avail
 `.Sitemap.ChangeFreq`
 : The page change frequency
 
+`.Sitemap.Hidden`
+: Whether the page should be hidden from the generated sitemap
+
 `.Sitemap.Priority`
 : The priority of the page
 
@@ -46,10 +49,12 @@ For multilingual sites, we also create a Sitemap index. You can provide a custom
 This template respects the version 0.9 of the [Sitemap Protocol](https://www.sitemaps.org/protocol.html).
 
 ```xml
-{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
+    {{- if not .Sitemap.Hidden -}}
+      {{- if .Permalink -}}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -57,15 +62,17 @@ This template respects the version 0.9 of the [Sitemap Protocol](https://www.sit
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
     <xhtml:link
                 rel="alternate"
-                hreflang="{{ .Lang }}"
+                hreflang="{{ .Language.Lang }}"
                 href="{{ .Permalink }}"
                 />{{ end }}
     <xhtml:link
                 rel="alternate"
-                hreflang="{{ .Lang }}"
+                hreflang="{{ .Language.Lang }}"
                 href="{{ .Permalink }}"
                 />{{ end }}
   </url>
+      {{- end -}}
+    {{- end -}}
   {{ end }}
 </urlset>
 ```
@@ -90,11 +97,12 @@ This is used to create a Sitemap index in multilingual mode:
 
 ## Configure `sitemap.xml`
 
-Defaults for `<changefreq>`, `<priority>` and `filename` values can be set in the site's config file, e.g.:
+Defaults for `<changefreq>`, `hidden`, `<priority>` and `filename` values can be set in the site's config file, e.g.:
 
 {{< code-toggle file="config" >}}
 [sitemap]
   changefreq = "monthly"
+  hidden = true
   priority = 0.5
   filename = "sitemap.xml"
 {{</ code-toggle >}}

--- a/tpl/tplimpl/embedded/templates/_default/sitemap.xml
+++ b/tpl/tplimpl/embedded/templates/_default/sitemap.xml
@@ -2,7 +2,8 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
-    {{- if .Permalink -}}
+    {{- if not .Sitemap.Hidden -}}
+      {{- if .Permalink -}}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -19,6 +20,7 @@
                 href="{{ .Permalink }}"
                 />{{ end }}
   </url>
+      {{- end -}}
     {{- end -}}
   {{ end }}
 </urlset>


### PR DESCRIPTION
This commit changes the default `sitemap.xml` to exclude pages from the
sitemap if a page author has set `.Sitemap.Hidden` to `true` in the
front-matter of a page.

The motivation for this change is for cases where a site maintainer
wants to use content from a special category to embed onto another page.
In this case, the content in the special category is already present on
the site, but the pages in the special category are created anyways.
These pages are included in the sitemap and will be indexed by search
engines, but this may not be the desired behavior. So, a site maintainer
is now able to exclude pages from the sitemap without making custom
modifications to the `sitemap.xml` and losing out on any changes made to
the default sitemap in Hugo in the future.

This change was inspired from a support thread from May 2015:

https://discourse.gohugo.io/t/how-to-omit-page-from-sitemap/1126?u=jwf

Documentation is also updated so designers can also take note of this
new change when reading about Hugo's sitemap template.