### PR TITLE
enable defaulting gtag consent to 'denied'

### DIFF
--- a/config/privacy/privacyConfig.go
+++ b/config/privacy/privacyConfig.go
@@ -53,6 +53,9 @@ type GoogleAnalytics struct {
 
 	// Enabling this will make it so the users' IP addresses are anonymized within Google Analytics.
 	AnonymizeIP bool
+
+	// Enabling this will default gtag's storage consent to 'denied'
+	DefaultGtagStorageDenied bool
 }
 
 // Instagram holds the privacy configuration settings related to the Instagram shortcode.

--- a/docs/content/en/about/hugo-and-gdpr.md
+++ b/docs/content/en/about/hugo-and-gdpr.md
@@ -42,6 +42,7 @@ disable = false
 respectDoNotTrack = false
 anonymizeIP = false
 useSessionStorage = false
+defaultGtagStorageDenied = false
 [privacy.instagram]
 disable = false
 simple = false
@@ -93,8 +94,16 @@ useSessionStorage
 : Enabling this will disable the use of Cookies and use Session Storage to Store the GA Client ID.
 
 {{% warning %}}
-`useSessionStorage` is not supported when using Google Analytics v4 (gtag.js).
+`useSessionStorage` is not supported when using Google Analytics v4 (gtag.js). To disable cookies for Google Analytics v4 see `defaultGtagStorageDenied`.
 {{% /warning %}}
+
+defaultGtagStorageDenied
+: Enabling this will default Gtag's storage consent to 'denied'. [See here](https://developers.google.com/tag-platform/devguides/consent#configure_default_behavior) for documentation on what this does.
+
+{{% warning %}}
+`defaultGtagStorageDenied` will not revoke consent for people who have already been to your site without this enabled. [See here](https://developers.google.com/tag-platform/devguides/consent) for Google's documentation on how to change values.
+{{% /warning %}}
+
 ### Instagram
 
 simple

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -129,6 +129,12 @@ var EmbeddedTemplates = [][2]string{
 if (!doNotTrack) {
 	window.dataLayer = window.dataLayer || [];
 	function gtag(){dataLayer.push(arguments);}
+	{{- if $pc.DefaultGtagStorageDenied }}
+	gtag('consent', 'default', {
+		'ad_storage': 'denied',
+		'analytics_storage': 'denied'
+	});
+	{{- end }}
 	gtag('js', new Date());
 	gtag('config', '{{ . }}', { 'anonymize_ip': {{- $pc.AnonymizeIP -}} });
 }


### PR DESCRIPTION
gtag actually defaults consent to 'granted': https://developers.google.com/tag-platform/devguides/consent#tracking_consent_status

but this is a bit of a legal footgun... I think we should default to denied. At minimum we should allow this to be configured.

maybe fixes: #8262 ?