### PR TITLE
lazy: Reset error in Reset

### DIFF
--- a/lazy/init.go
+++ b/lazy/init.go
@@ -136,6 +136,7 @@ func (ini *Init) shouldInitialize() bool {
 // Reset resets the current and all its dependencies.
 func (ini *Init) Reset() {
 	mu := ini.init.ResetWithLock()
+	ini.err = nil
 	defer mu.Unlock()
 	for _, d := range ini.children {
 		d.Reset()

--- a/lazy/init_test.go
+++ b/lazy/init_test.go
@@ -220,3 +220,22 @@ func TestInitBranchOrder(t *testing.T) {
 
 	c.Assert(state.V2, qt.Equals, "ABAB")
 }
+
+// See issue 7043
+func TestResetError(t *testing.T) {
+	c := qt.New(t)
+	r := false
+	i := New().Add(func() (interface{}, error) {
+		if r {
+			return nil, nil
+		}
+		return nil, errors.New("r is false")
+	})
+	_, err := i.Do()
+	c.Assert(err, qt.IsNotNil)
+	i.Reset()
+	r = true
+	_, err = i.Do()
+	c.Assert(err, qt.IsNil)
+
+}


### PR DESCRIPTION
To prevent sticky errors on server rebuilds.

Fixes #7043
Closes #9194
