### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cache/filecache/filecache_test.go
+++ b/cache/filecache/filecache_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -44,13 +43,8 @@ func TestFileCache(t *testing.T) {
 	t.Parallel()
 	c := qt.New(t)
 
-	tempWorkingDir, err := ioutil.TempDir("", "hugo_filecache_test_work")
-	c.Assert(err, qt.IsNil)
-	defer os.Remove(tempWorkingDir)
-
-	tempCacheDir, err := ioutil.TempDir("", "hugo_filecache_test_cache")
-	c.Assert(err, qt.IsNil)
-	defer os.Remove(tempCacheDir)
+	tempWorkingDir := t.TempDir()
+	tempCacheDir := t.TempDir()
 
 	osfs := afero.NewOsFs()
 

--- a/resources/testhelpers_test.go
+++ b/resources/testhelpers_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"image"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -105,8 +104,7 @@ func newTestResourceOsFs(c *qt.C) (*Spec, string) {
 	cfg := createTestCfg()
 	cfg.Set("baseURL", "https://example.com")
 
-	workDir, err := ioutil.TempDir("", "hugores")
-	c.Assert(err, qt.IsNil)
+	workDir := c.TempDir()
 	c.Assert(workDir, qt.Not(qt.Equals), "")
 
 	if runtime.GOOS == "darwin" && !strings.HasPrefix(workDir, "/private") {

--- a/watcher/filenotify/poller_test.go
+++ b/watcher/filenotify/poller_test.go
@@ -221,8 +221,7 @@ func BenchmarkPoller(b *testing.B) {
 }
 
 func prepareTestDirWithSomeFiles(c *qt.C, id string) string {
-	dir, err := ioutil.TempDir("", fmt.Sprintf("test-poller-dir-%s", id))
-	c.Assert(err, qt.IsNil)
+	dir := c.TempDir()
 	c.Assert(os.MkdirAll(filepath.Join(dir, subdir1), 0777), qt.IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(dir, subdir2), 0777), qt.IsNil)
 
@@ -233,10 +232,6 @@ func prepareTestDirWithSomeFiles(c *qt.C, id string) string {
 	for i := 0; i < 3; i++ {
 		c.Assert(ioutil.WriteFile(filepath.Join(dir, subdir2, fmt.Sprintf("file%d", i)), []byte("hello2"), 0600), qt.IsNil)
 	}
-
-	c.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
 
 	return dir
 }


### PR DESCRIPTION
A small testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir