### PR TITLE
Add a remote retry for resources.Get

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /hugo
 docs/public*
 /.idea
+.vscode/*
 hugo.exe
 *.test
 *.prof

--- a/cache/filecache/filecache_test.go
+++ b/cache/filecache/filecache_test.go
@@ -276,7 +276,7 @@ func TestFileCacheReadOrCreateErrorInRead(t *testing.T) {
 		}
 	}
 
-	cache := NewCache(afero.NewMemMapFs(), 100*time.Hour, "")
+	cache := NewCache(afero.NewMemMapFs(), 100*time.Hour, 0, "")
 
 	const id = "a32"
 

--- a/resources/resource_factories/create/create.go
+++ b/resources/resource_factories/create/create.go
@@ -243,7 +243,6 @@ func (c *Client) FromRemote(uri string, options map[string]interface{}) (resourc
 
 	return c.rs.New(
 		resources.ResourceSourceDescriptor{
-			Fs:          c.rs.FileCaches.AssetsCache().Fs,
 			LazyPublish: true,
 			OpenReadSeekCloser: func() (hugio.ReadSeekCloser, error) {
 				return hugio.NewReadSeekerNoOpCloser(bytes.NewReader(body)), nil

--- a/resources/resource_factories/create/create.go
+++ b/resources/resource_factories/create/create.go
@@ -18,6 +18,7 @@ package create
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -180,6 +181,14 @@ func (c *Client) FromRemote(uri string, options map[string]interface{}) (resourc
 			}
 			addUserProvidedHeaders(headers, req)
 		}
+
+		// Workaround for https://github.com/golang/go/issues/49366
+		// This is the entire lifetime of the request.
+		ctx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
+		defer cancel()
+
+		req = req.WithContext(ctx)
+
 		res, err := c.httpClient.Do(req)
 		if err != nil {
 			return nil, err

--- a/tpl/data/resources_test.go
+++ b/tpl/data/resources_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gohugoio/hugo/hugofs"
 	"github.com/gohugoio/hugo/langs"
 	"github.com/spf13/afero"
-	
 )
 
 func TestScpGetLocal(t *testing.T) {
@@ -87,7 +86,7 @@ func TestScpGetRemote(t *testing.T) {
 	t.Parallel()
 	c := qt.New(t)
 	fs := new(afero.MemMapFs)
-	cache := filecache.NewCache(fs, 100, "")
+	cache := filecache.NewCache(fs, 100, 0, "")
 
 	tests := []struct {
 		path    string


### PR DESCRIPTION
This is work in progress; I still get some context canceled errors from  httputil.DumpResponse when testing this, which I assume is:

https://github.com/golang/go/issues/49366﻿
