### PR TITLE
Remove code apparently obsoleted due to defaultness of pretty

### DIFF
--- a/common/paths/path.go
+++ b/common/paths/path.go
@@ -235,23 +235,6 @@ func GetRelativePath(path, base string) (final string, err error) {
 	return name, nil
 }
 
-func prettifyPath(in string, b filepathPathBridge) string {
-	if filepath.Ext(in) == "" {
-		// /section/name/  -> /section/name/index.html
-		if len(in) < 2 {
-			return b.Separator()
-		}
-		return b.Join(in, "index.html")
-	}
-	name, ext := fileAndExt(in, b)
-	if name == "index" {
-		// /section/name/index.html -> /section/name/index.html
-		return b.Clean(in)
-	}
-	// /section/name.html -> /section/name/index.html
-	return b.Join(b.Dir(in), name, "index"+ext)
-}
-
 type NamedSlice struct {
 	Name  string
 	Slice []string

--- a/common/paths/url.go
+++ b/common/paths/url.go
@@ -98,62 +98,6 @@ func AddContextRoot(baseURL, relativePath string) string {
 	return newPath
 }
 
-// URLizeAn
-
-// PrettifyURL takes a URL string and returns a semantic, clean URL.
-func PrettifyURL(in string) string {
-	x := PrettifyURLPath(in)
-
-	if path.Base(x) == "index.html" {
-		return path.Dir(x)
-	}
-
-	if in == "" {
-		return "/"
-	}
-
-	return x
-}
-
-// PrettifyURLPath takes a URL path to a content and converts it
-// to enable pretty URLs.
-//     /section/name.html       becomes /section/name/index.html
-//     /section/name/           becomes /section/name/index.html
-//     /section/name/index.html becomes /section/name/index.html
-func PrettifyURLPath(in string) string {
-	return prettifyPath(in, pb)
-}
-
-// Uglify does the opposite of PrettifyURLPath().
-//     /section/name/index.html becomes /section/name.html
-//     /section/name/           becomes /section/name.html
-//     /section/name.html       becomes /section/name.html
-func Uglify(in string) string {
-	if path.Ext(in) == "" {
-		if len(in) < 2 {
-			return "/"
-		}
-		// /section/name/  -> /section/name.html
-		return path.Clean(in) + ".html"
-	}
-
-	name, ext := fileAndExt(in, pb)
-	if name == "index" {
-		// /section/name/index.html -> /section/name.html
-		d := path.Dir(in)
-		if len(d) > 1 {
-			return d + ext
-		}
-		return in
-	}
-	// /.xml -> /index.xml
-	if name == "" {
-		return path.Dir(in) + "index" + ext
-	}
-	// /section/name.html -> /section/name.html
-	return path.Clean(in)
-}
-
 // UrlToFilename converts the URL s to a filename.
 // If ParseRequestURI fails, the input is just converted to OS specific slashes and returned.
 func UrlToFilename(s string) (string, bool) {

--- a/common/paths/url_test.go
+++ b/common/paths/url_test.go
@@ -15,8 +15,6 @@ package paths
 
 import (
 	"testing"
-
-	qt "github.com/frankban/quicktest"
 )
 
 func TestMakePermalink(t *testing.T) {

--- a/common/paths/url_test.go
+++ b/common/paths/url_test.go
@@ -65,35 +65,3 @@ func TestAddContextRoot(t *testing.T) {
 		}
 	}
 }
-
-func TestPretty(t *testing.T) {
-	c := qt.New(t)
-	c.Assert("/section/name/index.html", qt.Equals, PrettifyURLPath("/section/name.html"))
-	c.Assert("/section/sub/name/index.html", qt.Equals, PrettifyURLPath("/section/sub/name.html"))
-	c.Assert("/section/name/index.html", qt.Equals, PrettifyURLPath("/section/name/"))
-	c.Assert("/section/name/index.html", qt.Equals, PrettifyURLPath("/section/name/index.html"))
-	c.Assert("/index.html", qt.Equals, PrettifyURLPath("/index.html"))
-	c.Assert("/name/index.xml", qt.Equals, PrettifyURLPath("/name.xml"))
-	c.Assert("/", qt.Equals, PrettifyURLPath("/"))
-	c.Assert("/", qt.Equals, PrettifyURLPath(""))
-	c.Assert("/section/name", qt.Equals, PrettifyURL("/section/name.html"))
-	c.Assert("/section/sub/name", qt.Equals, PrettifyURL("/section/sub/name.html"))
-	c.Assert("/section/name", qt.Equals, PrettifyURL("/section/name/"))
-	c.Assert("/section/name", qt.Equals, PrettifyURL("/section/name/index.html"))
-	c.Assert("/", qt.Equals, PrettifyURL("/index.html"))
-	c.Assert("/name/index.xml", qt.Equals, PrettifyURL("/name.xml"))
-	c.Assert("/", qt.Equals, PrettifyURL("/"))
-	c.Assert("/", qt.Equals, PrettifyURL(""))
-}
-
-func TestUgly(t *testing.T) {
-	c := qt.New(t)
-	c.Assert("/section/name.html", qt.Equals, Uglify("/section/name.html"))
-	c.Assert("/section/sub/name.html", qt.Equals, Uglify("/section/sub/name.html"))
-	c.Assert("/section/name.html", qt.Equals, Uglify("/section/name/"))
-	c.Assert("/section/name.html", qt.Equals, Uglify("/section/name/index.html"))
-	c.Assert("/index.html", qt.Equals, Uglify("/index.html"))
-	c.Assert("/name.xml", qt.Equals, Uglify("/name.xml"))
-	c.Assert("/", qt.Equals, Uglify("/"))
-	c.Assert("/", qt.Equals, Uglify(""))
-}

--- a/helpers/url.go
+++ b/helpers/url.go
@@ -218,24 +218,3 @@ func (p *PathSpec) PrependBasePath(rel string, isAbs bool) string {
 	return rel
 }
 
-// URLizeAndPrep applies misc sanitation to the given URL to get it in line
-// with the Hugo standard.
-func (p *PathSpec) URLizeAndPrep(in string) string {
-	return p.URLPrep(p.URLize(in))
-}
-
-// URLPrep applies misc sanitation to the given URL.
-func (p *PathSpec) URLPrep(in string) string {
-	if p.UglyURLs {
-		return paths.Uglify(SanitizeURL(in))
-	}
-	pretty := paths.PrettifyURL(SanitizeURL(in))
-	if path.Ext(pretty) == ".xml" {
-		return pretty
-	}
-	url, err := purell.NormalizeURLString(pretty, purell.FlagAddTrailingSlash)
-	if err != nil {
-		return pretty
-	}
-	return url
-}

--- a/helpers/url_test.go
+++ b/helpers/url_test.go
@@ -234,27 +234,3 @@ func TestSanitizeURL(t *testing.T) {
 	}
 }
 
-func TestURLPrep(t *testing.T) {
-	type test struct {
-		ugly   bool
-		input  string
-		output string
-	}
-
-	data := []test{
-		{false, "/section/name.html", "/section/name/"},
-		{true, "/section/name/index.html", "/section/name.html"},
-	}
-
-	for i, d := range data {
-		v := newTestCfg()
-		v.Set("uglyURLs", d.ugly)
-		l := langs.NewDefaultLanguage(v)
-		p, _ := NewPathSpec(hugofs.NewMem(v), l, nil)
-
-		output := p.URLPrep(d.input)
-		if d.output != output {
-			t.Errorf("Test #%d failed. Expected %q got %q", i, d.output, output)
-		}
-	}
-}


### PR DESCRIPTION
I apologize for the very trivial pull request!

While beginning to learn / find my way around the codebase, I found a couple of methods of PathSpec that seem to be obsolete, replaced by more newer functionality. Maybe they should be removed?