### PR TITLE
markup/goldmark/codeblock: get attribute in no language identifier in CodeBlock

### DIFF
--- a/markup/goldmark/codeblocks/integration_test.go
+++ b/markup/goldmark/codeblocks/integration_test.go
@@ -285,7 +285,7 @@ Hello, World!
 -- layouts/_default/single.html --
 {{ .Content }}
 -- layouts/_default/_markup/render-codeblock.html --
-Attributes: {{ .Attributes }}
+Attributes: {{ .Attributes }}|Type: {{ .Type }}|
 `
 
 	b := hugolib.NewIntegrationTestBuilder(
@@ -295,7 +295,7 @@ Attributes: {{ .Attributes }}
 		},
 	).Build()
 
-	b.AssertFileContent("public/p1/index.html", "<h2 id=\"issue-10118\">Issue 10118</h2>\nAttributes: map[foo:bar]")
+	b.AssertFileContent("public/p1/index.html", "<h2 id=\"issue-10118\">Issue 10118</h2>\nAttributes: map[foo:bar]|Type: |")
 }
 
 // Issue 9571

--- a/markup/goldmark/codeblocks/integration_test.go
+++ b/markup/goldmark/codeblocks/integration_test.go
@@ -265,6 +265,39 @@ Position: {{ .Position | safeHTML }}
 	b.AssertFileContent("public/p1/index.html", filepath.FromSlash("Position: \"/content/p1.md:7:1\""))
 }
 
+// Issue 10118
+func TestAttributes(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- config.toml --
+-- content/p1.md --
+---
+title: "p1"
+---
+
+## Issue 10118
+
+§§§ {foo="bar"}
+Hello, World!
+§§§
+
+-- layouts/_default/single.html --
+{{ .Content }}
+-- layouts/_default/_markup/render-codeblock.html --
+Attributes: {{ .Attributes }}
+`
+
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+		},
+	).Build()
+
+	b.AssertFileContent("public/p1/index.html", "<h2 id=\"issue-10118\">Issue 10118</h2>\nAttributes: map[foo:bar]")
+}
+
 // Issue 9571
 func TestAttributesChroma(t *testing.T) {
 	t.Parallel()

--- a/markup/goldmark/codeblocks/render.go
+++ b/markup/goldmark/codeblocks/render.go
@@ -188,7 +188,7 @@ func getAttributes(node *ast.FencedCodeBlock, infostr []byte) []ast.Attribute {
 			}
 		}
 
-		if attrStartIdx > 0 {
+		if attrStartIdx != -1 {
 			n := ast.NewTextBlock() // dummy node for storing attributes
 			attrStr := infostr[attrStartIdx:]
 			if attrs, hasAttr := parser.ParseAttributes(text.NewReader(attrStr)); hasAttr {

--- a/markup/goldmark/codeblocks/render.go
+++ b/markup/goldmark/codeblocks/render.go
@@ -16,6 +16,7 @@ package codeblocks
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/alecthomas/chroma/v2/lexers"
@@ -69,7 +70,7 @@ func (r *htmlRenderer) renderCodeBlock(w util.BufWriter, src []byte, node ast.No
 	}
 
 	n := node.(*codeBlock)
-	lang := string(n.b.Language(src))
+	lang := getLang(n.b, src)
 	renderer := ctx.RenderContext().GetRenderer(hooks.CodeBlockRendererType, lang)
 	if renderer == nil {
 		return ast.WalkStop, fmt.Errorf("no code renderer found for %q", lang)
@@ -172,6 +173,12 @@ func (c *codeBlockContext) Position() htext.Position {
 		c.pos = c.createPos()
 	})
 	return c.pos
+}
+
+func getLang(node *ast.FencedCodeBlock, src []byte) string {
+	langWithAttributes := string(node.Language(src))
+	lang, _, _ := strings.Cut(langWithAttributes, "{")
+	return lang
 }
 
 func getAttributes(node *ast.FencedCodeBlock, infostr []byte) []ast.Attribute {


### PR DESCRIPTION
Fixes #10118 