### PR TITLE
Accept vendor-specified build date if .git/ is unavailable

### DIFF
--- a/common/hugo/hugo.go
+++ b/common/hugo/hugo.go
@@ -38,6 +38,8 @@ const (
 )
 
 var (
+	// buildDate allows vendor-specified build date when .git/ is unavailable.
+	buildDate string
 	// vendorInfo contains vendor notes about the current build.
 	vendorInfo string
 )

--- a/common/hugo/version.go
+++ b/common/hugo/version.go
@@ -154,6 +154,10 @@ func BuildVersionString() string {
 
 	date := bi.RevisionTime
 	if date == "" {
+		// Accept vendor-specified build date if .git/ is unavailable.
+		date = buildDate
+	}
+	if date == "" {
 		date = "unknown"
 	}
 


### PR DESCRIPTION
Fixes #10053