### PR TITLE
resources: Add more details to .Err

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -133,7 +133,7 @@ func (p *pageState) reusePageOutputContent() bool {
 	return p.pageOutputTemplateVariationsState.Load() == 1
 }
 
-func (p *pageState) Err() error {
+func (p *pageState) Err() resource.ResourceError {
 	return nil
 }
 

--- a/resources/errorResource.go
+++ b/resources/errorResource.go
@@ -19,9 +19,7 @@ import (
 	"github.com/gohugoio/hugo/common/hugio"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/media"
-
 	"github.com/gohugoio/hugo/resources/images/exif"
-
 	"github.com/gohugoio/hugo/resources/resource"
 )
 
@@ -40,94 +38,94 @@ var (
 )
 
 // NewErrorResource wraps err in a Resource where all but the Err method will panic.
-func NewErrorResource(err error) resource.Resource {
-	return &errorResource{error: err}
+func NewErrorResource(err resource.ResourceError) resource.Resource {
+	return &errorResource{ResourceError: err}
 }
 
 type errorResource struct {
-	error
+	resource.ResourceError
 }
 
-func (e *errorResource) Err() error {
-	return e.error
+func (e *errorResource) Err() resource.ResourceError {
+	return e.ResourceError
 }
 
 func (e *errorResource) ReadSeekCloser() (hugio.ReadSeekCloser, error) {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Content() (any, error) {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) ResourceType() string {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) MediaType() media.Type {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Permalink() string {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) RelPermalink() string {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Name() string {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Title() string {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Params() maps.Params {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Data() any {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Height() int {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Width() int {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Crop(spec string) (resource.Image, error) {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Fill(spec string) (resource.Image, error) {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Fit(spec string) (resource.Image, error) {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Resize(spec string) (resource.Image, error) {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Filter(filters ...any) (resource.Image, error) {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Exif() *exif.Exif {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) DecodeImage() (image.Image, error) {
-	panic(e.error)
+	panic(e.ResourceError)
 }
 
 func (e *errorResource) Transform(...ResourceTransformation) (ResourceTransformer, error) {
-	panic(e.error)
+	panic(e.ResourceError)
 }

--- a/resources/page/page_nop.go
+++ b/resources/page/page_nop.go
@@ -48,7 +48,7 @@ var (
 // PageNop implements Page, but does nothing.
 type nopPage int
 
-func (p *nopPage) Err() error {
+func (p *nopPage) Err() resource.ResourceError {
 	return nil
 }
 

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -120,7 +120,7 @@ type testPage struct {
 	sectionEntries []string
 }
 
-func (p *testPage) Err() error {
+func (p *testPage) Err() resource.ResourceError {
 	return nil
 }
 

--- a/resources/resource.go
+++ b/resources/resource.go
@@ -233,7 +233,7 @@ func (l *genericResource) Content() (any, error) {
 	return l.content, nil
 }
 
-func (r *genericResource) Err() error {
+func (r *genericResource) Err() resource.ResourceError {
 	return nil
 }
 

--- a/resources/resource/resourcetypes.go
+++ b/resources/resource/resourcetypes.go
@@ -24,6 +24,11 @@ import (
 	"github.com/gohugoio/hugo/common/hugio"
 )
 
+var (
+	_ ResourceDataProvider = (*resourceError)(nil)
+	_ ResourceError        = (*resourceError)(nil)
+)
+
 // Cloner is an internal template and not meant for use in the templates. It
 // may change without notice.
 type Cloner interface {
@@ -37,9 +42,33 @@ type OriginProvider interface {
 	GetFieldString(pattern string) (string, bool)
 }
 
+// NewResourceError creates a new ResourceError.
+func NewResourceError(err error, data any) ResourceError {
+	return &resourceError{
+		error: err,
+		data:  data,
+	}
+}
+
+type resourceError struct {
+	error
+	data any
+}
+
+// The data associated with this error.
+func (e *resourceError) Data() any {
+	return e.data
+}
+
+// ResourceError is the error return from .Err in Resource in error situations.
+type ResourceError interface {
+	error
+	ResourceDataProvider
+}
+
 // ErrProvider provides an Err.
 type ErrProvider interface {
-	Err() error
+	Err() ResourceError
 }
 
 // Resource represents a linkable resource, i.e. a content page, image etc.

--- a/resources/transform.go
+++ b/resources/transform.go
@@ -167,7 +167,7 @@ func (r *resourceAdapter) Content() (any, error) {
 	return r.target.Content()
 }
 
-func (r *resourceAdapter) Err() error {
+func (r *resourceAdapter) Err() resource.ResourceError {
 	return nil
 }
 

--- a/tpl/resources/resources.go
+++ b/tpl/resources/resources.go
@@ -151,8 +151,13 @@ func (ns *Namespace) GetRemote(args ...any) resource.Resource {
 
 	r, err := get(args...)
 	if err != nil {
-		// This allows the client to reason about the .Err in the template.
-		return resources.NewErrorResource(errors.Wrap(err, "error calling resources.GetRemote"))
+		switch v := err.(type) {
+		case *create.HTTPError:
+			return resources.NewErrorResource(resource.NewResourceError(v, v.Data))
+		default:
+			return resources.NewErrorResource(resource.NewResourceError(errors.Wrap(err, "error calling resources.GetRemote"), make(map[string]any)))
+		}
+
 	}
 	return r
 


### PR DESCRIPTION
This commit adds a .Data object (a map with `Body`, `StatusCode` etc.) to the .Err returned from `resources.GetRemote`, which means you can now do:

```
{{ with .Err }}
{{ range $k, $v := .Data }}
{{ end }}
{{ end }}
```

Fixes #9708
