### PR TITLE
Change `disqus_config` to `window.disqus_config`

### DIFF
--- a/tpl/tplimpl/embedded/templates/disqus.html
+++ b/tpl/tplimpl/embedded/templates/disqus.html
@@ -2,7 +2,7 @@
 {{- if not $pc.Disable -}}
 {{ if .Site.DisqusShortname }}<div id="disqus_thread"></div>
 <script type="application/javascript">
-    var disqus_config = function () {
+    window.disqus_config = function () {
     {{with .Params.disqus_identifier }}this.page.identifier = '{{ . }}';{{end}}
     {{with .Params.disqus_title }}this.page.title = '{{ . }}';{{end}}
     {{with .Params.disqus_url }}this.page.url = '{{ . | html  }}';{{end}}


### PR DESCRIPTION
The variable `disqus_config` doesn't work if we use `hugo --minify` because Hugo changes the name.
We can use `window.disqus_config` instead, and it won't be renamed.

Reference: https://developer.mozilla.org/en-US/docs/Glossary/Global_object