### PR TITLE
Fix erroneous warning with .Page.RenderString on a page without a backing file

### DIFF
--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/gohugoio/hugo/common/loggers"
 )
 
 func TestRenderHookEditNestedPartial(t *testing.T) {
@@ -483,4 +484,16 @@ func TestRenderStringOnListPage(t *testing.T) {
 	} {
 		b.AssertFileContent("public/"+filename, `<strong>Hello</strong>`)
 	}
+}
+
+// Issue 9433
+func TestRenderStringOnPageNotBackedByAFile(t *testing.T) {
+	t.Parallel()
+	logger := loggers.NewWarningLogger()
+	b := newTestSitesBuilder(t).WithLogger(logger).WithConfigFile("toml", `
+disableKinds = ["page", "section", "taxonomy", "term"]	
+`)
+	b.WithTemplates("index.html", `{{ .RenderString "**Hello**" }}`).WithContent("p1.md", "")
+	b.BuildE(BuildCfg{})
+	b.Assert(int(logger.LogCounters().WarnCounter.Count()), qt.Equals, 0)
 }

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -768,16 +768,20 @@ func (p *pageMeta) newContentConverter(ps *pageState, markup string, renderingCo
 
 	var id string
 	var filename string
+	var path string
 	if !p.f.IsZero() {
 		id = p.f.UniqueID()
 		filename = p.f.Filename()
+		path = p.f.Path()
+	} else {
+		path = p.Pathc()
 	}
 
 	cpp, err := cp.New(
 		converter.DocumentContext{
 			Document:        newPageForRenderHook(ps),
 			DocumentID:      id,
-			DocumentName:    p.File().Path(),
+			DocumentName:    path,
 			Filename:        filename,
 			ConfigOverrides: renderingConfigOverrides,
 		},


### PR DESCRIPTION
Fixes #9433
