### PR TITLE
deps: Update to github.com/pelletier/go-toml/v2 v2.0.1

### DIFF
--- a/deploy/deployConfig.go
+++ b/deploy/deployConfig.go
@@ -127,7 +127,7 @@ func decodeConfig(cfg config.Provider) (deployConfig, error) {
 		return dcfg, err
 	}
 	for _, tgt := range dcfg.Targets {
-		if tgt == nil {
+		if *tgt == (target{}) {
 			return dcfg, errors.New("empty deployment target")
 		}
 		if err := tgt.parseIncludeExclude(); err != nil {
@@ -136,7 +136,7 @@ func decodeConfig(cfg config.Provider) (deployConfig, error) {
 	}
 	var err error
 	for _, m := range dcfg.Matchers {
-		if m == nil {
+		if *m == (matcher{}) {
 			return dcfg, errors.New("empty deployment matcher")
 		}
 		m.re, err = regexp.Compile(m.Pattern)

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/muesli/smartcrop v0.3.0
 	github.com/niklasfasching/go-org v1.6.2
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/pelletier/go-toml/v2 v2.0.0-beta.7.0.20220408132554-2377ac4bc04c
+	github.com/pelletier/go-toml/v2 v2.0.1
 	github.com/rogpeppe/go-internal v1.8.1
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd
 	github.com/sanity-io/litter v1.5.5

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,8 @@ github.com/niklasfasching/go-org v1.6.2 h1:kQBIZlfL4oRNApJCrBgaeNBfzxWzP6XlC7/b7
 github.com/niklasfasching/go-org v1.6.2/go.mod h1:wn76Xgu4/KRe43WZhsgZjxYMaloSrl3BSweGV74SwHs=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/pelletier/go-toml/v2 v2.0.0-beta.7.0.20220408132554-2377ac4bc04c h1:tgrA7vMkP4q9diPCg3u4Ka4/g3fvkifBu1y9DL+uy7M=
-github.com/pelletier/go-toml/v2 v2.0.0-beta.7.0.20220408132554-2377ac4bc04c/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
+github.com/pelletier/go-toml/v2 v2.0.1 h1:8e3L2cCQzLFi2CR4g7vGFuFxX7Jl1kKX8gW+iV0GUKU=
+github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
For some reasons, dependabot did not pick up on this, probably because of the following test errors:

```
--- FAIL: TestEmptyTarget (0.00s)
    deployConfig_test.go:184: 
        error:
          got nil value but want non-nil
        got:
          nil
        stack:
          /mnt/easystore/git/hugo/deploy/deployConfig_test.go:184
            c.Assert(err, qt.Not(qt.IsNil))
        
--- FAIL: TestEmptyMatcher (0.00s)
    deployConfig_test.go:198: 
        error:
          got nil value but want non-nil
        got:
          nil
        stack:
          /mnt/easystore/git/hugo/deploy/deployConfig_test.go:198
            c.Assert(err, qt.Not(qt.IsNil))
```

due to

* pelletier/go-toml#755 (v2.0.0-beta.8 and newer)

I ended up modifying deploy/deployConfig.go (with help from <https://stackoverflow.com/questions/28447297/how-to-check-for-an-empty-struct>) to get the "empty deployment target/matcher" tests work with github.com/pelletier/go-toml/v2 v2.0.1

My knowledge of Go is still rather limited, so I hope I am doing it correctly.  Thanks in advance for your code reviews!