### PR TITLE
resources: Refix `resources.GetMatch/Match` case-sensitivity bug

### DIFF
--- a/resources/resource_cache.go
+++ b/resources/resource_cache.go
@@ -148,7 +148,11 @@ func (c *ResourceCache) Contains(key string) bool {
 }
 
 func (c *ResourceCache) cleanKey(key string) string {
-	return strings.TrimPrefix(path.Clean(strings.ToLower(key)), "/")
+	return strings.ToLower(c.cleanKeyNoLower(key))
+}
+
+func (c *ResourceCache) cleanKeyNoLower(key string) string {
+	return strings.TrimPrefix(path.Clean(key), "/")
 }
 
 func (c *ResourceCache) get(key string) (any, bool) {
@@ -175,7 +179,7 @@ func (c *ResourceCache) GetOrCreateResources(key string, f func() (resource.Reso
 }
 
 func (c *ResourceCache) getOrCreate(key string, f func() (any, error)) (any, error) {
-	key = c.cleanKey(key)
+	key = c.cleanKeyNoLower(key)
 	// First check in-memory cache.
 	r, found := c.get(key)
 	if found {

--- a/resources/resource_factories/create/create.go
+++ b/resources/resource_factories/create/create.go
@@ -93,7 +93,7 @@ func (c *Client) GetMatch(pattern string) (resource.Resource, error) {
 }
 
 func (c *Client) match(name, pattern string, matchFunc func(r resource.Resource) bool, firstOnly bool) (resource.Resources, error) {
-	pattern = glob.NormalizePath(pattern)
+	pattern = glob.NormalizePathNoLower(pattern)
 	partitions := glob.FilterGlobParts(strings.Split(pattern, "/"))
 	if len(partitions) == 0 {
 		partitions = []string{resources.CACHE_OTHER}


### PR DESCRIPTION
- fix
  - add integration tests
  - ~fix not found error in `walk.go`~
  - use canonical path for glog
  - fix cache key for resources

- issues
  - Fix https://github.com/gohugoio/hugo/issues/7686
  - Fix https://github.com/gohugoio/hugo/issues/10112

- ref
  - https://github.com/gohugoio/hugo/pull/10305
  - https://github.com/gohugoio/hugo/commit/281554ee97eb243af097611aaf6bfec8940ad6d1