### PR TITLE
Finally remove deprecated Page methods

### DIFF
--- a/hugolib/page__common.go
+++ b/hugolib/page__common.go
@@ -78,7 +78,6 @@ type pageCommon struct {
 	page.RefProvider
 	page.ShortcodeInfoProvider
 	page.SitesProvider
-	page.DeprecatedWarningPageMethods
 	page.TranslationsProvider
 	page.TreeProvider
 	resource.LanguageProvider

--- a/hugolib/page__new.go
+++ b/hugolib/page__new.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gohugoio/hugo/common/hugo"
 
 	"github.com/gohugoio/hugo/common/maps"
-	"github.com/gohugoio/hugo/source"
 
 	"github.com/gohugoio/hugo/output"
 
@@ -65,15 +64,6 @@ func newPageBase(metaProvider *pageMeta) (*pageState, error) {
 
 	siteAdapter := pageSiteAdapter{s: s, p: ps}
 
-	deprecatedWarningPage := struct {
-		source.FileWithoutOverlap
-		page.DeprecatedWarningPageMethods1
-	}{
-		FileWithoutOverlap:            metaProvider.File(),
-		DeprecatedWarningPageMethods1: &pageDeprecatedWarning{p: ps},
-	}
-
-	ps.DeprecatedWarningPageMethods = page.NewDeprecatedWarningPage(deprecatedWarningPage)
 	ps.pageMenus = &pageMenus{p: ps}
 	ps.PageMenusProvider = ps.pageMenus
 	ps.GetPageProvider = siteAdapter

--- a/resources/page/page.go
+++ b/resources/page/page.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/tpl"
 
-	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/compare"
 	"github.com/gohugoio/hugo/hugofs/files"
@@ -379,18 +378,7 @@ type TreeProvider interface {
 // DeprecatedWarningPageMethods lists deprecated Page methods that will trigger
 // a WARNING if invoked.
 // This was added in Hugo 0.55.
-type DeprecatedWarningPageMethods interface {
-	source.FileWithoutOverlap
-	DeprecatedWarningPageMethods1
-}
-
-type DeprecatedWarningPageMethods1 interface {
-	IsDraft() bool
-	Hugo() hugo.Info
-	LanguagePrefix() string
-	GetParam(key string) interface{}
-	RSSLink() template.URL
-	URL() string
+type DeprecatedWarningPageMethods interface { // This was emptied in Hugo 0.93.0.
 }
 
 // Move here to trigger ERROR instead of WARNING.

--- a/resources/page/page_marshaljson.autogen.go
+++ b/resources/page/page_marshaljson.autogen.go
@@ -17,9 +17,6 @@ package page
 
 import (
 	"encoding/json"
-	"html/template"
-	"time"
-
 	"github.com/bep/gitmap"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/config"
@@ -29,6 +26,8 @@ import (
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/navigation"
 	"github.com/gohugoio/hugo/source"
+	"html/template"
+	"time"
 )
 
 func MarshalPageToJSON(p Page) ([]byte, error) {
@@ -69,7 +68,8 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 	linkTitle := p.LinkTitle()
 	isNode := p.IsNode()
 	isPage := p.IsPage()
-	path := p.Pathc()
+	path := p.Path()
+	pathc := p.Pathc()
 	slug := p.Slug()
 	lang := p.Lang()
 	isSection := p.IsSection()
@@ -127,6 +127,7 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 		IsNode                   bool
 		IsPage                   bool
 		Path                     string
+		Pathc                    string
 		Slug                     string
 		Lang                     string
 		IsSection                bool
@@ -183,6 +184,7 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 		IsNode:                   isNode,
 		IsPage:                   isPage,
 		Path:                     path,
+		Pathc:                    pathc,
 		Slug:                     slug,
 		Lang:                     lang,
 		IsSection:                isSection,

--- a/resources/page/page_wrappers.autogen.go
+++ b/resources/page/page_wrappers.autogen.go
@@ -15,13 +15,6 @@
 
 package page
 
-import (
-	"github.com/gohugoio/hugo/common/hugo"
-	"github.com/gohugoio/hugo/helpers"
-	"github.com/gohugoio/hugo/hugofs"
-	"html/template"
-)
-
 // NewDeprecatedWarningPage adds deprecation warnings to the given implementation.
 func NewDeprecatedWarningPage(p DeprecatedWarningPageMethods) DeprecatedWarningPageMethods {
 	return &pageDeprecated{p: p}
@@ -29,69 +22,4 @@ func NewDeprecatedWarningPage(p DeprecatedWarningPageMethods) DeprecatedWarningP
 
 type pageDeprecated struct {
 	p DeprecatedWarningPageMethods
-}
-
-func (p *pageDeprecated) Filename() string {
-	helpers.Deprecated("Page.Filename", "Use .File.Filename", true)
-	return p.p.Filename()
-}
-func (p *pageDeprecated) Dir() string {
-	helpers.Deprecated("Page.Dir", "Use .File.Dir", true)
-	return p.p.Dir()
-}
-func (p *pageDeprecated) IsDraft() bool {
-	helpers.Deprecated("Page.IsDraft", "Use .Draft.", true)
-	return p.p.IsDraft()
-}
-func (p *pageDeprecated) Extension() string {
-	helpers.Deprecated("Page.Extension", "Use .File.Extension", true)
-	return p.p.Extension()
-}
-func (p *pageDeprecated) Hugo() hugo.Info {
-	helpers.Deprecated("Page.Hugo", "Use the global hugo function.", true)
-	return p.p.Hugo()
-}
-func (p *pageDeprecated) Ext() string {
-	helpers.Deprecated("Page.Ext", "Use .File.Ext", true)
-	return p.p.Ext()
-}
-func (p *pageDeprecated) LanguagePrefix() string {
-	helpers.Deprecated("Page.LanguagePrefix", "Use .Site.LanguagePrefix.", true)
-	return p.p.LanguagePrefix()
-}
-func (p *pageDeprecated) GetParam(arg0 string) interface{} {
-	helpers.Deprecated("Page.GetParam", "Use .Param or .Params.myParam.", true)
-	return p.p.GetParam(arg0)
-}
-func (p *pageDeprecated) LogicalName() string {
-	helpers.Deprecated("Page.LogicalName", "Use .File.LogicalName", true)
-	return p.p.LogicalName()
-}
-func (p *pageDeprecated) BaseFileName() string {
-	helpers.Deprecated("Page.BaseFileName", "Use .File.BaseFileName", true)
-	return p.p.BaseFileName()
-}
-func (p *pageDeprecated) RSSLink() template.URL {
-	helpers.Deprecated("Page.RSSLink", "Use the Output Format's link, e.g. something like:\n    {{ with .OutputFormats.Get \"RSS\" }}{{ .RelPermalink }}{{ end }}", true)
-	return p.p.RSSLink()
-}
-func (p *pageDeprecated) TranslationBaseName() string {
-	helpers.Deprecated("Page.TranslationBaseName", "Use .File.TranslationBaseName", true)
-	return p.p.TranslationBaseName()
-}
-func (p *pageDeprecated) URL() string {
-	helpers.Deprecated("Page.URL", "Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url", true)
-	return p.p.URL()
-}
-func (p *pageDeprecated) ContentBaseName() string {
-	helpers.Deprecated("Page.ContentBaseName", "Use .File.ContentBaseName", true)
-	return p.p.ContentBaseName()
-}
-func (p *pageDeprecated) UniqueID() string {
-	helpers.Deprecated("Page.UniqueID", "Use .File.UniqueID", true)
-	return p.p.UniqueID()
-}
-func (p *pageDeprecated) FileInfo() hugofs.FileMetaInfo {
-	helpers.Deprecated("Page.FileInfo", "Use .File.FileInfo", true)
-	return p.p.FileInfo()
 }


### PR DESCRIPTION
They have been deprecated for a very long time, first with a warning, then with an ERROR. Now they are removed.

Closes #4117
