### PR TITLE
markup/highlight: Add hl_inline option

### DIFF
--- a/markup/highlight/config.go
+++ b/markup/highlight/config.go
@@ -72,6 +72,9 @@ type Config struct {
 	// A space separated list of line numbers, e.g. “3-8 10-20”.
 	Hl_Lines string
 
+	// If set, the markup will not be wrapped in any container.
+	Hl_inline bool
+
 	// A parsed and ready to use list of line ranges.
 	HL_lines_parsed [][2]int `json:"-"`
 

--- a/markup/highlight/highlight.go
+++ b/markup/highlight/highlight.go
@@ -75,11 +75,24 @@ func (h chromaHighlighter) Highlight(code, lang string, opts interface{}) (strin
 	}
 	var b strings.Builder
 
-	if _, _, err := highlight(&b, code, lang, nil, cfg); err != nil {
+	low, high, err := highlight(&b, code, lang, nil, cfg)
+
+	if err != nil {
 		return "", err
 	}
 
-	return b.String(), nil
+	if !cfg.Hl_inline {
+		return b.String(), nil
+	}
+
+	hr := HightlightResult{
+		highlighted: template.HTML(b.String()),
+		innerLow:    low,
+		innerHigh:   high,
+	}
+
+	return string(hr.Inner()), nil
+
 }
 
 func (h chromaHighlighter) HighlightCodeBlock(ctx hooks.CodeblockContext, opts interface{}) (HightlightResult, error) {

--- a/markup/highlight/integration_test.go
+++ b/markup/highlight/integration_test.go
@@ -1,0 +1,53 @@
+// Copyright 2022 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package highlight_test
+
+import (
+	"testing"
+
+	"github.com/gohugoio/hugo/hugolib"
+)
+
+func TestHighlightInline(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- config.toml --
+[markup]
+[markup.highlight]
+codeFences = true
+noClasses = false
+-- content/p1.md --
+---
+title: "p1"
+---
+
+Inline:{{< highlight emacs "hl_inline=true" >}}(message "this highlight shortcode"){{< /highlight >}}:End.
+
+-- layouts/_default/single.html --
+{{ .Content }}
+`
+
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+			NeedsOsFS:   false,
+		},
+	).Build()
+
+	b.AssertFileContent("public/p1/index.html", `
+	<p>Inline:<span class="line"><span class="cl"><span class="p">(</span><span class="nf">message</span> <span class="s">&#34;this highlight shortcode&#34;</span><span class="p">)</span></span></span>:End.</p>
+	`)
+}

--- a/markup/internal/attributes/attributes.go
+++ b/markup/internal/attributes/attributes.go
@@ -38,6 +38,7 @@ var chromaHightlightProcessingAttributes = map[string]bool{
 	"nohl":               true,
 	"style":              true,
 	"tabWidth":           true,
+	"hl_inline":          true, // New in 0.94.0.
 }
 
 func init() {


### PR DESCRIPTION
If set to true, the highlighted code will not be wrapped in any div.

Closes #9442
