### PR TITLE
livereload: Inject script without head or body tag

### DIFF
--- a/transform/livereloadinject/livereloadinject_test.go
+++ b/transform/livereloadinject/livereloadinject_test.go
@@ -58,7 +58,15 @@ func TestLiveReloadInject(t *testing.T) {
 		c.Assert(apply("foo</BODY>"), qt.Equals, "foo"+expectBase+"</BODY>")
 	})
 
+	c.Run("Html upper", func(c *qt.C) {
+		c.Assert(apply("<html>foo"), qt.Equals, "<html>"+expectBase+warnScript+"foo")
+	})
+
+	c.Run("Html upper with attr", func(c *qt.C) {
+		c.Assert(apply(`<html lang="en">foo`), qt.Equals, `<html lang="en">`+expectBase+warnScript+"foo")
+	})
+
 	c.Run("No match", func(c *qt.C) {
-		c.Assert(apply("<h1>No match</h1>"), qt.Equals, "<h1>No match</h1>")
+		c.Assert(apply("<h1>No match</h1>"), qt.Equals, "<h1>No match</h1>"+expectBase+warnScript)
 	})
 }


### PR DESCRIPTION
Currently, Hugo does not inject `livereload` script if html does not contain `<head>` or `<body>`.
This sometimes happens if you create new sites without `theme` and it is hard to catch the cause soon.

This PR:

* Inject livereload script even if html does not include `<head>`, `<body>`, or `<html>`
    - Modern browsers execute scripts even if they are outside `<html>`
    - Some js frameworks (confirmed with vite) inject HRM script without `<html>` tag
* Append warning script to html if `<head>` or `<body>` is not in html
* Fix bug that livereload cannot be appended to the tags with attrs

Close #10105