### PR TITLE
feat: time.Format takes an optional 3rd parameter for language

### DIFF
--- a/docs/content/en/functions/dateformat.md
+++ b/docs/content/en/functions/dateformat.md
@@ -9,17 +9,21 @@ menu:
   docs:
     parent: "functions"
 keywords: [dates,time,strings]
-signature: ["time.Format LAYOUT INPUT"]
+signature: ["time.Format LAYOUT INPUT [LANGUAGE]"]
 workson: []
 hugoversion:
 relatedfuncs: [Format,now,Unix,time]
 deprecated: false
 ---
 
-`time.Format` (alias `dateFormat`) converts either a `time.Time` object (e.g. `.Date`) or a timestamp string `INPUT` into the format specified by the `LAYOUT` string.
+`time.Format` (alias `dateFormat`) converts either a `time.Time` object (e.g. `.Date`) or a timestamp string `INPUT` into the format specified by the `LAYOUT` string and an optional `LANGUAGE` code.
 
 ```go-html-template
-{{ time.Format "Monday, Jan 2, 2006" "2015-01-21" }} → "Wednesday, Jan 21, 2015"
+{{ time.Format "Monday, Jan 2, 2006" "2015-12-21" }} → "Monday, Dec 21, 2015"
+```
+
+```go-html-template
+{{ time.Format "Monday, Jan 2, 2006" "2015-12-21" "pt" }} → "lunes, dic. 21, 2015"
 ```
 
 Note that since Hugo 0.87.0, `time.Format` will return a localized string for the current language. {{< new-in "0.87.0" >}}

--- a/tpl/time/init.go
+++ b/tpl/time/init.go
@@ -28,7 +28,7 @@ func init() {
 		if d.Language == nil {
 			panic("Language must be set")
 		}
-		ctx := New(langs.GetTimeFormatter(d.Language), langs.GetLocation(d.Language))
+		ctx := New(d.Language.Lang, langs.GetTimeFormatter(d.Language), langs.GetLocation(d.Language))
 
 		ns := &internal.TemplateFuncsNamespace{
 			Name: name,


### PR DESCRIPTION
This feature allows the `time.Format` template feature to take an optional 3rd parameter for the time formatting language.

```
{{ time.Format ":date_medium" $date }} <!-- will use the page language -->
{{ time.Format ":date_medium" $date "pt" }} <!-- will use Portuguese (pt) -->
```

I added this feature because of citations. I needed a way to write the dates in Portuguese even for articles in English.