### PR TITLE
tpl: Use consistent delimiter spacing in examples

### DIFF
--- a/tpl/collections/init.go
+++ b/tpl/collections/init.go
@@ -42,7 +42,7 @@ func init() {
 		ns.AddMethodMapping(ctx.Complement,
 			[]string{"complement"},
 			[][2]string{
-				{`{{ slice "a" "b" "c" "d" "e" "f" | complement (slice "b" "c") (slice "d" "e")  }}`, `[a f]`},
+				{`{{ slice "a" "b" "c" "d" "e" "f" | complement (slice "b" "c") (slice "d" "e") }}`, `[a f]`},
 			},
 		)
 
@@ -197,11 +197,11 @@ func init() {
 					`[Yes, Hugo Rocks! Hugo Rocks!]`,
 				},
 				{
-					`{{  merge (dict "title" "Default Title" "description" "Yes, Hugo Rocks!") (dict "title" "Hugo Rocks!") | sort }}`,
+					`{{ merge (dict "title" "Default Title" "description" "Yes, Hugo Rocks!") (dict "title" "Hugo Rocks!") | sort }}`,
 					`[Yes, Hugo Rocks! Hugo Rocks!]`,
 				},
 				{
-					`{{  merge (dict "title" "Default Title" "description" "Yes, Hugo Rocks!") (dict "title" "Hugo Rocks!") (dict "extra" "For reals!") | sort }}`,
+					`{{ merge (dict "title" "Default Title" "description" "Yes, Hugo Rocks!") (dict "title" "Hugo Rocks!") (dict "extra" "For reals!") | sort }}`,
 					`[Yes, Hugo Rocks! For reals! Hugo Rocks!]`,
 				},
 			},

--- a/tpl/debug/init.go
+++ b/tpl/debug/init.go
@@ -32,9 +32,9 @@ func init() {
 		ns.AddMethodMapping(ctx.Dump,
 			nil,
 			[][2]string{
-				{`{{- $m := newScratch -}}
-{{- $m.Set "Hugo" "Rocks!" -}}
-{{- $m.Values | debug.Dump | safeHTML -}}`, "map[string]interface {}{\n  \"Hugo\": \"Rocks!\",\n}"},
+				{`{{ $m := newScratch }}
+{{ $m.Set "Hugo" "Rocks!" }}
+{{ $m.Values | debug.Dump | safeHTML }}`, "map[string]interface {}{\n  \"Hugo\": \"Rocks!\",\n}"},
 			},
 		)
 

--- a/tpl/math/init.go
+++ b/tpl/math/init.go
@@ -32,98 +32,98 @@ func init() {
 		ns.AddMethodMapping(ctx.Add,
 			[]string{"add"},
 			[][2]string{
-				{"{{add 1 2}}", "3"},
+				{"{{ add 1 2 }}", "3"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Ceil,
 			nil,
 			[][2]string{
-				{"{{math.Ceil 2.1}}", "3"},
+				{"{{ math.Ceil 2.1 }}", "3"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Div,
 			[]string{"div"},
 			[][2]string{
-				{"{{div 6 3}}", "2"},
+				{"{{ div 6 3 }}", "2"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Floor,
 			nil,
 			[][2]string{
-				{"{{math.Floor 1.9}}", "1"},
+				{"{{ math.Floor 1.9 }}", "1"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Log,
 			nil,
 			[][2]string{
-				{"{{math.Log 1}}", "0"},
+				{"{{ math.Log 1 }}", "0"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Max,
 			nil,
 			[][2]string{
-				{"{{math.Max 1 2 }}", "2"},
+				{"{{ math.Max 1 2 }}", "2"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Min,
 			nil,
 			[][2]string{
-				{"{{math.Min 1 2 }}", "1"},
+				{"{{ math.Min 1 2 }}", "1"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Mod,
 			[]string{"mod"},
 			[][2]string{
-				{"{{mod 15 3}}", "0"},
+				{"{{ mod 15 3 }}", "0"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.ModBool,
 			[]string{"modBool"},
 			[][2]string{
-				{"{{modBool 15 3}}", "true"},
+				{"{{ modBool 15 3 }}", "true"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Mul,
 			[]string{"mul"},
 			[][2]string{
-				{"{{mul 2 3}}", "6"},
+				{"{{ mul 2 3 }}", "6"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Pow,
 			[]string{"pow"},
 			[][2]string{
-				{"{{math.Pow 2 3}}", "8"},
+				{"{{ math.Pow 2 3 }}", "8"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Round,
 			nil,
 			[][2]string{
-				{"{{math.Round 1.5}}", "2"},
+				{"{{ math.Round 1.5 }}", "2"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Sqrt,
 			nil,
 			[][2]string{
-				{"{{math.Sqrt 81}}", "9"},
+				{"{{ math.Sqrt 81 }}", "9"},
 			},
 		)
 
 		ns.AddMethodMapping(ctx.Sub,
 			[]string{"sub"},
 			[][2]string{
-				{"{{sub 3 2}}", "1"},
+				{"{{ sub 3 2 }}", "1"},
 			},
 		)
 

--- a/tpl/path/init.go
+++ b/tpl/path/init.go
@@ -46,11 +46,11 @@ func init() {
 		ns.AddMethodMapping(ctx.Join,
 			nil,
 			[][2]string{
-				{fmt.Sprintf(`{{ slice %q "filename.txt" | path.Join  }}`, testDir), `my/path/filename.txt`},
-				{`{{  path.Join "my" "path" "filename.txt" }}`, `my/path/filename.txt`},
-				{fmt.Sprintf(`{{ %q | path.Ext  }}`, testFile), `.txt`},
-				{fmt.Sprintf(`{{ %q | path.Base  }}`, testFile), `filename.txt`},
-				{fmt.Sprintf(`{{ %q | path.Dir  }}`, testFile), `my/path`},
+				{fmt.Sprintf(`{{ slice %q "filename.txt" | path.Join }}`, testDir), `my/path/filename.txt`},
+				{`{{ path.Join "my" "path" "filename.txt" }}`, `my/path/filename.txt`},
+				{fmt.Sprintf(`{{ %q | path.Ext }}`, testFile), `.txt`},
+				{fmt.Sprintf(`{{ %q | path.Base }}`, testFile), `filename.txt`},
+				{fmt.Sprintf(`{{ %q | path.Dir }}`, testFile), `my/path`},
 			},
 		)
 

--- a/tpl/strings/init.go
+++ b/tpl/strings/init.go
@@ -32,7 +32,7 @@ func init() {
 		ns.AddMethodMapping(ctx.Chomp,
 			[]string{"chomp"},
 			[][2]string{
-				{`{{chomp "<p>Blockhead</p>\n" | safeHTML }}`, `<p>Blockhead</p>`},
+				{`{{ chomp "<p>Blockhead</p>\n" | safeHTML }}`, `<p>Blockhead</p>`},
 			},
 		)
 
@@ -54,7 +54,7 @@ func init() {
 		ns.AddMethodMapping(ctx.Count,
 			nil,
 			[][2]string{
-				{`{{"aabab" | strings.Count "a" }}`, `3`},
+				{`{{ "aabab" | strings.Count "a" }}`, `3`},
 			},
 		)
 
@@ -95,7 +95,7 @@ func init() {
 		ns.AddMethodMapping(ctx.ToLower,
 			[]string{"lower"},
 			[][2]string{
-				{`{{lower "BatMan"}}`, `batman`},
+				{`{{ lower "BatMan" }}`, `batman`},
 			},
 		)
 
@@ -130,8 +130,8 @@ func init() {
 		ns.AddMethodMapping(ctx.SliceString,
 			[]string{"slicestr"},
 			[][2]string{
-				{`{{slicestr "BatMan" 0 3}}`, `Bat`},
-				{`{{slicestr "BatMan" 3}}`, `Man`},
+				{`{{ slicestr "BatMan" 0 3 }}`, `Bat`},
+				{`{{ slicestr "BatMan" 3 }}`, `Man`},
 			},
 		)
 
@@ -143,8 +143,8 @@ func init() {
 		ns.AddMethodMapping(ctx.Substr,
 			[]string{"substr"},
 			[][2]string{
-				{`{{substr "BatMan" 0 -3}}`, `Bat`},
-				{`{{substr "BatMan" 3 3}}`, `Man`},
+				{`{{ substr "BatMan" 0 -3 }}`, `Bat`},
+				{`{{ substr "BatMan" 3 3 }}`, `Man`},
 			},
 		)
 
@@ -188,8 +188,8 @@ func init() {
 		ns.AddMethodMapping(ctx.Title,
 			[]string{"title"},
 			[][2]string{
-				{`{{title "Bat man"}}`, `Bat Man`},
-				{`{{title "somewhere over the rainbow"}}`, `Somewhere Over the Rainbow`},
+				{`{{ title "Bat man" }}`, `Bat Man`},
+				{`{{ title "somewhere over the rainbow" }}`, `Somewhere Over the Rainbow`},
 			},
 		)
 
@@ -218,7 +218,7 @@ func init() {
 		ns.AddMethodMapping(ctx.ToUpper,
 			[]string{"upper"},
 			[][2]string{
-				{`{{upper "BatMan"}}`, `BATMAN`},
+				{`{{ upper "BatMan" }}`, `BATMAN`},
 			},
 		)
 

--- a/tpl/transform/init.go
+++ b/tpl/transform/init.go
@@ -45,11 +45,11 @@ func init() {
 			[]string{"htmlEscape"},
 			[][2]string{
 				{
-					`{{ htmlEscape "Cathal Garvey & The Sunshine Band <cathal@foo.bar>" | safeHTML}}`,
+					`{{ htmlEscape "Cathal Garvey & The Sunshine Band <cathal@foo.bar>" | safeHTML }}`,
 					`Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;`,
 				},
 				{
-					`{{ htmlEscape "Cathal Garvey & The Sunshine Band <cathal@foo.bar>"}}`,
+					`{{ htmlEscape "Cathal Garvey & The Sunshine Band <cathal@foo.bar>" }}`,
 					`Cathal Garvey &amp;amp; The Sunshine Band &amp;lt;cathal@foo.bar&amp;gt;`,
 				},
 				{
@@ -63,15 +63,15 @@ func init() {
 			[]string{"htmlUnescape"},
 			[][2]string{
 				{
-					`{{ htmlUnescape "Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;" | safeHTML}}`,
+					`{{ htmlUnescape "Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;" | safeHTML }}`,
 					`Cathal Garvey & The Sunshine Band <cathal@foo.bar>`,
 				},
 				{
-					`{{"Cathal Garvey &amp;amp; The Sunshine Band &amp;lt;cathal@foo.bar&amp;gt;" | htmlUnescape | htmlUnescape | safeHTML}}`,
+					`{{ "Cathal Garvey &amp;amp; The Sunshine Band &amp;lt;cathal@foo.bar&amp;gt;" | htmlUnescape | htmlUnescape | safeHTML }}`,
 					`Cathal Garvey & The Sunshine Band <cathal@foo.bar>`,
 				},
 				{
-					`{{"Cathal Garvey &amp;amp; The Sunshine Band &amp;lt;cathal@foo.bar&amp;gt;" | htmlUnescape | htmlUnescape }}`,
+					`{{ "Cathal Garvey &amp;amp; The Sunshine Band &amp;lt;cathal@foo.bar&amp;gt;" | htmlUnescape | htmlUnescape }}`,
 					`Cathal Garvey &amp; The Sunshine Band &lt;cathal@foo.bar&gt;`,
 				},
 				{
@@ -84,7 +84,7 @@ func init() {
 		ns.AddMethodMapping(ctx.Markdownify,
 			[]string{"markdownify"},
 			[][2]string{
-				{`{{ .Title | markdownify}}`, `<strong>BatMan</strong>`},
+				{`{{ .Title | markdownify }}`, `<strong>BatMan</strong>`},
 			},
 		)
 


### PR DESCRIPTION
Consistently use `{{ this }}` instead of `{{this}}` in AddMethodMapping examples.

Most examples were already using this syntax. This just makes the it consistent.