### PR TITLE
Adds support for GA4 and UA at the same time

### DIFF
--- a/tpl/tplimpl/embedded/templates/google_analytics.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics.html
@@ -1,40 +1,49 @@
 {{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
 {{- if not $pc.Disable }}{{ with .Site.GoogleAnalytics -}}
-{{ if hasPrefix . "G-"}}
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+{{ $ga_ids := split . "," -}}
+{{ if (or (hasPrefix . "G-") (gt (len $ga_ids) 1)) -}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ index $ga_ids 0 }}"></script>
 <script>
 {{ template "__ga_js_set_doNotTrack" $ }}
 if (!doNotTrack) {
-	window.dataLayer = window.dataLayer || [];
-	function gtag(){dataLayer.push(arguments);}
-	gtag('js', new Date());
-	gtag('config', '{{ . }}', { 'anonymize_ip': {{- $pc.AnonymizeIP -}} });
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+{{ range $ga_ids }}
+{{ with trim . " " -}}
+gtag('config', '{{ . }}'
+	{{- if and $pc.AnonymizeIP (hasPrefix . "UA-") -}}
+	, { 'anonymize_ip': {{- $pc.AnonymizeIP -}} }
+	{{- end -}}
+);
+{{- end }}
+{{- end }}
 }
 </script>
 {{ else if hasPrefix . "UA-" }}
 <script type="application/javascript">
 {{ template "__ga_js_set_doNotTrack" $ }}
 if (!doNotTrack) {
-	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-	{{- if $pc.UseSessionStorage }}
-	if (window.sessionStorage) {
-		var GA_SESSION_STORAGE_KEY = 'ga:clientId';
-		ga('create', '{{ . }}', {
-	    'storage': 'none',
-	    'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
-	   });
-	   ga(function(tracker) {
-	    sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
-	   });
-   }
-	{{ else }}
-	ga('create', '{{ . }}', 'auto');
-	{{ end -}}
-	{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
-	ga('send', 'pageview');
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+{{- if $pc.UseSessionStorage }}
+if (window.sessionStorage) {
+	var GA_SESSION_STORAGE_KEY = 'ga:clientId';
+	ga('create', '{{ . }}', {
+		'storage': 'none',
+		'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+	 });
+	 ga(function(tracker) {
+		sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
+	 });
+ }
+{{ else }}
+ga('create', '{{ . }}', 'auto');
+{{ end -}}
+{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
+ga('send', 'pageview');
 }
 </script>
 {{- end -}}

--- a/tpl/tplimpl/embedded/templates/google_analytics.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics.html
@@ -6,44 +6,44 @@
 <script>
 {{ template "__ga_js_set_doNotTrack" $ }}
 if (!doNotTrack) {
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-{{ range $ga_ids }}
-{{ with trim . " " -}}
-gtag('config', '{{ . }}'
-	{{- if and $pc.AnonymizeIP (hasPrefix . "UA-") -}}
-	, { 'anonymize_ip': {{- $pc.AnonymizeIP -}} }
-	{{- end -}}
-);
-{{- end }}
-{{- end }}
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+	gtag('js', new Date());
+	{{ range $ga_ids }}
+	{{ with trim . " " -}}
+	gtag('config', '{{ . }}'
+		{{- if and $pc.AnonymizeIP (hasPrefix . "UA-") -}}
+		, { 'anonymize_ip': {{- $pc.AnonymizeIP -}} }
+		{{- end -}}
+	);
+	{{- end }}
+	{{- end }}
 }
 </script>
 {{ else if hasPrefix . "UA-" }}
 <script type="application/javascript">
 {{ template "__ga_js_set_doNotTrack" $ }}
 if (!doNotTrack) {
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-{{- if $pc.UseSessionStorage }}
-if (window.sessionStorage) {
-	var GA_SESSION_STORAGE_KEY = 'ga:clientId';
-	ga('create', '{{ . }}', {
-		'storage': 'none',
-		'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
-	 });
-	 ga(function(tracker) {
-		sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
-	 });
- }
-{{ else }}
-ga('create', '{{ . }}', 'auto');
-{{ end -}}
-{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
-ga('send', 'pageview');
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	{{- if $pc.UseSessionStorage }}
+	if (window.sessionStorage) {
+		var GA_SESSION_STORAGE_KEY = 'ga:clientId';
+		ga('create', '{{ . }}', {
+	    'storage': 'none',
+	    'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+	   });
+	   ga(function(tracker) {
+	    sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
+	   });
+   }
+	{{ else }}
+	ga('create', '{{ . }}', 'auto');
+	{{ end -}}
+	{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
+	ga('send', 'pageview');
 }
 </script>
 {{- end -}}


### PR DESCRIPTION
During **migration from Universal Analytics** (UA) **to Google Analytics 4** (GA) it is useful to be able to configure both site tags at the same time. This PR adds the ability to specify a site tag list.

- Closes #4327
- Closes #8549
- Closes #10093

(I experimented with multiple solutions and the one propose here seems the least obtrusive and most backwards compatible).

/cc @jmooring @nate-double-u