### PR TITLE
Fix readDir regression

### DIFF
--- a/hugofs/fs.go
+++ b/hugofs/fs.go
@@ -67,18 +67,25 @@ func NewFrom(fs afero.Fs, cfg config.Provider) *Fs {
 	return newFs(fs, cfg)
 }
 
+func NewForWorkingDir(base afero.Fs, workingDir string) *Fs {
+	return &Fs{
+		Source:      base,
+		Destination: base,
+		Os:          &afero.OsFs{},
+		WorkingDir:  getWorkingDirFs(base, workingDir),
+	}
+}
+
 func newFs(base afero.Fs, cfg config.Provider) *Fs {
 	return &Fs{
 		Source:      base,
 		Destination: base,
 		Os:          &afero.OsFs{},
-		WorkingDir:  getWorkingDirFs(base, cfg),
+		WorkingDir:  getWorkingDirFs(base, cfg.GetString("workingDir")),
 	}
 }
 
-func getWorkingDirFs(base afero.Fs, cfg config.Provider) *afero.BasePathFs {
-	workingDir := cfg.GetString("workingDir")
-
+func getWorkingDirFs(base afero.Fs, workingDir string) *afero.BasePathFs {
 	if workingDir != "" {
 		return afero.NewBasePathFs(afero.NewReadOnlyFs(base), workingDir).(*afero.BasePathFs)
 	}

--- a/hugolib/integrationtest_builder.go
+++ b/hugolib/integrationtest_builder.go
@@ -265,7 +265,7 @@ func (s *IntegrationTestBuilder) initBuilder() {
 
 		logger := loggers.NewBasicLoggerForWriter(s.Cfg.LogLevel, &s.logBuff)
 
-		fs := hugofs.NewFrom(afs, config.New())
+		fs := hugofs.NewForWorkingDir(afs, s.Cfg.WorkingDir)
 
 		for _, f := range s.data.Files {
 			filename := filepath.Join(s.Cfg.WorkingDir, f.Name)

--- a/tpl/os/integration_test.go
+++ b/tpl/os/integration_test.go
@@ -49,3 +49,5 @@ START:|{{ range $entry := $entries }}{{ if not $entry.IsDir }}{{ $entry.Name }}|
 START:|config.toml|myproject.txt|:END:
 `)
 }
+
+// Issue 9609


### PR DESCRIPTION
This reverts the `tpl/os` package, excluding new integration test, to `v0.92.2`.

We need some more tests and investigation into the old behaviour before we can change this.

Fixes #9609
