### PR TITLE
Remove forestry from frontends - it has a March 2023 EOL

### DIFF
--- a/docs/content/en/tools/frontends.md
+++ b/docs/content/en/tools/frontends.md
@@ -26,5 +26,4 @@ toc: false
 ## Commercial Services
 
 - [DATOCMS](https://www.datocms.com) DatoCMS is a fully customizable administrative area for your static websites. Use your favorite website generator, let your clients publish new content independently, and the host the site anywhere you like.
-- [Forestry.io](https://forestry.io/). Forestry is a git-backed CMS for Hugo, Gatsby, Jekyll and VuePress websites with support for GitHub, GitLab, Bitbucket and Azure Devops. Forestry provides a nice user interface to edit and model content for non technical editors. It supports S3, Cloudinary and Netlify Large Media integrations for storing media. Every time an update is made via the CMS, Forestry will commit changes back to your repo and vice-versa.
 - [CloudCannon](https://cloudcannon.com/hugo-cms/). The intuitive Git-based CMS for your Hugo website. CloudCannon syncs changes from your Git repository and pushes content changes back, so your development and content teams are always in sync. Edit all of your content on the page with visual editing, build entire pages with reusable custom components and then publish confidently.


### PR DESCRIPTION
This was announced over email.

That team is moving to a new project called [tina CMS](https://tina.io/guides/tinacms/non-react-based-ssg/guide/) that seems _possible_ to use with Hugo, but it appears less well supported than what we had on forestry (e.g. no automatic schema generation).