### PR TITLE
hotfix: Resolve dependency-path not found error in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,17 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
+        check-latest: true
         cache: true
+        cache-dependency-path: |
+          **/go.sum
+          **/go.mod
     - name: Install Ruby
       uses: actions/setup-ruby@5f29a1cd8dfebf420691c4c9a0e832e2fae5a526
       with:
@@ -34,8 +40,6 @@ jobs:
       run: go install github.com/magefile/mage@07afc7d24f4d6d6442305d49552f04fbda5ccb3e
     - name: Install asciidoctor
       uses: reitzig/actions-asciidoctor@7570212ae20b63653481675fb1ff62d1073632b0
-    - name: Checkout code
-      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
     - name: Install docutils
       run: |
         pip install docutils


### PR DESCRIPTION
## Description

Fixed #10359

![workflow](https://user-images.githubusercontent.com/44025432/194046429-322e70a0-36ab-4665-91df-af81fbda5e6d.png)

### AS-IS

```yml
- name: Install Go
  uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8
  with:
    go-version: ${{ matrix.go-version }}
    cache: true
- name: Checkout code
   uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
```

### TO-BE

```yml
- name: Checkout code
   uses: actions/checkout@v3
- name: Install Go
  uses: actions/setup-go@v3
  with:
    go-version: ${{ matrix.go-version }}
    cache: true
    cache-dependency-path: |
          **/go.sum
          **/go.mod
```
