### PR TITLE
Update error message about failed menus in config.toml

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1420,14 +1420,14 @@ func (s *Site) getMenusFromConfig() navigation.Menus {
 		for name, menu := range menus {
 			m, err := cast.ToSliceE(menu)
 			if err != nil {
-				s.Log.Errorf("unable to process menus in site config\n")
+				s.Log.Errorf("menus in site config contain errors\n")
 				s.Log.Errorln(err)
 			} else {
 				handleErr := func(err error) {
 					if err == nil {
 						return
 					}
-					s.Log.Errorf("unable to process menus in site config\n")
+					s.Log.Errorf("menus in site config contain errors\n")
 					s.Log.Errorln(err)
 				}
 


### PR DESCRIPTION
The string `unable to process menus in site config` made me think that menus aren't allowed to be in `config.toml` at all, period, but actually I was just missing the `[menu]` header (that is, I tried to put `[[menus.main]]` without `[menu]`). The language `menus in site config contain errors` seems more neutral, and won't lead users to believe they're **required** to make a separate menus file like I thought.

It might be better to have specific handling that detects the lack of `[menu]` and calls that out specifically, but at least this is a small change that will hopefully help people avoid the trouble that I had.