### PR TITLE
tpl/partials: Fix recently introduced deadlock in partials cache

### DIFF
--- a/tpl/collections/apply_test.go
+++ b/tpl/collections/apply_test.go
@@ -14,6 +14,7 @@
 package collections
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"reflect"
@@ -48,6 +49,10 @@ func (templateFinder) LookupLayout(d output.LayoutDescriptor, f output.Format) (
 }
 
 func (templateFinder) Execute(t tpl.Template, wr io.Writer, data interface{}) error {
+	return nil
+}
+
+func (templateFinder) ExecuteWithContext(ctx context.Context, t tpl.Template, wr io.Writer, data interface{}) error {
 	return nil
 }
 

--- a/tpl/partials/integration_test.go
+++ b/tpl/partials/integration_test.go
@@ -75,6 +75,34 @@ partialCached: foo
 `)
 }
 
+// Issue 9519
+func TestIncludeCachedRecursion(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- config.toml --
+baseURL = 'http://example.com/'
+-- layouts/index.html --
+{{ partials.IncludeCached "p1.html" . }}
+-- layouts/partials/p1.html --
+{{ partials.IncludeCached "p2.html" . }}
+-- layouts/partials/p2.html --
+P2
+
+  `
+
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+		},
+	).Build()
+
+	b.AssertFileContent("public/index.html", `
+P2
+`)
+}
+
 func TestIncludeCacheHints(t *testing.T) {
 	t.Parallel()
 

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -14,6 +14,7 @@
 package tpl
 
 import (
+	"context"
 	"io"
 	"reflect"
 	"regexp"
@@ -53,6 +54,7 @@ type UnusedTemplatesProvider interface {
 type TemplateHandler interface {
 	TemplateFinder
 	Execute(t Template, wr io.Writer, data interface{}) error
+	ExecuteWithContext(ctx context.Context, t Template, wr io.Writer, data interface{}) error
 	LookupLayout(d output.LayoutDescriptor, f output.Format) (Template, bool, error)
 	HasTemplate(name string) bool
 }
@@ -143,4 +145,21 @@ func extractBaseOf(err string) string {
 // TemplateFuncGetter allows to find a template func by name.
 type TemplateFuncGetter interface {
 	GetFunc(name string) (reflect.Value, bool)
+}
+
+// GetDataFromContext returns the template data context (usually .Page) from ctx if set.
+// NOte: This is not fully implemented yet.
+func GetDataFromContext(ctx context.Context) interface{} {
+	return ctx.Value(texttemplate.DataContextKey)
+}
+
+func GetHasLockFromContext(ctx context.Context) bool {
+	if v := ctx.Value(texttemplate.HasLockContextKey); v != nil {
+		return v.(bool)
+	}
+	return false
+}
+
+func SetHasLockInContext(ctx context.Context, hasLock bool) context.Context {
+	return context.WithValue(ctx, texttemplate.HasLockContextKey, hasLock)
 }

--- a/tpl/tplimpl/template.go
+++ b/tpl/tplimpl/template.go
@@ -15,6 +15,7 @@ package tplimpl
 
 import (
 	"bytes"
+	"context"
 	"embed"
 	"io"
 	"io/fs"
@@ -225,6 +226,10 @@ func (t templateExec) Clone(d *deps.Deps) *templateExec {
 }
 
 func (t *templateExec) Execute(templ tpl.Template, wr io.Writer, data interface{}) error {
+	return t.ExecuteWithContext(context.Background(), templ, wr, data)
+}
+
+func (t *templateExec) ExecuteWithContext(ctx context.Context, templ tpl.Template, wr io.Writer, data interface{}) error {
 	if rlocker, ok := templ.(types.RLocker); ok {
 		rlocker.RLock()
 		defer rlocker.RUnlock()
@@ -249,11 +254,10 @@ func (t *templateExec) Execute(templ tpl.Template, wr io.Writer, data interface{
 		}
 	}
 
-	execErr := t.executor.Execute(templ, wr, data)
+	execErr := t.executor.ExecuteWithContext(ctx, templ, wr, data)
 	if execErr != nil {
 		execErr = t.addFileContext(templ, execErr)
 	}
-
 	return execErr
 }
 

--- a/tpl/tplimpl/template_funcs_test.go
+++ b/tpl/tplimpl/template_funcs_test.go
@@ -15,6 +15,7 @@ package tplimpl
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -145,8 +146,7 @@ func TestPartialCached(t *testing.T) {
 	partial := `Now: {{ now.UnixNano }}`
 	name := "testing"
 
-	var data struct {
-	}
+	var data struct{}
 
 	v := newTestConfig()
 
@@ -168,19 +168,19 @@ func TestPartialCached(t *testing.T) {
 
 	ns := partials.New(de)
 
-	res1, err := ns.IncludeCached(name, &data)
+	res1, err := ns.IncludeCached(context.Background(), name, &data)
 	c.Assert(err, qt.IsNil)
 
 	for j := 0; j < 10; j++ {
 		time.Sleep(2 * time.Nanosecond)
-		res2, err := ns.IncludeCached(name, &data)
+		res2, err := ns.IncludeCached(context.Background(), name, &data)
 		c.Assert(err, qt.IsNil)
 
 		if !reflect.DeepEqual(res1, res2) {
 			t.Fatalf("cache mismatch")
 		}
 
-		res3, err := ns.IncludeCached(name, &data, fmt.Sprintf("variant%d", j))
+		res3, err := ns.IncludeCached(context.Background(), name, &data, fmt.Sprintf("variant%d", j))
 		c.Assert(err, qt.IsNil)
 
 		if reflect.DeepEqual(res1, res3) {
@@ -191,14 +191,14 @@ func TestPartialCached(t *testing.T) {
 
 func BenchmarkPartial(b *testing.B) {
 	doBenchmarkPartial(b, func(ns *partials.Namespace) error {
-		_, err := ns.Include("bench1")
+		_, err := ns.Include(context.Background(), "bench1")
 		return err
 	})
 }
 
 func BenchmarkPartialCached(b *testing.B) {
 	doBenchmarkPartial(b, func(ns *partials.Namespace) error {
-		_, err := ns.IncludeCached("bench1", nil)
+		_, err := ns.IncludeCached(context.Background(), "bench1", nil)
 		return err
 	})
 }


### PR DESCRIPTION
The change in lock logic for `partialCached` in  0927cf739fee9646c7fb917965799d9acf080922 was naive as it didn't consider cached partials calling other cached partials.

This changeset may look on the large side for this particular issue, but it pulls in part of a working branch, introducing `context.Context` in the template execution.

Note that the context is only partially implemented in this PR, but the upcoming use cases will, as one example, include having access to the top "dot" (e.g. `Page`) all the way down into partials and shortcodes etc.

The earlier benchmarks rerun against master:

```bash
name              old time/op    new time/op    delta
IncludeCached-10    13.6ms ± 2%    13.8ms ± 1%    ~     (p=0.343 n=4+4)

name              old alloc/op   new alloc/op   delta
IncludeCached-10    5.30MB ± 0%    5.35MB ± 0%  +0.96%  (p=0.029 n=4+4)

name              old allocs/op  new allocs/op  delta
IncludeCached-10     74.7k ± 0%     75.3k ± 0%  +0.77%  (p=0.029 n=4+4)
```

Fixes #9519
