### PR TITLE
Youtube add start offset support

### DIFF
--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -190,6 +190,16 @@ func TestShortcodeYoutube(t *testing.T) {
 			`{{< youtube id="w7Ft2ymGmfc" title="A New Hugo Site in Under Two Minutes" >}}`,
 			"(?s)\n<div style=\".*?\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\" style=\".*?\" allowfullscreen title=\"A New Hugo Site in Under Two Minutes\">.*?</iframe>.*?</div>",
 		},
+		// provide start time offset
+		{
+			`{{< youtube id="w7Ft2ymGmfc" title="A New Hugo Site in Under Two Minutes" start="90" >}}`,
+			"(?s)\n<div style=\".*?\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?start=90\" style=\".*?\" allowfullscreen title=\"A New Hugo Site in Under Two Minutes\">.*?</iframe>.*?</div>",
+		},
+		// provide start time offset AND autoplay
+		{
+			`{{< youtube id="w7Ft2ymGmfc" title="A New Hugo Site in Under Two Minutes" start="90" autoplay="true" >}}`,
+			"(?s)\n<div style=\".*?\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?autoplay=1&amp;start=90\" style=\".*?\" allowfullscreen title=\"A New Hugo Site in Under Two Minutes\">.*?</iframe>.*?</div>",
+		},
 	} {
 		var (
 			cfg, fs = newTestCfg()

--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
@@ -5,9 +5,13 @@
 {{- $class := .Get "class" | default (.Get 1) -}}
 {{- $title := .Get "title" | default "YouTube Video" -}}
 {{- $autoplay := .Get "autoplay" | default "" -}}
+{{- $start := .Get "start" | default "" -}}
 {{- $queryParams := slice -}}
 {{- if (and $autoplay (eq $autoplay "true")) -}}
 {{- $queryParams = $queryParams | append "autoplay" 1 -}}
+{{- end -}}
+{{- if $start -}}
+  {{- $queryParams = $queryParams | append "start" $start -}}
 {{- end -}}
 {{- $queryString := (querify $queryParams | safeURL) | default "" }}
 <div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>

--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
@@ -3,8 +3,14 @@
 {{- $ytHost := cond $pc.PrivacyEnhanced  "www.youtube-nocookie.com" "www.youtube.com" -}}
 {{- $id := .Get "id" | default (.Get 0) -}}
 {{- $class := .Get "class" | default (.Get 1) -}}
-{{- $title := .Get "title" | default "YouTube Video" }}
+{{- $title := .Get "title" | default "YouTube Video" -}}
+{{- $autoplay := .Get "autoplay" | default "" -}}
+{{- $queryParams := slice -}}
+{{- if (and $autoplay (eq $autoplay "true")) -}}
+{{- $queryParams = $queryParams | append "autoplay" 1 -}}
+{{- end -}}
+{{- $queryString := (querify $queryParams | safeURL) | default "" }}
 <div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
-  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
+  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with $queryString}}?{{ . }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
 </div>
 {{ end -}}


### PR DESCRIPTION
In conjunction with #10575, this PR provides the ability to add a `start` attribute to the shortcode to start the included YouTube video _n_ seconds from the beginning. #10575 should be landed first.