### PR TITLE
youtube shortcode: Gen. query string w/ querify

### DIFF
--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
@@ -3,8 +3,14 @@
 {{- $ytHost := cond $pc.PrivacyEnhanced  "www.youtube-nocookie.com" "www.youtube.com" -}}
 {{- $id := .Get "id" | default (.Get 0) -}}
 {{- $class := .Get "class" | default (.Get 1) -}}
-{{- $title := .Get "title" | default "YouTube Video" }}
+{{- $title := .Get "title" | default "YouTube Video" -}}
+{{- $autoplay := .Get "autoplay" | default "" -}}
+{{- $queryParams := slice -}}
+{{- if (and $autoplay (eq $autoplay "true")) -}}
+{{- $queryParams = $queryParams | append "autoplay" 1 -}}
+{{- end -}}
+{{- $queryString := (querify $queryParams | safeURL) | default "" }}
 <div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
-  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
+  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with $queryString}}?{{ . }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
 </div>
 {{ end -}}


### PR DESCRIPTION
The construction of the query string relied on a
generation method that assumed there would only
ever one be parameter (`autoplay`).

Adding support for an additional param e.g.
`start` requires detecting whether either option
was set in the shortcode, delimiting with `&` and
various other logic that are captured in
`querify`.

Move to using `querify` and ship, under separate
PR, addition of support for a `start` offset
parameter (see: #10521).