### PR TITLE
Use setup-go action to cache dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8
+      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
       with:
         go-version: ${{ matrix.go-version }}
+        cache: true
     - name: Install Ruby
       uses: actions/setup-ruby@5f29a1cd8dfebf420691c4c9a0e832e2fae5a526
       with:


### PR DESCRIPTION
## Description

I changed the workflow to cache dependencies using [actions/setup-go](https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs). `actions/setup-go@v3` or newer has caching **built-in**.
### AS-IS

```yml
- name: Install Go
  uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8
  with:
    go-version: ${{ matrix.go-version }}
```

### TO-BE

```yml
- name: Install Go
  uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
  with:
    go-version: ${{ matrix.go-version }}
    cache: true
```

> It’s literally a one line change to pass the `cache: true` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)