### PR TITLE
Fixes #10468 : Problem if the url parameter of a page contains a dot

### DIFF
--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -482,7 +482,7 @@ func (pm *pageMeta) setMetadata(parentBucket *pagesMapBucket, p *pageState, fron
 					p.s.Log.Warnf(`Front matter in %q with the url %q with no leading / has what looks like the language prefix added. In Hugo 0.55 we added support for page relative URLs in front matter, no language prefix needed. Check the URL and consider to either add a leading / or remove the language prefix.`, p.pathOrTitle(), url)
 				}
 			}
-			if !strings.HasSuffix(url, "/") {
+			if url != "" && !strings.HasSuffix(url, "/") && !strings.HasSuffix(url, ".html") && !strings.HasSuffix(url, ".htm") {
 				url += "/"
 			}
 			pm.urlPaths.URL = url

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -482,6 +482,9 @@ func (pm *pageMeta) setMetadata(parentBucket *pagesMapBucket, p *pageState, fron
 					p.s.Log.Warnf(`Front matter in %q with the url %q with no leading / has what looks like the language prefix added. In Hugo 0.55 we added support for page relative URLs in front matter, no language prefix needed. Check the URL and consider to either add a leading / or remove the language prefix.`, p.pathOrTitle(), url)
 				}
 			}
+			if !strings.HasSuffix(url, "/") {
+				url += "/"
+			}
 			pm.urlPaths.URL = url
 			pm.params[loki] = url
 		case "type":


### PR DESCRIPTION
Add a path seperator suffix if url in meta data does not end with /