### PR TITLE
markup/goldmark: Escape image alt attribute

### DIFF
--- a/markup/goldmark/integration_test.go
+++ b/markup/goldmark/integration_test.go
@@ -394,3 +394,32 @@ FENCE
 		builders[i].Build()
 	}
 }
+
+// Issue 9594
+func TestQuotesInImgAltAttr(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- config.toml --
+[markup.goldmark.extensions]
+  typographer = false
+-- content/p1.md --
+---
+title: "p1"
+---
+!["a"](b.jpg)
+-- layouts/_default/single.html --
+{{ .Content }}
+`
+
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+		},
+	).Build()
+
+	b.AssertFileContent("public/p1/index.html", `
+		<img src="b.jpg" alt="&quot;a&quot;">
+	`)
+}

--- a/markup/goldmark/render_hooks.go
+++ b/markup/goldmark/render_hooks.go
@@ -175,7 +175,7 @@ func (r *hookedRenderer) renderImageDefault(w util.BufWriter, source []byte, nod
 		_, _ = w.Write(util.EscapeHTML(util.URLEscape(n.Destination, true)))
 	}
 	_, _ = w.WriteString(`" alt="`)
-	_, _ = w.Write(n.Text(source))
+	_, _ = w.Write(util.EscapeHTML(n.Text(source)))
 	_ = w.WriteByte('"')
 	if n.Title != nil {
 		_, _ = w.WriteString(` title="`)


### PR DESCRIPTION
Fixes #9594