### PR TITLE
Changed wording a message

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -288,7 +288,7 @@ func (c *commandeer) fullBuild(noBuildLock bool) error {
 	)
 
 	if !c.h.quiet {
-		fmt.Println("Start building sites … ")
+		fmt.Println("Starting to build sites … ")
 		fmt.Println(hugo.BuildVersionString())
 		if isTerminal() {
 			defer func() {
@@ -508,7 +508,7 @@ func (c *commandeer) build() error {
 		c.hugo().PrintProcessingStats(os.Stdout)
 		fmt.Println()
 
-		if createCounter, ok := c.publishDirFs.(hugofs.DuplicatesReporter); ok {
+		if createCounter, ok := c.destinationFs.(hugofs.DuplicatesReporter); ok {
 			dupes := createCounter.ReportDuplicates()
 			if dupes != "" {
 				c.logger.Warnln("Duplicate target paths:", dupes)
@@ -634,7 +634,11 @@ func chmodFilter(dst, src os.FileInfo) bool {
 }
 
 func (c *commandeer) copyStaticTo(sourceFs *filesystems.SourceFilesystem) (uint64, error) {
-	publishDir := helpers.FilePathSeparator
+	publishDir := c.hugo().PathSpec.PublishDir
+	// If root, remove the second '/'
+	if publishDir == "//" {
+		publishDir = helpers.FilePathSeparator
+	}
 
 	if sourceFs.PublishFolder != "" {
 		publishDir = filepath.Join(publishDir, sourceFs.PublishFolder)
@@ -647,10 +651,7 @@ func (c *commandeer) copyStaticTo(sourceFs *filesystems.SourceFilesystem) (uint6
 	syncer.NoChmod = c.Cfg.GetBool("noChmod")
 	syncer.ChmodFilter = chmodFilter
 	syncer.SrcFs = fs
-	syncer.DestFs = c.Fs.PublishDir
-	if c.renderStaticToDisk {
-		syncer.DestFs = c.Fs.PublishDirStatic
-	}
+	syncer.DestFs = c.Fs.Destination
 	// Now that we are using a unionFs for the static directories
 	// We can effectively clean the publishDir on initial sync
 	syncer.Delete = c.Cfg.GetBool("cleanDestinationDir")


### PR DESCRIPTION
The message "Start building sites ..." (line 291) reads like a command to the user. Not usually an issue, but when it's taking a long time it looks like it's waiting for the user to do something.

Changed to "Starting to build sites ..." so it's clearer it's just a notification and requires no action.