### PR TITLE
Ensure page translation CPs are initialized

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -635,7 +635,19 @@ func (p *pageState) RenderString(args ...interface{}) (template.HTML, error) {
 		}
 	}
 
-	c, err := p.pageOutput.cp.renderContentWithConverter(conv, []byte(s), false)
+	var cp *pageContentOutput
+
+	// If the current content provider is not yet initialized, do so now.
+	if lcp, ok := p.pageOutput.ContentProvider.(*page.LazyContentProvider); ok {
+		c := lcp.Init()
+		if pco, ok := c.(*pageContentOutput); ok {
+			cp = pco
+		}
+	} else {
+		cp = p.pageOutput.cp
+	}
+
+	c, err := cp.renderContentWithConverter(conv, []byte(s), false)
 	if err != nil {
 		return "", p.wrapError(err)
 	}

--- a/hugolib/page__common.go
+++ b/hugolib/page__common.go
@@ -64,7 +64,6 @@ type pageCommon struct {
 	maps.Scratcher
 	navigation.PageMenusProvider
 	page.AuthorProvider
-	page.PageRenderProvider
 	page.AlternativeOutputFormatsProvider
 	page.ChildCareProvider
 	page.FileProvider

--- a/hugolib/page__new.go
+++ b/hugolib/page__new.go
@@ -86,7 +86,6 @@ func newPageBase(metaProvider *pageMeta) (*pageState, error) {
 	ps.Eqer = ps
 	ps.TranslationKeyProvider = ps
 	ps.ShortcodeInfoProvider = ps
-	ps.PageRenderProvider = ps
 	ps.AlternativeOutputFormatsProvider = ps
 
 	return ps, nil

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -24,6 +24,9 @@ import (
 	"unicode/utf8"
 
 	"github.com/gohugoio/hugo/identity"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"github.com/spf13/cast"
 
 	"github.com/gohugoio/hugo/markup/converter/hooks"
 
@@ -94,7 +97,7 @@ func newPageContentOutput(p *pageState, po *pageOutput) (*pageContentOutput, err
 			}
 		}()
 
-		if err := po.initRenderHooks(); err != nil {
+		if err := po.cp.initRenderHooks(); err != nil {
 			return err
 		}
 
@@ -347,6 +350,145 @@ func (p *pageContentOutput) Truncated() bool {
 func (p *pageContentOutput) WordCount() int {
 	p.p.s.initInit(p.initPlain, p.p)
 	return p.wordCount
+}
+
+func (p *pageContentOutput) RenderString(args ...interface{}) (template.HTML, error) {
+	if len(args) < 1 || len(args) > 2 {
+		return "", errors.New("want 1 or 2 arguments")
+	}
+
+	var s string
+	opts := defaultRenderStringOpts
+	sidx := 1
+
+	if len(args) == 1 {
+		sidx = 0
+	} else {
+		m, ok := args[0].(map[string]interface{})
+		if !ok {
+			return "", errors.New("first argument must be a map")
+		}
+
+		if err := mapstructure.WeakDecode(m, &opts); err != nil {
+			return "", errors.WithMessage(err, "failed to decode options")
+		}
+	}
+
+	var err error
+	s, err = cast.ToStringE(args[sidx])
+	if err != nil {
+		return "", err
+	}
+
+	if err = p.initRenderHooks(); err != nil {
+		return "", err
+	}
+
+	conv := p.p.getContentConverter()
+	if opts.Markup != "" && opts.Markup != p.p.m.markup {
+		var err error
+		// TODO(bep) consider cache
+		conv, err = p.p.m.newContentConverter(p.p, opts.Markup, nil)
+		if err != nil {
+			return "", p.p.wrapError(err)
+		}
+	}
+
+	c, err := p.renderContentWithConverter(conv, []byte(s), false)
+	if err != nil {
+		return "", p.p.wrapError(err)
+	}
+
+	b := c.Bytes()
+
+	if opts.Display == "inline" {
+		// We may have to rethink this in the future when we get other
+		// renderers.
+		b = p.p.s.ContentSpec.TrimShortHTML(b)
+	}
+
+	return template.HTML(string(b)), nil
+}
+
+func (p *pageContentOutput) RenderWithTemplateInfo(info tpl.Info, layout ...string) (template.HTML, error) {
+	p.p.addDependency(info)
+	return p.Render(layout...)
+}
+
+func (p *pageContentOutput) Render(layout ...string) (template.HTML, error) {
+	templ, found, err := p.p.resolveTemplate(layout...)
+	if err != nil {
+		return "", p.p.wrapError(err)
+	}
+
+	if !found {
+		return "", nil
+	}
+
+	p.p.addDependency(templ.(tpl.Info))
+
+	// Make sure to send the *pageState and not the *pageContentOutput to the template.
+	res, err := executeToString(p.p.s.Tmpl(), templ, p.p)
+	if err != nil {
+		return "", p.p.wrapError(errors.Wrapf(err, "failed to execute template %q v", layout))
+	}
+	return template.HTML(res), nil
+}
+
+func (p *pageContentOutput) initRenderHooks() error {
+	if p == nil {
+		return nil
+	}
+
+	var initErr error
+
+	p.renderHooks.init.Do(func() {
+		ps := p.p
+
+		c := ps.getContentConverter()
+		if c == nil || !c.Supports(converter.FeatureRenderHooks) {
+			return
+		}
+
+		h, err := ps.createRenderHooks(p.f)
+		if err != nil {
+			initErr = err
+			return
+		}
+		p.renderHooks.hooks = h
+
+		if !p.renderHooksHaveVariants || h.IsZero() {
+			// Check if there is a different render hooks template
+			// for any of the other page output formats.
+			// If not, we can reuse this.
+			for _, po := range ps.pageOutputs {
+				if po.f.Name != p.f.Name {
+					h2, err := ps.createRenderHooks(po.f)
+					if err != nil {
+						initErr = err
+						return
+					}
+
+					if h2.IsZero() {
+						continue
+					}
+
+					if p.renderHooks.hooks.IsZero() {
+						p.renderHooks.hooks = h2
+					}
+
+					p.renderHooksHaveVariants = !h2.Eq(p.renderHooks.hooks)
+
+					if p.renderHooksHaveVariants {
+						break
+					}
+
+				}
+			}
+		}
+	})
+
+	return initErr
 }
 
 func (p *pageContentOutput) setAutoSummary() error {

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -772,7 +772,7 @@ Here is the last report for commits in the year 2016. It covers hrev50718-hrev50
 func TestRenderStringForRegularPageTranslations(t *testing.T) {
 	c := qt.New(t)
 	b := newTestSitesBuilder(t)
-	b.WithLogger(loggers.NewBasicLoggerForWriter(jwalterweatherman.LevelDebug, os.Stderr))
+	b.WithLogger(loggers.NewBasicLoggerForWriter(jwalterweatherman.LevelError, os.Stderr))
 
 	b.WithConfigFile("toml",
 		`baseurl = "https://example.org/"
@@ -828,7 +828,6 @@ home = ["HTML", "JSON"]`)
 <p>bar</p>
 <p>bar</p>
 `)
-
 }
 
 // Issue 8919

--- a/resources/page/page_lazy_contentprovider.go
+++ b/resources/page/page_lazy_contentprovider.go
@@ -49,6 +49,11 @@ func NewLazyContentProvider(f func() (ContentProvider, error)) *LazyContentProvi
 	return &lcp
 }
 
+func (lcp *LazyContentProvider) Init() ContentProvider {
+	lcp.init.Do()
+	return lcp.cp
+}
+
 func (lcp *LazyContentProvider) Reset() {
 	lcp.init.Reset()
 }


### PR DESCRIPTION
PR #9342 introduced a regression in which calling .Translations in a
template and calling RenderString on a translated Page caused a nil
pointer dereference. The issue was that some Pages returned from
.Translations had a nil cp field at the time the calling template was
being executed.

While PR #9342 had attempted to ensure that all ContentProviders were
initialized for translations at build time, it only performed the
initialization for receivers of ContentProvider methods such as
.Summary. However, the ContentProvider's *pageState.pageOutput.cp would
remain uninitialized, causing the nil pointer dereference.

This change edits the .Translations and .AllTranslations methods to
ensure that all of a page's translations have an initialized
content provider in time for a template to be executed.

Since LazyContentProvider is no longer needed with this approach, this
change also reverts the following commits:

- cdcd15b6c2abbb76fd95fbbf90365c56e82f46aa
- 25d645f47ae0a32470d303c9478c9e0b2fff0f0e

Fixes #9383