### PR TITLE
Fix HasMenuCurrent and IsDescendant/IsAncestor when comparing to itself

### DIFF
--- a/hugolib/content_map_test.go
+++ b/hugolib/content_map_test.go
@@ -383,8 +383,8 @@ Blog Section: {{ template "print-page" $blog }}
 Blog Sub Section: {{ template "print-page" $blogSub }}
 Page: {{ template "print-page" $page }}
 Bundle: {{ template "print-page" $bundle }}
-IsDescendant: true: {{ $page.IsDescendant $blog }} true: {{ $blogSub.IsDescendant $blog }} true: {{ $bundle.IsDescendant $blog }} true: {{ $page4.IsDescendant $blog }} true: {{ $blog.IsDescendant $home }} true: {{ $blog.IsDescendant $blog }} false: {{ $home.IsDescendant $blog }}
-IsAncestor: true: {{ $blog.IsAncestor $page }} true: {{ $home.IsAncestor $blog }} true: {{ $blog.IsAncestor $blogSub }} true: {{ $blog.IsAncestor $bundle }} true: {{ $blog.IsAncestor $page4 }} true: {{ $home.IsAncestor $page }} true: {{ $blog.IsAncestor $blog }} false: {{ $page.IsAncestor $blog }} false: {{ $blog.IsAncestor $home }}  false: {{ $blogSub.IsAncestor $blog }}
+IsDescendant: true: {{ $page.IsDescendant $blog }} true: {{ $blogSub.IsDescendant $blog }} true: {{ $bundle.IsDescendant $blog }} true: {{ $page4.IsDescendant $blog }} true: {{ $blog.IsDescendant $home }} false: {{ $blog.IsDescendant $blog }} false: {{ $home.IsDescendant $blog }}
+IsAncestor: true: {{ $blog.IsAncestor $page }} true: {{ $home.IsAncestor $blog }} true: {{ $blog.IsAncestor $blogSub }} true: {{ $blog.IsAncestor $bundle }} true: {{ $blog.IsAncestor $page4 }} true: {{ $home.IsAncestor $page }} false: {{ $blog.IsAncestor $blog }} false: {{ $page.IsAncestor $blog }} false: {{ $blog.IsAncestor $home }}  false: {{ $blogSub.IsAncestor $blog }}
 IsDescendant overlap1: false: {{ $overlap1.IsDescendant $overlap2 }}
 IsDescendant overlap2: false: {{ $overlap2.IsDescendant $overlap1 }}
 IsAncestor overlap1: false: {{ $overlap1.IsAncestor $overlap2 }}
@@ -426,8 +426,8 @@ Draft5: {{ if (.Site.GetPage "blog/draftsection/sub/page") }}FOUND{{ end }}|
         Blog Sub Section: Page 3|/blog/subsection/|2019-06-03|Current Section: blog/subsection|Resources: application: /blog/subsection/subdata.json|
         Page: Page 1|/blog/page1/|2019-06-01|Current Section: blog|Resources: 
         Bundle: Page 12|/blog/bundle/|0001-01-01|Current Section: blog|Resources: application: /blog/bundle/data.json|page: |
-        IsDescendant: true: true true: true true: true true: true true: true true: true false: false
-        IsAncestor: true: true true: true true: true true: true true: true true: true true: true false: false false: false  false: false
+        IsDescendant: true: true true: true true: true true: true true: true false: false false: false
+        IsAncestor: true: true true: true true: true true: true true: true true: true false: false false: false false: false  false: false
         IsDescendant overlap1: false: false
         IsDescendant overlap2: false: false
         IsAncestor overlap1: false: false

--- a/hugolib/page__tree.go
+++ b/hugolib/page__tree.go
@@ -36,6 +36,9 @@ func (pt pageTree) IsAncestor(other any) (bool, error) {
 	}
 
 	ref1, ref2 := pt.p.getTreeRef(), tp.getTreeRef()
+	if ref1 != nil && ref2 != nil && ref1.key == ref2.key {
+		return false, nil
+	}
 
 	if ref1 != nil && ref1.key == "/" {
 		return true, nil
@@ -48,10 +51,6 @@ func (pt pageTree) IsAncestor(other any) (bool, error) {
 		}
 
 		return ref1.n.p.IsHome(), nil
-	}
-
-	if ref1.key == ref2.key {
-		return true, nil
 	}
 
 	if strings.HasPrefix(ref2.key, ref1.key) {
@@ -82,6 +81,9 @@ func (pt pageTree) IsDescendant(other any) (bool, error) {
 	}
 
 	ref1, ref2 := pt.p.getTreeRef(), tp.getTreeRef()
+	if ref1 != nil && ref2 != nil && ref1.key == ref2.key {
+		return false, nil
+	}
 
 	if ref2 != nil && ref2.key == "/" {
 		return true, nil
@@ -94,10 +96,6 @@ func (pt pageTree) IsDescendant(other any) (bool, error) {
 		}
 
 		return ref2.n.p.IsHome(), nil
-	}
-
-	if ref1.key == ref2.key {
-		return true, nil
 	}
 
 	if strings.HasPrefix(ref1.key, ref2.key) {


### PR DESCRIPTION
Fix HasMenuCurrent and IsDescendant/IsAncestor when comparing to itself

There may be sites in the wild that depends on the faulty behaviour of IsDescendant/IsAncestor when comparing to itself, but

* The documentation and common sense says that a thing cannot be descendant or ancestor to itself.
* The bug introduced in `HasMenuCurrent` comes directly from that confusion.

Fixes #9846