### PR TITLE
hugo: Add basic gemini file type

### DIFF
--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -233,6 +233,7 @@ var (
 	TypeScriptType = newMediaType("application", "typescript", []string{"ts"})
 	TSXType        = newMediaType("text", "tsx", []string{"tsx"})
 	JSXType        = newMediaType("text", "jsx", []string{"jsx"})
+	GEMINIType     = newMediaType("text", "gemini", []string{"gmi", "gmni", "gemini"})
 
 	JSONType           = newMediaType("application", "json", []string{"json"})
 	WebAppManifestType = newMediaTypeWithMimeSuffix("application", "manifest", "json", []string{"webmanifest"})
@@ -304,6 +305,7 @@ var DefaultTypes = Types{
 	OpenTypeFontType,
 	TrueTypeFontType,
 	PDFType,
+	GEMINIType,
 }
 
 func init() {

--- a/media/mediaType_test.go
+++ b/media/mediaType_test.go
@@ -45,6 +45,7 @@ func TestDefaultTypes(t *testing.T) {
 		{TSXType, "text", "tsx", "tsx", "text/tsx", "text/tsx"},
 		{JSXType, "text", "jsx", "jsx", "text/jsx", "text/jsx"},
 		{JSONType, "application", "json", "json", "application/json", "application/json"},
+		{GEMINIType, "text", "gemini", "gemini", "text/gemini", "text/gemini"},
 		{RSSType, "application", "rss", "xml", "application/rss+xml", "application/rss+xml"},
 		{SVGType, "image", "svg", "svg", "image/svg+xml", "image/svg+xml"},
 		{TextType, "text", "plain", "txt", "text/plain", "text/plain"},

--- a/output/outputFormat.go
+++ b/output/outputFormat.go
@@ -135,6 +135,16 @@ var (
 		Weight: 10,
 	}
 
+	GEMINIFormat = Format{
+		Name:          "GEMINI",
+		MediaType:     media.GEMINIType,
+		BaseName:      "index",
+		Protocol:      "gemini://",
+		IsPlainText:   true,
+		IsHTML:        false,
+		Permalinkable: true,
+	}
+
 	JSONFormat = Format{
 		Name:        "JSON",
 		MediaType:   media.JSONType,
@@ -184,6 +194,7 @@ var DefaultFormats = Formats{
 	CSSFormat,
 	CSVFormat,
 	HTMLFormat,
+	GEMINIFormat,
 	JSONFormat,
 	WebAppManifestFormat,
 	RobotsTxtFormat,

--- a/output/outputFormat_test.go
+++ b/output/outputFormat_test.go
@@ -61,6 +61,14 @@ func TestDefaultTypes(t *testing.T) {
 	c.Assert(AMPFormat.IsHTML, qt.Equals, true)
 	c.Assert(AMPFormat.Permalinkable, qt.Equals, true)
 
+	c.Assert(GEMINIFormat.Name, qt.Equals, "GEMINI")
+	c.Assert(GEMINIFormat.MediaType, qt.Equals, media.GEMINIType)
+	c.Assert(GEMINIFormat.Path, qt.HasLen, 0)
+	c.Assert(GEMINIFormat.Protocol, qt.Equals, "gemini://")
+	c.Assert(GEMINIFormat.IsPlainText, qt.Equals, true)
+	c.Assert(GEMINIFormat.IsHTML, qt.Equals, false)
+	c.Assert(GEMINIFormat.Permalinkable, qt.Equals, true)
+
 	c.Assert(RSSFormat.Name, qt.Equals, "RSS")
 	c.Assert(RSSFormat.MediaType, qt.Equals, media.RSSType)
 	c.Assert(RSSFormat.Path, qt.HasLen, 0)


### PR DESCRIPTION
* Gemini is a lightweight text-only web protocol which falls
  somewhere between gopher and html.
* This adds native filetype support which the community has
  been hacking into config files for quite some time.
* Hugo is unable to serve gemini (since it isn't http), however the outputed documents
  can be passed to one of the many small + simple gemini server choices out there.
* Based on the examples here:
  https://sylvaindurand.org/gemini-and-hugo/