### PR TITLE
import: Fix importing jekyll site

### DIFF
--- a/commands/import_jekyll.go
+++ b/commands/import_jekyll.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/hugofs"
-	"github.com/gohugoio/hugo/hugolib"
 	"github.com/gohugoio/hugo/parser"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -202,12 +201,7 @@ func (i *importCmd) retrieveJekyllPostDir(fs afero.Fs, dir string) (bool, bool) 
 }
 
 func (i *importCmd) createSiteFromJekyll(jekyllRoot, targetDir string, jekyllPostDirs map[string]bool, force bool) error {
-	s, err := hugolib.NewSiteDefaultLang()
-	if err != nil {
-		return err
-	}
-
-	fs := s.Fs.Source
+	fs := &afero.OsFs{}
 	if exists, _ := helpers.Exists(targetDir, fs); exists {
 		if isDir, _ := helpers.IsDir(targetDir, fs); !isDir {
 			return errors.New("target path \"" + targetDir + "\" exists but is not a directory")


### PR DESCRIPTION
Just use `afero.OsFs` without building site.
Close #9817