### PR TITLE
tpl/os: Add filesystem option to ReadDir

### DIFF
--- a/docs/content/en/functions/readdir.md
+++ b/docs/content/en/functions/readdir.md
@@ -8,15 +8,34 @@ menu:
   docs:
     parent: "functions"
 keywords: [files]
-signature: ["os.ReadDir PATH", "readDir PATH"]
+signature: ["os.ReadDir PATH", "readDir PATH", "readDir PATH DIRECTORY"]
 workson: []
 hugoversion:
 relatedfuncs: ['os.FileExists','os.ReadFile','os.Stat']
 deprecated: false
 aliases: []
 ---
-The `os.ReadDir` function resolves the path relative to the root of your project directory. A leading path separator (`/`) is optional.
+The `os.ReadDir` function resolves the path relative to the root of your project directory unless the optional directory parameter is provided. A leading path separator (`/`) is optional.
 
+The following DIRECTORY values are supported
+* assets
+* archetypes
+* data
+* content
+* layouts
+* i18n
+
+For more information on the hugo directory structure see [Directory Structure]({{< relref "/getting-started/directory-structure" >}}).
+
+{{% note %}}
+Note that `os.ReadDir` is not recursive.
+{{% /note %}}
+
+Details of the `FileInfo` structure are available in the [Go documentation](https://pkg.go.dev/io/fs#FileInfo).
+
+For more information on using `readDir` and `readFile` in your templates, see [Local File Templates]({{< relref "/templates/files" >}}).
+
+## Example with path parameter
 With this directory structure:
 
 ```text
@@ -44,8 +63,39 @@ contact.md --> false
 news --> true
 ```
 
-Note that `os.ReadDir` is not recursive.
+## Example with path and directory parameters
 
-Details of the `FileInfo` structure are available in the [Go documentation](https://pkg.go.dev/io/fs#FileInfo).
+With this directory structure:
 
-For more information on using `readDir` and `readFile` in your templates, see [Local File Templates]({{< relref "/templates/files" >}}).
+```text
+.
+├── config.toml
+├── themes/
+    ├── mytheme/
+        ├── mytheme.txt
+        └── archetypes/
+          └── mytheme-default.md
+└── archetypes/
+    ├── default.md
+    └── post-bundle/
+        ├── bio.md
+        ├── index.md
+        └── images/
+            └── featured.jpg
+```
+
+This template code:
+
+```go-html-template
+{{ range os.ReadDir "." "archetypes" }}
+  {{ .Name }} --> {{ .IsDir }}
+{{ end }}
+```
+
+Produces:
+
+```html
+default.md --> false
+post-bundle --> true
+mytheme-default.md --> false
+```

--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -196,6 +196,28 @@ func (fs *BaseFs) ResolveJSConfigFile(name string) string {
 	return ""
 }
 
+func (fs *BaseFs) GetFilesystemByName(name string) (afero.Fs, error) {
+	switch name {
+	case files.ComponentFolderArchetypes:
+		return fs.SourceFilesystems.Archetypes.Fs, nil
+	case files.ComponentFolderContent:
+		return fs.SourceFilesystems.Content.Fs, nil
+	case files.ComponentFolderStatic:
+		// TODO(lukeryannetnz) static
+		return nil, errors.New("static folder is not yet supported")
+	case files.ComponentFolderLayouts:
+		return fs.SourceFilesystems.Layouts.Fs, nil
+	case files.ComponentFolderData:
+		return fs.SourceFilesystems.Data.Fs, nil
+	case files.ComponentFolderAssets:
+		return fs.SourceFilesystems.Assets.Fs, nil
+	case files.ComponentFolderI18n:
+		return fs.SourceFilesystems.I18n.Fs, nil
+	default:
+		return nil, fmt.Errorf("filesystem name not recognised: %s", name)
+	}
+}
+
 // SourceFilesystems contains the different source file systems. These can be
 // composite file systems (theme and project etc.), and they have all root
 // set to the source type the provides: data, i18n, static, layouts.

--- a/tpl/os/integration_test.go
+++ b/tpl/os/integration_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Issue 9599
-func TestReadDirWorkDir(t *testing.T) {
+func TestReadDir(t *testing.T) {
 	t.Parallel()
 
 	files := `
@@ -30,13 +30,36 @@ theme = "mytheme"
 Hello project!
 -- themes/mytheme/mytheme.txt --
 Hello theme!
+-- themes/mytheme/archetypes/mytheme-default.md --
+draft: true
+-- archetypes/default.md --
+draft: true
+-- content/content-example.md --
+draft: true
+-- layouts/404.html --
+<html></html>
+-- data/data.csv --
+1,2,3
+-- assets/asset.jpg --
+YWJjMTIzIT8kKiYoKSctPUB+
+-- i18n/en-NZ.yaml --
+summarized: "summarised"
 -- layouts/index.html --
+{{ $archetypeentries := (readDir "." "archetypes") }}
+START archteypes:|{{ range $entry := $archetypeentries }}{{ if not $entry.IsDir }}{{ $entry.Name }}|{{ end }}{{ end }}:END:
+{{ $content := (readDir "." "content") }}
+START content:|{{ range $entry := $content }}{{ if not $entry.IsDir }}{{ $entry.Name }}|{{ end }}{{ end }}:END:
+{{ $layouts := (readDir "." "layouts") }}
+START layouts:|{{ range $entry := $layouts }}{{ if not $entry.IsDir }}{{ $entry.Name }}|{{ end }}{{ end }}:END:
+{{ $data := (readDir "." "data") }}
+START data:|{{ range $entry := $data }}{{ if not $entry.IsDir }}{{ $entry.Name }}|{{ end }}{{ end }}:END:
+{{ $assets := (readDir "." "assets") }}
+START assets:|{{ range $entry := $assets }}{{ if not $entry.IsDir }}{{ $entry.Name }}|{{ end }}{{ end }}:END:
+{{ $i18n := (readDir "." "i18n") }}
+START i18n:|{{ range $entry := $i18n }}{{ if not $entry.IsDir }}{{ $entry.Name }}|{{ end }}{{ end }}:END:
 {{ $entries := (readDir ".") }}
-START:|{{ range $entry := $entries }}{{ if not $entry.IsDir }}{{ $entry.Name }}|{{ end }}{{ end }}:END:
-
-
-  `
-
+START work:|{{ range $entry := $entries }}{{ if not $entry.IsDir }}{{ $entry.Name }}|{{ end }}{{ end }}:END:
+`
 	b := hugolib.NewIntegrationTestBuilder(
 		hugolib.IntegrationTestConfig{
 			T:           t,
@@ -45,7 +68,12 @@ START:|{{ range $entry := $entries }}{{ if not $entry.IsDir }}{{ $entry.Name }}|
 		},
 	).Build()
 
-	b.AssertFileContent("public/index.html", `
-START:|config.toml|myproject.txt|:END:
-`)
+	b.AssertFileContent("public/index.html",
+		"START archteypes:|default.md|mytheme-default.md|:END:",
+		"START content:|content-example.md|:END:",
+		"START layouts:|404.html|index.html|:END:",
+		"START data:|data.csv|:END:",
+		"START assets:|asset.jpg|:END:",
+		"START i18n:|en-NZ.yaml|:END:",
+		"START work:|config.toml|myproject.txt|:END:")
 }


### PR DESCRIPTION
This is my first contribution to this project, the issue was labelled as `[GoodFirstIssue]` so I jumped in. As such, any feedback or guidance :100: appreciated.

Make ReadDir function variadic. Optional second param specifies FileSystem. The default if not specified remains work dir, to retain backwards compatibility.

I largely followed the breadcrumbs @bep left in the issue comments (thanks!).  Things I'm not sure about:
- how best to support the static FS given when in multihost we have one static filesystem per language
- if I need to better test my input checks in `os`
- how best to update docs (I can spend time looking at this if I get positive feedback on this change)

Fixes #9604