### PR TITLE
Don't use path.Join to calculate the unique key for mounts

### DIFF
--- a/modules/config.go
+++ b/modules/config.go
@@ -15,7 +15,6 @@ package modules
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -389,7 +388,7 @@ type Mount struct {
 
 // Used as key to remove duplicates.
 func (m Mount) key() string {
-	return path.Join(m.Lang, m.Source, m.Target)
+	return strings.Join([]string{m.Lang, m.Source, m.Target}, "/")
 }
 
 func (m Mount) Component() string {


### PR DESCRIPTION
`path.Join` cleans the final path. Especially with relative paths it could create a key which causes incorrectly ignored mounts.

I had these three mounts:
```yaml
    - source: ../src/docs/arithmeticOperators/binary
      target: content/bash/arithmetic/binary
      lang: en
    - source: ../src/docs/arithmeticOperators/binary
      target: content/bash/arithmetic/binary
      lang: zh-cn
    - source: ../src/docs/arithmeticOperators/binary
      target: content/bash/arithmetic/binary
      lang: de
```

The last two mounts were ignored. This happened because the intermediate path value `zh-cn/../src/docs/arithmeticOperators/binary/content/bash/arithmetic/binary` was cleaned up to `src/docs/arithmeticOperators/binary/content/bash/arithmetic/binary`.
Due to the relative `..` the language was in fact ignored and the last two mounts were seen as identical to the first.

This PR uses strings.Join with the same `/` delimiter.