### PR TITLE
rss template: Set lastBuildDate to latest included page modification

### DIFF
--- a/tpl/tplimpl/embedded/templates/_default/rss.xml
+++ b/tpl/tplimpl/embedded/templates/_default/rss.xml
@@ -10,7 +10,6 @@
 {{- if ge $limit 1 -}}
 {{- $pages = $pages | first $limit -}}
 {{- end -}}
-{{- $lastModPage := (sort $pages "Lastmod" "desc") | first 1 }}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
@@ -21,8 +20,7 @@
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
-    <copyright>{{.}}</copyright>{{end}}
-    {{- with index $lastModPage 0 -}}{{- if not .Lastmod.IsZero -}}
+    <copyright>{{.}}</copyright>{{end}}{{- with index $pages.ByLastmod.Reverse 0 -}}{{- if not .Lastmod.IsZero -}}
     <lastBuildDate>{{ .Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     {{- end -}}{{- end -}}
     {{- with .OutputFormats.Get "RSS" -}}

--- a/tpl/tplimpl/embedded/templates/_default/rss.xml
+++ b/tpl/tplimpl/embedded/templates/_default/rss.xml
@@ -10,6 +10,7 @@
 {{- if ge $limit 1 -}}
 {{- $pages = $pages | first $limit -}}
 {{- end -}}
+{{- $lastModPage := (sort $pages "Lastmod" "desc") | first 1 }}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
@@ -20,8 +21,10 @@
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
-    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
-    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    <copyright>{{.}}</copyright>{{end}}
+    {{- with index $lastModPage 0 -}}{{- if not .Lastmod.IsZero -}}
+    <lastBuildDate>{{ .Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    {{- end -}}{{- end -}}
     {{- with .OutputFormats.Get "RSS" -}}
     {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{- end -}}


### PR DESCRIPTION
Set `lastBuildDate` to `Lastmod` of the pages included in the feed.

- Using `Lastmod` gives the last modified date of the top level of the tree but not of the pages included in the feed.
- Using `Site.LastChanged` as suggested by @jmooring gives the date of the last change to the site, it's more effective than `Date` or `Lastmod` as these would indicate no changes when there might be.

(sorry, I unintentionally closed #9283)