### PR TITLE
Listitem render hook

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "image": "registry.hansenet.local/tools/hugo-devcontainer:0.97.0",
+    "extensions": [
+        "golang.go",
+        "budparr.language-hugo-vscode",
+        "bungcip.better-toml"
+    ]
+}

--- a/docs/content/en/templates/render-hooks.md
+++ b/docs/content/en/templates/render-hooks.md
@@ -26,6 +26,8 @@ The hook kinds currently supported are:
 * `link`
 * `heading` {{< new-in "0.71.0" >}}
 * `codeblock`{{< new-in "0.93.0" >}}
+* `list`{{< new-in "0.99.0" >}}
+* `listitem`{{< new-in "0.99.0" >}}
 
 You can define [Output-Format-](/templates/output-formats) and [language-](/content-management/multilingual/)specific templates if needed. Your `layouts` folder may look like this:
 
@@ -170,3 +172,98 @@ Page
 
 Position
 : Useful in error logging as it prints the filename and position (linenumber, column), e.g. `{{ errorf "error in code block: %s" .Position }}`.
+
+## Render Hooks for Lists and List Items
+
+{{< new-in "0.99.0" >}}
+
+You can add a hook template for lists and list items e.g. for different output types
+
+```goat { class="black f7" }
+layouts
+└── _default
+    └── _markup
+        └── render-listitem.html
+        └── render-listitem.json
+        └── render-list.html
+        └── render-list.json
+```
+
+The `render-list` template will receive this context:
+
+Page
+: The [Page](/variables/page/) being rendered.
+
+Text
+: The rendered (HTML) list content.
+
+PlainText
+: The plain variant of the above.
+
+IsOrdered (bool)
+: If this is an ordered list.
+
+Parent 
+: The Parent node of the list.
+
+Attributes (map) {{< new-in "0.82.0" >}}
+: A map of attributes (e.g. `id`, `class`)
+
+
+The `render-listitem` template will receive this context:
+
+Page
+: The [Page](/variables/page/) being rendered.
+
+Text
+: The rendered (HTML) list content.
+
+PlainText
+: The plain variant of the above.
+
+IsFirst (bool)
+: If this is the first item in the list.
+
+IsLast (bool)
+: If this is the last item in the list.
+
+Parent 
+: The Parent node of the item, the list node.
+
+### ListItem rendered as JSON-LD example:
+
+```md
+1. Do This
+2. Then That
+```
+
+Here is a code example for how the render-listitem.json template could look:
+
+{{< code file="layouts/_default/_markup/render-list.html" >}}
+{{- if eq .Parent.IsOrdered true -}}
+{
+    "@type": "HowToStep",
+    "text": "{{ .Text | plainify}}"
+}{{ if not .IsLast }},{{ end }}{{ print "\n"}}
+{{- else -}}
+{{- if not .IsLast -}}
+    {{ printf "\"%s\",\n" .Text | plainify}}
+{{- else -}}
+    {{ printf "\"%s\"" .Text | plainify}}
+{{- end -}}
+{{- end -}}
+{{< /code >}}
+
+
+The rendered html will be
+
+```js
+{
+    "@type": "HowToStep",
+    "text": "Do This"
+},
+{
+    "@type": "HowToStep",
+    "text": "Then That"
+}
+```

--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -98,8 +98,8 @@ Inner Block: {{ .Inner | .Page.RenderString (dict "display" "block" ) }}
 	b.WithTemplatesAdded("_default/_markup/render-image.html", `IMAGE: {{ .Page.Title }}||{{ .Destination | safeURL }}|Title: {{ .Title | safeHTML }}|Text: {{ .Text | safeHTML }}|END`)
 	b.WithTemplatesAdded("_default/_markup/render-heading.html", `HEADING: {{ .Page.Title }}||Level: {{ .Level }}|Anchor: {{ .Anchor | safeURL }}|Text: {{ .Text | safeHTML }}|Attributes: {{ .Attributes }}|END`)
 	b.WithTemplatesAdded("docs/_markup/render-heading.html", `Docs Level: {{ .Level }}|END`)
-	b.WithTemplatesAdded("_default/_markup/render-list.html", `LIST: {{ .Text | safeHTML }} {{ .Attributes }} {{ .IsOrdered }} `)
-	b.WithTemplatesAdded("_default/_markup/render-listitem.html", `LISTITEM: {{ .Text | safeHTML }} {{ .Attributes }}`)
+	b.WithTemplatesAdded("_default/_markup/render-list.html", `LIST: {{ .Text | safeHTML }}|{{ .Attributes }}|{{ .IsOrdered }} `)
+	b.WithTemplatesAdded("_default/_markup/render-listitem.html", `LISTITEM: {{ .Text | safeHTML }}`)
 	b.WithContent("customview/p1.md", `---
 title: Custom View
 ---
@@ -203,7 +203,9 @@ title: With List Items
 - Dog
 - Cat
 - Mouse **Fat**
-- Bird{.parrot}
+- Bird
+  {.parrot}
+{.animals}
 `, "blog/p10.md", `---
 title: With Ordered List
 ---

--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -204,8 +204,7 @@ title: With List Items
 - Cat
 - Mouse **Fat**
 - Bird
-  {.parrot}
-{.animals}
+{.animal}
 `, "blog/p10.md", `---
 title: With Ordered List
 ---
@@ -213,7 +212,6 @@ title: With Ordered List
 2. Boat
 3. Plane
 {.transportation}
-
 `,
 	)
 
@@ -287,8 +285,10 @@ SHORT3|
 	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Dog")
 	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Cat")
 	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Mouse <strong>Fat</strong>")
+	b.AssertFileContent("public/blog/p9/index.html", "class:animal")
 
 	b.AssertFileContent("public/blog/p10/index.html", "LIST:")
+	b.AssertFileContent("public/blog/p10/index.html", "class:transportation")
 }
 
 func TestRenderHooksDeleteTemplate(t *testing.T) {

--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -98,7 +98,7 @@ Inner Block: {{ .Inner | .Page.RenderString (dict "display" "block" ) }}
 	b.WithTemplatesAdded("_default/_markup/render-image.html", `IMAGE: {{ .Page.Title }}||{{ .Destination | safeURL }}|Title: {{ .Title | safeHTML }}|Text: {{ .Text | safeHTML }}|END`)
 	b.WithTemplatesAdded("_default/_markup/render-heading.html", `HEADING: {{ .Page.Title }}||Level: {{ .Level }}|Anchor: {{ .Anchor | safeURL }}|Text: {{ .Text | safeHTML }}|Attributes: {{ .Attributes }}|END`)
 	b.WithTemplatesAdded("docs/_markup/render-heading.html", `Docs Level: {{ .Level }}|END`)
-	b.WithTemplatesAdded("_default/_markup/render-listitem.html", `LISTITEM: {{ .Text | safeHTML }} {{ .Attributes }} {{ .FirstChild }} {{ .Parent }}`)
+	b.WithTemplatesAdded("_default/_markup/render-listitem.html", `LISTITEM: {{ .Text | safeHTML }} {{ .Attributes }}`)
 	b.WithContent("customview/p1.md", `---
 title: Custom View
 ---
@@ -201,8 +201,8 @@ title: With List Items
 ---
 - Dog
 - Cat
-- Mouse
-- Bird{ parrot=true }
+- Mouse **Fat**
+- Bird{.parrot}
 `,
 	)
 
@@ -275,7 +275,7 @@ SHORT3|
 
 	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Dog")
 	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Cat")
-	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Mouse")
+	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Mouse <strong>Fat</strong>")
 }
 
 func TestRenderHooksDeleteTemplate(t *testing.T) {

--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -99,7 +99,7 @@ Inner Block: {{ .Inner | .Page.RenderString (dict "display" "block" ) }}
 	b.WithTemplatesAdded("_default/_markup/render-heading.html", `HEADING: {{ .Page.Title }}||Level: {{ .Level }}|Anchor: {{ .Anchor | safeURL }}|Text: {{ .Text | safeHTML }}|Attributes: {{ .Attributes }}|END`)
 	b.WithTemplatesAdded("docs/_markup/render-heading.html", `Docs Level: {{ .Level }}|END`)
 	b.WithTemplatesAdded("_default/_markup/render-list.html", `LIST: {{ .Text | safeHTML }}|{{ .Attributes }}|{{ .IsOrdered }} `)
-	b.WithTemplatesAdded("_default/_markup/render-listitem.html", `LISTITEM: {{ .Text | safeHTML }}`)
+	b.WithTemplatesAdded("_default/_markup/render-listitem.html", `LISTITEM: {{ .Text | safeHTML }} {{ .IsFirst }} {{ .IsLast }} `)
 	b.WithContent("customview/p1.md", `---
 title: Custom View
 ---

--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -98,7 +98,7 @@ Inner Block: {{ .Inner | .Page.RenderString (dict "display" "block" ) }}
 	b.WithTemplatesAdded("_default/_markup/render-image.html", `IMAGE: {{ .Page.Title }}||{{ .Destination | safeURL }}|Title: {{ .Title | safeHTML }}|Text: {{ .Text | safeHTML }}|END`)
 	b.WithTemplatesAdded("_default/_markup/render-heading.html", `HEADING: {{ .Page.Title }}||Level: {{ .Level }}|Anchor: {{ .Anchor | safeURL }}|Text: {{ .Text | safeHTML }}|Attributes: {{ .Attributes }}|END`)
 	b.WithTemplatesAdded("docs/_markup/render-heading.html", `Docs Level: {{ .Level }}|END`)
-
+	b.WithTemplatesAdded("_default/_markup/render-listitem.html", `LISTITEM: {{ .Text | safeHTML }} {{ .Attributes }} {{ .FirstChild }} {{ .Parent }}`)
 	b.WithContent("customview/p1.md", `---
 title: Custom View
 ---
@@ -196,6 +196,13 @@ title: Doc With Heading
 
 # Docs lvl 1
 
+`, "blog/p9.md", `---
+title: With List Items
+---
+- Dog
+- Cat
+- Mouse
+- Bird{ parrot=true }
 `,
 	)
 
@@ -210,7 +217,7 @@ title: No Template
 	}
 	counters := &testCounters{}
 	b.Build(BuildCfg{testCounters: counters})
-	b.Assert(int(counters.contentRenderCounter), qt.Equals, 45)
+	b.Assert(int(counters.contentRenderCounter), qt.Equals, 46)
 
 	b.AssertFileContent("public/blog/p1/index.html", `
 Cool Page|https://www.google.com|Title: Google's Homepage|Text: First Link|END
@@ -265,6 +272,10 @@ SHORT3|
 
 	// https://github.com/gohugoio/hugo/issues/7349
 	b.AssertFileContent("public/docs/p8/index.html", "Docs Level: 1")
+
+	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Dog")
+	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Cat")
+	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Mouse")
 }
 
 func TestRenderHooksDeleteTemplate(t *testing.T) {

--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -98,6 +98,7 @@ Inner Block: {{ .Inner | .Page.RenderString (dict "display" "block" ) }}
 	b.WithTemplatesAdded("_default/_markup/render-image.html", `IMAGE: {{ .Page.Title }}||{{ .Destination | safeURL }}|Title: {{ .Title | safeHTML }}|Text: {{ .Text | safeHTML }}|END`)
 	b.WithTemplatesAdded("_default/_markup/render-heading.html", `HEADING: {{ .Page.Title }}||Level: {{ .Level }}|Anchor: {{ .Anchor | safeURL }}|Text: {{ .Text | safeHTML }}|Attributes: {{ .Attributes }}|END`)
 	b.WithTemplatesAdded("docs/_markup/render-heading.html", `Docs Level: {{ .Level }}|END`)
+	b.WithTemplatesAdded("_default/_markup/render-list.html", `LIST: {{ .Text | safeHTML }} {{ .Attributes }} {{ .IsOrdered }} `)
 	b.WithTemplatesAdded("_default/_markup/render-listitem.html", `LISTITEM: {{ .Text | safeHTML }} {{ .Attributes }}`)
 	b.WithContent("customview/p1.md", `---
 title: Custom View
@@ -203,6 +204,14 @@ title: With List Items
 - Cat
 - Mouse **Fat**
 - Bird{.parrot}
+`, "blog/p10.md", `---
+title: With Ordered List
+---
+1. Car
+2. Boat
+3. Plane
+{.transportation}
+
 `,
 	)
 
@@ -217,7 +226,7 @@ title: No Template
 	}
 	counters := &testCounters{}
 	b.Build(BuildCfg{testCounters: counters})
-	b.Assert(int(counters.contentRenderCounter), qt.Equals, 46)
+	b.Assert(int(counters.contentRenderCounter), qt.Equals, 47)
 
 	b.AssertFileContent("public/blog/p1/index.html", `
 Cool Page|https://www.google.com|Title: Google's Homepage|Text: First Link|END
@@ -276,6 +285,8 @@ SHORT3|
 	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Dog")
 	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Cat")
 	b.AssertFileContent("public/blog/p9/index.html", "LISTITEM: Mouse <strong>Fat</strong>")
+
+	b.AssertFileContent("public/blog/p10/index.html", "LIST:")
 }
 
 func TestRenderHooksDeleteTemplate(t *testing.T) {

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -494,7 +494,7 @@ func (p *pageContentOutput) initRenderHooks() error {
 			case hooks.ListItemRendererType:
 				layoutDescriptor.Kind = "render-listitem"
 			case hooks.ListRendererType:
-				layoutDescriptor.Kind = "render-listitem"
+				layoutDescriptor.Kind = "render-list"
 			}
 
 			getHookTemplate := func(f output.Format) (tpl.Template, bool) {

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -491,6 +491,8 @@ func (p *pageContentOutput) initRenderHooks() error {
 						layoutDescriptor.KindVariants = lang
 					}
 				}
+			case hooks.ListItemRendererType:
+				layoutDescriptor.Kind = "render-listitem"
 			}
 
 			getHookTemplate := func(f output.Format) (tpl.Template, bool) {

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -493,6 +493,8 @@ func (p *pageContentOutput) initRenderHooks() error {
 				}
 			case hooks.ListItemRendererType:
 				layoutDescriptor.Kind = "render-listitem"
+			case hooks.ListRendererType:
+				layoutDescriptor.Kind = "render-listitem"
 			}
 
 			getHookTemplate := func(f output.Format) (tpl.Template, bool) {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1808,6 +1808,10 @@ func (hr hookRendererTemplate) RenderListItem(w io.Writer, ctx hooks.ListItemCon
 	return hr.templateHandler.Execute(hr.templ, w, ctx)
 }
 
+func (hr hookRendererTemplate) RenderList(w io.Writer, ctx hooks.ListContext) error {
+	return hr.templateHandler.Execute(hr.templ, w, ctx)
+}
+
 func (hr hookRendererTemplate) ResolvePosition(ctx any) text.Position {
 	return hr.resolvePosition(ctx)
 }

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1804,6 +1804,10 @@ func (hr hookRendererTemplate) RenderCodeblock(w hugio.FlexiWriter, ctx hooks.Co
 	return hr.templateHandler.Execute(hr.templ, w, ctx)
 }
 
+func (hr hookRendererTemplate) RenderListItem(w io.Writer, ctx hooks.ListItemContext) error {
+	return hr.templateHandler.Execute(hr.templ, w, ctx)
+}
+
 func (hr hookRendererTemplate) ResolvePosition(ctx any) text.Position {
 	return hr.resolvePosition(ctx)
 }

--- a/markup/converter/hooks/hooks.go
+++ b/markup/converter/hooks/hooks.go
@@ -111,7 +111,7 @@ type ListContext interface {
 	Page() interface{}
 	Text() hstring.RenderedString
 	PlainText() string
-
+	IsOrdered() bool
 	Parent() interface{}
 
 	AttributesProvider

--- a/markup/converter/hooks/hooks.go
+++ b/markup/converter/hooks/hooks.go
@@ -98,8 +98,6 @@ type ListItemContext interface {
 	Offset() int
 	FirstChild() interface{}
 	Parent() interface{}
-
-	AttributesProvider
 }
 
 type ListItemRenderer interface {

--- a/markup/converter/hooks/hooks.go
+++ b/markup/converter/hooks/hooks.go
@@ -95,8 +95,8 @@ type ListItemContext interface {
 	Page() interface{}
 	Text() hstring.RenderedString
 	PlainText() string
-	Offset() int
-	FirstChild() interface{}
+	IsFirst() bool
+	IsLast() bool
 	Parent() interface{}
 }
 

--- a/markup/converter/hooks/hooks.go
+++ b/markup/converter/hooks/hooks.go
@@ -91,6 +91,22 @@ type HeadingRenderer interface {
 	identity.Provider
 }
 
+type ListItemContext interface {
+	Page() interface{}
+	Text() hstring.RenderedString
+	PlainText() string
+	Offset() int
+	FirstChild() interface{}
+	Parent() interface{}
+
+	AttributesProvider
+}
+
+type ListItemRenderer interface {
+	RenderListItem(w io.Writer, ctx ListItemContext) error
+	identity.Provider
+}
+
 // ElementPositionResolver provides a way to resolve the start Position
 // of a markdown element in the original source document.
 // This may be both slow and approximate, so should only be
@@ -106,6 +122,7 @@ const (
 	ImageRendererType
 	HeadingRendererType
 	CodeBlockRendererType
+	ListItemRendererType
 )
 
 type GetRendererFunc func(t RendererType, id any) any

--- a/markup/converter/hooks/hooks.go
+++ b/markup/converter/hooks/hooks.go
@@ -107,6 +107,21 @@ type ListItemRenderer interface {
 	identity.Provider
 }
 
+type ListContext interface {
+	Page() interface{}
+	Text() hstring.RenderedString
+	PlainText() string
+
+	Parent() interface{}
+
+	AttributesProvider
+}
+
+type ListRenderer interface {
+	RenderList(w io.Writer, ctx ListContext) error
+	identity.Provider
+}
+
 // ElementPositionResolver provides a way to resolve the start Position
 // of a markdown element in the original source document.
 // This may be both slow and approximate, so should only be
@@ -123,6 +138,7 @@ const (
 	HeadingRendererType
 	CodeBlockRendererType
 	ListItemRendererType
+	ListRendererType
 )
 
 type GetRendererFunc func(t RendererType, id any) any

--- a/markup/goldmark/render_hooks.go
+++ b/markup/goldmark/render_hooks.go
@@ -109,12 +109,12 @@ func (ctx headingContext) PlainText() string {
 }
 
 type listItemContext struct {
-	page       interface{}
-	text       hstring.RenderedString
-	plainText  string
-	offset     int
-	firstChild interface{}
-	parent     interface{}
+	page      interface{}
+	text      hstring.RenderedString
+	plainText string
+	isFirst   bool
+	isLast    bool
+	parent    interface{}
 }
 
 func (ctx listItemContext) Page() interface{} {
@@ -129,12 +129,12 @@ func (ctx listItemContext) PlainText() string {
 	return ctx.plainText
 }
 
-func (ctx listItemContext) Offset() int {
-	return ctx.offset
+func (ctx listItemContext) IsFirst() bool {
+	return ctx.isFirst
 }
 
-func (ctx listItemContext) FirstChild() interface{} {
-	return ctx.firstChild
+func (ctx listItemContext) IsLast() bool {
+	return ctx.isLast
 }
 
 func (ctx listItemContext) Parent() interface{} {
@@ -505,12 +505,12 @@ func (r *hookedRenderer) renderListItem(w util.BufWriter, source []byte, node as
 	err := hli.RenderListItem(
 		w,
 		listItemContext{
-			page:       ctx.DocumentContext().Document,
-			text:       hstring.RenderedString(text),
-			plainText:  string(n.Text(source)),
-			offset:     int(n.Offset),
-			firstChild: n.FirstChild(),
-			parent:     n.Parent(),
+			page:      ctx.DocumentContext().Document,
+			text:      hstring.RenderedString(text),
+			plainText: string(n.Text(source)),
+			isFirst:   n.PreviousSibling() == nil,
+			isLast:    n.NextSibling() == nil,
+			parent:    n.Parent(),
 		},
 	)
 

--- a/markup/goldmark/render_hooks.go
+++ b/markup/goldmark/render_hooks.go
@@ -519,6 +519,8 @@ func (r *hookedRenderer) renderListItem(w util.BufWriter, source []byte, node as
 	return ast.WalkContinue, err
 }
 
+// Fall back to the default Goldmark render funcs. Method below borrowed from:
+// https://github.com/yuin/goldmark/blob/5588d92a56fe1642791cf4aa8e9eae8227cfeecd/renderer/html/html.go#L353
 func (r *hookedRenderer) renderListItemDefault(w util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		_, _ = w.WriteString("<li>")
@@ -534,6 +536,8 @@ func (r *hookedRenderer) renderListItemDefault(w util.BufWriter, source []byte, 
 	return ast.WalkContinue, nil
 }
 
+// Fall back to the default Goldmark render funcs. Method below borrowed from:
+// https://github.com/yuin/goldmark/blob/5588d92a56fe1642791cf4aa8e9eae8227cfeecd/renderer/html/html.go#L324
 func (r *hookedRenderer) renderListDefault(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n := node.(*ast.List)
 	tag := "ul"

--- a/markup/goldmark/render_hooks.go
+++ b/markup/goldmark/render_hooks.go
@@ -15,6 +15,7 @@ package goldmark
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 
 	"github.com/gohugoio/hugo/common/types/hstring"
@@ -141,6 +142,30 @@ func (ctx listItemContext) Parent() interface{} {
 	return ctx.parent
 }
 
+type listContext struct {
+	page      interface{}
+	text      hstring.RenderedString
+	plainText string
+	parent    interface{}
+	*attributes.AttributesHolder
+}
+
+func (ctx listContext) Page() interface{} {
+	return ctx.page
+}
+
+func (ctx listContext) Text() hstring.RenderedString {
+	return ctx.text
+}
+
+func (ctx listContext) PlainText() string {
+	return ctx.plainText
+}
+
+func (ctx listContext) Parent() interface{} {
+	return ctx.parent
+}
+
 type hookedRenderer struct {
 	linkifyProtocol []byte
 	html.Config
@@ -157,6 +182,7 @@ func (r *hookedRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) 
 	reg.Register(ast.KindImage, r.renderImage)
 	reg.Register(ast.KindHeading, r.renderHeading)
 	reg.Register(ast.KindListItem, r.renderListItem)
+	reg.Register(ast.KindList, r.renderList)
 }
 
 func (r *hookedRenderer) renderImage(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -504,6 +530,75 @@ func (r *hookedRenderer) renderListItemDefault(w util.BufWriter, source []byte, 
 		_, _ = w.WriteString("</li>\n")
 	}
 	return ast.WalkContinue, nil
+}
+
+func (r *hookedRenderer) renderListDefault(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	n := node.(*ast.List)
+	tag := "ul"
+	if n.IsOrdered() {
+		tag = "ol"
+	}
+	if entering {
+		_ = w.WriteByte('<')
+		_, _ = w.WriteString(tag)
+		if n.IsOrdered() && n.Start != 1 {
+			fmt.Fprintf(w, " start=\"%d\"", n.Start)
+		}
+		if n.Attributes() != nil {
+			html.RenderAttributes(w, n, html.ListAttributeFilter)
+		}
+		_, _ = w.WriteString(">\n")
+	} else {
+		_, _ = w.WriteString("</")
+		_, _ = w.WriteString(tag)
+		_, _ = w.WriteString(">\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *hookedRenderer) renderList(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	n := node.(*ast.List)
+	n.FirstChild()
+	var hli hooks.ListRenderer
+
+	ctx, ok := w.(*render.Context)
+	if ok {
+		h := ctx.RenderContext().GetRenderer(hooks.ListItemRendererType, nil)
+		ok = h != nil
+		if ok {
+			hli = h.(hooks.ListRenderer)
+		}
+	}
+
+	if !ok {
+		return r.renderListDefault(w, source, node, entering)
+	}
+
+	if entering {
+		// Store the current pos so we can capture the rendered text.
+		ctx.PushPos(ctx.Buffer.Len())
+		return ast.WalkContinue, nil
+	}
+
+	pos := ctx.PopPos()
+	text := ctx.Buffer.Bytes()[pos:]
+	ctx.Buffer.Truncate(pos)
+
+	err := hli.RenderList(
+		w,
+		listItemContext{
+			page:             ctx.DocumentContext().Document,
+			text:             hstring.RenderedString(text),
+			plainText:        string(n.Text(source)),
+			parent:           n.Parent(),
+			AttributesHolder: attributes.New(n.Attributes(), attributes.AttributesOwnerGeneral),
+		},
+	)
+
+	ctx.AddIdentity(hli)
+
+	return ast.WalkContinue, err
+	//return r.renderListDefault(w, source, node, entering)
 }
 
 type links struct {

--- a/markup/goldmark/render_hooks.go
+++ b/markup/goldmark/render_hooks.go
@@ -115,7 +115,6 @@ type listItemContext struct {
 	offset     int
 	firstChild interface{}
 	parent     interface{}
-	*attributes.AttributesHolder
 }
 
 func (ctx listItemContext) Page() interface{} {
@@ -506,13 +505,12 @@ func (r *hookedRenderer) renderListItem(w util.BufWriter, source []byte, node as
 	err := hli.RenderListItem(
 		w,
 		listItemContext{
-			page:             ctx.DocumentContext().Document,
-			text:             hstring.RenderedString(text),
-			plainText:        string(n.Text(source)),
-			offset:           int(n.Offset),
-			firstChild:       n.FirstChild(),
-			parent:           n.Parent(),
-			AttributesHolder: attributes.New(n.Attributes(), attributes.AttributesOwnerGeneral),
+			page:       ctx.DocumentContext().Document,
+			text:       hstring.RenderedString(text),
+			plainText:  string(n.Text(source)),
+			offset:     int(n.Offset),
+			firstChild: n.FirstChild(),
+			parent:     n.Parent(),
 		},
 	)
 


### PR DESCRIPTION
I needed a way to render lists and list items for different output formats.

I'm writing a food blog and wrote the recipes directly in json-ld format first and used the JSON as input for my template. This has some drawbacks. I use the image processing quite extensively and that's something that couldn't be used in this scenario. Also google recently changed the way json-ld is accepted with sub-recipes so I decided to instead write my recipes in markdown (with the help of some shortcakes) and render them to html and json-ld, so that I can react to changes with a simple edit of my templates. 

But this required the list and especially listitem hooks provided in this PR.