### PR TITLE
hugofs: Fix glob case-sensitivity bug

### DIFF
--- a/hugofs/glob.go
+++ b/hugofs/glob.go
@@ -26,14 +26,14 @@ import (
 // Glob walks the fs and passes all matches to the handle func.
 // The handle func can return true to signal a stop.
 func Glob(fs afero.Fs, pattern string, handle func(fi FileMetaInfo) (bool, error)) error {
-	pattern = glob.NormalizePath(pattern)
+	pattern = glob.NormalizePathCaseSensitive(pattern)
 	if pattern == "" {
 		return nil
 	}
 
-	g, err := glob.GetGlob(pattern)
+	g, err := glob.GetFilenamesGlob(pattern)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	hasSuperAsterisk := strings.Contains(pattern, "**")

--- a/hugofs/glob_test.go
+++ b/hugofs/glob_test.go
@@ -49,12 +49,17 @@ func TestGlob(t *testing.T) {
 	create("jsonfiles/sub/d3.json")
 	create("jsonfiles/d1.xml")
 	create("a/b/c/e/f.json")
+	create("UPPER/sub/style.css")
+	create("root/UPPER/sub/style.css")
 
 	c.Assert(collect("**.json"), qt.HasLen, 5)
-	c.Assert(collect("**"), qt.HasLen, 6)
+	c.Assert(collect("**"), qt.HasLen, 8)
 	c.Assert(collect(""), qt.HasLen, 0)
 	c.Assert(collect("jsonfiles/*.json"), qt.HasLen, 2)
 	c.Assert(collect("*.json"), qt.HasLen, 1)
 	c.Assert(collect("**.xml"), qt.HasLen, 1)
 	c.Assert(collect(filepath.FromSlash("/jsonfiles/*.json")), qt.HasLen, 2)
+	c.Assert(collect("UPPER/sub/style.css"), qt.HasLen, 1)
+	c.Assert(collect("root/UPPER/sub/style.css"), qt.HasLen, 1)
+
 }

--- a/resources/resource_factories/create/create.go
+++ b/resources/resource_factories/create/create.go
@@ -93,7 +93,7 @@ func (c *Client) GetMatch(pattern string) (resource.Resource, error) {
 }
 
 func (c *Client) match(name, pattern string, matchFunc func(r resource.Resource) bool, firstOnly bool) (resource.Resources, error) {
-	pattern = glob.NormalizePath(pattern)
+	pattern = glob.NormalizePathCaseSensitive(pattern)
 	partitions := glob.FilterGlobParts(strings.Split(pattern, "/"))
 	if len(partitions) == 0 {
 		partitions = []string{resources.CACHE_OTHER}


### PR DESCRIPTION
On Linux, `hugofs.Glob` does not hit any directories which include uppercase letters. (This does not happen on macOS.)

Since `resources.GetMatch/Match` uses `Glob`,

```
{{ resources.GetMatch "FOO/bar.css" }}
```

this does not match `assets/FOO/bar.css` .

On the other hand, you can get it with

```
{{ resources.Get "FOO/bar.css" }}
```