### PR TITLE
tpl: Improve internal YouTube Shortcode

### DIFF
--- a/docs/content/en/content-management/shortcodes.md
+++ b/docs/content/en/content-management/shortcodes.md
@@ -337,7 +337,7 @@ Using the preceding `tweet` example, the following simulates the displayed exper
 
 ### `vimeo`
 
-Adding a video from [Vimeo][] is equivalent to the [YouTube Input shortcode][].
+Adding a video from [Vimeo][] is similar to the [YouTube Input shortcode][].
 
 ```
 https://vimeo.com/channels/staffpicks/146022717
@@ -375,7 +375,7 @@ Using the preceding `vimeo` example, the following simulates the displayed exper
 
 ### `youtube`
 
-The `youtube` shortcode embeds a responsive video player for [YouTube videos][]. Only the ID of the video is required, e.g.:
+The `youtube` shortcode can be used to embed a responsive video player, or add a linked thumbnail for [YouTube videos][]. Only the ID of the video is required, e.g.:
 
 ```
 https://www.youtube.com/watch?v=w7Ft2ymGmfc
@@ -390,33 +390,92 @@ Copy the YouTube video ID that follows `v=` in the video's URL and pass it to th
 {{</* youtube w7Ft2ymGmfc */>}}
 {{< /code >}}
 
-Furthermore, you can automatically start playback of the embedded video by setting the `autoplay` parameter to `true`. Remember that you can't mix named and unnamed parameters, so you'll need to assign the yet unnamed video id to the parameter `id`:
+#### Example `youtube` Display
+
+The following simulates the displayed experience for visitors to your website. Naturally, the final display will be contingent on your stylesheets and surrounding markup. The video is also included in the [Quick Start of the Hugo documentation][quickstart].
+
+{{< youtube w7Ft2ymGmfc >}}
+
+#### Additional Playback Options
+
+You can automatically start playback of the embedded video by setting the `autoplay` parameter to `true`. Remember that you can't mix named and unnamed parameters, so you'll need to assign the yet unnamed video id to the parameter `id`:
 
 
 {{< code file="example-youtube-input-with-autoplay.md" >}}
 {{</* youtube id="w7Ft2ymGmfc" autoplay="true" */>}}
 {{< /code >}}
 
-For [accessibility reasons](https://dequeuniversity.com/tips/provide-iframe-titles), it's best to provide a title for your YouTube video.  You  can do this using the shortcode by providing a `title` parameter. If no title is provided, a default of "YouTube Video" will be used.
+For [accessibility reasons](https://dequeuniversity.com/tips/provide-iframe-titles), it's best to provide a title for your YouTube video.  You  can do this using the shortcode by providing a `title` parameter. If no title is provided, a default value of "YouTube Video" will be used.
 
 {{< code file="example-youtube-input-with-title.md" >}}
 {{</* youtube id="w7Ft2ymGmfc" title="A New Hugo Site in Under Two Minutes" */>}}
 {{< /code >}}
 
+You're also able to set the start and end timestamps using the `start` and `end` parameters. Values should be in seconds from the start of the video. In the following example, the embedded video will play from the 90-second mark until the 6-minute mark:
+
+{{< code file="example-youtube-input-with-start-end.md" >}}
+{{</* youtube id="w7Ft2ymGmfc" start=90 end=360 */>}}
+{{< /code >}}
 
 #### Example `youtube` Output
 
 Using the preceding `youtube` example, the following HTML will be added to your rendered website's markup:
 
 {{< code file="example-youtube-output.html" >}}
-{{< youtube id="w7Ft2ymGmfc" autoplay="true" >}}
+{{< youtube id="w7Ft2ymGmfc" start=90 end=360 >}}
 {{< /code >}}
 
-#### Example `youtube` Display
+The `youtube` shortcode can also use the following named parameters:
 
-Using the preceding `youtube` example (without `autoplay="true"`), the following simulates the displayed experience for visitors to your website. Naturally, the final display will be contingent on your stylesheets and surrounding markup. The video is also include in the [Quick Start of the Hugo documentation][quickstart].
+linkthumbnail
+: When set to `"true"`, the video will be embeded as a thumbnail linked to the YouTube video, instead of embedding a responsive video player. In this case, all other parameters are ignored.
 
-{{< youtube w7Ft2ymGmfc >}}
+loop
+: When set to `"true"`, If the player is loading a single video, it will play the video again and again. If the player is loading a playlist, it will play the entire playlist and then start again at the first video.
+
+controls
+: Set to `"false"` to not display the player controls in the video player.
+
+disablekb
+: Setting the parameter's value to `"true"` causes the player to not respond to keyboard controls.
+
+language
+: Set the player's interface language. The interface language is used for tooltips in the player and also affects the default caption track. The parameter's value is an [ISO 639-1 two-letter language code](http://www.loc.gov/standards/iso639-2/php/code_list.php) or a fully specified locale, such as `fr` or `fr-ca`.
+
+playlist
+: a comma-separated list of video IDs to play.
+
+listtype
+: When the parameter’s value is set to `"playlist"` then, in conjunction with the `list` parameter, identifies the content that will load in the player.
+
+list
+: If the `listType` parameter's value is `"playlist"`, then the list parameter value specifies a YouTube playlist ID. Make sure the parameter value begins with the letter PL.
+
+enablejsapi
+: Setting this parameter to `"true"` enables a player to be controlled via API calls. The API could be either the [IFrame Player API](https://developers.google.com/youtube/iframe_api_reference) or the [JavaScript Player API](https://developers.google.com/youtube/js_api_reference).
+
+fs
+: Setting this parameter to `"false"` prevents the fullscreen button from displaying in the player
+
+novideoannotations
+: Setting novideoannotations to `"true"` causes video annotations to not be shown by default.
+
+modestbranding
+: Set the parameter value to `"true"` to prevent the YouTube logo from displaying in the control bar.
+
+ccloadpolicy
+: Setting the parameter's value to `"true"` causes closed captions to be shown by default, even if the user has turned captions off. The default behavior is based on user preference.
+
+color
+: This parameter specifies the color that will be used in the player's video progress bar to highlight the amount of the video that the viewer has already seen. Valid parameter values are `"red"` and `"white"`, and, by default, the player uses the color red in the video progress bar.
+
+Note: Setting the color parameter to white will disable the modestbranding option.
+
+playsinline
+: This parameter controls whether videos play inline or fullscreen on iOS. Setting the value to `"true"` Results in inline playback for mobile browsers and for WebViews created with the [allowsInlineMediaPlayback](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/1614793-allowsinlinemediaplayback?language=objc) property set to YES.
+
+notwidescreen
+: Setting the parameter's value to `"true"` causes the player to display in 4:3 ratio, instead of widescreen ratio.
 
 ## Privacy Config
 

--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -190,6 +190,31 @@ func TestShortcodeYoutube(t *testing.T) {
 			`{{< youtube id="w7Ft2ymGmfc" title="A New Hugo Site in Under Two Minutes" >}}`,
 			"(?s)\n<div style=\".*?\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\" style=\".*?\" allowfullscreen title=\"A New Hugo Site in Under Two Minutes\">.*?</iframe>.*?</div>",
 		},
+		// set start (using named params, as string)
+		{
+			`{{< youtube id="w7Ft2ymGmfc" start="5" >}}`,
+			"(?s)\n<div style=\".*?\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?start=5\" style=\".*?\" allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>\n",
+		},
+		// set class, start and end (using named params, start and end are ints)
+		{
+			`{{< youtube id="w7Ft2ymGmfc" class="video" start=5 end=10 >}}`,
+			"(?s)\n<div class=\"video\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?start=5&amp;end=10\".*?allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>",
+		},
+		// set class, start, autoplay, and end (using named params)
+		{
+			`{{< youtube id="w7Ft2ymGmfc" class="video" start=5 end=10 autoplay="true" >}}`,
+			"(?s)\n<div class=\"video\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?autoplay=1&amp;start=5&amp;end=10\".*?allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>",
+		},
+		// set linkthumbnail
+		{
+			`{{< youtube id="w7Ft2ymGmfc" linkthumbnail="true" >}}`,
+			"(?s)\n<div class=\".*?s_video_simple.*?\">.*?<img src=\"https://img.youtube.com/vi/w7Ft2ymGmfc/maxresdefault.jpg\" srcset=\"https://img.youtube.com/vi/w7Ft2ymGmfc/hqdefault.jpg 1x https://img.youtube.com/vi/w7Ft2ymGmfc/maxresdefault.jpg 2x\" alt=\"YouTube Video\"/>.*?</div>",
+		},
+		// set all additional parameters, including notwidescreen
+		{
+			`{{< youtube id="w7Ft2ymGmfc" start=5 end=10 loop="true" controls="false" disablekb="true" language="fr-ca" playlist="ZICu88Gxl0c,eNV4eSMztmg,74NGImio7oQ" listtype="playlist" list="PLOU2XLYxmsIKQPrmzi3ZXep2rlMnmQwjQ" enablejsapi="true" fs="false" novideoannotations="true" modestbranding="true" ccloadpolicy="true" color="white" playsinline="true" notwidescreen="true">}}`,
+			"(?s)\n<div style=\".*?padding-bottom: 75%;.*?\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?start=5&amp;end=10&amp;cc_load_policy=1&amp;color=white&amp;controls=0&amp;disablekb=1&amp;enablejsapi=1&amp;fs=0&amp;hl=fr-ca&amp;iv_load_policy=3&amp;listType=playlist&amp;list=PLOU2XLYxmsIKQPrmzi3ZXep2rlMnmQwjQ&amp;loop=1&amp;modestbranding=1&amp;playlist=ZICu88Gxl0c%2CeNV4eSMztmg%2C74NGImio7oQ&amp;playsinline=1\".*?style=\".*?\".*?allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>",
+		},
 	} {
 		var (
 			cfg, fs = newTestCfg()

--- a/resources/page/page_marshaljson.autogen.go
+++ b/resources/page/page_marshaljson.autogen.go
@@ -17,9 +17,6 @@ package page
 
 import (
 	"encoding/json"
-	"html/template"
-	"time"
-
 	"github.com/bep/gitmap"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/config"
@@ -29,6 +26,8 @@ import (
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/navigation"
 	"github.com/gohugoio/hugo/source"
+	"html/template"
+	"time"
 )
 
 func MarshalPageToJSON(p Page) ([]byte, error) {
@@ -69,7 +68,8 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 	linkTitle := p.LinkTitle()
 	isNode := p.IsNode()
 	isPage := p.IsPage()
-	path := p.Pathc()
+	path := p.Path()
+	pathc := p.Pathc()
 	slug := p.Slug()
 	lang := p.Lang()
 	isSection := p.IsSection()
@@ -127,6 +127,7 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 		IsNode                   bool
 		IsPage                   bool
 		Path                     string
+		Pathc                    string
 		Slug                     string
 		Lang                     string
 		IsSection                bool
@@ -183,6 +184,7 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 		IsNode:                   isNode,
 		IsPage:                   isPage,
 		Path:                     path,
+		Pathc:                    pathc,
 		Slug:                     slug,
 		Lang:                     lang,
 		IsSection:                isSection,

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -728,11 +728,85 @@ if (!doNotTrack) {
 {{- $id := .Get "id" | default (.Get 0) -}}
 {{- $class := .Get "class" | default (.Get 1) -}}
 {{- $title := .Get "title" | default "YouTube Video" }}
-<div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
-  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
-</div>
+
+{{- if eq (.Get "linkthumbnail") "true" -}}
+{{ template "_internal/shortcodes/youtube_linkthumbnail.html" . }}
+{{- else -}}
+
+{{- $padding_bottom := "56.25%" -}}{{- if eq (.Get "notwidescreen") "true"}}{{$padding_bottom = "75%"}}{{end -}}
+
+{{- $params := slice -}}
+{{- if eq (.Get "autoplay") "true" -}}
+    {{- $params = $params | append (querify "autoplay" 1) -}}
+{{- end -}}
+{{- with (.Get "start") -}}
+    {{- $params = $params | append (querify "start" (. | int)) -}}
+{{- end -}}
+{{- with (.Get "end") -}}
+    {{- $params = $params | append (querify "end" (. | int)) -}}
+{{- end }}
+{{- if eq (.Get "ccloadpolicy") "true" -}}
+    {{- $params = $params | append (querify "cc_load_policy" 1) -}}
+{{- end }}
+{{- if eq (.Get "color") "white" -}}
+    {{- $params = $params | append (querify "color" "white") -}}
+{{- end }}
+{{- if eq (.Get "controls") "false" -}}
+    {{- $params = $params | append (querify "controls" 0) -}}
+{{- end }}
+{{- if eq (.Get "disablekb") "true" -}}
+    {{- $params = $params | append (querify "disablekb" 1) -}}
+{{- end }}
+{{- if eq (.Get "enablejsapi") "true" -}}
+    {{- $params = $params | append (querify "enablejsapi" 1) -}}
+{{- end }}
+{{- if eq (.Get "fs") "false" -}}
+    {{- $params = $params | append (querify "fs" 0) -}}
+{{- end }}
+{{- with (.Get "language") -}}
+    {{- $params = $params | append (querify "hl" .) -}}
+{{- end }}
+{{- if eq (.Get "novideoannotations") "true" -}}
+    {{- $params = $params | append (querify "iv_load_policy" 3) -}}
+{{- end }}
+{{- if and (eq (.Get "listtype") "playlist") (.Get "list") -}}
+    {{- $params = $params | append (querify "listType" "playlist") | append (querify "list" (.Get "list")) -}}
+{{- end }}
+{{- if eq (.Get "loop") "true" -}}
+    {{- $params = $params | append (querify "loop" 1) -}}
+{{- end }}
+{{- if eq (.Get "modestbranding") "true" -}}
+    {{- $params = $params | append (querify "modestbranding" 1) -}}
+{{- end }}
+{{- if (.Get "playlist") -}}
+    {{- $params = $params | append (querify "playlist" (.Get "playlist")) -}}
+{{- end }}
+{{- if eq (.Get "playsinline") "true" -}}
+    {{- $params = $params | append (querify "playsinline" 1) -}}
+{{- end }}
+
+<div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: {{$padding_bottom}}; height: 0; overflow: hidden;"{{ end }}>
+    <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with $params }}?{{ delimit $params "&" | safeURL }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
+  </div>
 {{ end -}}
-`},
+{{ end -}}`},
+	{`shortcodes/youtube_linkthumbnail.html`, `{{- $id := .Get "id" | default (.Get 0) -}}
+{{- $class := .Get "class" | default (.Get 1) -}}
+{{- $title := .Get "title" | default "YouTube Video" }}
+{{ $hasClass := $class }}
+{{ $class := $class | default "__h_video" }}
+{{ if not $hasClass }}
+{{/* If class is set, assume the user wants to provide his own styles. */}}
+{{ template "__h_simple_css" $ }}
+{{ end }}
+{{ $secondClass := "s_video_simple" }}
+<div class="{{ $secondClass }} {{ $class }}">
+    {{ $tb := printf "https://img.youtube.com/vi/%s/" $id }}
+    <a href="https://youtube.com/watch?v={{ $id | safeHTMLAttr }} " target="_blank">
+         <img src="{{ printf "%smaxresdefault.jpg" $tb}}" srcset="{{ printf "%shqdefault.jpg" $tb }} 1x {{ printf "%smaxresdefault.jpg" $tb}} 2x" alt="{{ $title }}"/>
+         <div class="play">{{ template "__h_simple_icon_play" $ }}</div>
+    </a>
+</div>`},
 	{`twitter_cards.html`, `{{- with $.Params.images -}}
 <meta name="twitter:card" content="summary_large_image"/>
 <meta name="twitter:image" content="{{ index . 0 | absURL }}"/>

--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
@@ -4,7 +4,65 @@
 {{- $id := .Get "id" | default (.Get 0) -}}
 {{- $class := .Get "class" | default (.Get 1) -}}
 {{- $title := .Get "title" | default "YouTube Video" }}
-<div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
-  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
-</div>
+
+{{- if eq (.Get "linkthumbnail") "true" -}}
+{{ template "_internal/shortcodes/youtube_linkthumbnail.html" . }}
+{{- else -}}
+
+{{- $padding_bottom := "56.25%" -}}{{- if eq (.Get "notwidescreen") "true"}}{{$padding_bottom = "75%"}}{{end -}}
+
+{{- $params := slice -}}
+{{- if eq (.Get "autoplay") "true" -}}
+    {{- $params = $params | append (querify "autoplay" 1) -}}
+{{- end -}}
+{{- with (.Get "start") -}}
+    {{- $params = $params | append (querify "start" (. | int)) -}}
+{{- end -}}
+{{- with (.Get "end") -}}
+    {{- $params = $params | append (querify "end" (. | int)) -}}
+{{- end }}
+{{- if eq (.Get "ccloadpolicy") "true" -}}
+    {{- $params = $params | append (querify "cc_load_policy" 1) -}}
+{{- end }}
+{{- if eq (.Get "color") "white" -}}
+    {{- $params = $params | append (querify "color" "white") -}}
+{{- end }}
+{{- if eq (.Get "controls") "false" -}}
+    {{- $params = $params | append (querify "controls" 0) -}}
+{{- end }}
+{{- if eq (.Get "disablekb") "true" -}}
+    {{- $params = $params | append (querify "disablekb" 1) -}}
+{{- end }}
+{{- if eq (.Get "enablejsapi") "true" -}}
+    {{- $params = $params | append (querify "enablejsapi" 1) -}}
+{{- end }}
+{{- if eq (.Get "fs") "false" -}}
+    {{- $params = $params | append (querify "fs" 0) -}}
+{{- end }}
+{{- with (.Get "language") -}}
+    {{- $params = $params | append (querify "hl" .) -}}
+{{- end }}
+{{- if eq (.Get "novideoannotations") "true" -}}
+    {{- $params = $params | append (querify "iv_load_policy" 3) -}}
+{{- end }}
+{{- if and (eq (.Get "listtype") "playlist") (.Get "list") -}}
+    {{- $params = $params | append (querify "listType" "playlist") | append (querify "list" (.Get "list")) -}}
+{{- end }}
+{{- if eq (.Get "loop") "true" -}}
+    {{- $params = $params | append (querify "loop" 1) -}}
+{{- end }}
+{{- if eq (.Get "modestbranding") "true" -}}
+    {{- $params = $params | append (querify "modestbranding" 1) -}}
+{{- end }}
+{{- if (.Get "playlist") -}}
+    {{- $params = $params | append (querify "playlist" (.Get "playlist")) -}}
+{{- end }}
+{{- if eq (.Get "playsinline") "true" -}}
+    {{- $params = $params | append (querify "playsinline" 1) -}}
+{{- end }}
+
+<div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: {{$padding_bottom}}; height: 0; overflow: hidden;"{{ end }}>
+    <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with $params }}?{{ delimit $params "&" | safeURL }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
+  </div>
+{{ end -}}
 {{ end -}}

--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube_linkthumbnail.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube_linkthumbnail.html
@@ -1,0 +1,17 @@
+{{- $id := .Get "id" | default (.Get 0) -}}
+{{- $class := .Get "class" | default (.Get 1) -}}
+{{- $title := .Get "title" | default "YouTube Video" }}
+{{ $hasClass := $class }}
+{{ $class := $class | default "__h_video" }}
+{{ if not $hasClass }}
+{{/* If class is set, assume the user wants to provide his own styles. */}}
+{{ template "__h_simple_css" $ }}
+{{ end }}
+{{ $secondClass := "s_video_simple" }}
+<div class="{{ $secondClass }} {{ $class }}">
+    {{ $tb := printf "https://img.youtube.com/vi/%s/" $id }}
+    <a href="https://youtube.com/watch?v={{ $id | safeHTMLAttr }} " target="_blank">
+         <img src="{{ printf "%smaxresdefault.jpg" $tb}}" srcset="{{ printf "%shqdefault.jpg" $tb }} 1x {{ printf "%smaxresdefault.jpg" $tb}} 2x" alt="{{ $title }}"/>
+         <div class="play">{{ template "__h_simple_icon_play" $ }}</div>
+    </a>
+</div>


### PR DESCRIPTION
Added support for displaying Embedded YouTube player in 4:3 ratio, in addition to the default widescreen ratio. Also added support for all the latest parameters supported by embedded YouTube player including start/end time, looping, language, playlist, etc. Also added support for for diaplying a linked thumbnail to the YouTube video, instead of the embedded plyaer using the "linkthumbnail" parameter.

Fixes #3694 