### PR TITLE
Fixes #9127: Support '-u=patch' in hugo mod get

### DIFF
--- a/modules/client.go
+++ b/modules/client.go
@@ -305,8 +305,9 @@ func (c *Client) Vendor() error {
 
 // Get runs "go get" with the supplied arguments.
 func (c *Client) Get(args ...string) error {
-	if len(args) == 0 || (len(args) == 1 && args[0] == "-u") {
+	if len(args) == 0 || (len(args) == 1 && strings.Contains(args[0], "-u")) {
 		update := len(args) != 0
+		patch := update && (args[0] == "-u=patch") //
 
 		// We need to be explicit about the modules to get.
 		for _, m := range c.moduleConfig.Imports {
@@ -318,10 +319,14 @@ func (c *Client) Get(args ...string) error {
 				continue
 			}
 			var args []string
-			if update {
+
+			if update && !patch {
 				args = append(args, "-u")
+			} else if update && patch {
+				args = append(args, "-u=patch")
 			}
 			args = append(args, m.Path)
+
 			if err := c.get(args...); err != nil {
 				return err
 			}


### PR DESCRIPTION
I believe I have implemented the required fix #9127. 

I changed the aforementioned if-statement to check whether the supplied argument contains `-u`, as opposed to whether the supplied argument is identical to `-u`.  A flag called `patch`, similar to the `update` flag, was added. The `patch` flag will be true if the supplied argument is exactly  `-u=patch`. The appropriate command is then passed down.

I am unsure of how to add tests for this fix, so any pointers on how to get started writing tests would be highly appreciated @bep .