### PR TITLE
fix/apply namespace 9393

### DIFF
--- a/hugolib/template_test.go
+++ b/hugolib/template_test.go
@@ -460,7 +460,6 @@ complex: 80: 80
 
 // Issue 7528
 func TestPartialWithZeroedArgs(t *testing.T) {
-
 	b := newTestSitesBuilder(t)
 	b.WithTemplatesAdded("index.html",
 		` 
@@ -483,7 +482,6 @@ X123X
 X123X
 X123X
 `)
-
 }
 
 func TestPartialCached(t *testing.T) {
@@ -756,4 +754,21 @@ This is home main
 This is single main
 `,
 	)
+}
+
+// Issue 9393.
+func TestApplyWithNamespace(t *testing.T) {
+	b := newTestSitesBuilder(t)
+
+	b.WithTemplates(
+		"index.html", `
+{{ $b := slice " a " "     b "   "       c" }}		
+{{ $a := apply $b "strings.Trim" "." " " }}
+a: {{ $a }}
+`,
+	).WithContent("p1.md", "")
+
+	b.Build(BuildCfg{})
+
+	b.AssertFileContent("public/index.html", `a: [a b c]`)
 }

--- a/tpl/collections/apply.go
+++ b/tpl/collections/apply.go
@@ -111,15 +111,25 @@ func (ns *Namespace) lookupFunc(fname string) (reflect.Value, bool) {
 
 	ss := strings.SplitN(fname, ".", 2)
 
-	// namespace
+	// Namespace
 	nv, found := ns.lookupFunc(ss[0])
 	if !found {
 		return reflect.Value{}, false
 	}
 
+	fn, ok := nv.Interface().(func(...interface{}) (interface{}, error))
+	if !ok {
+		return reflect.Value{}, false
+	}
+	v, err := fn()
+	if err != nil {
+		panic(err)
+	}
+	nv = reflect.ValueOf(v)
+
 	// method
 	m := nv.MethodByName(ss[1])
-	// if reflect.DeepEqual(m, reflect.Value{}) {
+
 	if m.Kind() == reflect.Invalid {
 		return reflect.Value{}, false
 	}


### PR DESCRIPTION
We changed the signature to `func(...interface{}) (interface{}, error)` some time ago, but sadly we had no test for this for `apply`. Now we do.
