### PR TITLE
hugo deploy also sets an md5 attribute & checks it

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -21,6 +21,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -72,6 +73,8 @@ type Deployer struct {
 type deploySummary struct {
 	NumLocal, NumRemote, NumUploads, NumDeletes int
 }
+
+var metaMD5Hash = "md5chksum" // the meta key to store md5hash in
 
 // New constructs a new *Deployer.
 func New(cfg config.Provider, localFs afero.Fs) (*Deployer, error) {
@@ -314,6 +317,7 @@ func doSingleUpload(ctx context.Context, bucket *blob.Bucket, upload *fileToUplo
 		CacheControl:    upload.Local.CacheControl(),
 		ContentEncoding: upload.Local.ContentEncoding(),
 		ContentType:     upload.Local.ContentType(),
+		Metadata:        map[string]string{strings.ToLower(metaMD5Hash): hex.EncodeToString(upload.Local.MD5())},
 	}
 	w, err := bucket.NewWriter(ctx, upload.Local.SlashPath, opts)
 	if err != nil {

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -74,7 +74,7 @@ type deploySummary struct {
 	NumLocal, NumRemote, NumUploads, NumDeletes int
 }
 
-var metaMD5Hash = "md5chksum" // the meta key to store md5hash in
+const metaMD5Hash = "md5chksum" // the meta key to store md5hash in
 
 // New constructs a new *Deployer.
 func New(cfg config.Provider, localFs afero.Fs) (*Deployer, error) {
@@ -317,7 +317,7 @@ func doSingleUpload(ctx context.Context, bucket *blob.Bucket, upload *fileToUplo
 		CacheControl:    upload.Local.CacheControl(),
 		ContentEncoding: upload.Local.ContentEncoding(),
 		ContentType:     upload.Local.ContentType(),
-		Metadata:        map[string]string{strings.ToLower(metaMD5Hash): hex.EncodeToString(upload.Local.MD5())},
+		Metadata:        map[string]string{metaMD5Hash: hex.EncodeToString(upload.Local.MD5())},
 	}
 	w, err := bucket.NewWriter(ctx, upload.Local.SlashPath, opts)
 	if err != nil {
@@ -581,9 +581,9 @@ func walkRemote(ctx context.Context, bucket *blob.Bucket, include, exclude glob.
 			var attrMD5 []byte
 			attrs, err := bucket.Attributes(ctx, obj.Key)
 			if err == nil {
-				md5String, exists := attrs.Metadata[strings.ToLower(metaMD5Hash)]
+				md5String, exists := attrs.Metadata[metaMD5Hash]
 				if exists {
-					attrMD5, err = hex.DecodeString(md5String)
+					attrMD5, _ = hex.DecodeString(md5String)
 				}
 			}
 			if len(attrMD5) == 0 {


### PR DESCRIPTION
Improves https://github.com/gohugoio/hugo/issues/9735

### Problem

During Hugo deploy when a remote MD5 is invalid (e.g due to multipart etag) hugo reads the entire remote file and calculates the md5 again which can be slow.

### This PR

- Updates file upload so that it will also store an md5 hash in the cloud providers attributes. e.g in aws this looks like `x-amz-meta-md5chksum: 26fe392386a8123bf8956a16e08cb841`
- Updates the walkremote so that if an MD5 is nonexistent/invalid then it attempts to read the attribute md5 before falling back to reading the entire remote file

### What impact does this have?

Hugo deploy will be faster in the diffing stage between remote and local. 
**_IF_** files come through with `len(obj.MD5) == 0` but store an attribute md5.

### Caveats

Only files uploaded with hugo will have this attribute. 

**Existing users**
Existing hugo deploy users running this in a new release would only get the attributes set on files that are uploaded going forward. If they want all files to have the md5 attribute then running with `--force` should work.

**Other files in the bucket**
If you have files uploaded by another tool in the same bucket that hugo deploy is using and these don't have valid a MD5. Then you can see a perf boost if you manually upload these to have the md5 as an attribute.