### PR TITLE
Append scheme to the printed server address url

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -519,7 +519,7 @@ func (c *commandeer) serve(s *serverCmd) error {
 			mu.HandleFunc(u.Path+"/livereload.js", livereload.ServeJS)
 			mu.HandleFunc(u.Path+"/livereload", livereload.Handler)
 		}
-		jww.FEEDBACK.Printf("Web Server is available at %s (bind address %s)\n", serverURL, s.serverInterface)
+		jww.FEEDBACK.Printf("Web Server is available at http:%s (bind address %s)\n", serverURL, s.serverInterface)
 		go func() {
 			err = http.ListenAndServe(endpoint, mu)
 			if err != nil {


### PR DESCRIPTION
In essence, it adds http: to the printed url, when hugo is serving files
It saves the user a keystroke, since most modern terminals support links in the shell.
One can easily just ctrl+click to open the browser for that particular url.