### PR TITLE
livereload: Use `X-Forwarded-Host` for Codespace livereload

### DIFF
--- a/livereload/livereload.go
+++ b/livereload/livereload.go
@@ -62,7 +62,13 @@ var upgrader = &websocket.Upgrader{
 			return false
 		}
 
-		if u.Host == r.Host {
+		rHost := r.Host
+		// For Github codespace in browser #9936
+		if forwardedHost := r.Header.Get("X-Forwarded-Host"); forwardedHost != "" {
+			rHost = forwardedHost
+		}
+
+		if u.Host == rHost {
 			return true
 		}
 


### PR DESCRIPTION
Codespace has 2 types of usage

1. in browser
2. vscode on local computer

As long as you select 2 (on local), Hugo handles livereload expectedly.
But if you use it in browser, Hugo does not reload on file change, as #9936 said.

This issue happens because `CheckOrigin` always fails.
Remote server could rewrite request host name.
Fix this by respecting `X-Forwarded-Host` header during origin checking

After merging this, you can preview changes lively with codespaece in browser.

```sh
hugo server --liveReloadPort 443
```

Close #9936