### PR TITLE
commands: Remove extraneous newline from result of convert toTOML

### DIFF
--- a/parser/frontmatter.go
+++ b/parser/frontmatter.go
@@ -109,7 +109,7 @@ func InterfaceToFrontMatter(in any, format metadecoders.Format, w io.Writer) err
 			return err
 		}
 
-		_, err = w.Write([]byte("\n" + tomlDelimLf))
+		_, err = w.Write([]byte(tomlDelimLf))
 		return err
 
 	default:


### PR DESCRIPTION
Fixes #10351