### PR TITLE
Fix /static performance regression from Hugo 0.103.0

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -653,10 +653,7 @@ func (c *commandeer) copyStaticTo(sourceFs *filesystems.SourceFilesystem) (uint6
 	syncer.NoChmod = c.Cfg.GetBool("noChmod")
 	syncer.ChmodFilter = chmodFilter
 	syncer.SrcFs = fs
-	syncer.DestFs = c.Fs.PublishDir
-	if c.renderStaticToDisk {
-		syncer.DestFs = c.Fs.PublishDirStatic
-	}
+	syncer.DestFs = c.Fs.PublishDirStatic
 	// Now that we are using a unionFs for the static directories
 	// We can effectively clean the publishDir on initial sync
 	syncer.Delete = c.Cfg.GetBool("cleanDestinationDir")

--- a/hugofs/fs.go
+++ b/hugofs/fs.go
@@ -40,8 +40,7 @@ type Fs struct {
 	// It's mounted inside publishDir (default /public).
 	PublishDir afero.Fs
 
-	// PublishDirStatic is the file system used for static files  when --renderStaticToDisk is set.
-	// When this is set, PublishDir is set to write to memory.
+	// PublishDirStatic is the file system used for static files.
 	PublishDirStatic afero.Fs
 
 	// PublishDirServer is the file system used for serving the public directory with Hugo's development server.
@@ -142,7 +141,6 @@ func isWrite(flag int) bool {
 // MakeReadableAndRemoveAllModulePkgDir makes any subdir in dir readable and then
 // removes the root.
 // TODO(bep) move this to a more suitable place.
-//
 func MakeReadableAndRemoveAllModulePkgDir(fs afero.Fs, dir string) (int, error) {
 	// Safe guard
 	if !strings.Contains(dir, "pkg") {

--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -67,7 +67,7 @@ type BaseFs struct {
 	// This usually maps to /my-project/public.
 	PublishFs afero.Fs
 
-	// The filesystem used for renderStaticToDisk.
+	// The filesystem used for static files.
 	PublishFsStatic afero.Fs
 
 	// A read-only filesystem starting from the project workDir.

--- a/hugolib/pages_process.go
+++ b/hugolib/pages_process.go
@@ -32,10 +32,9 @@ func newPagesProcessor(h *HugoSites, sp *source.SourceSpec) *pagesProcessor {
 	procs := make(map[string]pagesCollectorProcessorProvider)
 	for _, s := range h.Sites {
 		procs[s.Lang()] = &sitePagesProcessor{
-			m:                  s.pageMap,
-			errorSender:        s.h,
-			itemChan:           make(chan interface{}, config.GetNumWorkerMultiplier()*2),
-			renderStaticToDisk: h.Cfg.GetBool("renderStaticToDisk"),
+			m:           s.pageMap,
+			errorSender: s.h,
+			itemChan:    make(chan interface{}, config.GetNumWorkerMultiplier()*2),
 		}
 	}
 	return &pagesProcessor{
@@ -118,8 +117,6 @@ type sitePagesProcessor struct {
 	ctx       context.Context
 	itemChan  chan any
 	itemGroup *errgroup.Group
-
-	renderStaticToDisk bool
 }
 
 func (p *sitePagesProcessor) Process(item any) error {
@@ -164,10 +161,7 @@ func (p *sitePagesProcessor) copyFile(fim hugofs.FileMetaInfo) error {
 
 	defer f.Close()
 
-	fs := s.PublishFs
-	if p.renderStaticToDisk {
-		fs = s.PublishFsStatic
-	}
+	fs := s.PublishFsStatic
 
 	return s.publish(&s.PathSpec.ProcessingStats.Files, target, f, fs)
 }


### PR DESCRIPTION
In `v0.103.0` we added support for `resources.PostProcess` for all file types, not just HTML. We had benchmarks that said we were fine in that department, but those did not consider the static file syncing.

This fixes that by:

* Making sure that the /static syncer always gets its own file system without any checks for the post process token.
* For dynamic files (e.g. rendered HTML files) we add an additional check to make sure that we skip binary files (e.g. images)

Fixes #10328
