### PR TITLE
A new config option to fill translation gaps

### DIFF
--- a/docs/content/en/content-management/multilingual.md
+++ b/docs/content/en/content-management/multilingual.md
@@ -494,10 +494,10 @@ defaultContentLanguage = "en"
 [languages]
 [languages.en]
 title = "My blog"
-mergeLangContentTo = "es"
 
 [languages.es]
 title = "Mi blog"
+mergeLangContent = "en"
 {{< /code-toggle >}}
 
 In this example, if you have the following content:
@@ -507,7 +507,7 @@ posts
 ├── one.es.md
 └── two.md
 ```
-hugo will behave as if there was `two.es.md` with contents of `two.md`. In case of more than two languages a slice can be used instead: `mergeLangContentTo = ["es", "de"]`.
+hugo will behave as if there was `two.es.md` with contents of `two.md`. A slice can also be used to merge `de`, and `en` only if there is no `de` translation: `mergeLangContent = ["de", "en"]`.
 
 [lang.Merge](/functions/lang.merge/) does not affect site content, and is used to fill page lists with content from other languages without copying it.
 

--- a/docs/content/en/content-management/multilingual.md
+++ b/docs/content/en/content-management/multilingual.md
@@ -480,14 +480,36 @@ While translating a Hugo website, it can be handy to have a visual indicator of 
 Hugo will generate your website with these missing translation placeholders. It might not be suitable for production environments.
 {{% /note %}}
 
-For merging of content from other languages (i.e. missing content translations), see [lang.Merge](/functions/lang.merge/).
-
 To track down missing translation strings, run Hugo with the `--i18n-warnings` flag:
 
 ```
  hugo --i18n-warnings | grep i18n
 i18n|MISSING_TRANSLATION|en|wordCount
 ```
+
+To merge content from other language, you can use **experimental** `mergeLangContentTo` config option, or [lang.Merge](/functions/lang.merge/) function in your templates. Here is an example to fill missing Spanish content with English:
+{{< code-toggle file="config" >}}
+defaultContentLanguage = "en"
+
+[languages]
+[languages.en]
+title = "My blog"
+mergeLangContentTo = "es"
+
+[languages.es]
+title = "Mi blog"
+{{< /code-toggle >}}
+
+In this example, if you have the following content:
+```
+posts
+├── one.md
+├── one.es.md
+└── two.md
+```
+hugo will behave as if there was `two.es.md` with contents of `two.md`. In case of more than two languages a slice can be used instead: `mergeLangContentTo = ["es", "de"]`.
+
+[lang.Merge](/functions/lang.merge/) does not affect site content, and is used to fill page lists with content from other languages without copying it.
 
 ## Multilingual Themes support
 

--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -623,26 +623,40 @@ func (m *pageMap) ProcessFilesBundle(header hugofs.FileMetaInfo, resources ...hu
 	}
 
 	lang := m.s.Language().Get("mergeLangContentTo")
+
 	switch v := lang.(type) {
 	case string:
-		translated := false
-		for _, tr := range header.Meta().Translations {
-			if tr == v {
-				translated = true
-			}
-		}
-		if !translated {
-			for _, s := range m.s.h.Sites {
-				if s.Lang() == v {
-					s.pageMap.AddFilesBundle(header, resources...)
-				}
+		m.MergeLang(v, header, resources...)
+	case []interface{}:
+		for _, l := range v {
+			switch vv := l.(type) {
+			case string:
+				m.MergeLang(vv, header, resources...)
+			default:
+				fmt.Printf("mergeLangContentTo should only contain strings, not %T = %+v\n", l, l)
 			}
 		}
 	default:
-		fmt.Println("mergeLangContent is set for", m.s.Language().Lang, "language, but is not a string, ignoring")
+		fmt.Printf("mergeLangContentTo should be a string or array of strings, %T = %+v provided\n", lang, lang)
 	}
 
 	return nil
+}
+
+func (m *pageMap) MergeLang(lang string, header hugofs.FileMetaInfo, resources ...hugofs.FileMetaInfo) {
+	translated := false
+	for _, tr := range header.Meta().Translations {
+		if tr == lang {
+			translated = true
+		}
+	}
+	if !translated {
+		for _, s := range m.s.h.Sites {
+			if s.Lang() == lang {
+				s.pageMap.AddFilesBundle(header, resources...)
+			}
+		}
+	}
 }
 
 type pageMapQuery struct {

--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -618,45 +618,13 @@ func (m *pageMap) attachPageToViews(s string, b *contentNode) {
 func (m *pageMap) ProcessFilesBundle(header hugofs.FileMetaInfo, resources ...hugofs.FileMetaInfo) error {
 	m.AddFilesBundle(header, resources...)
 
-	if !m.s.Language().IsSet("mergeLangContentTo") {
-		return nil;
-	}
-
-	lang := m.s.Language().Get("mergeLangContentTo")
-
-	switch v := lang.(type) {
-	case string:
-		m.MergeLang(v, header, resources...)
-	case []interface{}:
-		for _, l := range v {
-			switch vv := l.(type) {
-			case string:
-				m.MergeLang(vv, header, resources...)
-			default:
-				fmt.Printf("mergeLangContentTo should only contain strings, not %T = %+v\n", l, l)
-			}
+	for _, s := range m.s.h.Sites {
+		if s.shouldMerge(header) {
+			s.pageMap.AddFilesBundle(header, resources...)
 		}
-	default:
-		fmt.Printf("mergeLangContentTo should be a string or array of strings, %T = %+v provided\n", lang, lang)
 	}
 
 	return nil
-}
-
-func (m *pageMap) MergeLang(lang string, header hugofs.FileMetaInfo, resources ...hugofs.FileMetaInfo) {
-	translated := false
-	for _, tr := range header.Meta().Translations {
-		if tr == lang {
-			translated = true
-		}
-	}
-	if !translated {
-		for _, s := range m.s.h.Sites {
-			if s.Lang() == lang {
-				s.pageMap.AddFilesBundle(header, resources...)
-			}
-		}
-	}
 }
 
 type pageMapQuery struct {

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -124,6 +124,8 @@ type pageMeta struct {
 	renderingConfigOverrides map[string]interface{}
 	contentConverterInit     sync.Once
 	contentConverter         converter.Converter
+
+	ignoreOnLangMerge bool
 }
 
 func (p *pageMeta) Aliases() []string {
@@ -499,6 +501,8 @@ func (pm *pageMeta) setMetadata(parentBucket *pagesMapBucket, p *pageState, fron
 		case "draft":
 			draft = new(bool)
 			*draft = cast.ToBool(v)
+		case "ignoreonlangmerge":
+			pm.ignoreOnLangMerge = cast.ToBool(v)
 		case "layout":
 			pm.layout = cast.ToString(v)
 			pm.params[loki] = pm.layout
@@ -782,6 +786,10 @@ func (m *pageMeta) outputFormats() output.Formats {
 
 func (p *pageMeta) Slug() string {
 	return p.urlPaths.Slug
+}
+
+func (p *pageMeta) IgnoreOnLangMerge() bool {
+	return p.ignoreOnLangMerge
 }
 
 func getParam(m resource.ResourceParamsProvider, key string, stringToLower bool) interface{} {

--- a/hugolib/pages_process.go
+++ b/hugolib/pages_process.go
@@ -162,7 +162,7 @@ func (p *sitePagesProcessor) doProcess(item interface{}) error {
 	m := p.m
 	switch v := item.(type) {
 	case *fileinfoBundle:
-		if err := m.AddFilesBundle(v.header, v.resources...); err != nil {
+		if err := m.ProcessFilesBundle(v.header, v.resources...); err != nil {
 			return err
 		}
 	case hugofs.FileMetaInfo:
@@ -174,7 +174,7 @@ func (p *sitePagesProcessor) doProcess(item interface{}) error {
 		classifier := meta.Classifier
 		switch classifier {
 		case files.ContentClassContent:
-			if err := m.AddFilesBundle(v); err != nil {
+			if err := m.ProcessFilesBundle(v); err != nil {
 				return err
 			}
 		case files.ContentClassFile:

--- a/langs/i18n/i18n.go
+++ b/langs/i18n/i18n.go
@@ -49,9 +49,9 @@ func MakeMergeMap(cfg config.Provider) map[string]string {
 			switch v := lv.Get("mergelangcontentto").(type) {
 			case string:
 				m[v] = k
-			case []string:
+			case []interface{}:
 				for _, vv := range v {
-					m[vv] = k
+					m[vv.(string)] = k
 				}
 			}
 		}


### PR DESCRIPTION
Introduces a new config option `mergeLangContent` to fill translation gaps with another language. It is somewhat similar to existing langs.Merge function, but literally copies content on build level, thus fixing the issue of a visitor leaving his native locale by clicking on outputs of langs.Merge.

Here is an example:
```toml
# config.toml
[languages]
[languages.en]
  ...
[languages.es]
  ...
  mergeLangContent = "en"
```

```
# Content tree (note missing translation for post.md):
content/
├── _index.es.md
├── _index.md
├── post2.es.md
├── post2.md
└── post.md

# Output in public:
public/
├── index.html
├── post/index.html
├── post2/index.html
├── es
│   ├── index.html
│   ├── post/index.html
│   ├── post2/index.html
```
Here `/es/post2.index.html` would have the same content as english version, except it would keep spanish header, footer and so on.

Similar behavior is set for i18n translations - if translation file is missing, merged language will take precedence over defaultContentLanguage.

To exclude a single page from this, there is a front matter option `ignoreOnLangMerge`.

#### A note on performance

The current implementation reads content file one more time whenever there is a need to merge it. For me it seems okay for the following reasons:
- I already use bash script to do the same job in production by just copying files in CI
- Current implementation is 2x+ faster than reading copies
- Can't be fixed without rewriting existing methods
