### PR TITLE
modules: Add modules.Workspace config for Go 1.18

### DIFF
--- a/docs/content/en/hugo-modules/configuration.md
+++ b/docs/content/en/hugo-modules/configuration.md
@@ -23,6 +23,7 @@ proxy = "direct"
 noProxy = "none"
 private = "*.*"
 replacements = ""
+workspace = ""
 {{< /code-toggle >}}
 
 
@@ -40,6 +41,9 @@ noProxy
 
 private
 : Comma separated glob list matching paths that should be treated as private.
+
+workspace {{< new-in "0.83.0" >}}
+The workspace file to use. This enables Go workspace mode. Note that this can also be set via OS env, e.g. `export HUGO_MODULE_WORKSPACE=/my/hugo.work` This only works with Go 1.18+.
 
 replacements {{< new-in "0.77.0" >}}
 : A comma separated (or a slice) list of module path to directory replacement mapping, e.g. `github.com/bep/myprettytheme -> ../..,github.com/bep/shortcodes -> /some/path`. This is mostly useful for temporary locally development of a module, and then it makes sense to set it as an OS environment variable, e.g: `env HUGO_MODULE_REPLACEMENTS="github.com/bep/myprettytheme -> ../.."`. Any relative path is relate to [themesDir](https://gohugo.io/getting-started/configuration/#all-configuration-settings), and absolute paths are allowed.

--- a/modules/client.go
+++ b/modules/client.go
@@ -90,6 +90,7 @@ func NewClient(cfg ClientConfig) *Client {
 		"GOPRIVATE", mcfg.Private,
 		"GONOPROXY", mcfg.NoProxy,
 		"GOPATH", cfg.CacheDir,
+		"GOWORK", mcfg.Workspace, // Requires Go 1.18, see https://tip.golang.org/doc/go1.18
 		// GOCACHE was introduced in Go 1.15. This matches the location derived from GOPATH above.
 		"GOCACHE", filepath.Join(cfg.CacheDir, "pkg", "mod"),
 	)

--- a/modules/config.go
+++ b/modules/config.go
@@ -295,6 +295,12 @@ type Config struct {
 	NoProxy string
 	// Configures GOPRIVATE.
 	Private string
+
+	// Set the workspace file to use, e.g. hugo.work.
+	// Enables Go "Workspace" mode.
+	// Requires Go 1.18+
+	// See https://tip.golang.org/doc/go1.18
+	Workspace string
 }
 
 // hasModuleImport reports whether the project config have one or more


### PR DESCRIPTION
Sets `GOWORK` env var for Go 1.18.
