### PR TITLE
resources: Increase timeout for http.Client

### DIFF
--- a/resources/resource_factories/create/create.go
+++ b/resources/resource_factories/create/create.go
@@ -45,7 +45,7 @@ func New(rs *resources.Spec) *Client {
 	return &Client{
 		rs: rs,
 		httpClient: &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: time.Minute,
 		},
 		cacheGetResource: rs.FileCaches.GetResourceCache(),
 	}


### PR DESCRIPTION
Increase timeout for http.Client in resources.GetRemote  from 10 second to 1 minute

Issue #10478