### PR TITLE
hugo/parser: Fix shortcode boolean param parsing

### DIFF
--- a/parser/pageparser/item.go
+++ b/parser/pageparser/item.go
@@ -215,7 +215,7 @@ const (
 )
 
 var (
-	boolRe  = regexp.MustCompile(`^(true$)|(false$)`)
+	boolRe  = regexp.MustCompile(`^(true|false)$`)
 	intRe   = regexp.MustCompile(`^[-+]?\d+$`)
 	floatRe = regexp.MustCompile(`^[-+]?\d*\.\d+$`)
 )

--- a/parser/pageparser/item_test.go
+++ b/parser/pageparser/item_test.go
@@ -38,6 +38,13 @@ func TestItemValTyped(t *testing.T) {
 	c.Assert(Item{low: 0, high: len(source)}.ValTyped(source), qt.Equals, true)
 	source = []byte("false")
 	c.Assert(Item{low: 0, high: len(source)}.ValTyped(source), qt.Equals, false)
-	source = []byte("trued")
+	source = []byte("falsex")
+	c.Assert(Item{low: 0, high: len(source)}.ValTyped(source), qt.Equals, "falsex")
+	source = []byte("xfalse")
+	c.Assert(Item{low: 0, high: len(source)}.ValTyped(source), qt.Equals, "xfalse")
+	source = []byte("truex")
+	c.Assert(Item{low: 0, high: len(source)}.ValTyped(source), qt.Equals, "truex")
+	source = []byte("xtrue")
+	c.Assert(Item{low: 0, high: len(source)}.ValTyped(source), qt.Equals, "xtrue")
 
 }


### PR DESCRIPTION
Fixes #10451