### PR TITLE
Make Snap and Docker build with Go 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         # Note: We upgraded to Go 1.18 in Hugo v0.95.0
         # Go 1.18 had some breaking changes on the source level which means Hugo cannot be built
-        # with older Go versions, but the improvements in Go 1.18 were to good to pass on (e.g. break and continue).
+        # with older Go versions, but the improvements in Go 1.18 were too good to pass on (e.g. break and continue).
         # Note that you don't need Go (or Go 1.18) to run a pre-built binary.
         go-version: [1.18.x]
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ go install
 For some convenient build and test targets, you also will want to install Mage:
 
 ```bash
-go get github.com/magefile/mage
+go install github.com/magefile/mage
 ```
 
 Now, to make a change to Hugo's source:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Twitter:      https://twitter.com/gohugoio
 # Website:      https://gohugo.io/
 
-FROM golang:1.16-alpine AS build
+FROM golang:1.18-alpine AS build
 
 # Optionally set HUGO_BUILD_TAGS to "extended" or "nodeploy" when building like so:
 #   docker build --build-arg HUGO_BUILD_TAGS=extended .
@@ -20,7 +20,7 @@ COPY . /go/src/github.com/gohugoio/hugo/
 # gcc/g++ are required to build SASS libraries for extended version
 RUN apk update && \
     apk add --no-cache gcc g++ musl-dev git && \
-    go get github.com/magefile/mage
+    go install github.com/magefile/mage
 
 RUN mage hugo && mage install
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,8 +47,8 @@ parts:
       export GOPATH=$(realpath ../go)
       export PATH=$GOPATH/bin:$PATH
 
-      echo ' * Running "go get -v github.com/magefile/mage"...'
-      go get -v github.com/magefile/mage
+      echo ' * Running "go install -v github.com/magefile/mage"...'
+      go install -v github.com/magefile/mage
 
       #echo ' * Running "mage -v test"...'
       #mage -v test


### PR DESCRIPTION
* snap: Make it build with Go 1.18
    Tested to work with hugo's `stable` branch; see the recent builds for ["hugo"](https://launchpad.net/~gohugoio/+snap/hugo) and ["hugo-extended"](https://launchpad.net/~gohugoio/+snap/hugo-extended) on Ubuntu/Canonical's Launchpad

* Dockerfile: Make it build with Go 1.18

* Update CONTRIBUTING.md to use `go install` to install mage.
    In Go 1.18, `go get` no longer builds packages.