### PR TITLE
dartsass: Import CSS without extension at compile time

### DIFF
--- a/resources/resource_transformers/tocss/dartsass/integration_test.go
+++ b/resources/resource_transformers/tocss/dartsass/integration_test.go
@@ -68,22 +68,24 @@ $moolor: #fff;
 moo {
 	color: $moolor;
 }
--- assets/scss/another.css --
-
+-- node_modules/foo/another.css --
+another {
+	color: #000;
+}
 -- assets/scss/main.scss --
 @import "moo";
 @import "regular.css";
 @import "moo";
-@import "another.css";
+@import "another";
 
 /* foo */
 -- assets/scss/regular.css --
 
 -- config.toml --
 -- layouts/index.html --
-{{ $r := resources.Get "scss/main.scss" |  toCSS (dict "transpiler" "dartsass")  }}
+{{ $cssOpts := (dict "includePaths" (slice "node_modules/foo") "transpiler" "dartsass") }}
+{{ $r := resources.Get "scss/main.scss" | toCSS $cssOpts }}
 T1: {{ $r.Content | safeHTML }}
-
 	`
 
 	b := hugolib.NewIntegrationTestBuilder(
@@ -97,15 +99,18 @@ T1: {{ $r.Content | safeHTML }}
 	// Dart Sass does not follow regular CSS import, but they
 	// get pulled to the top.
 	b.AssertFileContent("public/index.html", `T1: @import "regular.css";
-		@import "another.css";
 		moo {
 		  color: #fff;
 		}
-		
+
 		moo {
 		  color: #fff;
 		}
-		
+
+		another {
+			color: #000;
+		}
+
 		/* foo */`)
 }
 
@@ -291,7 +296,7 @@ body {
 	body {
 		background: url(vars.$image) no-repeat center/cover;
 		font-family: vars.$font;
-	  }	  
+	  }
 }
 
 p {
@@ -341,7 +346,7 @@ image = "images/hero.jpg"
 body {
 	body {
 		background: url(vars.$image) no-repeat center/cover;
-	  }	  
+	  }
 }
 
 p {

--- a/resources/resource_transformers/tocss/dartsass/transform.go
+++ b/resources/resource_transformers/tocss/dartsass/transform.go
@@ -163,9 +163,9 @@ func (t importResolver) CanonicalizeURL(url string) (string, error) {
 	if strings.Contains(name, ".") {
 		namePatterns = []string{"_%s", "%s"}
 	} else if strings.HasPrefix(name, "_") {
-		namePatterns = []string{"_%s.scss", "_%s.sass"}
+		namePatterns = []string{"_%s.scss", "_%s.sass", "_%s.css"}
 	} else {
-		namePatterns = []string{"_%s.scss", "%s.scss", "_%s.sass", "%s.sass"}
+		namePatterns = []string{"_%s.scss", "%s.scss", "_%s.sass", "%s.sass", "_%s.css", "%s.css"}
 	}
 
 	name = strings.TrimPrefix(name, "_")


### PR DESCRIPTION
Applicable to Dart Sass only:

- Sass imports with the .css extension indicate a plain CSS @import.
- Sass imports without the .css extension are imported at compile time.

Fixes #10592