### PR TITLE
Add Markdown as an output format

### DIFF
--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -1398,3 +1398,36 @@ outputs: ["html", "css", "csv", "json"]
 
 	}
 }
+
+// #9821
+func TestShortcodeMarkdownOutputFormat(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- config.toml --
+-- content/p1.md --
+---
+title: "p1"
+---
+{{< foo >}}
+-- layouts/shortcodes/foo.md --
+§§§
+<x
+§§§
+-- layouts/_default/single.html --
+{{ .Content }}
+`
+
+	b := NewIntegrationTestBuilder(
+		IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+			Running:     true,
+		},
+	).Build()
+
+	b.AssertFileContent("public/p1/index.html", `
+<x
+	`)
+
+}

--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -257,7 +257,8 @@ var (
 	OpenTypeFontType = newMediaType("font", "otf", []string{"otf"})
 
 	// Common document types
-	PDFType = newMediaType("application", "pdf", []string{"pdf"})
+	PDFType      = newMediaType("application", "pdf", []string{"pdf"})
+	MarkdownType = newMediaType("text", "markdown", []string{"md", "markdown"})
 
 	// Common video types
 	AVIType  = newMediaType("video", "x-msvideo", []string{"avi"})
@@ -278,6 +279,7 @@ var DefaultTypes = Types{
 	SCSSType,
 	SASSType,
 	HTMLType,
+	MarkdownType,
 	JavascriptType,
 	TypeScriptType,
 	TSXType,

--- a/media/mediaType_test.go
+++ b/media/mediaType_test.go
@@ -63,7 +63,7 @@ func TestDefaultTypes(t *testing.T) {
 
 	}
 
-	c.Assert(len(DefaultTypes), qt.Equals, 33)
+	c.Assert(len(DefaultTypes), qt.Equals, 34)
 }
 
 func TestGetByType(t *testing.T) {

--- a/output/outputFormat.go
+++ b/output/outputFormat.go
@@ -133,6 +133,14 @@ var (
 		Weight: 10,
 	}
 
+	MarkdownFormat = Format{
+		Name:        "MARKDOWN",
+		MediaType:   media.MarkdownType,
+		BaseName:    "index",
+		Rel:         "alternate",
+		IsPlainText: true,
+	}
+
 	JSONFormat = Format{
 		Name:        "JSON",
 		MediaType:   media.JSONType,
@@ -183,6 +191,7 @@ var DefaultFormats = Formats{
 	CSVFormat,
 	HTMLFormat,
 	JSONFormat,
+	MarkdownFormat,
 	WebAppManifestFormat,
 	RobotsTxtFormat,
 	RSSFormat,

--- a/output/outputFormat_test.go
+++ b/output/outputFormat_test.go
@@ -68,7 +68,7 @@ func TestDefaultTypes(t *testing.T) {
 	c.Assert(RSSFormat.NoUgly, qt.Equals, true)
 	c.Assert(CalendarFormat.IsHTML, qt.Equals, false)
 
-	c.Assert(len(DefaultFormats), qt.Equals, 10)
+	c.Assert(len(DefaultFormats), qt.Equals, 11)
 
 }
 


### PR DESCRIPTION
The motivation behind this is not to make it easier to publish Markdown files, as that sounds unusual.

This is mainly meant for shortcodes that produces Markdown to be inlined.

You would do this by creating shortcodes with `*.md` suffix (e.g. `layouts/shortcodes/myshortcode.md`).

This output format is defined as plain text, and will use Go's much more lenient text template parser.

Updates #9821