### PR TITLE
Fix surprise OutputFormat.Rel overwriting

### DIFF
--- a/resources/page/page_outputformat.go
+++ b/resources/page/page_outputformat.go
@@ -66,8 +66,18 @@ func (o OutputFormat) RelPermalink() string {
 }
 
 func NewOutputFormat(relPermalink, permalink string, isCanonical bool, f output.Format) OutputFormat {
+	isUserConfigured := true
+	for _, d := range output.DefaultFormats {
+		if strings.EqualFold(d.Name, f.Name) {
+			isUserConfigured = false
+		}
+	}
 	rel := f.Rel
-	if isCanonical {
+	// If the output format is the canonical format for the content, we want
+	// to specify this in the "rel" attribute of an HTML "link" element.
+	// However, for custom output formats, we don't want to surprise users by
+	// overwriting "rel"
+	if isCanonical && !isUserConfigured {
 		rel = "canonical"
 	}
 	return OutputFormat{Rel: rel, Format: f, relPermalink: relPermalink, permalink: permalink}


### PR DESCRIPTION
In page.NewOutputFormat, we take an output.Format f and use it to
create a page.OutputFormat. If the format is canonical, we assign
the final OutputFormat's Rel to "canonical" rather than using
f.Rel. However, this leads to unexpected behavior for custom
output formats, where a user can define a "rel" for a format
via the config file.

For example, the standard for "humans.txt" files requires using
rel="author" in HTML "link" elements. Meanwhile, humans.txt is
usually the only format used for its content. As a result, for
Hugo configurations that define a humans.txt custom output format,
Hugo will render "link" elements to content in this format with
rel="canonical," rather than "author" as required by the standard.

This commit changes page.NewOutputFormat to check whether a given
format is user defined and, if so, skips assigning Rel to
"canonical," even if isCanonical is true.

Fixes #8030