### PR TITLE
feat: add parents property

### DIFF
--- a/hugolib/page__tree.go
+++ b/hugolib/page__tree.go
@@ -178,6 +178,15 @@ func (pt pageTree) Parent() page.Page {
 	return b.p
 }
 
+func (pt pageTree) Parents() (parents []page.Page) {
+	var parent page.Page
+	for parent != nil {
+		parent = pt.Parent()
+		parents = append(parents, parent)
+	}
+	return
+}
+
 func (pt pageTree) Sections() page.Pages {
 	if pt.p.bucket == nil {
 		return nil

--- a/resources/page/page.go
+++ b/resources/page/page.go
@@ -407,6 +407,9 @@ type TreeProvider interface {
 	// To get a section's subsections, see Page's Sections method.
 	Parent() Page
 
+	// Parents returns all parents section or a page's section.
+	Parents() []Page
+
 	// Sections returns this section's subsections, if any.
 	// Note that for non-sections, this method will always return an empty list.
 	Sections() Pages

--- a/resources/page/page_nop.go
+++ b/resources/page/page_nop.go
@@ -348,6 +348,10 @@ func (p *nopPage) Parent() Page {
 	return nil
 }
 
+func (p *nopPage) Parents() []Page {
+	return nil
+}
+
 func (p *nopPage) Path() string {
 	return ""
 }

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -416,6 +416,10 @@ func (p *testPage) Parent() Page {
 	panic("not implemented")
 }
 
+func (p *testPage) Parents() []Page {
+	panic("not implemented")
+}
+
 func (p *testPage) Path() string {
 	return p.path
 }


### PR DESCRIPTION
Simple breadcrumb navigation implementation method

more breadcrumb trick code see https://discourse.gohugo.io/search?q=breadcrumb

the feature after

```gohtml
<nav class="breadcrumb">
<ul>
{{- template "breadcrumbs" (dict "context" . "parent" .) }}
</ul>
</nav>
{{- define "breadcrumbs" }}
{{- $parent := .parent }}
{{- with .context -}}
{{- with .Parent }}{{- template "breadcrumbs" (dict "context" . "parent" $parent) -}}{{- end }}
<li {{- if eq . $parent }} class="is-active"{{ end }}>
<a href="{{ .Permalink }}">{{ .LinkTitle }}</a>
</li>
{{- end -}}
{{- end }}
```

the feature before

```gohtml
{{- $page := . -}
<nav class="breadcrumb">
<ul>
{{- range .Parents }}
<li {{- if eq $page . }} class="is-active"{{ end }}>
<a href="{{ .Permalink }}">{{ .LinkTitle }}</a>
</li>
{{- end }}
</ul>
</nav>
```