### PR TITLE
common/htime: add `:date_time`, `:date_only`, `:time_only`

### DIFF
--- a/common/htime/time.go
+++ b/common/htime/time.go
@@ -107,6 +107,10 @@ func (f TimeFormatter) Format(t time.Time, layout string) string {
 			return f.ltr.FmtDateMedium(t)
 		case "date_short":
 			return f.ltr.FmtDateShort(t)
+		case "date_time":
+			return t.Format("2006-01-02 15:04:05")
+		case "date_only":
+			return t.Format("2006-01-02")
 		case "time_full":
 			return f.ltr.FmtTimeFull(t)
 		case "time_long":
@@ -115,6 +119,8 @@ func (f TimeFormatter) Format(t time.Time, layout string) string {
 			return f.ltr.FmtTimeMedium(t)
 		case "time_short":
 			return f.ltr.FmtTimeShort(t)
+		case "time_only":
+			return t.Format("15:04:05")
 		}
 	}
 

--- a/common/htime/time_test.go
+++ b/common/htime/time_test.go
@@ -63,11 +63,14 @@ func TestTimeFormatter(t *testing.T) {
 		c.Assert(f.Format(june06, ":date_long"), qt.Equals, "June 6, 2018")
 		c.Assert(f.Format(june06, ":date_medium"), qt.Equals, "Jun 6, 2018")
 		c.Assert(f.Format(june06, ":date_short"), qt.Equals, "6/6/18")
+		c.Assert(f.Format(june06, ":date_time"), qt.Equals, "2018-06-06 02:09:37")
+		c.Assert(f.Format(june06, ":date_only"), qt.Equals, "2018-06-06")
 
 		c.Assert(f.Format(june06, ":time_full"), qt.Equals, "2:09:37 am UTC")
 		c.Assert(f.Format(june06, ":time_long"), qt.Equals, "2:09:37 am UTC")
 		c.Assert(f.Format(june06, ":time_medium"), qt.Equals, "2:09:37 am")
 		c.Assert(f.Format(june06, ":time_short"), qt.Equals, "2:09 am")
+		c.Assert(f.Format(june06, ":time_only"), qt.Equals, "02:09:37")
 
 	})
 

--- a/docs/content/en/functions/dateformat.md
+++ b/docs/content/en/functions/dateformat.md
@@ -46,8 +46,11 @@ The full list of custom layouts with examples for English:
 * `:date_long` => `June 6, 2018`
 * `:date_medium` => `Jun 6, 2018`
 * `:date_short` => `6/6/18`
+* `:date_time` => `2018-06-06 02:09:37`
+* `:date_only` => `2018-06-06`
 
 * `:time_full` => `2:09:37 am UTC`
 * `:time_long` => `2:09:37 am UTC`
 * `:time_medium` => `2:09:37 am`
 * `:time_short` => `2:09 am`
+* `:time_only` => `02:09:37`

--- a/magefile.go
+++ b/magefile.go
@@ -268,7 +268,7 @@ func Lint() error {
 	return nil
 }
 
-//  Run go vet linter
+// Run go vet linter
 func Vet() error {
 	if err := sh.Run(goexe, "vet", "./..."); err != nil {
 		return fmt.Errorf("error running go vet: %v", err)


### PR DESCRIPTION
This PR adds `:date_time ("2006-01-02 15:04:05")`, `:date_only ("2006-01-02")`, `:time_only ("15:04:05")` to the custom layouts.   

Those are popular layouts and will be added to golang's time pkg as well.

Reference: https://github.com/golang/go/commit/0981d9fff1fa5601a2b7833473955252425bd923