### PR TITLE
metrics: Fix divide by zero error

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -281,6 +281,10 @@ func howSimilarStrings(a, b string) int {
 		}
 	}
 
+	if common == 0 && common == len(af) {
+		return 100
+	}
+
 	return int(math.Floor((float64(common) / float64(len(af)) * 100)))
 }
 

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -43,6 +43,7 @@ func TestSimilarPercentage(t *testing.T) {
 	c.Assert(howSimilar(template.HTML("Hugo Rules"), template.HTML("Hugo Rules")), qt.Equals, 100)
 	c.Assert(howSimilar(map[string]any{"a": 32, "b": 33}, map[string]any{"a": 32, "b": 33}), qt.Equals, 100)
 	c.Assert(howSimilar(map[string]any{"a": 32, "b": 33}, map[string]any{"a": 32, "b": 34}), qt.Equals, 0)
+	c.Assert(howSimilar("\n", ""), qt.Equals, 100)
 }
 
 type testStruct struct {


### PR DESCRIPTION
Under certain conditions, `howSimilarString` could reach a divide-by-
zero situation which causes bogus values to print in the cache potential
column of the template hints output.  This situation essentially causes
a `int(math.NaN())` value to be returned and hilarity ensues thereafter.