### PR TITLE
Make hugo.toml the new config.toml

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -177,7 +177,7 @@ Complete documentation is available at https://gohugo.io/.`,
 		},
 	})
 
-	cc.cmd.PersistentFlags().StringVar(&cc.cfgFile, "config", "", "config file (default is path/config.yaml|json|toml)")
+	cc.cmd.PersistentFlags().StringVar(&cc.cfgFile, "config", "", "config file (default is hugo.yaml|json|toml)")
 	cc.cmd.PersistentFlags().StringVar(&cc.cfgDir, "configDir", "config", "config dir")
 	cc.cmd.PersistentFlags().BoolVar(&cc.quiet, "quiet", false, "build in quiet mode")
 

--- a/commands/new_site.go
+++ b/commands/new_site.go
@@ -83,6 +83,7 @@ func (n *newSiteCmd) doNewSite(fs *hugofs.Fs, basepath string, force bool) error
 			return errors.New(basepath + " already exists and is not empty. See --force.")
 
 		case !isEmpty && force:
+			// TODO(bep) eventually rename this to hugo.
 			all := append(dirs, filepath.Join(basepath, "config."+n.configFormat))
 			for _, path := range all {
 				if exists, _ := helpers.Exists(path, fs.Source); exists {

--- a/config/configLoader.go
+++ b/config/configLoader.go
@@ -29,11 +29,22 @@ import (
 )
 
 var (
+	// See issue #8979 for context.
+	// Hugo has always used config.toml etc. as the default config file name.
+	// But hugo.toml is a more descriptive name, but we need to check for both.
+	DefaultConfigNames = []string{"hugo", "config"}
+
+	DefaultConfigNamesSet = make(map[string]bool)
+
 	ValidConfigFileExtensions                    = []string{"toml", "yaml", "yml", "json"}
 	validConfigFileExtensionsMap map[string]bool = make(map[string]bool)
 )
 
 func init() {
+	for _, name := range DefaultConfigNames {
+		DefaultConfigNamesSet[name] = true
+	}
+
 	for _, ext := range ValidConfigFileExtensions {
 		validConfigFileExtensionsMap[ext] = true
 	}
@@ -142,8 +153,7 @@ func LoadConfigFromDir(sourceFs afero.Fs, configDir, environment string) (Provid
 			}
 
 			var keyPath []string
-
-			if name != "config" {
+			if !DefaultConfigNamesSet[name] {
 				// Can be params.jp, menus.en etc.
 				name, lang := paths.FileAndExtNoDelimiter(name)
 

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -69,18 +69,35 @@ func LoadConfig(d ConfigSourceDescriptor, doWithConfig ...func(cfg config.Provid
 	// use a partial configuration to do its job.
 	defer l.deleteMergeStrategies()
 
-	for _, name := range d.configFilenames() {
-		var filename string
-		filename, err := l.loadConfig(name)
-		if err == nil {
-			configFiles = append(configFiles, filename)
-		} else if err != ErrNoConfigFile {
-			return nil, nil, l.wrapFileError(err, filename)
+	names := d.configFilenames()
+
+	if names != nil {
+		for _, name := range names {
+			var filename string
+			filename, err := l.loadConfig(name)
+			if err == nil {
+				configFiles = append(configFiles, filename)
+			} else if err != ErrNoConfigFile {
+				return nil, nil, l.wrapFileError(err, filename)
+			}
+		}
+	} else {
+		for _, name := range config.DefaultConfigNames {
+			var filename string
+			filename, err := l.loadConfig(name)
+			if err == nil {
+				configFiles = append(configFiles, filename)
+				break
+			} else if err != ErrNoConfigFile {
+				return nil, nil, l.wrapFileError(err, filename)
+			}
 		}
 	}
 
 	if d.AbsConfigDir != "" {
+
 		dcfg, dirnames, err := config.LoadConfigFromDir(l.Fs, d.AbsConfigDir, l.Environment)
+
 		if err == nil {
 			if len(dirnames) > 0 {
 				l.cfg.Set("", dcfg.Get(""))
@@ -162,9 +179,9 @@ func LoadConfig(d ConfigSourceDescriptor, doWithConfig ...func(cfg config.Provid
 	return l.cfg, configFiles, err
 }
 
-// LoadConfigDefault is a convenience method to load the default "config.toml" config.
+// LoadConfigDefault is a convenience method to load the default "hugo.toml" config.
 func LoadConfigDefault(fs afero.Fs) (config.Provider, error) {
-	v, _, err := LoadConfig(ConfigSourceDescriptor{Fs: fs, Filename: "config.toml"})
+	v, _, err := LoadConfig(ConfigSourceDescriptor{Fs: fs})
 	return v, err
 }
 
@@ -202,7 +219,7 @@ func (d ConfigSourceDescriptor) configFileDir() string {
 
 func (d ConfigSourceDescriptor) configFilenames() []string {
 	if d.Filename == "" {
-		return []string{"config"}
+		return nil
 	}
 	return strings.Split(d.Filename, ",")
 }

--- a/hugolib/integrationtest_builder.go
+++ b/hugolib/integrationtest_builder.go
@@ -301,13 +301,18 @@ func (s *IntegrationTestBuilder) initBuilder() error {
 			s.Assert(afero.WriteFile(afs, filename, data, 0666), qt.IsNil)
 		}
 
+		configDirFilename := filepath.Join(s.Cfg.WorkingDir, "config")
+		if _, err := afs.Stat(configDirFilename); err != nil {
+			configDirFilename = ""
+		}
+
 		cfg, _, err := LoadConfig(
 			ConfigSourceDescriptor{
-				WorkingDir: s.Cfg.WorkingDir,
-				Fs:         afs,
-				Logger:     logger,
-				Environ:    []string{},
-				Filename:   "config.toml",
+				WorkingDir:   s.Cfg.WorkingDir,
+				AbsConfigDir: configDirFilename,
+				Fs:           afs,
+				Logger:       logger,
+				Environ:      []string{},
 			},
 			func(cfg config.Provider) error {
 				return nil

--- a/modules/collect.go
+++ b/modules/collect.go
@@ -423,12 +423,14 @@ func (c *collector) applyThemeConfig(tc *moduleAdapter) error {
 		err            error
 	)
 
-	// Viper supports more, but this is the sub-set supported by Hugo.
-	for _, configFormats := range config.ValidConfigFileExtensions {
-		configFilename = filepath.Join(tc.Dir(), "config."+configFormats)
-		hasConfigFile, _ = afero.Exists(c.fs, configFilename)
-		if hasConfigFile {
-			break
+LOOP:
+	for _, configBaseName := range config.DefaultConfigNames {
+		for _, configFormats := range config.ValidConfigFileExtensions {
+			configFilename = filepath.Join(tc.Dir(), configBaseName+"."+configFormats)
+			hasConfigFile, _ = afero.Exists(c.fs, configFilename)
+			if hasConfigFile {
+				break LOOP
+			}
 		}
 	}
 


### PR DESCRIPTION
Both will of course work, but hugo.toml will win if both are set.

We should have done this a long time ago, of course, but the reason I'm picking this up now is that my VS Code setup by default picks up some
JSON config schema from some random other software which also names its config files config.toml.

Fixes #8979
