### PR TITLE
feat: exemption `CI` enviroment variable

### DIFF
--- a/config/security/securityConfig.go
+++ b/config/security/securityConfig.go
@@ -45,7 +45,7 @@ var DefaultConfig = Config{
 		OsEnv: NewWhitelist("(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM)$"),
 	},
 	Funcs: Funcs{
-		Getenv: NewWhitelist("^HUGO_"),
+		Getenv: NewWhitelist("^HUGO_", "^CI$"),
 	},
 	HTTP: HTTP{
 		URLs:    NewWhitelist(".*"),

--- a/config/security/securityConfig_test.go
+++ b/config/security/securityConfig_test.go
@@ -140,7 +140,7 @@ func TestToTOML(t *testing.T) {
 	got := DefaultConfig.ToTOML()
 
 	c.Assert(got, qt.Equals,
-		"[security]\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['.*']",
+		"[security]\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_', '^CI$']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['.*']",
 	)
 }
 


### PR DESCRIPTION
exemption `CI` enviroment variable

can to implement such a function:

```
{{- if getenv "CI" -}}
   {{ /* e.g: save remote image to local */ }}
{{- end -}}
```

see https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
see https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
see https://circleci.com/docs/variables/#built-in-environment-variables
see https://docs.gitlab.com/ee/ci/variables/#debug-logging
see https://www.appveyor.com/docs/environment-variables/
etc CI/CD service providers