### PR TITLE
postcss: Fix import error handling

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -482,6 +482,7 @@ func removeErrorPrefixFromLog(content string) string {
 var logReplacer = strings.NewReplacer(
 	"can't", "can’t", // Chroma lexer does'nt do well with "can't"
 	"*hugolib.pageState", "page.Page", // Page is the public interface.
+	"Rebuild failed:", "",
 )
 
 func cleanErrorLog(content string) string {

--- a/common/herrors/error_locator.go
+++ b/common/herrors/error_locator.go
@@ -52,6 +52,16 @@ var NopLineMatcher = func(m LineMatcher) int {
 	return 1
 }
 
+// OffsetMatcher is a line matcher that matches by offset.
+var OffsetMatcher = func(m LineMatcher) int {
+	if m.Offset+len(m.Line) >= m.Position.Offset {
+		// We found the line, but return 0 to signal that we want to determine
+		// the column from the error.
+		return 0
+	}
+	return -1
+}
+
 // ErrorContext contains contextual information about an error. This will
 // typically be the lines surrounding some problem in a file.
 type ErrorContext struct {

--- a/common/herrors/file_error_test.go
+++ b/common/herrors/file_error_test.go
@@ -30,7 +30,7 @@ func TestNewFileError(t *testing.T) {
 
 	c := qt.New(t)
 
-	fe := NewFileError(errors.New("bar"), "foo.html")
+	fe := NewFileErrorFromName(errors.New("bar"), "foo.html")
 	c.Assert(fe.Error(), qt.Equals, `"foo.html:1:1": bar`)
 
 	lines := ""
@@ -70,7 +70,7 @@ func TestNewFileErrorExtractFromMessage(t *testing.T) {
 		{errors.New(`execute of template failed: template: index.html:2:5: executing "index.html" at <partial "foo.html" .>: error calling partial: "/layouts/partials/foo.html:3:6": execute of template failed: template: partials/foo.html:3:6: executing "partials/foo.html" at <.ThisDoesNotExist>: can't evaluate field ThisDoesNotExist in type *hugolib.pageStat`), 0, 2, 5},
 	} {
 
-		got := NewFileError(test.in, "test.txt")
+		got := NewFileErrorFromName(test.in, "test.txt")
 
 		errMsg := qt.Commentf("[%d][%T]", i, got)
 

--- a/common/herrors/file_error_test.go
+++ b/common/herrors/file_error_test.go
@@ -30,7 +30,7 @@ func TestNewFileError(t *testing.T) {
 
 	c := qt.New(t)
 
-	fe := NewFileError("foo.html", errors.New("bar"))
+	fe := NewFileError(errors.New("bar"), "foo.html")
 	c.Assert(fe.Error(), qt.Equals, `"foo.html:1:1": bar`)
 
 	lines := ""
@@ -70,7 +70,7 @@ func TestNewFileErrorExtractFromMessage(t *testing.T) {
 		{errors.New(`execute of template failed: template: index.html:2:5: executing "index.html" at <partial "foo.html" .>: error calling partial: "/layouts/partials/foo.html:3:6": execute of template failed: template: partials/foo.html:3:6: executing "partials/foo.html" at <.ThisDoesNotExist>: can't evaluate field ThisDoesNotExist in type *hugolib.pageStat`), 0, 2, 5},
 	} {
 
-		got := NewFileError("test.txt", test.in)
+		got := NewFileError(test.in, "test.txt")
 
 		errMsg := qt.Commentf("[%d][%T]", i, got)
 

--- a/common/paths/url.go
+++ b/common/paths/url.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -151,4 +152,30 @@ func Uglify(in string) string {
 	}
 	// /section/name.html -> /section/name.html
 	return path.Clean(in)
+}
+
+// UrlToFilename converts the URL s to a filename.
+// If ParseRequestURI fails, the input is just converted to OS specific slashes and returned.
+func UrlToFilename(s string) (string, bool) {
+	u, err := url.ParseRequestURI(s)
+
+	if err != nil {
+		return filepath.FromSlash(s), false
+	}
+
+	p := u.Path
+
+	if p == "" {
+		p, _ = url.QueryUnescape(u.Opaque)
+		return filepath.FromSlash(p), true
+	}
+
+	p = filepath.FromSlash(p)
+
+	if u.Host != "" {
+		// C:\data\file.txt
+		p = strings.ToUpper(u.Host) + ":" + p
+	}
+
+	return p, true
 }

--- a/config/configLoader.go
+++ b/config/configLoader.go
@@ -59,7 +59,7 @@ func FromConfigString(config, configType string) (Provider, error) {
 func FromFile(fs afero.Fs, filename string) (Provider, error) {
 	m, err := loadConfigFromFile(fs, filename)
 	if err != nil {
-		return nil, herrors.NewFileErrorFromFile(err, filename, filename, fs, nil)
+		return nil, herrors.NewFileErrorFromFile(err, filename, fs, nil)
 	}
 	return NewFrom(m), nil
 }

--- a/docs/content/en/hugo-pipes/postcss.md
+++ b/docs/content/en/hugo-pipes/postcss.md
@@ -44,6 +44,10 @@ URL imports (e.g. `@import url('https://fonts.googleapis.com/css?family=Open+San
 Note that this import routine does not care about the CSS spec, so you can have @import anywhere in the file.
 Hugo will look for imports relative to the module mount and will respect theme overrides.
 
+skipInlineImportsNotFound [bool] {{< new-in "0.99.0" >}}
+
+Before Hugo 0.99.0 when `inlineImports` was enabled and we failed to resolve an import, we logged it as a warning. We now fail the build. If you have regular CSS imports in your CSS that you want to preserve, you can either use imports with URL or media queries (Hugo does not try to resolve those) or set `skipInlineImportsNotFound` to true.
+
 _If no configuration file is used:_
 
 use [string]

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bep/gitmap v1.1.2
 	github.com/bep/goat v0.5.0
 	github.com/bep/godartsass v0.14.0
-	github.com/bep/golibsass v1.0.0
+	github.com/bep/golibsass v1.1.0
 	github.com/bep/gowebp v0.1.0
 	github.com/bep/overlayfs v0.6.0
 	github.com/bep/tmc v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/bep/godartsass v0.14.0 h1:pPb6XkpyDEppS+wK0veh7OXDQc4xzOJI9Qcjb743UeQ
 github.com/bep/godartsass v0.14.0/go.mod h1:6LvK9RftsXMxGfsA0LDV12AGc4Jylnu6NgHL+Q5/pE8=
 github.com/bep/golibsass v1.0.0 h1:gNguBMSDi5yZEZzVZP70YpuFQE3qogJIGUlrVILTmOw=
 github.com/bep/golibsass v1.0.0/go.mod h1:DL87K8Un/+pWUS75ggYv41bliGiolxzDKWJAq3eJ1MA=
+github.com/bep/golibsass v1.1.0 h1:pjtXr00IJZZaOdfryNa9wARTB3Q0BmxC3/V1KNcgyTw=
+github.com/bep/golibsass v1.1.0/go.mod h1:DL87K8Un/+pWUS75ggYv41bliGiolxzDKWJAq3eJ1MA=
 github.com/bep/gowebp v0.1.0 h1:4/iQpfnxHyXs3x/aTxMMdOpLEQQhFmF6G7EieWPTQyo=
 github.com/bep/gowebp v0.1.0/go.mod h1:ZhFodwdiFp8ehGJpF4LdPl6unxZm9lLFjxD3z2h2AgI=
 github.com/bep/overlayfs v0.6.0 h1:sgLcq/qtIzbaQNl2TldGXOkHvqeZB025sPvHOQL+DYo=

--- a/hugofs/fileinfo.go
+++ b/hugofs/fileinfo.go
@@ -139,6 +139,17 @@ type fileInfoMeta struct {
 	m *FileMeta
 }
 
+type filenameProvider interface {
+	Filename() string
+}
+
+var _ filenameProvider = (*fileInfoMeta)(nil)
+
+// Filename returns the full filename.
+func (fi *fileInfoMeta) Filename() string {
+	return fi.m.Filename
+}
+
 // Name returns the file's name. Note that we follow symlinks,
 // if supported by the file system, and the Name given here will be the
 // name of the symlink, which is what Hugo needs in all situations.

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -511,5 +511,5 @@ func (configLoader) loadSiteConfig(cfg config.Provider) (scfg SiteConfig, err er
 }
 
 func (l configLoader) wrapFileError(err error, filename string) error {
-	return herrors.NewFileErrorFromFile(err, filename, filename, l.Fs, nil)
+	return herrors.NewFileErrorFromFile(err, filename, l.Fs, nil)
 }

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -968,7 +968,7 @@ func (h *HugoSites) errWithFileContext(err error, f source.File) error {
 	}
 	realFilename := fim.Meta().Filename
 
-	return herrors.NewFileErrorFromFile(err, realFilename, realFilename, h.SourceSpec.Fs.Source, nil)
+	return herrors.NewFileErrorFromFile(err, realFilename, h.SourceSpec.Fs.Source, nil)
 
 }
 

--- a/hugolib/integrationtest_builder.go
+++ b/hugolib/integrationtest_builder.go
@@ -168,8 +168,9 @@ func (s *IntegrationTestBuilder) destinationExists(filename string) bool {
 	return b
 }
 
-func (s *IntegrationTestBuilder) AssertIsFileError(err error) {
+func (s *IntegrationTestBuilder) AssertIsFileError(err error) herrors.FileError {
 	s.Assert(err, qt.ErrorAs, new(herrors.FileError))
+	return herrors.UnwrapFileError(err)
 }
 
 func (s *IntegrationTestBuilder) AssertRenderCountContent(count int) {

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -588,7 +588,7 @@ func (p *pageState) wrapError(err error) error {
 		}
 	}
 
-	return herrors.NewFileErrorFromFile(err, filename, filename, p.s.SourceSpec.Fs.Source, herrors.NopLineMatcher)
+	return herrors.NewFileErrorFromFile(err, filename, p.s.SourceSpec.Fs.Source, herrors.NopLineMatcher)
 
 }
 
@@ -788,7 +788,7 @@ func (p *pageState) outputFormat() (f output.Format) {
 
 func (p *pageState) parseError(err error, input []byte, offset int) error {
 	pos := p.posFromInput(input, offset)
-	return herrors.NewFileError(p.File().Filename(), err).UpdatePosition(pos)
+	return herrors.NewFileError(err, p.File().Filename()).UpdatePosition(pos)
 }
 
 func (p *pageState) pathOrTitle() string {

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -788,7 +788,7 @@ func (p *pageState) outputFormat() (f output.Format) {
 
 func (p *pageState) parseError(err error, input []byte, offset int) error {
 	pos := p.posFromInput(input, offset)
-	return herrors.NewFileError(err, p.File().Filename()).UpdatePosition(pos)
+	return herrors.NewFileErrorFromName(err, p.File().Filename()).UpdatePosition(pos)
 }
 
 func (p *pageState) pathOrTitle() string {

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -298,7 +298,7 @@ func renderShortcode(
 			var err error
 			tmpl, err = s.TextTmpl().Parse(templName, templStr)
 			if err != nil {
-				fe := herrors.NewFileError(p.File().Filename(), err)
+				fe := herrors.NewFileError(err, p.File().Filename())
 				pos := fe.Position()
 				pos.LineNumber += p.posOffset(sc.pos).LineNumber
 				fe = fe.UpdatePosition(pos)
@@ -391,7 +391,7 @@ func renderShortcode(
 	result, err := renderShortcodeWithPage(s.Tmpl(), tmpl, data)
 
 	if err != nil && sc.isInline {
-		fe := herrors.NewFileError(p.File().Filename(), err)
+		fe := herrors.NewFileError(err, p.File().Filename())
 		pos := fe.Position()
 		pos.LineNumber += p.posOffset(sc.pos).LineNumber
 		fe = fe.UpdatePosition(pos)

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -298,7 +298,7 @@ func renderShortcode(
 			var err error
 			tmpl, err = s.TextTmpl().Parse(templName, templStr)
 			if err != nil {
-				fe := herrors.NewFileError(err, p.File().Filename())
+				fe := herrors.NewFileErrorFromName(err, p.File().Filename())
 				pos := fe.Position()
 				pos.LineNumber += p.posOffset(sc.pos).LineNumber
 				fe = fe.UpdatePosition(pos)
@@ -391,7 +391,7 @@ func renderShortcode(
 	result, err := renderShortcodeWithPage(s.Tmpl(), tmpl, data)
 
 	if err != nil && sc.isInline {
-		fe := herrors.NewFileError(err, p.File().Filename())
+		fe := herrors.NewFileErrorFromName(err, p.File().Filename())
 		pos := fe.Position()
 		pos.LineNumber += p.posOffset(sc.pos).LineNumber
 		fe = fe.UpdatePosition(pos)

--- a/langs/i18n/translationProvider.go
+++ b/langs/i18n/translationProvider.go
@@ -138,6 +138,6 @@ func errWithFileContext(inerr error, r source.File) error {
 	}
 	defer f.Close()
 
-	return herrors.NewFileError(realFilename, inerr).UpdateContent(f, nil)
+	return herrors.NewFileError(inerr, realFilename).UpdateContent(f, nil)
 
 }

--- a/langs/i18n/translationProvider.go
+++ b/langs/i18n/translationProvider.go
@@ -138,6 +138,6 @@ func errWithFileContext(inerr error, r source.File) error {
 	}
 	defer f.Close()
 
-	return herrors.NewFileError(inerr, realFilename).UpdateContent(f, nil)
+	return herrors.NewFileErrorFromName(inerr, realFilename).UpdateContent(f, nil)
 
 }

--- a/markup/goldmark/codeblocks/render.go
+++ b/markup/goldmark/codeblocks/render.go
@@ -130,7 +130,7 @@ func (r *htmlRenderer) renderCodeBlock(w util.BufWriter, src []byte, node ast.No
 	ctx.AddIdentity(cr)
 
 	if err != nil {
-		return ast.WalkContinue, herrors.NewFileErrorFromPos(cbctx.createPos(), err)
+		return ast.WalkContinue, herrors.NewFileErrorFromPos(err, cbctx.createPos())
 	}
 
 	return ast.WalkContinue, nil

--- a/parser/metadecoders/decoder.go
+++ b/parser/metadecoders/decoder.go
@@ -260,7 +260,7 @@ func (d Decoder) unmarshalORG(data []byte, v any) error {
 }
 
 func toFileError(f Format, data []byte, err error) error {
-	return herrors.NewFileError(err, fmt.Sprintf("_stream.%s", f)).UpdateContent(bytes.NewReader(data), nil)
+	return herrors.NewFileErrorFromName(err, fmt.Sprintf("_stream.%s", f)).UpdateContent(bytes.NewReader(data), nil)
 }
 
 // stringifyMapKeys recurses into in and changes all instances of

--- a/parser/metadecoders/decoder.go
+++ b/parser/metadecoders/decoder.go
@@ -260,7 +260,7 @@ func (d Decoder) unmarshalORG(data []byte, v any) error {
 }
 
 func toFileError(f Format, data []byte, err error) error {
-	return herrors.NewFileError(fmt.Sprintf("_stream.%s", f), err).UpdateContent(bytes.NewReader(data), nil)
+	return herrors.NewFileError(err, fmt.Sprintf("_stream.%s", f)).UpdateContent(bytes.NewReader(data), nil)
 }
 
 // stringifyMapKeys recurses into in and changes all instances of

--- a/resources/resource_transformers/js/build.go
+++ b/resources/resource_transformers/js/build.go
@@ -165,7 +165,7 @@ func (t *buildTransformation) Transform(ctx *resources.ResourceTransformationCtx
 
 			if err == nil {
 				fe := herrors.
-					NewFileError(errors.New(errorMessage), path).
+					NewFileErrorFromName(errors.New(errorMessage), path).
 					UpdatePosition(text.Position{Offset: -1, LineNumber: loc.Line, ColumnNumber: loc.Column}).
 					UpdateContent(f, nil)
 

--- a/resources/resource_transformers/js/build.go
+++ b/resources/resource_transformers/js/build.go
@@ -165,7 +165,7 @@ func (t *buildTransformation) Transform(ctx *resources.ResourceTransformationCtx
 
 			if err == nil {
 				fe := herrors.
-					NewFileError(path, errors.New(errorMessage)).
+					NewFileError(errors.New(errorMessage), path).
 					UpdatePosition(text.Position{Offset: -1, LineNumber: loc.Line, ColumnNumber: loc.Column}).
 					UpdateContent(f, nil)
 

--- a/resources/resource_transformers/postcss/integration_test.go
+++ b/resources/resource_transformers/postcss/integration_test.go
@@ -183,6 +183,6 @@ func TestTransformPostCSSImporSkipInlineImportsNotFound(t *testing.T) {
 			TxtarString:     files,
 		}).Build()
 
-	s.AssertFileContent("public/css/styles.css", filepath.FromSlash(`@import "components/doesnotexist.css";`))
+	s.AssertFileContent("public/css/styles.css", `@import "components/doesnotexist.css";`)
 
 }

--- a/resources/resource_transformers/postcss/postcss.go
+++ b/resources/resource_transformers/postcss/postcss.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gohugoio/hugo/common/collections"
 	"github.com/gohugoio/hugo/common/hexec"
+	"github.com/gohugoio/hugo/common/text"
 	"github.com/gohugoio/hugo/hugofs"
 
 	"github.com/gohugoio/hugo/common/hugo"
@@ -49,9 +50,10 @@ import (
 
 const importIdentifier = "@import"
 
-var cssSyntaxErrorRe = regexp.MustCompile(`> (\d+) \|`)
-
-var shouldImportRe = regexp.MustCompile(`^@import ["'].*["'];?\s*(/\*.*\*/)?$`)
+var (
+	cssSyntaxErrorRe = regexp.MustCompile(`> (\d+) \|`)
+	shouldImportRe   = regexp.MustCompile(`^@import ["'].*["'];?\s*(/\*.*\*/)?$`)
+)
 
 // New creates a new Client with the given specification.
 func New(rs *resources.Spec) *Client {
@@ -99,6 +101,12 @@ type Options struct {
 	// Note that this import routine does not care about the CSS spec,
 	// so you can have @import anywhere in the file.
 	InlineImports bool
+
+	// When InlineImports is enabled, we fail the build if an import cannot be resolved.
+	// You can enable this to allow the build to continue and leave the import statement in place.
+	// Note that the inline importer does not process url location or imports with media queries,
+	// so those will be left as-is even without enabling this option.
+	SkipInlineImportsNotFound bool
 
 	// Options for when not using a config file
 	Use         string // List of postcss plugins to use
@@ -204,6 +212,7 @@ func (t *postcssTransformation) Transform(ctx *resources.ResourceTransformationC
 	imp := newImportResolver(
 		ctx.From,
 		ctx.InPath,
+		t.options,
 		t.rs.Assets.Fs, t.rs.Logger,
 	)
 
@@ -239,6 +248,7 @@ type fileOffset struct {
 type importResolver struct {
 	r      io.Reader
 	inPath string
+	opts   Options
 
 	contentSeen map[string]bool
 	linemap     map[int]fileOffset
@@ -246,12 +256,13 @@ type importResolver struct {
 	logger      loggers.Logger
 }
 
-func newImportResolver(r io.Reader, inPath string, fs afero.Fs, logger loggers.Logger) *importResolver {
+func newImportResolver(r io.Reader, inPath string, opts Options, fs afero.Fs, logger loggers.Logger) *importResolver {
 	return &importResolver{
 		r:      r,
 		inPath: inPath,
 		fs:     fs, logger: logger,
 		linemap: make(map[int]fileOffset), contentSeen: make(map[string]bool),
+		opts: opts,
 	}
 }
 
@@ -282,20 +293,31 @@ func (imp *importResolver) importRecursive(
 	i := 0
 	for offset, line := range lines {
 		i++
-		line = strings.TrimSpace(line)
+		lineTrimmed := strings.TrimSpace(line)
+		column := strings.Index(line, lineTrimmed)
+		line = lineTrimmed
 
 		if !imp.shouldImport(line) {
 			trackLine(i, offset, line)
 		} else {
-			i--
 			path := strings.Trim(strings.TrimPrefix(line, importIdentifier), " \"';")
 			filename := filepath.Join(basePath, path)
 			importContent, hash := imp.contentHash(filename)
+
 			if importContent == nil {
-				trackLine(i, offset, "ERROR")
-				imp.logger.Warnf("postcss: Failed to resolve CSS @import in %q for path %q", inPath, filename)
-				continue
+				if imp.opts.SkipInlineImportsNotFound {
+					trackLine(i, offset, line)
+					continue
+				}
+				pos := text.Position{
+					Filename:     inPath,
+					LineNumber:   offset + 1,
+					ColumnNumber: column + 1,
+				}
+				return 0, "", herrors.NewFileErrorFromFileInPos(fmt.Errorf("failed to resolve CSS @import %q", filename), pos, imp.fs, nil)
 			}
+
+			i--
 
 			if imp.contentSeen[hash] {
 				i++
@@ -399,7 +421,7 @@ func (imp *importResolver) toFileError(output string) error {
 	}
 	defer f.Close()
 
-	ferr := herrors.NewFileError(realFilename, inErr)
+	ferr := herrors.NewFileError(inErr, realFilename)
 	pos := ferr.Position()
 	pos.LineNumber = file.Offset + 1
 	return ferr.UpdatePosition(pos).UpdateContent(f, nil)

--- a/resources/resource_transformers/postcss/postcss.go
+++ b/resources/resource_transformers/postcss/postcss.go
@@ -314,7 +314,7 @@ func (imp *importResolver) importRecursive(
 					LineNumber:   offset + 1,
 					ColumnNumber: column + 1,
 				}
-				return 0, "", herrors.NewFileErrorFromFileInPos(fmt.Errorf("failed to resolve CSS @import %q", filename), pos, imp.fs, nil)
+				return 0, "", herrors.NewFileErrorFromFileInPos(fmt.Errorf("failed to resolve CSS @import \"%s\"", filename), pos, imp.fs, nil)
 			}
 
 			i--
@@ -421,7 +421,7 @@ func (imp *importResolver) toFileError(output string) error {
 	}
 	defer f.Close()
 
-	ferr := herrors.NewFileError(inErr, realFilename)
+	ferr := herrors.NewFileErrorFromName(inErr, realFilename)
 	pos := ferr.Position()
 	pos.LineNumber = file.Offset + 1
 	return ferr.UpdatePosition(pos).UpdateContent(f, nil)

--- a/resources/resource_transformers/postcss/postcss_test.go
+++ b/resources/resource_transformers/postcss/postcss_test.go
@@ -60,6 +60,7 @@ func TestShouldImport(t *testing.T) {
 		{input: `@import 'navigation.css';`, expect: true},
 		{input: `@import url("navigation.css");`, expect: false},
 		{input: `@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,400i,800,800i&display=swap');`, expect: false},
+		{input: `@import "printstyle.css" print;`, expect: false},
 	} {
 		c.Assert(imp.shouldImport(test.input), qt.Equals, test.expect)
 	}
@@ -88,12 +89,12 @@ A_STYLE2
 @import "b.css";
 LOCAL_STYLE
 @import "c.css";
-@import "e.css";
-@import "missing.css";`)
+@import "e.css";`)
 
 	imp := newImportResolver(
 		mainStyles,
 		"styles.css",
+		Options{},
 		fs, loggers.NewErrorLogger(),
 	)
 
@@ -108,8 +109,7 @@ C_STYLE
 A_STYLE1
 A_STYLE2
 LOCAL_STYLE
-E_STYLE
-@import "missing.css";`)
+E_STYLE`)
 
 	dline := imp.linemap[3]
 	c.Assert(dline, qt.DeepEquals, fileOffset{
@@ -151,6 +151,7 @@ LOCAL_STYLE
 		imp := newImportResolver(
 			strings.NewReader(mainStyles),
 			"styles.css",
+			Options{},
 			fs, logger,
 		)
 

--- a/resources/resource_transformers/tocss/dartsass/transform.go
+++ b/resources/resource_transformers/tocss/dartsass/transform.go
@@ -16,13 +16,12 @@ package dartsass
 import (
 	"fmt"
 	"io"
-	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
 
-	"github.com/gohugoio/hugo/common/herrors"
 	"github.com/gohugoio/hugo/common/hexec"
+	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/htesting"
 	"github.com/gohugoio/hugo/media"
 
@@ -38,9 +37,6 @@ import (
 )
 
 const (
-	// See https://github.com/sass/dart-sass-embedded/issues/24
-	// Note: This prefix must be all lower case.
-	stdinPrefix                = "hugostdin:"
 	dartSassEmbeddedBinaryName = "dart-sass-embedded"
 )
 
@@ -76,7 +72,7 @@ func (t *transform) Transform(ctx *resources.ResourceTransformationCtx) error {
 	}
 
 	baseDir := path.Dir(ctx.SourcePath)
-	filename := stdinPrefix
+	filename := dartSassStdinPrefix
 
 	if ctx.SourcePath != "" {
 		filename += t.c.sfs.RealFilename(ctx.SourcePath)
@@ -108,26 +104,6 @@ func (t *transform) Transform(ctx *resources.ResourceTransformationCtx) error {
 
 	res, err := t.c.toCSS(args, ctx.From)
 	if err != nil {
-		if sassErr, ok := err.(godartsass.SassError); ok {
-			start := sassErr.Span.Start
-			context := strings.TrimSpace(sassErr.Span.Context)
-			filename, _ := urlToFilename(sassErr.Span.Url)
-			if strings.HasPrefix(filename, stdinPrefix) {
-				filename = filename[len(stdinPrefix):]
-			}
-
-			offsetMatcher := func(m herrors.LineMatcher) int {
-				if m.Offset+len(m.Line) >= start.Offset && strings.Contains(m.Line, context) {
-					// We found the line, but return 0 to signal that we want to determine
-					// the column from the error.
-					return 0
-				}
-				return -1
-			}
-
-			return herrors.NewFileErrorFromFile(sassErr, filename, hugofs.Os, offsetMatcher)
-
-		}
 		return err
 	}
 
@@ -154,7 +130,7 @@ type importResolver struct {
 }
 
 func (t importResolver) CanonicalizeURL(url string) (string, error) {
-	filePath, isURL := urlToFilename(url)
+	filePath, isURL := paths.UrlToFilename(url)
 	var prevDir string
 	var pathDir string
 	if isURL {
@@ -200,23 +176,7 @@ func (t importResolver) CanonicalizeURL(url string) (string, error) {
 }
 
 func (t importResolver) Load(url string) (string, error) {
-	filename, _ := urlToFilename(url)
+	filename, _ := paths.UrlToFilename(url)
 	b, err := afero.ReadFile(hugofs.Os, filename)
 	return string(b), err
-}
-
-// TODO(bep) add tests
-func urlToFilename(urls string) (string, bool) {
-	u, err := url.ParseRequestURI(urls)
-	if err != nil {
-		return filepath.FromSlash(urls), false
-	}
-	p := filepath.FromSlash(u.Path)
-
-	if u.Host != "" {
-		// C:\data\file.txt
-		p = strings.ToUpper(u.Host) + ":" + p
-	}
-
-	return p, true
 }

--- a/resources/resource_transformers/tocss/dartsass/transform.go
+++ b/resources/resource_transformers/tocss/dartsass/transform.go
@@ -125,7 +125,7 @@ func (t *transform) Transform(ctx *resources.ResourceTransformationCtx) error {
 				return -1
 			}
 
-			return herrors.NewFileErrorFromFile(sassErr, filename, filename, hugofs.Os, offsetMatcher)
+			return herrors.NewFileErrorFromFile(sassErr, filename, hugofs.Os, offsetMatcher)
 
 		}
 		return err

--- a/resources/resource_transformers/tocss/scss/client_extended.go
+++ b/resources/resource_transformers/tocss/scss/client_extended.go
@@ -47,6 +47,7 @@ func (c *Client) ToCSS(res resources.ResourceTransformer, opts Options) (resourc
 	}
 
 	return res.Transform(&toCSSTransformation{c: c, options: internalOptions})
+
 }
 
 type toCSSTransformation struct {

--- a/tpl/tplimpl/template.go
+++ b/tpl/tplimpl/template.go
@@ -554,7 +554,7 @@ func (t *templateHandler) addFileContext(templ tpl.Template, inerr error) error 
 		}
 		defer f.Close()
 
-		fe := herrors.NewFileError(info.realFilename, inErr)
+		fe := herrors.NewFileError(inErr, info.realFilename)
 		fe.UpdateContent(f, lineMatcher)
 
 		if !fe.ErrorContext().Position.IsValid() {

--- a/tpl/tplimpl/template.go
+++ b/tpl/tplimpl/template.go
@@ -554,7 +554,7 @@ func (t *templateHandler) addFileContext(templ tpl.Template, inerr error) error 
 		}
 		defer f.Close()
 
-		fe := herrors.NewFileError(inErr, info.realFilename)
+		fe := herrors.NewFileErrorFromName(inErr, info.realFilename)
 		fe.UpdateContent(f, lineMatcher)
 
 		if !fe.ErrorContext().Position.IsValid() {

--- a/tpl/tplimpl/template_errors.go
+++ b/tpl/tplimpl/template_errors.go
@@ -53,7 +53,7 @@ func (t templateInfo) resolveType() templateType {
 
 func (info templateInfo) errWithFileContext(what string, err error) error {
 	err = fmt.Errorf(what+": %w", err)
-	fe := herrors.NewFileError(err, info.realFilename)
+	fe := herrors.NewFileErrorFromName(err, info.realFilename)
 	f, err := info.fs.Open(info.filename)
 	if err != nil {
 		return err

--- a/tpl/tplimpl/template_errors.go
+++ b/tpl/tplimpl/template_errors.go
@@ -53,7 +53,7 @@ func (t templateInfo) resolveType() templateType {
 
 func (info templateInfo) errWithFileContext(what string, err error) error {
 	err = fmt.Errorf(what+": %w", err)
-	fe := herrors.NewFileError(info.realFilename, err)
+	fe := herrors.NewFileError(err, info.realFilename)
 	f, err := info.fs.Open(info.filename)
 	if err != nil {
 		return err

--- a/transform/chain.go
+++ b/transform/chain.go
@@ -115,7 +115,7 @@ func (c *Chain) Apply(to io.Writer, from io.Reader) error {
 				_, _ = io.Copy(tempfile, fb.from)
 				return herrors.NewFileErrorFromFile(err, filename, hugofs.Os, nil)
 			}
-			return herrors.NewFileError(err, filename).UpdateContent(fb.from, nil)
+			return herrors.NewFileErrorFromName(err, filename).UpdateContent(fb.from, nil)
 
 		}
 	}

--- a/transform/chain.go
+++ b/transform/chain.go
@@ -113,9 +113,9 @@ func (c *Chain) Apply(to io.Writer, from io.Reader) error {
 				filename = tempfile.Name()
 				defer tempfile.Close()
 				_, _ = io.Copy(tempfile, fb.from)
-				return herrors.NewFileErrorFromFile(err, filename, filename, hugofs.Os, nil)
+				return herrors.NewFileErrorFromFile(err, filename, hugofs.Os, nil)
 			}
-			return herrors.NewFileError(filename, err).UpdateContent(fb.from, nil)
+			return herrors.NewFileError(err, filename).UpdateContent(fb.from, nil)
 
 		}
 	}


### PR DESCRIPTION
Note that we will now fail if `inlineImports` is enabled and we cannot resolve an import.

You can work around this by either:

* Use url imports or imports with media queries.
* Set `skipInlineImportsNotFound=true` in the options

Also get the argument order in the different NewFileError* funcs in line.

Fixes #9895
