### PR TITLE
tpl: Add Classnames function

### DIFF
--- a/tpl/strings/classnames.go
+++ b/tpl/strings/classnames.go
@@ -1,0 +1,66 @@
+package strings
+
+import (
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// ClassNames the method ported npm package. see https://npm.im/classnames
+func (ns *Namespace) ClassNames(inputs ...any) string {
+	var classes []string
+	for _, input := range inputs {
+		v := reflect.ValueOf(input)
+		if isZeroValue(v) {
+			continue
+		}
+		switch v.Kind() {
+		case reflect.String:
+			classes = append(classes, v.String())
+		case reflect.Array, reflect.Slice:
+			for i := 0; i < v.Len(); i++ {
+				if inner := ns.ClassNames(v.Index(i).Interface()); inner != "" {
+					classes = append(classes, inner)
+				}
+			}
+		case reflect.Map:
+			var keys []string
+			iter := v.MapRange()
+			for iter.Next() {
+				key := reflect.ValueOf(iter.Key().Interface())
+				value := reflect.ValueOf(iter.Value().Interface())
+				if key.Kind() != reflect.String || key.IsZero() {
+					continue
+				}
+				if isZeroValue(value) {
+					continue
+				}
+				keys = append(keys, key.String())
+			}
+			sort.Strings(keys)
+			classes = append(classes, keys...)
+		default:
+		}
+		switch {
+		case v.CanInt():
+			classes = append(classes, strconv.FormatInt(v.Int(), 10))
+		case v.CanUint():
+			classes = append(classes, strconv.FormatUint(v.Uint(), 10))
+		case v.CanFloat():
+			classes = append(classes, strconv.FormatFloat(v.Float(), 'f', 32, 64))
+		}
+	}
+	return strings.Join(classes, " ")
+}
+
+func isZeroValue(value reflect.Value) bool {
+	if !value.IsValid() || value.IsZero() {
+		return true
+	}
+	switch value.Kind() {
+	case reflect.Slice:
+		return value.Len() == 0
+	}
+	return false
+}

--- a/tpl/strings/classnames_test.go
+++ b/tpl/strings/classnames_test.go
@@ -1,0 +1,97 @@
+package strings
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestClassNames(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	// The unit tests port from classnames
+	// see https://github.com/JedWatson/classnames/blob/495e24d9/tests/index.js
+
+	t.Run("keeps object keys with truthy values", func(t *testing.T) {
+		classes := ns.ClassNames(map[any]any{
+			"a": true,
+			"b": false,
+			"c": 0,
+			"d": nil,
+			"e": "",
+			"f": 1,
+			"g": []any{},
+			"":  0,
+		})
+		c.Assert(classes, qt.Equals, "a f")
+	})
+
+	t.Run("joins arrays of class names and ignore falsy values", func(t *testing.T) {
+		classes := ns.ClassNames("a", 0, nil, true, 1, "b")
+		c.Assert(classes, qt.Equals, "a 1 b")
+	})
+
+	t.Run("supports heterogeneous arguments", func(t *testing.T) {
+		classes := ns.ClassNames(map[any]any{"a": true}, "b", 0)
+		c.Assert(classes, qt.Equals, "a b")
+	})
+
+	t.Run("should be trimmed", func(t *testing.T) {
+		classes := ns.ClassNames("", "b", map[any]any{}, "")
+		c.Assert(classes, qt.Equals, "b")
+	})
+
+	t.Run("returns an empty string for an empty configuration", func(t *testing.T) {
+		classes := ns.ClassNames(map[any]any{})
+		c.Assert(classes, qt.Equals, "")
+	})
+
+	t.Run("returns an empty string for an empty configuration", func(t *testing.T) {
+		classes := ns.ClassNames([]any{"a", "b"})
+		c.Assert(classes, qt.Equals, "a b")
+	})
+
+	t.Run("joins array arguments with string arguments", func(t *testing.T) {
+		classes := ns.ClassNames([]any{"a", "b"}, "c")
+		c.Assert(classes, qt.Equals, "a b c")
+
+		classes = ns.ClassNames("c", []any{"a", "b"})
+		c.Assert(classes, qt.Equals, "c a b")
+	})
+
+	t.Run("handles multiple array arguments", func(t *testing.T) {
+		classes := ns.ClassNames([]any{"a", "b"}, []any{"c", "d"})
+		c.Assert(classes, qt.Equals, "a b c d")
+	})
+
+	t.Run("handles arrays that include falsy and true values", func(t *testing.T) {
+		classes := ns.ClassNames([]any{"a", 0, nil, false, true, "b"})
+		c.Assert(classes, qt.Equals, "a b")
+	})
+
+	t.Run("handles arrays that include arrays", func(t *testing.T) {
+		classes := ns.ClassNames([]any{"a", []any{"b", "c"}})
+		c.Assert(classes, qt.Equals, "a b c")
+	})
+
+	t.Run("handles arrays that include arrays", func(t *testing.T) {
+		classes := ns.ClassNames([]any{"a", map[any]any{"b": true, "c": false}})
+		c.Assert(classes, qt.Equals, "a b")
+	})
+
+	t.Run("handles deep array recursion", func(t *testing.T) {
+		classes := ns.ClassNames([]any{"a", []any{"b", []any{"c", map[any]any{"d": true}}}})
+		c.Assert(classes, qt.Equals, "a b c d")
+	})
+
+	t.Run("handles arrays that are empty", func(t *testing.T) {
+		classes := ns.ClassNames([]any{"a", []any{}})
+		c.Assert(classes, qt.Equals, "a")
+	})
+
+	t.Run("handles nested arrays that have empty nested arrays", func(t *testing.T) {
+		classes := ns.ClassNames([]any{"a", []any{[]any{}}})
+		c.Assert(classes, qt.Equals, "a")
+	})
+}

--- a/tpl/strings/init.go
+++ b/tpl/strings/init.go
@@ -74,6 +74,15 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(
+			ctx.ClassNames,
+			[]string{"classnames", "clsx"},
+			[][2]string{
+				{`{{ classnames "a" "b" }}`, "a b"},
+				{`{{ clsx "a" "b" }}`, "a b"},
+			},
+		)
+
 		ns.AddMethodMapping(ctx.FindRE,
 			[]string{"findRE"},
 			[][2]string{


### PR DESCRIPTION
port classnames from https://npm.im/classnames

the feature can simplify class names builder, no need to join-strings in the template

after:

```
class="table
{{- if $striped }}table-striped{{ end }}
{{- if $bordered }}table-bordered{{ end }}
{{- if $borderless }}table-borderless{{ end }}
{{- if $hoverable }}table-hover{{ end }}
{{- if $small }}table-sm{{ end }}
"
```

before:

```
{{-
$classes := classnames
  "table"
  (dict
    "table-striped" $striped
    "table-bordered" $bordered
    "table-borderless" $borderless
    "table-hover" $hoverable
    "table-sm" $small
  )
-}}
class="{{ $classes }}"
```

of course you can

```
{{- $classes := classnames "table" .Attibutes -}}
class="{{ $classes }}"
```