### PR TITLE
build/go19etc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-      - image: bepsays/ci-goreleaser:1.1800.300
+      - image: bepsays/ci-goreleaser:1.21900.20000
   environment:
     CGO_ENABLED: "0"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         # Go 1.18 had some breaking changes on the source level which means Hugo cannot be built
         # with older Go versions, but the improvements in Go 1.18 were too good to pass on (e.g. break and continue).
         # Note that you don't need Go (or Go 1.18) to run a pre-built binary.
-        go-version: [1.18.x]
+        go-version: [1.18.x,1.19.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -103,7 +103,7 @@ release:
 archives:
   -
     id: "hugo"
-    builds: ['hugo', 'hugo_unix']
+    builds: ['hugo', 'hugo_unix', 'hugo_fat_darwin']
     format: tar.gz
     format_overrides:
       - goos: windows
@@ -126,7 +126,7 @@ archives:
       - LICENSE
   -
     id: "hugo_extended"
-    builds: ['hugo_extended_windows', 'hugo_extended_linux', 'hugo_extended_darwin']
+    builds: ['hugo_extended_windows', 'hugo_extended_linux', 'hugo_extended_fat_darwin']
     format: tar.gz
     format_overrides:
       - goos: windows
@@ -148,6 +148,23 @@ archives:
       - README.md
       - LICENSE
 
+universal_binaries:
+-
+  id: hugo_fat_darwin
+
+  ids:
+  - hugo
+
+  replace: true
+
+-
+  id: hugo_extended_fat_darwin
+
+  ids:
+  - hugo_extended_darwin
+
+  replace: true
+  
 nfpms:
   -
     id: "hugo"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,7 +53,7 @@ parts:
 
   hugo:
     plugin: nil
-    build-snaps: [go/1.18/stable]
+    build-snaps: [go/1.19/stable]
     source: .
     override-build: |
       set -ex


### PR DESCRIPTION
- Update to Go 1.19
- releaser: Fat MacOS binaries
