### PR TITLE
Add HUGO_PUBLISHDIR to the Node environment

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -408,6 +408,9 @@ func (c *commandeer) loadConfig() error {
 
 	createMemFs := config.GetBool("renderToMemory")
 	c.renderStaticToDisk = config.GetBool("renderStaticToDisk")
+	// TODO(bep) we/I really need to look at the config set up, but to prevent changing too much
+	// we store away the original.
+	config.Set("publishDirOrig", config.GetString("publishDir"))
 
 	if createMemFs {
 		// Rendering to memoryFS, publish to Root regardless of publishDir.

--- a/common/hugo/hugo.go
+++ b/common/hugo/hugo.go
@@ -126,6 +126,8 @@ func GetExecEnviron(workDir string, cfg config.Provider, fs afero.Fs) []string {
 	config.SetEnvVars(&env, "HUGO_ENVIRONMENT", cfg.GetString("environment"))
 	config.SetEnvVars(&env, "HUGO_ENV", cfg.GetString("environment"))
 
+	config.SetEnvVars(&env, "HUGO_PUBLISHDIR", filepath.Join(workDir, cfg.GetString("publishDirOrig")))
+
 	if fs != nil {
 		fis, err := afero.ReadDir(fs, files.FolderJSConfig)
 		if err == nil {

--- a/docs/content/en/hugo-pipes/postprocess.md
+++ b/docs/content/en/hugo-pipes/postprocess.md
@@ -68,3 +68,30 @@ Note that in the example above, the "CSS purge step" will only be applied to the
 {{ end }}
 <link href="{{ $css.RelPermalink }}" rel="stylesheet" />
 ```
+
+
+## Hugo Environment variables available in PostCSS
+
+These are the environment variables Hugo passes down to PostCSS (and Babel), which allows you do do `process.env.HUGO_ENVIRONMENT === 'production' ? [autoprefixer] : []` and similar:
+
+PWD
+: The absolute path to the project working directory.
+HUGO_ENVIRONMENT (and the alias HUGO_ENV)
+: The value e.g. set with `hugo -e production` (defaults to `production` for `hugo` and `development` for `hugo server`).
+
+HUGO_PUBLISHDIR
+: {{ new-in "0.109.0" }} The absolute path to the publish directory (the `public` directory). Note that the value will always point to a directory on disk even when running `hugo server` in memory mode. If you write to this folder from PostCSS when running the server, you could run the server with one of these flags:
+
+```
+hugo server --renderToDisk
+hugo server --renderStaticToDisk
+```
+
+Also, Hugo will add environment variables for all files mounted below `assets/_jsconfig`. A default mount will be set up with files in the project root matching this regexp: `(babel|postcss|tailwind)\.config\.js`.
+
+These will get environment variables named on the form `HUGO_FILE_:filename:` where `:filename:` is all upper case with periods replaced with underscore. This allows you do do this and similar:
+
+```js
+let tailwindConfig = process.env.HUGO_FILE_TAILWIND_CONFIG_JS || './tailwind.config.js';
+```
+

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -242,6 +242,7 @@ func (l configLoader) applyConfigDefaults() error {
 		"watch":                                false,
 		"resourceDir":                          "resources",
 		"publishDir":                           "public",
+		"publishDirOrig":                       "public",
 		"themesDir":                            "themes",
 		"buildDrafts":                          false,
 		"buildFuture":                          false,

--- a/resources/resource_transformers/postcss/integration_test.go
+++ b/resources/resource_transformers/postcss/integration_test.go
@@ -85,6 +85,7 @@ Styles Content: Len: {{ len $styles.Content }}|
 }
 -- postcss.config.js --
 console.error("Hugo Environment:", process.env.HUGO_ENVIRONMENT );
+console.error("Hugo PublishDir:", process.env.HUGO_PUBLISHDIR );
 // https://github.com/gohugoio/hugo/issues/7656
 console.error("package.json:", process.env.HUGO_FILE_PACKAGE_JSON );
 console.error("PostCSS Config File:", process.env.HUGO_FILE_POSTCSS_CONFIG_JS );
@@ -118,8 +119,6 @@ func TestTransformPostCSS(t *testing.T) {
 
 		files := repl.Replace(postCSSIntegrationTestFiles)
 
-		fmt.Println("===>", s, files)
-
 		b := hugolib.NewIntegrationTestBuilder(
 			hugolib.IntegrationTestConfig{
 				T:               c,
@@ -135,6 +134,10 @@ Styles RelPermalink: /foo/css/styles.css
 Styles Content: Len: 770917|
 `)
 
+		if s == "never" {
+			b.AssertLogContains("Hugo Environment: production")
+			b.AssertLogContains("Hugo PublishDir: " + filepath.Join(tempDir, "public"))
+		}
 	}
 
 }


### PR DESCRIPTION
So you can do  `process.env.HUGO_PUBLISHDIR` in your `postcss.config.js` to figure out where Hugo publishes
its files.

Note that the value will always be an absolute file path and will point to a directory on disk even when running `hugo server` in memory mode.

If you write to this folder from PostCSS when running the server, you could run the server with one of these flags:

```
hugo server --renderToDisk
hugo server --renderStaticToDisk
```

Fixes #10554
