### PR TITLE
Change Open Graph's series as optional

### DIFF
--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -33,12 +33,14 @@
 {{- /* If it is part of a series, link to related articles */}}
 {{- $permalink := .Permalink }}
 {{- $siteSeries := .Site.Taxonomies.series }}
+{{- if $siteSeries }}
 {{ with .Params.series }}{{- range $name := . }}
   {{- $series := index $siteSeries ($name | urlize) }}
   {{- range $page := first 6 $series.Pages }}
     {{- if ne $page.Permalink $permalink }}<meta property="og:see_also" content="{{ $page.Permalink }}" />{{ end }}
   {{- end }}
 {{ end }}{{ end }}
+{{- end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
 {{- with .Site.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}


### PR DESCRIPTION
Hi, the site builds fails with default taxonomies, the internal Open Graph template requires `series` taxonomy, but I didn't find documentations about the `og:see_also` tag.

It would be great that print a more specified ERROR message if the `series` is required, for users who forgot to config.

```
Error: Error building site: failed to render pages: render of "page" failed: execute of template failed: template:
_internal/opengraph.html:37:17: executing "_internal/opengraph.html" at <index $siteSeries ($name | urlize)>: error calling index: index of untyped nil
```