### PR TITLE
Misc Go Workspace fixes

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -924,6 +924,7 @@ func (c *commandeer) printChangeDetected(typ string) {
 const (
 	configChangeConfig = "config file"
 	configChangeGoMod  = "go.mod file"
+	configChangeGoWork = "go work file"
 )
 
 func (c *commandeer) handleEvents(watcher *watcher.Batcher,
@@ -942,6 +943,9 @@ func (c *commandeer) handleEvents(watcher *watcher.Batcher,
 		if isConfig {
 			if strings.Contains(ev.Name, "go.mod") {
 				configChangeType = configChangeGoMod
+			}
+			if strings.Contains(ev.Name, ".work") {
+				configChangeType = configChangeGoWork
 			}
 		}
 		if !isConfig {

--- a/docs/content/en/hugo-modules/configuration.md
+++ b/docs/content/en/hugo-modules/configuration.md
@@ -23,7 +23,7 @@ proxy = "direct"
 noProxy = "none"
 private = "*.*"
 replacements = ""
-workspace = ""
+workspace = "off"
 {{< /code-toggle >}}
 
 noVendor
@@ -42,7 +42,7 @@ private
 : Comma separated glob list matching paths that should be treated as private.
 
 workspace
-: The workspace file to use. This enables Go workspace mode. Note that this can also be set via OS env, e.g. `export HUGO_MODULE_WORKSPACE=/my/hugo.work` This only works with Go 1.18+.
+: The workspace file to use. This enables Go workspace mode. Note that this can also be set via OS env, e.g. `export HUGO_MODULE_WORKSPACE=/my/hugo.work` This only works with Go 1.18+. In Hugo `v0.109.0` we changed the default to `off` and we now resolve any relative work filenames relative to the working directory.
 
 replacements
 : A comma separated (or a slice) list of module path to directory replacement mapping, e.g. `github.com/bep/my-theme -> ../..,github.com/bep/shortcodes -> /some/path`. This is mostly useful for temporary locally development of a module, and then it makes sense to set it as an OS environment variable, e.g: `env HUGO_MODULE_REPLACEMENTS="github.com/bep/my-theme -> ../.."`. Any relative path is relate to [themesDir](https://gohugo.io/getting-started/configuration/#all-configuration-settings), and absolute paths are allowed.

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -417,10 +417,16 @@ func (l configLoader) collectModules(modConfig modules.Config, v1 config.Provide
 	// Avoid recreating these later.
 	v1.Set("allModules", moduleConfig.ActiveModules)
 
+	// We want to watch these for changes and trigger rebuild on version
+	// changes etc.
 	if moduleConfig.GoModulesFilename != "" {
-		// We want to watch this for changes and trigger rebuild on version
-		// changes etc.
+
 		configFilenames = append(configFilenames, moduleConfig.GoModulesFilename)
+	}
+
+	if moduleConfig.GoWorkspaceFilename != "" {
+		configFilenames = append(configFilenames, moduleConfig.GoWorkspaceFilename)
+
 	}
 
 	return moduleConfig.ActiveModules, configFilenames, err

--- a/hugolib/hugo_sites_build_test.go
+++ b/hugolib/hugo_sites_build_test.go
@@ -206,6 +206,7 @@ func TestMultiSitesBuild(t *testing.T) {
 		{multiSiteYAMLConfigTemplate, "yml"},
 		{multiSiteJSONConfigTemplate, "json"},
 	} {
+		config := config
 		t.Run(config.suffix, func(t *testing.T) {
 			t.Parallel()
 			doTestMultiSitesBuild(t, config.content, config.suffix)

--- a/hugolib/page_permalink_test.go
+++ b/hugolib/page_permalink_test.go
@@ -63,6 +63,7 @@ func TestPermalink(t *testing.T) {
 	}
 
 	for i, test := range tests {
+		i := i
 		test := test
 		t.Run(fmt.Sprintf("%s-%d", test.file, i), func(t *testing.T) {
 			t.Parallel()

--- a/modules/collect.go
+++ b/modules/collect.go
@@ -107,9 +107,15 @@ func (h *Client) collect(tidy bool) (ModulesConfig, *collector) {
 		}
 	}*/
 
+	var workspaceFilename string
+	if h.ccfg.ModuleConfig.Workspace != WorkspaceDisabled {
+		workspaceFilename = h.ccfg.ModuleConfig.Workspace
+	}
+
 	return ModulesConfig{
-		AllModules:        c.modules,
-		GoModulesFilename: c.GoModulesFilename,
+		AllModules:          c.modules,
+		GoModulesFilename:   c.GoModulesFilename,
+		GoWorkspaceFilename: workspaceFilename,
 	}, c
 }
 
@@ -122,6 +128,9 @@ type ModulesConfig struct {
 
 	// Set if this is a Go modules enabled project.
 	GoModulesFilename string
+
+	// Set if a Go workspace file is configured.
+	GoWorkspaceFilename string
 }
 
 func (m *ModulesConfig) setActiveMods(logger loggers.Logger) error {

--- a/modules/config.go
+++ b/modules/config.go
@@ -15,6 +15,7 @@ package modules
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -260,6 +261,9 @@ func decodeConfig(cfg config.Provider, pathReplacements map[string]string) (Conf
 			if !filepath.IsAbs(c.Workspace) {
 				workingDir := cfg.GetString("workingDir")
 				c.Workspace = filepath.Join(workingDir, c.Workspace)
+			}
+			if _, err := os.Stat(c.Workspace); err != nil {
+				return c, fmt.Errorf("module workspace %q does not exist", c.Workspace)
 			}
 		}
 	}

--- a/modules/config.go
+++ b/modules/config.go
@@ -26,6 +26,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+const WorkspaceDisabled = "off"
+
 var DefaultModuleConfig = Config{
 
 	// Default to direct, which means "git clone" and similar. We
@@ -40,6 +42,9 @@ var DefaultModuleConfig = Config{
 	// Comma separated glob list matching paths that should be
 	// treated as private.
 	Private: "*.*",
+
+	// Default is no workspace resolution.
+	Workspace: WorkspaceDisabled,
 
 	// A list of replacement directives mapping a module path to a directory
 	// or a theme component in the themes folder.
@@ -247,6 +252,16 @@ func decodeConfig(cfg config.Provider, pathReplacements map[string]string) (Conf
 			c.Mounts[i] = mnt
 		}
 
+		if c.Workspace == "" {
+			c.Workspace = WorkspaceDisabled
+		}
+		if c.Workspace != WorkspaceDisabled {
+			c.Workspace = filepath.Clean(c.Workspace)
+			if !filepath.IsAbs(c.Workspace) {
+				workingDir := cfg.GetString("workingDir")
+				c.Workspace = filepath.Join(workingDir, c.Workspace)
+			}
+		}
 	}
 
 	if themeSet {
@@ -294,8 +309,9 @@ type Config struct {
 	// Configures GOPRIVATE.
 	Private string
 
-	// Set the workspace file to use, e.g. hugo.work.
-	// Enables Go "Workspace" mode.
+	// Defaults to "off".
+	// Set to a work file, e.g. hugo.work, to enable Go "Workspace" mode.
+	// Can be relative to the working directory or absolute.
 	// Requires Go 1.18+
 	// See https://tip.golang.org/doc/go1.18
 	Workspace string

--- a/modules/config_test.go
+++ b/modules/config_test.go
@@ -14,6 +14,9 @@
 package modules
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gohugoio/hugo/common/hugo"
@@ -43,8 +46,9 @@ func TestDecodeConfig(t *testing.T) {
 	c := qt.New(t)
 
 	c.Run("Basic", func(c *qt.C) {
+		tempDir := c.TempDir()
 		tomlConfig := `
-workingDir = "/src/project"
+workingDir = %q
 [module]
 workspace = "hugo.work"
 [module.hugoVersion]
@@ -65,7 +69,11 @@ source="src/markdown/blog"
 target="content/blog"
 lang="en"
 `
-		cfg, err := config.FromConfigString(tomlConfig, "toml")
+
+		hugoWorkFilename := filepath.Join(tempDir, "hugo.work")
+		f, _ := os.Create(hugoWorkFilename)
+		f.Close()
+		cfg, err := config.FromConfigString(fmt.Sprintf(tomlConfig, tempDir), "toml")
 		c.Assert(err, qt.IsNil)
 
 		mcfg, err := DecodeConfig(cfg)
@@ -83,7 +91,7 @@ lang="en"
 			c.Assert(hv.IsValid(), qt.Equals, true)
 		}
 
-		c.Assert(mcfg.Workspace, qt.Equals, "/src/project/hugo.work")
+		c.Assert(mcfg.Workspace, qt.Equals, hugoWorkFilename)
 
 		c.Assert(len(mcfg.Mounts), qt.Equals, 1)
 		c.Assert(len(mcfg.Imports), qt.Equals, 1)

--- a/modules/config_test.go
+++ b/modules/config_test.go
@@ -44,13 +44,13 @@ func TestDecodeConfig(t *testing.T) {
 
 	c.Run("Basic", func(c *qt.C) {
 		tomlConfig := `
+workingDir = "/src/project"
 [module]
-
+workspace = "hugo.work"
 [module.hugoVersion]
 min = "0.54.2"
 max = "0.199.0"
 extended = true
-
 [[module.mounts]]
 source="src/project/blog"
 target="content/blog"
@@ -83,6 +83,8 @@ lang="en"
 			c.Assert(hv.IsValid(), qt.Equals, true)
 		}
 
+		c.Assert(mcfg.Workspace, qt.Equals, "/src/project/hugo.work")
+
 		c.Assert(len(mcfg.Mounts), qt.Equals, 1)
 		c.Assert(len(mcfg.Imports), qt.Equals, 1)
 		imp := mcfg.Imports[0]
@@ -90,6 +92,7 @@ lang="en"
 		c.Assert(imp.Mounts[1].Source, qt.Equals, "src/markdown/blog")
 		c.Assert(imp.Mounts[1].Target, qt.Equals, "content/blog")
 		c.Assert(imp.Mounts[1].Lang, qt.Equals, "en")
+
 	})
 
 	c.Run("Replacements", func(c *qt.C) {

--- a/modules/module.go
+++ b/modules/module.go
@@ -184,5 +184,7 @@ func (m *moduleAdapter) Watch() bool {
 		return m.Replace().Version() == ""
 	}
 
-	return false
+	// Any module set up in a workspace file will have Indirect set to false.
+	// That leaves modules inside the read-only module cache.
+	return !m.gomod.Indirect
 }


### PR DESCRIPTION
- modules: Make the module.workspace=off as default (note)
- Add any configured Go Workspace file to the config watcher
