### PR TITLE
Fix missing page data for alternative formats

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -940,20 +940,6 @@ func (p *pageState) shiftToOutputFormat(isRenderingSite bool, idx int) error {
 		panic(fmt.Sprintf("pageOutput is nil for output idx %d", idx))
 	}
 
-	// We attempt to assign pageContentOutputs while preparing each site
-	// for rendering and before rendering each site. This lets us share
-	// content between page outputs to conserve resources. But if a template
-	// unexpectedly calls a method of a ContentProvider that is not yet
-	// initialized, we assign a LazyContentProvider that performs the
-	// initialization just in time.
-	p.pageOutput.ContentProvider = page.NewLazyContentProvider(func() (page.ContentProvider, error) {
-		cp, err := newPageContentOutput(p, p.pageOutput)
-		if err != nil {
-			return nil, err
-		}
-		return cp, nil
-	})
-
 	// Reset any built paginator. This will trigger when re-rendering pages in
 	// server mode.
 	if isRenderingSite && p.pageOutput.paginator != nil && p.pageOutput.paginator.current != nil {
@@ -985,7 +971,24 @@ func (p *pageState) shiftToOutputFormat(isRenderingSite bool, idx int) error {
 			}
 		}
 		p.pageOutput.initContentProvider(cp)
-		p.pageOutput.cp = cp
+	} else {
+		// We attempt to assign pageContentOutputs while preparing each site
+		// for rendering and before rendering each site. This lets us share
+		// content between page outputs to conserve resources. But if a template
+		// unexpectedly calls a method of a ContentProvider that is not yet
+		// initialized, we assign a LazyContentProvider that performs the
+		// initialization just in time.
+		if lcp, ok := (p.pageOutput.ContentProvider.(*page.LazyContentProvider)); ok {
+			lcp.Reset()
+		} else {
+			p.pageOutput.ContentProvider = page.NewLazyContentProvider(func() (page.ContentProvider, error) {
+				cp, err := newPageContentOutput(p, p.pageOutput)
+				if err != nil {
+					return nil, err
+				}
+				return cp, nil
+			})
+		}
 	}
 
 	return nil

--- a/resources/page/page_lazy_contentprovider.go
+++ b/resources/page/page_lazy_contentprovider.go
@@ -1,0 +1,101 @@
+// Copyright 2019 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package page
+
+import (
+	"html/template"
+
+	"github.com/gohugoio/hugo/lazy"
+)
+
+// LazyContentProvider initializes itself when read. Each method of the
+// ContentProvider interface initializes a content provider and shares it
+// with other methods.
+//
+// Used in cases where we cannot guarantee whether the content provider
+// will be needed. Must create via NewLazyContentProvider.
+type LazyContentProvider struct {
+	init *lazy.Init
+	cp   ContentProvider
+}
+
+// NewLazyContentProvider returns a LazyContentProvider initialized with
+// function f. The resulting LazyContentProvider calls f in order to
+// retrieve a ContentProvider
+func NewLazyContentProvider(f func() (ContentProvider, error)) *LazyContentProvider {
+	lcp := LazyContentProvider{
+		init: lazy.New(),
+		cp:   NopPage,
+	}
+	lcp.init.Add(func() (interface{}, error) {
+		cp, err := f()
+		if err != nil {
+			return nil, err
+		}
+		lcp.cp = cp
+		return nil, nil
+	})
+	return &lcp
+}
+
+func (lcp *LazyContentProvider) Content() (interface{}, error) {
+	lcp.init.Do()
+	return lcp.cp.Content()
+}
+
+func (lcp *LazyContentProvider) Plain() string {
+	lcp.init.Do()
+	return lcp.cp.Plain()
+}
+
+func (lcp *LazyContentProvider) PlainWords() []string {
+	lcp.init.Do()
+	return lcp.cp.PlainWords()
+}
+
+func (lcp *LazyContentProvider) Summary() template.HTML {
+	lcp.init.Do()
+	return lcp.cp.Summary()
+
+}
+
+func (lcp *LazyContentProvider) Truncated() bool {
+	lcp.init.Do()
+	return lcp.cp.Truncated()
+
+}
+
+func (lcp *LazyContentProvider) FuzzyWordCount() int {
+	lcp.init.Do()
+	return lcp.cp.FuzzyWordCount()
+
+}
+
+func (lcp *LazyContentProvider) WordCount() int {
+	lcp.init.Do()
+	return lcp.cp.WordCount()
+
+}
+
+func (lcp *LazyContentProvider) ReadingTime() int {
+	lcp.init.Do()
+	return lcp.cp.ReadingTime()
+
+}
+
+func (lcp *LazyContentProvider) Len() int {
+	lcp.init.Do()
+	return lcp.cp.Len()
+
+}

--- a/resources/page/page_lazy_contentprovider.go
+++ b/resources/page/page_lazy_contentprovider.go
@@ -49,6 +49,10 @@ func NewLazyContentProvider(f func() (ContentProvider, error)) *LazyContentProvi
 	return &lcp
 }
 
+func (lcp *LazyContentProvider) Reset() {
+	lcp.init.Reset()
+}
+
 func (lcp *LazyContentProvider) Content() (interface{}, error) {
 	lcp.init.Do()
 	return lcp.cp.Content()
@@ -67,35 +71,29 @@ func (lcp *LazyContentProvider) PlainWords() []string {
 func (lcp *LazyContentProvider) Summary() template.HTML {
 	lcp.init.Do()
 	return lcp.cp.Summary()
-
 }
 
 func (lcp *LazyContentProvider) Truncated() bool {
 	lcp.init.Do()
 	return lcp.cp.Truncated()
-
 }
 
 func (lcp *LazyContentProvider) FuzzyWordCount() int {
 	lcp.init.Do()
 	return lcp.cp.FuzzyWordCount()
-
 }
 
 func (lcp *LazyContentProvider) WordCount() int {
 	lcp.init.Do()
 	return lcp.cp.WordCount()
-
 }
 
 func (lcp *LazyContentProvider) ReadingTime() int {
 	lcp.init.Do()
 	return lcp.cp.ReadingTime()
-
 }
 
 func (lcp *LazyContentProvider) Len() int {
 	lcp.init.Do()
 	return lcp.cp.Len()
-
 }


### PR DESCRIPTION
When a template calls the .Translations function and a
Hugo environment is using multiple output formats,
a template that calls methods like .Summary and .Len on
each translation will unexpectedly show empty return
values for these methods.

This is because each pageOutput's ContentProvider is
assigned to a page.NopPage in newPageOutput. When
*HugoSites.render assigns pageContentOutputs to
pageOutputs in *pageState.shiftToOutputFormat, it
reuses pageContentOutputs from other pageOutputs,
leaving some pageContentOutputs as NopPages. While this
approach conserves resources, sometimes it means that
a template will unexpectedly call a method on a
pageContentOutput that is actually a NopPage.

In the case of ContentProvider methods called on
translations for alternative output formats, the methods
were called on NopPages.

This change introduces LazyContentProvider, which
performs late initialization when one of its methods is
called. This way, we can reuse content in "normal" cases
but ensure that ContentProvider methods work as expected
when a pageOutput is not assigned a pageContentOutput
during the initial pre-render phase.

Fixes #8919