### PR TITLE
HTML5 standard: don't use self closing tags

### DIFF
--- a/common/hugo/hugo.go
+++ b/common/hugo/hugo.go
@@ -68,7 +68,7 @@ func (i Info) Version() VersionString {
 
 // Generator a Hugo meta generator HTML tag.
 func (i Info) Generator() template.HTML {
-	return template.HTML(fmt.Sprintf(`<meta name="generator" content="Hugo %s" />`, CurrentVersion.String()))
+	return template.HTML(fmt.Sprintf(`<meta name="generator" content="Hugo %s">`, CurrentVersion.String()))
 }
 
 func (i Info) IsProduction() bool {

--- a/docs/content/en/functions/hugo.md
+++ b/docs/content/en/functions/hugo.md
@@ -22,7 +22,7 @@ aliases: []
 `hugo` returns an instance that contains the following functions:
 
 hugo.Generator
-: `<meta>` tag for the version of Hugo that generated the site. `hugo.Generator` outputs a *complete* HTML tag; e.g. `<meta name="generator" content="Hugo 0.63.2" />`
+: `<meta>` tag for the version of Hugo that generated the site. `hugo.Generator` outputs a *complete* HTML tag; e.g. `<meta name="generator" content="Hugo 0.63.2">`
 
 hugo.Version
 : the current version of the Hugo binary you are using e.g. `0.63.2`

--- a/transform/metainject/hugogenerator.go
+++ b/transform/metainject/hugogenerator.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	metaTagsCheck    = regexp.MustCompile(`(?i)<meta\s+name=['|"]?generator['|"]?`)
-	hugoGeneratorTag = fmt.Sprintf(`<meta name="generator" content="Hugo %s" />`, hugo.CurrentVersion)
+	hugoGeneratorTag = fmt.Sprintf(`<meta name="generator" content="Hugo %s">`, hugo.CurrentVersion)
 )
 
 // HugoGenerator injects a meta generator tag for Hugo if none present.

--- a/transform/metainject/hugogenerator_test.go
+++ b/transform/metainject/hugogenerator_test.go
@@ -39,10 +39,10 @@ func TestHugoGeneratorInject(t *testing.T) {
 	META
 	<foo />
 </HEAD>`},
-		{`<head><meta name="generator" content="Jekyll" /></head>`, `<head><meta name="generator" content="Jekyll" /></head>`},
-		{`<head><meta name='generator' content='Jekyll' /></head>`, `<head><meta name='generator' content='Jekyll' /></head>`},
-		{`<head><meta name=generator content=Jekyll /></head>`, `<head><meta name=generator content=Jekyll /></head>`},
-		{`<head><META     NAME="GENERATOR" content="Jekyll" /></head>`, `<head><META     NAME="GENERATOR" content="Jekyll" /></head>`},
+		{`<head><meta name="generator" content="Jekyll"></head>`, `<head><meta name="generator" content="Jekyll"></head>`},
+		{`<head><meta name='generator' content='Jekyll'></head>`, `<head><meta name='generator' content='Jekyll'></head>`},
+		{`<head><meta name=generator content=Jekyll></head>`, `<head><meta name=generator content=Jekyll></head>`},
+		{`<head><META     NAME="GENERATOR" content="Jekyll"></head>`, `<head><META     NAME="GENERATOR" content="Jekyll"></head>`},
 		{"", ""},
 		{"</head>", "</head>"},
 		{"<head>", "<head>\n\tMETA"},


### PR DESCRIPTION
Remove self-closing tags to conform to W3C recommendations: Self-closing tag syntax in text/html documents is widely discouraged

<https://html.spec.whatwg.org/multipage/semantics.html#meta-generator>