### PR TITLE
Improve readiness waiting in server tests

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -46,7 +46,7 @@ import (
 
 type serverCmd struct {
 	// Can be used to stop the server. Useful in tests
-	stop <-chan bool
+	stop <-chan struct{}
 
 	// Sent to when the server is ready for connections. Used for testing
 	ready chan struct{}
@@ -74,7 +74,7 @@ func (b *commandsBuilder) newServerCmd() *serverCmd {
 // newServerCmdSignaled takes a channel used to stop the server and returns
 // data required to run the hugo server command. Also returns a channel that
 // the command sends to when the server is ready.
-func (b *commandsBuilder) newServerCmdSignaled(stop <-chan bool) *serverCmd {
+func (b *commandsBuilder) newServerCmdSignaled(stop <-chan struct{}) *serverCmd {
 	cc := &serverCmd{
 		stop: stop,
 		// Buffered channel so the server can keep running without blocking

--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -58,10 +58,14 @@ func TestServer(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 	}()
 
-	// There is no way to know exactly when the server is ready for connections.
-	// We could improve by something like https://golang.org/pkg/net/http/httptest/#Server
-	// But for now, let us sleep and pray!
-	time.Sleep(2 * time.Second)
+	// Wait for the server to become ready or fail on timeout
+	k := time.NewTimer(5 * time.Second)
+	select {
+	case <-k.C:
+		t.Error("hugo server took too long to respond")
+	case <-scmd.ready:
+		break
+	}
 
 	resp, err := http.Get("http://localhost:1331/")
 	c.Assert(err, qt.IsNil)

--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -45,7 +45,7 @@ func TestServer(t *testing.T) {
 		os.RemoveAll(dir)
 	}()
 
-	stop := make(chan bool)
+	stop := make(chan struct{})
 
 	b := newCommandsBuilder()
 	scmd := b.newServerCmdSignaled(stop)
@@ -76,7 +76,7 @@ func TestServer(t *testing.T) {
 	c.Assert(homeContent, qt.Contains, "Environment: development")
 
 	// Stop the server.
-	stop <- true
+	stop <- struct{}{}
 }
 
 func TestFixURL(t *testing.T) {


### PR DESCRIPTION
commands.TestServer waits for the Hugo server to be ready by calling:

```go
time.Sleep(2 * time.Second)

```

While this approach prevents us from needing to modify the server
command for tests, it also means that any new hugo server test would
add another two seconds to the test suite. The server is also not
guaranteed to be ready after two seconds.

commands.TestServer is currently the only test that runs the hugo
server command and waits for the server to be ready, but we will
eventually need more of these tests in order to address bugs when
running the hugo server command.

This change adds a "ready" channel to commands.serverCmd. The server
command sends to the channel when the server is ready for connections.
Tests can then block on receiving from the channel instead of sleeping
for a fixed interval.

This speeds up TestServer. Here are the results of running the test
with a clean test cache:

Sleeping two seconds:

```
$ go test github.com/gohugoio/hugo/commands -run TestServer
ok      github.com/gohugoio/hugo/commands       2.618s
```

Using a ready channel:

```
$ go test github.com/gohugoio/hugo/commands -run TestServer
ok      github.com/gohugoio/hugo/commands       0.556s
```

Fixes #9421