### PR TITLE
Revert "config/security: Add HOME to default exec env var whitelist"

### DIFF
--- a/config/security/securityConfig.go
+++ b/config/security/securityConfig.go
@@ -42,7 +42,7 @@ var DefaultConfig = Config{
 		),
 		// These have been tested to work with Hugo's external programs
 		// on Windows, Linux and MacOS.
-		OsEnv: NewWhitelist("(?i)^(PATH|PATHEXT|APPDATA|HOME|TMP|TEMP|TERM)$"),
+		OsEnv: NewWhitelist("(?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM)$"),
 	},
 	Funcs: Funcs{
 		Getenv: NewWhitelist("^HUGO_"),
@@ -110,6 +110,7 @@ func (c Config) CheckAllowedExec(name string) error {
 		}
 	}
 	return nil
+
 }
 
 func (c Config) CheckAllowedGetEnv(name string) error {
@@ -158,6 +159,7 @@ func (c Config) ToSecurityMap() map[string]interface{} {
 		"security": m,
 	}
 	return sec
+
 }
 
 // DecodeConfig creates a privacy Config from a given Hugo configuration.
@@ -187,6 +189,7 @@ func DecodeConfig(cfg config.Provider) (Config, error) {
 	}
 
 	return sc, nil
+
 }
 
 func stringSliceToWhitelistHook() mapstructure.DecodeHookFuncType {
@@ -202,6 +205,7 @@ func stringSliceToWhitelistHook() mapstructure.DecodeHookFuncType {
 		wl := types.ToStringSlicePreserveString(data)
 
 		return NewWhitelist(wl...), nil
+
 	}
 }
 

--- a/config/security/securityonfig_test.go
+++ b/config/security/securityonfig_test.go
@@ -53,6 +53,7 @@ getEnv=["a", "b"]
 		c.Assert(pc.Exec.OsEnv.Accept("e"), qt.IsFalse)
 		c.Assert(pc.Funcs.Getenv.Accept("a"), qt.IsTrue)
 		c.Assert(pc.Funcs.Getenv.Accept("c"), qt.IsFalse)
+
 	})
 
 	c.Run("String whitelist", func(c *qt.C) {
@@ -79,6 +80,7 @@ osEnv="b"
 		c.Assert(pc.Exec.Allow.Accept("d"), qt.IsFalse)
 		c.Assert(pc.Exec.OsEnv.Accept("b"), qt.IsTrue)
 		c.Assert(pc.Exec.OsEnv.Accept("e"), qt.IsFalse)
+
 	})
 
 	c.Run("Default exec.osEnv", func(c *qt.C) {
@@ -103,6 +105,7 @@ allow="a"
 		c.Assert(pc.Exec.Allow.Accept("a"), qt.IsTrue)
 		c.Assert(pc.Exec.OsEnv.Accept("PATH"), qt.IsTrue)
 		c.Assert(pc.Exec.OsEnv.Accept("e"), qt.IsFalse)
+
 	})
 
 	c.Run("Enable inline shortcodes, legacy", func(c *qt.C) {
@@ -126,7 +129,9 @@ osEnv="b"
 		pc, err := DecodeConfig(cfg)
 		c.Assert(err, qt.IsNil)
 		c.Assert(pc.EnableInlineShortcodes, qt.IsTrue)
+
 	})
+
 }
 
 func TestToTOML(t *testing.T) {
@@ -135,7 +140,7 @@ func TestToTOML(t *testing.T) {
 	got := DefaultConfig.ToTOML()
 
 	c.Assert(got, qt.Equals,
-		"[security]\n  enableInlineShortcodes = false\n  [security.exec]\n    allow = ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$']\n    osEnv = ['(?i)^(PATH|PATHEXT|APPDATA|HOME|TMP|TEMP|TERM)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['.*']",
+		"[security]\n  enableInlineShortcodes = false\n  [security.exec]\n    allow = ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$']\n    osEnv = ['(?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['.*']",
 	)
 }
 

--- a/docs/data/docs.json
+++ b/docs/data/docs.json
@@ -1839,7 +1839,7 @@
           "^postcss$"
         ],
         "osEnv": [
-          "(?i)^(PATH|PATHEXT|APPDATA|HOME|TMP|TEMP|TERM)$"
+          "(?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM)$"
         ]
       },
       "funcs": {


### PR DESCRIPTION
There have been one report in the wild suggesting that this needs to be tested better before doing:

https://discourse.gohugo.io/t/hugo-mod-failing-in-v0-91-1-but-works-in-v0-91-0/36180/5

This reverts commit fca266ebbb81af3d4479873a7a79759033c7ce25.
