### PR TITLE
github: Set HUGO_BUILD_TAGS: extended when running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,10 +72,11 @@ jobs:
         echo "6ae442129dbb3334bc21ef851261da6c0c1b560da790ca2e1350871d00ab816d  sass_embedded-1.0.0-beta.6-windows-x64.zip" | sha256sum -c;
         unzip sass_embedded-1.0.0-beta.6-windows-x64.zip;
         echo  "$env:GITHUB_WORKSPACE/sass_embedded/" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf-8 -Append
-    - name: Test
+    - name: Check
       run: |
-        mage -v test
         mage -v check;
+      env:
+        HUGO_BUILD_TAGS: extended
     - name: Build Docs
       env:
         HUGO_BUILD_TAGS: extended

--- a/magefile.go
+++ b/magefile.go
@@ -144,13 +144,6 @@ func Docker() error {
 
 // Run tests and linters
 func Check() {
-	if strings.Contains(runtime.Version(), "1.8") {
-		// Go 1.8 doesn't play along with go test ./... and /vendor.
-		// We could fix that, but that would take time.
-		fmt.Printf("Skip Check on %s\n", runtime.Version())
-		return
-	}
-
 	if runtime.GOARCH == "amd64" && runtime.GOOS != "darwin" {
 		mg.Deps(Test386)
 	} else {

--- a/modules/config_test.go
+++ b/modules/config_test.go
@@ -48,7 +48,7 @@ func TestDecodeConfig(t *testing.T) {
 
 [module.hugoVersion]
 min = "0.54.2"
-max = "0.99.0"
+max = "0.199.0"
 extended = true
 
 [[module.mounts]]

--- a/resources/resource_transformers/tocss/scss/integration_test.go
+++ b/resources/resource_transformers/tocss/scss/integration_test.go
@@ -236,7 +236,7 @@ T1: {{ $r.Content }}
 			}).BuildE()
 
 		b.Assert(err, qt.IsNotNil)
-		b.Assert(err.Error(), qt.Contains, filepath.FromSlash(`assets/scss/components/_foo.scss:2:1": expected ':' after $foocolor in assignment statement`))
+		b.Assert(err.Error(), qt.Contains, `assets/scss/components/_foo.scss:2:1": expected ':' after $foocolor in assignment statement`)
 		fe := b.AssertIsFileError(err)
 		b.Assert(fe.ErrorContext(), qt.IsNotNil)
 		b.Assert(fe.ErrorContext().Lines, qt.DeepEquals, []string{"/* comment line 1 */", "$foocolor #ccc;", "", "foo {"})


### PR DESCRIPTION
Also fix TestDecodeConfig/Basic which started to fail in the extended build in 0.99.1.

Closes #9935
