### PR TITLE
postcss: Make the resource cache key more stable

### DIFF
--- a/resources/resource_transformers/postcss/postcss_test.go
+++ b/resources/resource_transformers/postcss/postcss_test.go
@@ -31,14 +31,14 @@ import (
 // Issue 6166
 func TestDecodeOptions(t *testing.T) {
 	c := qt.New(t)
-	opts1, err := DecodeOptions(map[string]any{
+	opts1, err := decodeOptions(map[string]any{
 		"no-map": true,
 	})
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(opts1.NoMap, qt.Equals, true)
 
-	opts2, err := DecodeOptions(map[string]any{
+	opts2, err := decodeOptions(map[string]any{
 		"noMap": true,
 	})
 

--- a/tpl/resources/resources.go
+++ b/tpl/resources/resources.go
@@ -405,15 +405,8 @@ func (ns *Namespace) PostCSS(args ...any) (resource.Resource, error) {
 	if err != nil {
 		return nil, err
 	}
-	var options postcss.Options
-	if m != nil {
-		options, err = postcss.DecodeOptions(m)
-		if err != nil {
-			return nil, err
-		}
-	}
 
-	return ns.postcssClient.Process(r, options)
+	return ns.postcssClient.Process(r, m)
 }
 
 func (ns *Namespace) PostProcess(r resource.Resource) (postpub.PostPublishedResource, error) {


### PR DESCRIPTION
By using the input map as the basis, which means the hash will not change if we add/rename/remove options.

This happened in Hugo 0.99, as we added a new options. This is unortunate.

Unfortunately this means that the cache keys for PostCSS will change one more time in 0.100, but will be stable going forward.

Note that we have implemented this pattern in all the other resource transformers.

Updates #9787
