### PR TITLE
rss: Add config variable to output full content

### DIFF
--- a/config/services/servicesConfig.go
+++ b/config/services/servicesConfig.go
@@ -72,6 +72,8 @@ type Twitter struct {
 type RSS struct {
 	// Limit the number of pages.
 	Limit int
+	// Output the full content for each article instead of just the summary
+	FullContent bool
 }
 
 // DecodeConfig creates a services Config from a given Hugo configuration.

--- a/config/services/servicesConfig_test.go
+++ b/config/services/servicesConfig_test.go
@@ -36,6 +36,8 @@ id = "ga_id"
 disableInlineCSS = true
 [services.twitter]
 disableInlineCSS = true
+[services.rss]
+fullContent = true
 `
 	cfg, err := config.FromConfigString(tomlConfig, "toml")
 	c.Assert(err, qt.IsNil)
@@ -48,6 +50,7 @@ disableInlineCSS = true
 	c.Assert(config.GoogleAnalytics.ID, qt.Equals, "ga_id")
 
 	c.Assert(config.Instagram.DisableInlineCSS, qt.Equals, true)
+	c.Assert(config.RSS.FullContent, qt.Equals, true)
 }
 
 // Support old root-level GA settings etc.

--- a/docs/content/en/templates/rss.md
+++ b/docs/content/en/templates/rss.md
@@ -43,6 +43,10 @@ The table below shows the RSS template lookup order for the different page kinds
 
 By default, Hugo will create an unlimited number of RSS entries. You can limit the number of articles included in the built-in RSS templates by assigning a numeric value to `rssLimit:` field in your project's [`config` file][config].
 
+By default, the built-in RSS templates outputs only the summary of an article in the RSS feed, not the full content.
+This behavior can be changed by assigning `true` to the `services.rss.fullContent` filed in your project's [`config`
+file][config].
+
 The following values will also be included in the RSS output if specified:
 
 {{< code-toggle file="config" >}}

--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -98,3 +98,24 @@ Figure:
 
 	b.AssertFileContent("public/index.xml", "img src=&#34;http://example.com/images/sunset.jpg")
 }
+
+func TestFullContent(t *testing.T) {
+	t.Parallel()
+
+	b := newTestSitesBuilder(t)
+	b.WithSimpleConfigFile()
+	b.WithConfigFile("toml", `
+	[services]
+	[services.rss]
+	fullContent = true
+	`)
+	b.WithContent("page.md", `---
+Title: My Page
+Summary: summary-test
+---
+content-text
+`)
+	b.Build(BuildCfg{})
+
+	b.AssertFileContent("public/index.xml", "<description>&lt;p&gt;content-text&lt;/p&gt;\n</description>")
+}

--- a/tpl/tplimpl/embedded/templates/_default/rss.xml
+++ b/tpl/tplimpl/embedded/templates/_default/rss.xml
@@ -32,7 +32,13 @@
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | html }}</description>
+      <description>
+      {{- if .Site.Config.Services.RSS.FullContent -}}
+      {{ .Content | html }}
+      {{- else -}}
+      {{ .Summary | html }}
+      {{- end -}}
+      </description>
     </item>
     {{ end }}
   </channel>


### PR DESCRIPTION
The RSS 2.0 specification states:
"An item's description element holds character data that contains the item's full content or a summary of its contents, a decision entirely at the discretion of the publisher."

So far, we do the latter only. But it can sometimes be useful to have the full content included instead, so let's add a config variable to also support the former.