### PR TITLE
Exclude event attributes from markdown render hook

### DIFF
--- a/markup/goldmark/render_hooks.go
+++ b/markup/goldmark/render_hooks.go
@@ -57,6 +57,9 @@ func (a *attributesHolder) Attributes() map[string]string {
 	a.attributesInit.Do(func() {
 		a.attributes = make(map[string]string)
 		for _, attr := range a.astAttributes {
+			if strings.HasPrefix(string(attr.Name), "on") {
+				continue
+			}
 			a.attributes[string(attr.Name)] = string(util.EscapeHTML(attr.Value.([]byte)))
 		}
 	})


### PR DESCRIPTION
Fixes #9511