### PR TITLE
Fix trailing comma in keyword meta tag for schema.html

### DIFF
--- a/hugolib/embedded_templates_test.go
+++ b/hugolib/embedded_templates_test.go
@@ -25,7 +25,8 @@ baseURL = "https://example.org"
 
 [params]
 images=["siteimg1.jpg", "siteimg2.jpg"]
-
+[taxonomies]
+series="series"
 `
 	b := newTestSitesBuilder(t).WithConfigFile("toml", config)
 
@@ -33,6 +34,7 @@ images=["siteimg1.jpg", "siteimg2.jpg"]
 title: My Bundle
 date: 2021-02-26T18:02:00-01:00
 lastmod: 2021-05-22T19:25:00-01:00
+tags: ["test1", "test2"]
 ---
 `)
 
@@ -41,11 +43,14 @@ title: My Page
 images: ["pageimg1.jpg", "pageimg2.jpg"]
 date: 2021-02-26T18:02:00+01:00
 lastmod: 2021-05-22T19:25:00+01:00
+tags: ["test1", "test2"]
+series: ["series1", "series2"]
 ---
 `)
 
 	b.WithContent("mysite.md", `---
 title: My Site
+tags: ["test1", "test2"]
 ---
 `)
 
@@ -72,7 +77,7 @@ title: My Site
 <meta itemprop="image" content="https://example.org/mybundle/featured-sunset.jpg">
 <meta itemprop="datePublished" content="2021-02-26T18:02:00-01:00" />
 <meta itemprop="dateModified" content="2021-05-22T19:25:00-01:00" />
-
+<meta itemprop="keywords" content="test1,test2,series1,series2" />
 `)
 	b.AssertFileContent("public/mypage/index.html", `
 <meta name="twitter:image" content="https://example.org/pageimg1.jpg"/>
@@ -84,11 +89,13 @@ title: My Site
 <meta itemprop="image" content="https://example.org/pageimg2.jpg">
 <meta itemprop="datePublished" content="2021-02-26T18:02:00+01:00" />
 <meta itemprop="dateModified" content="2021-05-22T19:25:00+01:00" />
+<meta itemprop="keywords" content="test1,test2,series1,series2" />
 `)
 	b.AssertFileContent("public/mysite/index.html", `
 <meta name="twitter:image" content="https://example.org/siteimg1.jpg"/>
 <meta property="og:image" content="https://example.org/siteimg1.jpg"/>
 <meta itemprop="image" content="https://example.org/siteimg1.jpg"/>
+<meta itemprop="keywords" content="test1,test2,series1,series2" />
 `)
 }
 

--- a/hugolib/embedded_templates_test.go
+++ b/hugolib/embedded_templates_test.go
@@ -27,6 +27,8 @@ baseURL = "https://example.org"
 images=["siteimg1.jpg", "siteimg2.jpg"]
 [taxonomies]
 series="series"
+category="categories"
+tag="tags"
 `
 	b := newTestSitesBuilder(t).WithConfigFile("toml", config)
 
@@ -77,7 +79,7 @@ tags: ["test1", "test2"]
 <meta itemprop="image" content="https://example.org/mybundle/featured-sunset.jpg">
 <meta itemprop="datePublished" content="2021-02-26T18:02:00-01:00" />
 <meta itemprop="dateModified" content="2021-05-22T19:25:00-01:00" />
-<meta itemprop="keywords" content="test1,test2,series1,series2" />
+<meta itemprop="keywords" content="test1,test2" />
 `)
 	b.AssertFileContent("public/mypage/index.html", `
 <meta name="twitter:image" content="https://example.org/pageimg1.jpg"/>
@@ -89,13 +91,13 @@ tags: ["test1", "test2"]
 <meta itemprop="image" content="https://example.org/pageimg2.jpg">
 <meta itemprop="datePublished" content="2021-02-26T18:02:00+01:00" />
 <meta itemprop="dateModified" content="2021-05-22T19:25:00+01:00" />
-<meta itemprop="keywords" content="test1,test2,series1,series2" />
+<meta itemprop="keywords" content="series1,series2,test1,test2" />
 `)
 	b.AssertFileContent("public/mysite/index.html", `
 <meta name="twitter:image" content="https://example.org/siteimg1.jpg"/>
 <meta property="og:image" content="https://example.org/siteimg1.jpg"/>
 <meta itemprop="image" content="https://example.org/siteimg1.jpg"/>
-<meta itemprop="keywords" content="test1,test2,series1,series2" />
+<meta itemprop="keywords" content="test1,test2" />
 `)
 }
 

--- a/tpl/tplimpl/embedded/templates/schema.html
+++ b/tpl/tplimpl/embedded/templates/schema.html
@@ -20,10 +20,10 @@
 {{- end -}}
 {{- end -}}
 
-{{ $keywords := .Params.tags }}
+{{ $keywords := slice }}
 {{- range $plural, $terms := .Site.Taxonomies -}}
-    {{ range $term, $val := $terms }}
-        {{- $keywords = $keywords | append $term -}}
+    {{ range $.Page.Param $plural}}
+        {{ $keywords = $keywords | append . }}
     {{ end }}
 {{- end -}}
 <meta itemprop="keywords" content="{{ if .IsPage}}{{ delimit $keywords "," }}{{ end }}" />

--- a/tpl/tplimpl/embedded/templates/schema.html
+++ b/tpl/tplimpl/embedded/templates/schema.html
@@ -20,6 +20,11 @@
 {{- end -}}
 {{- end -}}
 
-<!-- Output all taxonomies as schema.org keywords -->
-<meta itemprop="keywords" content="{{ if .IsPage}}{{ range $index, $tag := .Params.tags }}{{ $tag }},{{ end }}{{ else }}{{ range $plural, $terms := .Site.Taxonomies }}{{ range $term, $val := $terms }}{{ printf "%s," $term }}{{ end }}{{ end }}{{ end }}" />
+{{ $keywords := .Params.tags }}
+{{- range $plural, $terms := .Site.Taxonomies -}}
+    {{ range $term, $val := $terms }}
+        {{- $keywords = $keywords | append $term -}}
+    {{ end }}
+{{- end -}}
+<meta itemprop="keywords" content="{{ if .IsPage}}{{ delimit $keywords "," }}{{ end }}" />
 {{- end -}}

--- a/tpl/tplimpl/embedded/templates/schema.html
+++ b/tpl/tplimpl/embedded/templates/schema.html
@@ -20,6 +20,7 @@
 {{- end -}}
 {{- end -}}
 
+<!-- Output all taxonomies as schema.org keywords -->
 {{ $keywords := slice }}
 {{- range $plural, $terms := .Site.Taxonomies -}}
     {{ range $.Page.Param $plural}}


### PR DESCRIPTION
This aimed to fix the trailing comma in the keywords meta tag for schema.html - there seemed to be more opportunities for improvement and so not only tags but all taxonomies are now included. 