### PR TITLE
Update to Go 1.17.4 and remove timeout in resources.Get

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-      - image: bepsays/ci-goreleaser:1.17.2
+      - image: bepsays/ci-goreleaser:1.17.4
   environment:
     CGO_ENABLED: "0"
 

--- a/resources/resource_factories/create/create.go
+++ b/resources/resource_factories/create/create.go
@@ -18,7 +18,6 @@ package create
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -181,13 +180,6 @@ func (c *Client) FromRemote(uri string, options map[string]interface{}) (resourc
 			}
 			addUserProvidedHeaders(headers, req)
 		}
-
-		// Workaround for https://github.com/golang/go/issues/49366
-		// This is the entire lifetime of the request.
-		ctx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
-		defer cancel()
-
-		req = req.WithContext(ctx)
 
 		res, err := c.httpClient.Do(req)
 		if err != nil {


### PR DESCRIPTION
Fixes #9265
