### PR TITLE
Updated links to Golang in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://gohugo.io/"><img src="https://raw.githubusercontent.com/gohugoio/gohugoioTheme/master/static/images/hugo-logo-wide.svg?sanitize=true" alt="Hugo" width="565"></a>
 
-A Fast and Flexible Static Site Generator built with love by [bep](https://github.com/bep), [spf13](https://spf13.com/) and [friends](https://github.com/gohugoio/hugo/graphs/contributors) in [Go][].
+A Fast and Flexible Static Site Generator built with love by [bep](https://github.com/bep), [spf13](https://spf13.com/) and [friends](https://github.com/gohugoio/hugo/graphs/contributors) in [Go](https://go.dev/).
 
 [Website](https://gohugo.io) |
 [Forum](https://discourse.gohugo.io) |
@@ -24,7 +24,7 @@ A Fast and Flexible Static Site Generator built with love by [bep](https://githu
 
 ## Overview
 
-Hugo is a static HTML and CSS website generator written in [Go][].
+Hugo is a static HTML and CSS website generator written in [Go](https://go.dev/).
 It is optimized for speed, ease of use, and configurability.
 Hugo takes a directory with content and templates and renders them into a full HTML website.
 


### PR DESCRIPTION
There was a few references to Go, without the link - so I've added those.

I've set the links to [https://go.dev/](https://go.dev/), but left the link in the tools section to the Go download page.