### PR TITLE
scss: Handle single-file sourcemaps correctly

### DIFF
--- a/resources/resource_transformers/tocss/scss/tocss.go
+++ b/resources/resource_transformers/tocss/scss/tocss.go
@@ -163,7 +163,7 @@ func (t *toCSSTransformation) Transform(ctx *resources.ResourceTransformationCtx
 		// This is a workaround for what looks like a bug in Libsass. But
 		// getting this resolution correct in tools like Chrome Workspaces
 		// is important enough to go this extra mile.
-		mapContent := strings.Replace(res.SourceMapContent, `stdin",`, fmt.Sprintf("%s\",", sourcePath), 1)
+		mapContent := strings.Replace(res.SourceMapContent, `stdin"`, fmt.Sprintf("%s\"", sourcePath), 1)
 
 		return ctx.PublishSourceMap(mapContent)
 	}


### PR DESCRIPTION
Simple sites may only have one css file. Update the replace directive to
correctly match single-file sourcemaps and multi-file sourcemaps.

Verified locally with and without SASS and CSS imports.

Fixes #8174