### PR TITLE
tpl: improve youtube shortcode through use of oEmbed data

### DIFF
--- a/config/privacy/privacyConfig.go
+++ b/config/privacy/privacyConfig.go
@@ -98,6 +98,11 @@ type YouTube struct {
 	// YouTube won’t store information about visitors on your website
 	// unless the user plays the embedded video.
 	PrivacyEnhanced bool
+
+	// If simple mode is enabled, only a thumbnail is fetched from i.ytimg.com and
+	// shown with a play button overlaid. If a user clicks the button, he/she will
+	// be taken to the video page on youtube.com in a new browser tab.
+	Simple bool
 }
 
 // DecodeConfig creates a privacy Config from a given Hugo configuration.

--- a/config/privacy/privacyConfig_test.go
+++ b/config/privacy/privacyConfig_test.go
@@ -64,7 +64,7 @@ simple = true
 		pc.GoogleAnalytics.UseSessionStorage, pc.Instagram.Disable,
 		pc.Instagram.Simple, pc.Twitter.Disable, pc.Twitter.EnableDNT,
 		pc.Twitter.Simple, pc.Vimeo.Disable, pc.Vimeo.EnableDNT, pc.Vimeo.Simple,
-		pc.YouTube.PrivacyEnhanced, pc.YouTube.Disable,
+		pc.YouTube.PrivacyEnhanced, pc.YouTube.Disable, pc.YouTube.Simple,
 	}
 
 	c.Assert(got, qt.All(qt.Equals), true)

--- a/docs/content/en/about/hugo-and-gdpr.md
+++ b/docs/content/en/about/hugo-and-gdpr.md
@@ -56,6 +56,7 @@ simple = false
 [privacy.youtube]
 disable = false
 privacyEnhanced = false
+simple = false
 {{< /code-toggle >}}
 
 
@@ -129,6 +130,9 @@ disableInlineCSS = true
 
 privacyEnhanced
 : When you turn on privacy-enhanced mode, YouTube won’t store information about visitors on your website unless the user plays the embedded video.
+
+simple
+: If simple mode is enabled, the video thumbnail is fetched from YouTube's servers and it is overlayed with a play button. If the user clicks to play the video, it will open in a new tab directly on YouTube's website.
 
 ### Vimeo
 

--- a/docs/content/en/content-management/shortcodes.md
+++ b/docs/content/en/content-management/shortcodes.md
@@ -397,7 +397,7 @@ Furthermore, you can automatically start playback of the embedded video by setti
 {{</* youtube id="w7Ft2ymGmfc" autoplay="true" */>}}
 {{< /code >}}
 
-For [accessibility reasons](https://dequeuniversity.com/tips/provide-iframe-titles), it's best to provide a title for your YouTube video.  You  can do this using the shortcode by providing a `title` parameter. If no title is provided, a default of "YouTube Video" will be used.
+For [accessibility reasons](https://dequeuniversity.com/tips/provide-iframe-titles), it's best to provide a title for your YouTube video.  You  can do this using the shortcode by providing a `title` parameter. If no title is provided, the video's YouTube title will be used by default.
 
 {{< code file="example-youtube-input-with-title.md" >}}
 {{</* youtube id="w7Ft2ymGmfc" title="A New Hugo Site in Under Two Minutes" */>}}

--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -168,33 +168,85 @@ title: Shorty
 func TestShortcodeYoutube(t *testing.T) {
 	t.Parallel()
 
-	for _, this := range []struct {
-		in, expected string
+	for i, this := range []struct {
+		privacy            map[string]any
+		in, resp, expected string
 	}{
 		{
+			nil,
 			`{{< youtube w7Ft2ymGmfc >}}`,
-			"(?s)\n<div style=\".*?\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\" style=\".*?\" allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>\n",
+			`{"title":"A New Hugo Site in Under 2 Minutes","author_name":"Dan Hersam","author_url":"https://www.youtube.com/c/DanHersam","type":"video","height":1080,"width":1920,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/w7Ft2ymGmfc/hqdefault.jpg","html":"\u003ciframe width=\u00221920\u0022 height=\u00221080\u0022 src=\u0022https://www.youtube.com/embed/w7Ft2ymGmfc?feature=oembed\u0022 frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen title=\u0022A New Hugo Site in Under 2 Minutes\u0022\u003e\u003c/iframe\u003e"}`,
+			"(?s)\n<div style=\".*?padding-bottom: 56.25%;.*?\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\" style=\".*?\" allowfullscreen title=\"A New Hugo Site in Under 2 Minutes\">.*?</iframe>.*?</div>\n",
 		},
 		// set class
 		{
+			nil,
 			`{{< youtube w7Ft2ymGmfc video>}}`,
-			"(?s)\n<div class=\"video\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\" allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>\n",
+			`{"title":"A New Hugo Site in Under 2 Minutes","author_name":"Dan Hersam","author_url":"https://www.youtube.com/c/DanHersam","type":"video","height":1080,"width":1920,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/w7Ft2ymGmfc/hqdefault.jpg","html":"\u003ciframe width=\u00221920\u0022 height=\u00221080\u0022 src=\u0022https://www.youtube.com/embed/w7Ft2ymGmfc?feature=oembed\u0022 frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen title=\u0022A New Hugo Site in Under 2 Minutes\u0022\u003e\u003c/iframe\u003e"}`,
+			"(?s)\n<div class=\"video\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\" allowfullscreen title=\"A New Hugo Site in Under 2 Minutes\">.*?</iframe>.*?</div>\n",
 		},
 		// set class and autoplay (using named params)
 		{
+			nil,
 			`{{< youtube id="w7Ft2ymGmfc" class="video" autoplay="true" >}}`,
-			"(?s)\n<div class=\"video\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?autoplay=1\".*?allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>",
+			`{"title":"A New Hugo Site in Under 2 Minutes","author_name":"Dan Hersam","author_url":"https://www.youtube.com/c/DanHersam","type":"video","height":1080,"width":1920,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/w7Ft2ymGmfc/hqdefault.jpg","html":"\u003ciframe width=\u00221920\u0022 height=\u00221080\u0022 src=\u0022https://www.youtube.com/embed/w7Ft2ymGmfc?feature=oembed\u0022 frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen title=\u0022A New Hugo Site in Under 2 Minutes\u0022\u003e\u003c/iframe\u003e"}`,
+			"(?s)\n<div class=\"video\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?autoplay=1\".*?allowfullscreen title=\"A New Hugo Site in Under 2 Minutes\">.*?</iframe>.*?</div>",
 		},
 		// set custom title for accessibility)
 		{
+			nil,
 			`{{< youtube id="w7Ft2ymGmfc" title="A New Hugo Site in Under Two Minutes" >}}`,
+			`{"title":"A New Hugo Site in Under 2 Minutes","author_name":"Dan Hersam","author_url":"https://www.youtube.com/c/DanHersam","type":"video","height":1080,"width":1920,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/w7Ft2ymGmfc/hqdefault.jpg","html":"\u003ciframe width=\u00221920\u0022 height=\u00221080\u0022 src=\u0022https://www.youtube.com/embed/w7Ft2ymGmfc?feature=oembed\u0022 frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen title=\u0022A New Hugo Site in Under 2 Minutes\u0022\u003e\u003c/iframe\u003e"}`,
 			"(?s)\n<div style=\".*?\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\" style=\".*?\" allowfullscreen title=\"A New Hugo Site in Under Two Minutes\">.*?</iframe>.*?</div>",
 		},
+		// 4:3 videos are displayed at that aspect ratio
+		{
+			nil,
+			`{{< youtube Y7dpJ0oseIA >}}`,
+			`{"title":"YouTube","author_name":"YouTube","author_url":"https://www.youtube.com/c/youtube","type":"video","height":1080,"width":1440,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/Y7dpJ0oseIA/hqdefault.jpg","html":"\u003ciframe width=\u00221440\u0022 height=\u00221080\u0022 src=\u0022https://www.youtube.com/embed/Y7dpJ0oseIA?feature=oembed\u0022 frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen title=\u0022YouTube\u0022\u003e\u003c/iframe\u003e"}`,
+			"(?s)\n<div style=\".*?padding-bottom: 75%;.*?\">.*?<iframe src=\"https://www.youtube.com/embed/Y7dpJ0oseIA\" style=\".*?\" allowfullscreen title=\"YouTube\">.*?</iframe>.*?</div>",
+		},
+		// privacy enhanced mode
+		{
+			map[string]any{
+				"youtube": map[string]any{
+					"privacyEnhanced": true,
+				},
+			},
+			`{{< youtube w7Ft2ymGmfc >}}`,
+			`{"title":"A New Hugo Site in Under 2 Minutes","author_name":"Dan Hersam","author_url":"https://www.youtube.com/c/DanHersam","type":"video","height":1080,"width":1920,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/w7Ft2ymGmfc/hqdefault.jpg","html":"\u003ciframe width=\u00221920\u0022 height=\u00221080\u0022 src=\u0022https://www.youtube.com/embed/w7Ft2ymGmfc?feature=oembed\u0022 frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen title=\u0022A New Hugo Site in Under 2 Minutes\u0022\u003e\u003c/iframe\u003e"}`,
+			"(?s)\n<div style=\".*?\">.*?<iframe src=\"https://www.youtube-nocookie.com/embed/w7Ft2ymGmfc\" style=\".*?\" allowfullscreen title=\"A New Hugo Site in Under 2 Minutes\">.*?</iframe>.*</div>\n",
+		},
+		// simple mode provides a link to the Youtube video
+		{
+			map[string]any{
+				"youtube": map[string]any{
+					"simple": true,
+				},
+			},
+			`{{< youtube w7Ft2ymGmfc >}}`,
+			`{"title":"A New Hugo Site in Under 2 Minutes","author_name":"Dan Hersam","author_url":"https://www.youtube.com/c/DanHersam","type":"video","height":1080,"width":1920,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/w7Ft2ymGmfc/hqdefault.jpg","html":"\u003ciframe width=\u00221920\u0022 height=\u00221080\u0022 src=\u0022https://www.youtube.com/embed/w7Ft2ymGmfc?feature=oembed\u0022 frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen title=\u0022A New Hugo Site in Under 2 Minutes\u0022\u003e\u003c/iframe\u003e"}`,
+			"(?s)\n.*?<div class=\"s_video_simple __h_video\">\n<a href=\"https://youtube.com/watch\\?v=w7Ft2ymGmfc\" rel=\"noopener\" target=\"_blank\">\n<img src=\"https://i.ytimg.com/vi/w7Ft2ymGmfc/hqdefault.jpg\" alt=\"A New Hugo Site in Under 2 Minutes\">\n<div class=\"play\"><svg.*</svg></div></a></div>\n",
+		},
 	} {
+		// overload getJSON to return mock API response from YouTube
+		ytFuncMap := template.FuncMap{
+			"getJSON": func(urlParts ...any) any {
+				var v any
+				err := json.Unmarshal([]byte(this.resp), &v)
+				if err != nil {
+					t.Fatalf("[%d] unexpected error in json.Unmarshal: %s", i, err)
+					return err
+				}
+				return v
+			},
+		}
 		var (
 			cfg, fs = newTestCfg()
 			th      = newTestHelper(cfg, fs, t)
 		)
+
+		cfg.Set("privacy", this.privacy)
 
 		writeSource(t, fs, filepath.Join("content", "simple.md"), fmt.Sprintf(`---
 title: Shorty
@@ -202,7 +254,7 @@ title: Shorty
 %s`, this.in))
 		writeSource(t, fs, filepath.Join("layouts", "_default", "single.html"), `{{ .Content }}`)
 
-		buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{})
+		buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg, OverloadedTemplateFuncs: ytFuncMap}, BuildCfg{})
 
 		th.assertFileContentRegexp(filepath.Join("public", "simple", "index.html"), this.expected)
 	}

--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
@@ -2,9 +2,13 @@
 {{- if not $pc.Disable -}}
 {{- $ytHost := cond $pc.PrivacyEnhanced  "www.youtube-nocookie.com" "www.youtube.com" -}}
 {{- $id := .Get "id" | default (.Get 0) -}}
+{{- $url := printf "https://youtube.com/watch?v=%v" $id -}}
+{{- $request := print "https://youtube.com/oembed?" (querify "format" "json" "maxwidth" "1980" "maxheight" "1080" "url" $url) -}}
+{{- $json := getJSON $request -}}
+{{- $heightPct := div (mul 100.0 $json.height) $json.width -}}
 {{- $class := .Get "class" | default (.Get 1) -}}
-{{- $title := .Get "title" | default "YouTube Video" }}
-<div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
+{{- $title := .Get "title" | default $json.title }}
+<div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: {{ $heightPct }}%; height: 0; overflow: hidden;"{{ end }}>
   <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
 </div>
 {{ end -}}

--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
@@ -1,5 +1,8 @@
 {{- $pc := .Page.Site.Config.Privacy.YouTube -}}
 {{- if not $pc.Disable -}}
+{{- if $pc.Simple -}}
+{{ template "_internal/shortcodes/youtube_simple.html" . }}
+{{- else -}}
 {{- $ytHost := cond $pc.PrivacyEnhanced  "www.youtube-nocookie.com" "www.youtube.com" -}}
 {{- $id := .Get "id" | default (.Get 0) -}}
 {{- $url := printf "https://youtube.com/watch?v=%v" $id -}}
@@ -12,3 +15,4 @@
   <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
 </div>
 {{ end -}}
+{{- end -}}

--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube_simple.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube_simple.html
@@ -1,0 +1,21 @@
+{{- $pc := .Page.Site.Config.Privacy.YouTube -}}
+{{- if not $pc.Disable -}}
+{{- $id := .Get "id" | default (.Get 0) -}}
+{{- $url := printf "https://youtube.com/watch?v=%v" $id -}}
+{{- $request := print "https://youtube.com/oembed?" (querify "format" "json" "maxwidth" "1980" "maxheight" "1080" "url" $url) -}}
+{{- $json := getJSON $request -}}
+{{- $class := .Get "class" | default (.Get 1) -}}
+{{- $hasClass := $class -}}
+{{- $class := $class | default "__h_video" -}}
+{{- if not $hasClass -}}
+{{- /* If class is set, assume the user wants to provide his own styles. */ -}}
+{{ template "__h_simple_css" $ }}
+{{- end -}}
+{{- $secondClass := "s_video_simple" }}
+<div class="{{ $secondClass }} {{ $class }}">
+{{- with $json }}
+<a href="{{ $url }}" rel="noopener" target="_blank">
+<img src="{{ .thumbnail_url }}" alt="{{ .title }}">
+<div class="play">{{ template "__h_simple_icon_play" $ }}</div></a></div>
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
This PR implements some improvements to the youtube shortcode. This covers some of the suggestions from #3694, but rather than implementing everything I looked at what I could accomplish using YouTube's [oEmbed](https://oembed.com/) API endpoint and no additional shortcode arguments.

Unlike the main YouTube API, the oEmbed endpoint doesn't require any API keys or secrets. Using this API, I was able to add the following:

1. set the default value for the iframe title to the video's title on YouTube.
2. determine the video's aspect ratio, and style the iframe to match.
3. get a URL for the video thumbnail image, which I used to implement a "simple" mode modeled after the same mode in the Vimeo shortcode.

(3) is potentially useful for websites concerned about GDPR compliance. The thumbnail URL provided by YouTube uses the `i.ytimg.com`, which Google doesn't seem to be setting any cookies on at present.

The provided thumbnail is the "hq" version. For many videos there is a corresponding "maxres" thumbnail with a higher resolution, but the oEmbed API doesn't tell us whether it'll be usable: for older SD videos, the maxres thumbnail URL will return a placeholder image rather than the actual thumbnail.