### PR TITLE
resources: Register MediaTypes before build

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -127,8 +127,10 @@ func initializeConfig(mustHaveConfigFile, failOnInitErr, running bool,
 		return nil, err
 	}
 
-	for _, s := range c.hugo().Sites {
-		s.RegisterMediaTypes()
+	if h := c.hugoTry(); h != nil {
+		for _, s := range h.Sites {
+			s.RegisterMediaTypes()
+		}
 	}
 
 	return c, nil

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -127,6 +127,10 @@ func initializeConfig(mustHaveConfigFile, failOnInitErr, running bool,
 		return nil, err
 	}
 
+	for _, s := range c.hugo().Sites {
+		s.RegisterMediaTypes()
+	}
+
 	return c, nil
 }
 

--- a/commands/server.go
+++ b/commands/server.go
@@ -272,10 +272,6 @@ func (sc *serverCmd) server(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	for _, s := range c.hugo().Sites {
-		s.RegisterMediaTypes()
-	}
-
 	// Watch runs its own server as part of the routine
 	if sc.serverWatch {
 


### PR DESCRIPTION
This fixes an issue with the `resources.GetRemote` call that fails for some media types, even when these are included in the default Hugo configuring. This is because the media types only get registered when running Hugo as a server and after the build is completed.

Fixes: #9971