### PR TITLE
Add empty JSON data file as empty map

### DIFF
--- a/parser/metadecoders/decoder.go
+++ b/parser/metadecoders/decoder.go
@@ -112,7 +112,7 @@ func (d Decoder) UnmarshalStringTo(data string, typ any) (any, error) {
 // Unmarshal will unmarshall data in format f into an interface{}.
 // This is what's needed for Hugo's /data handling.
 func (d Decoder) Unmarshal(data []byte, f Format) (any, error) {
-	if data == nil {
+	if data == nil || len(data) == 0 {
 		switch f {
 		case CSV:
 			return make([][]string, 0), nil

--- a/parser/metadecoders/decoder_test.go
+++ b/parser/metadecoders/decoder_test.go
@@ -122,6 +122,7 @@ func TestUnmarshalToInterface(t *testing.T) {
 	}{
 		{`[ "Brecker", "Blake", "Redman" ]`, JSON, []any{"Brecker", "Blake", "Redman"}},
 		{`{ "a": "b" }`, JSON, expect},
+		{``, JSON, map[string]any{}},
 		{`#+a: b`, ORG, expect},
 		{`#+DATE: <2020-06-26 Fri>`, ORG, map[string]any{"date": "2020-06-26"}},
 		{`a = "b"`, TOML, expect},


### PR DESCRIPTION
This fixes issue #8601.

Test Case:
1. Create a new Hugo Project or use an existing one
2. Add an empty JSON file to the data folder

Result:
The site will not crash even when the data is accessed in the layout files like this: 
```
{{ range .Site.Data.jazz.bass }}
   {{ . }}
{{ end }}
```

This is my first pull request. So any suggestion for improvement is highly welcome.