### PR TITLE
Remove the decorator from the fs used in ReadDir

### DIFF
--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -68,7 +68,7 @@ type BaseFs struct {
 	// This usually maps to /my-project/public.
 	PublishFs afero.Fs
 
-	// A read-only filesystem from the project workDir (no theme here).
+	// A read-only filesystem starting from the project workDir.
 	WorkDir afero.Fs
 
 	theBigFs *filesystemsCollector
@@ -438,7 +438,9 @@ func NewBase(p *paths.Paths, logger loggers.Logger, options ...func(*BaseFs) err
 
 	publishFs := hugofs.NewBaseFileDecorator(afero.NewBasePathFs(fs.Destination, p.AbsPublishDir))
 	sourceFs := hugofs.NewBaseFileDecorator(afero.NewBasePathFs(fs.Source, p.WorkingDir))
-	workDir := hugofs.NewBaseFileDecorator(afero.NewBasePathFs(afero.NewReadOnlyFs(fs.Source), p.WorkingDir))
+
+	// Same as sourceFs, but no decoration. This is what's used by os.ReadDir etc.
+	workDir := afero.NewBasePathFs(afero.NewReadOnlyFs(fs.Source), p.WorkingDir)
 
 	b := &BaseFs{
 		SourceFs:  sourceFs,


### PR DESCRIPTION
There have been a site breakage reported in the wild after 0.93.1. With this commit we shoudl be back to how it behaved in 0.92.2.

Closes #9609
