### PR TITLE
templates/opengraph: Add site_name and article tags as OpenGraph data

### DIFF
--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -1,3 +1,6 @@
+<meta name="application-name" content="{{ .Site.Title }}" />
+
+<meta property="og:site_name" content="{{ .Site.Title }}" />
 <meta property="og:title" content="{{ .Title }}" />
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
@@ -19,6 +22,9 @@
 {{- if .IsPage }}
 {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
 <meta property="article:section" content="{{ .Section }}" />
+{{- if (isset .Params "tags") }}
+  {{- with .Params.tags }}<meta property="article:tag" content="{{ . }}" />{{ end }}
+{{ end }}
 {{ with .PublishDate }}<meta property="article:published_time" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />{{ end }}
 {{ with .Lastmod }}<meta property="article:modified_time" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />{{ end }}
 {{- end -}}


### PR DESCRIPTION
This commit modifies `_internal/opengraph.html` to be inclusive of three
new types of `<meta>` elements into the `<header>` section:

* `name="application-name"`
* `property="og:site_name"`
* `property="article:tag"`

`application-name` and `og:site_name` use `.Site.Title` since this meta-
data is intended to represent the name of the web application and/or
site. `application-name` is a standard metadata name included in the
HTML spec maintained by the Web Hypertext Application Technology Working
Group (WHATWG):

https://html.spec.whatwg.org/multipage/semantics.html#standard-metadata-names

`og:site_name` is optional metadata in the Open Graph Protocol. It
indicates the collection with a larger web site. Instead of leaving it
unset, this can be inferred from `.Site.Title`:

https://ogp.me/#optional

`article:tag` is not part of the Open Graph Protocol but it is used by
Facebook's crawler as extra metadata used in a Facebook Open Graph
render. This hooks into the existing tags taxonomy on the site.

https://webmasters.stackexchange.com/questions/86920/is-articletag-meta-tag-necessary

Signed-off-by: Justin W. Flory (he/him) <git@jwf.io>