### PR TITLE
markup/goldmark: Default to https for linkify

### DIFF
--- a/markup/goldmark/convert.go
+++ b/markup/goldmark/convert.go
@@ -94,7 +94,7 @@ func newMarkdown(pcfg converter.ProviderConfig) goldmark.Markdown {
 
 	var (
 		extensions = []goldmark.Extender{
-			newLinks(),
+			newLinks(cfg),
 			newTocExtension(rendererOptions),
 		}
 		parserOptions []parser.Option

--- a/markup/goldmark/goldmark_config/config.go
+++ b/markup/goldmark/goldmark_config/config.go
@@ -23,13 +23,14 @@ const (
 // DefaultConfig holds the default Goldmark configuration.
 var Default = Config{
 	Extensions: Extensions{
-		Typographer:    true,
-		Footnote:       true,
-		DefinitionList: true,
-		Table:          true,
-		Strikethrough:  true,
-		Linkify:        true,
-		TaskList:       true,
+		Typographer:     true,
+		Footnote:        true,
+		DefinitionList:  true,
+		Table:           true,
+		Strikethrough:   true,
+		Linkify:         true,
+		LinkifyProtocol: "https",
+		TaskList:        true,
 	},
 	Renderer: Renderer{
 		Unsafe: false,
@@ -57,10 +58,11 @@ type Extensions struct {
 	DefinitionList bool
 
 	// GitHub flavored markdown
-	Table         bool
-	Strikethrough bool
-	Linkify       bool
-	TaskList      bool
+	Table           bool
+	Strikethrough   bool
+	Linkify         bool
+	LinkifyProtocol string
+	TaskList        bool
 }
 
 type Renderer struct {

--- a/markup/goldmark/integration_test.go
+++ b/markup/goldmark/integration_test.go
@@ -423,3 +423,70 @@ title: "p1"
 		<img src="b.jpg" alt="&quot;a&quot;">
 	`)
 }
+
+func TestLinkifyProtocol(t *testing.T) {
+	t.Parallel()
+
+	runTest := func(protocol string, withHook bool) *hugolib.IntegrationTestBuilder {
+
+		files := `
+-- config.toml --
+[markup.goldmark]
+[markup.goldmark.extensions]
+linkify = true
+linkifyProtocol = "PROTOCOL"
+-- content/p1.md --
+---
+title: "p1"
+---
+Link no procol: www.example.org
+Link http procol: http://www.example.org
+Link https procol: https://www.example.org
+
+-- layouts/_default/single.html --
+{{ .Content }}
+`
+		files = strings.ReplaceAll(files, "PROTOCOL", protocol)
+
+		if withHook {
+			files += `-- layouts/_default/_markup/render-link.html --
+<a href="{{ .Destination | safeURL }}">{{ .Text | safeHTML }}</a>`
+		}
+
+		return hugolib.NewIntegrationTestBuilder(
+			hugolib.IntegrationTestConfig{
+				T:           t,
+				TxtarString: files,
+			},
+		).Build()
+
+	}
+
+	for _, withHook := range []bool{false, true} {
+
+		b := runTest("https", withHook)
+
+		b.AssertFileContent("public/p1/index.html",
+			"Link no procol: <a href=\"https://www.example.org\">www.example.org</a>",
+			"Link http procol: <a href=\"http://www.example.org\">http://www.example.org</a>",
+			"Link https procol: <a href=\"https://www.example.org\">https://www.example.org</a></p>",
+		)
+
+		b = runTest("http", withHook)
+
+		b.AssertFileContent("public/p1/index.html",
+			"Link no procol: <a href=\"http://www.example.org\">www.example.org</a>",
+			"Link http procol: <a href=\"http://www.example.org\">http://www.example.org</a>",
+			"Link https procol: <a href=\"https://www.example.org\">https://www.example.org</a></p>",
+		)
+
+		b = runTest("gopher", withHook)
+
+		b.AssertFileContent("public/p1/index.html",
+			"Link no procol: <a href=\"gopher://www.example.org\">www.example.org</a>",
+			"Link http procol: <a href=\"http://www.example.org\">http://www.example.org</a>",
+			"Link https procol: <a href=\"https://www.example.org\">https://www.example.org</a></p>",
+		)
+
+	}
+}


### PR DESCRIPTION
Fixes #9639
