### PR TITLE
snap: Use "snapcraftctl set-grade"

### DIFF
--- a/releaser/releaser.go
+++ b/releaser/releaser.go
@@ -147,16 +147,6 @@ func (r *ReleaseHandler) bumpVersions(ver hugo.Version) error {
 		return err
 	}
 
-	snapcraftGrade := "stable"
-	if ver.Suffix != "" {
-		snapcraftGrade = "devel"
-	}
-	if err := r.replaceInFile("snap/snapcraft.yaml",
-		`version: "(.*)"`, fmt.Sprintf(`version: "%s"`, ver),
-		`grade: (.*) #`, fmt.Sprintf(`grade: %s #`, snapcraftGrade)); err != nil {
-		return err
-	}
-
 	var minVersion string
 	if ver.Suffix != "" {
 		// People use the DEV version in daily use, and we cannot create new themes

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,6 @@ description: |
 license: "Apache-2.0"
 base: core20
 confinement: strict
-grade: devel # "devel" or "stable"
 adopt-info: hugo
 
 package-repositories:
@@ -80,6 +79,11 @@ parts:
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version "$(git describe --tags --always --match 'v[0-9]*' | sed 's/^v//; s/-/+git/; s/-g/./')"
+      if grep -q 'Suffix:\s*""' common/hugo/version_current.go; then
+        snapcraftctl set-grade "stable"
+      else
+        snapcraftctl set-grade "devel"
+      fi
     override-build: |
       echo "\nStarting override-build:"
       set -ex
@@ -104,7 +108,7 @@ parts:
       fi
 
       echo " * Building hugo (HUGO_BUILD_TAGS=\"$HUGO_BUILD_TAGS\")..."
-      go build -v -ldflags '-X github.com/gohugoio/hugo/common/hugo.vendorInfo=snap' -tags "$HUGO_BUILD_TAGS"
+      go build -v -ldflags "-X github.com/gohugoio/hugo/common/hugo.vendorInfo=snap:$(git describe --tags --always --match 'v[0-9]*' | sed 's/^v//; s/-/+git/; s/-g/./')" -tags "$HUGO_BUILD_TAGS"
       ./hugo version
       ldd hugo || :
 


### PR DESCRIPTION
This, together with `snapcraftctl set-version`, negates the need to modify snap/snapcraft.yaml upon each release,
so the corresponding code is removed from releaser/releaser.go.

Also, `vendorInfo` is extended to include the snap version number.

See #10225