### PR TITLE
tpl/collections: Fix apply when function have Context as first arg

### DIFF
--- a/common/hreflect/helpers.go
+++ b/common/hreflect/helpers.go
@@ -17,6 +17,7 @@
 package hreflect
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/gohugoio/hugo/common/types"
@@ -124,3 +125,5 @@ func indirectInterface(v reflect.Value) reflect.Value {
 	}
 	return v.Elem()
 }
+
+var ContextInterface = reflect.TypeOf((*context.Context)(nil)).Elem()

--- a/tpl/collections/apply_test.go
+++ b/tpl/collections/apply_test.go
@@ -73,21 +73,23 @@ func TestApply(t *testing.T) {
 
 	strings := []interface{}{"a\n", "b\n"}
 
-	result, err := ns.Apply(strings, "print", "a", "b", "c")
+	ctx := context.Background()
+
+	result, err := ns.Apply(ctx, strings, "print", "a", "b", "c")
 	c.Assert(err, qt.IsNil)
 	c.Assert(result, qt.DeepEquals, []interface{}{"abc", "abc"})
 
-	_, err = ns.Apply(strings, "apply", ".")
+	_, err = ns.Apply(ctx, strings, "apply", ".")
 	c.Assert(err, qt.Not(qt.IsNil))
 
 	var nilErr *error
-	_, err = ns.Apply(nilErr, "chomp", ".")
+	_, err = ns.Apply(ctx, nilErr, "chomp", ".")
 	c.Assert(err, qt.Not(qt.IsNil))
 
-	_, err = ns.Apply(strings, "dobedobedo", ".")
+	_, err = ns.Apply(ctx, strings, "dobedobedo", ".")
 	c.Assert(err, qt.Not(qt.IsNil))
 
-	_, err = ns.Apply(strings, "foo.Chomp", "c\n")
+	_, err = ns.Apply(ctx, strings, "foo.Chomp", "c\n")
 	if err == nil {
 		t.Errorf("apply with unknown func should fail")
 	}

--- a/tpl/collections/integration_test.go
+++ b/tpl/collections/integration_test.go
@@ -1,0 +1,45 @@
+// Copyright 2022 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collections_test
+
+import (
+	"testing"
+
+	"github.com/gohugoio/hugo/hugolib"
+)
+
+// Issue 9585
+func TestApplyWithContext(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- config.toml --
+baseURL = 'http://example.com/'
+-- layouts/index.html --
+{{ apply (seq 3) "partial" "foo.html"}}
+-- layouts/partials/foo.html --
+{{ return "foo"}}
+  `
+
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+		},
+	).Build()
+
+	b.AssertFileContent("public/index.html", `
+	[foo foo foo]
+`)
+}


### PR DESCRIPTION
As introduced in `partial` and `partialCached` in Hugo 0.93.0.

Fixes #9585
