### PR TITLE
preallocate memory

### DIFF
--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -248,12 +248,12 @@ func (sc shortcode) String() string {
 	switch v := sc.params.(type) {
 	case map[string]any:
 		// sort the keys so test assertions won't fail
-		var keys []string
+		keys := make([]string, 0, len(v))
 		for k := range v {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
-		tmp := make(map[string]any)
+		tmp := make(map[string]any, len(keys))
 
 		for _, k := range keys {
 			tmp[k] = v[k]


### PR DESCRIPTION
**What this PR does / why we need it:**

Preallocate memory instead of enforcing an incremental growth. This will result in less work for the garbage collector.