### PR TITLE
feat: reduce alt output format template code in theme

### DIFF
--- a/resources/page/page_outputformat.go
+++ b/resources/page/page_outputformat.go
@@ -18,6 +18,7 @@ package page
 import (
 	"fmt"
 	"strings"
+	"text/template"
 
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/output"
@@ -56,7 +57,10 @@ type OutputFormat struct {
 }
 
 func (o OutputFormat) String() string {
-	return fmt.Sprintf("<link rel=%q type=%q href=%q>", o.Rel, o.MediaType().Type(), o.Permalink())
+	rel := template.HTMLEscapeString(o.Rel)
+	mediaType := template.HTMLEscapeString(o.MediaType().Type())
+	permalink := template.HTMLEscapeString(o.Permalink())
+	return fmt.Sprintf(`<link rel=%q type=%q href=%q>`, rel, mediaType, permalink)
 }
 
 // Name returns this OutputFormat's name, i.e. HTML, AMP, JSON etc.

--- a/resources/page/page_outputformat.go
+++ b/resources/page/page_outputformat.go
@@ -60,7 +60,7 @@ func (o OutputFormat) String() string {
 	rel := template.HTMLEscapeString(o.Rel)
 	mediaType := template.HTMLEscapeString(o.MediaType().Type())
 	permalink := template.HTMLEscapeString(o.Permalink())
-	return fmt.Sprintf(`<link rel=%q type=%q href=%q>`, rel, mediaType, permalink)
+	return fmt.Sprintf(`<link rel="%s" type="%s" href="%s">`, rel, mediaType, permalink)
 }
 
 // Name returns this OutputFormat's name, i.e. HTML, AMP, JSON etc.

--- a/resources/page/page_outputformat.go
+++ b/resources/page/page_outputformat.go
@@ -28,12 +28,11 @@ import (
 type OutputFormats []OutputFormat
 
 func (o OutputFormats) String() string {
-	var builder strings.Builder
-	for _, link := range o {
-		builder.WriteString(link.String())
-		builder.WriteRune('\n')
+	links := make([]string, len(o))
+	for index, link := range o {
+		links[index] = link.String()
 	}
-	return builder.String()
+	return strings.Join(links, "\n")
 }
 
 // OutputFormat links to a representation of a resource.

--- a/resources/page/page_outputformat.go
+++ b/resources/page/page_outputformat.go
@@ -16,6 +16,7 @@
 package page
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gohugoio/hugo/media"
@@ -24,6 +25,15 @@ import (
 
 // OutputFormats holds a list of the relevant output formats for a given page.
 type OutputFormats []OutputFormat
+
+func (o OutputFormats) String() string {
+	var builder strings.Builder
+	for _, link := range o {
+		builder.WriteString(link.String())
+		builder.WriteRune('\n')
+	}
+	return builder.String()
+}
 
 // OutputFormat links to a representation of a resource.
 type OutputFormat struct {
@@ -43,6 +53,10 @@ type OutputFormat struct {
 
 	relPermalink string
 	permalink    string
+}
+
+func (o OutputFormat) String() string {
+	return fmt.Sprintf("<link rel=%q type=%q href=%q>", o.Rel, o.MediaType().Type(), o.Permalink())
 }
 
 // Name returns this OutputFormat's name, i.e. HTML, AMP, JSON etc.

--- a/resources/page/page_outputformat_test.go
+++ b/resources/page/page_outputformat_test.go
@@ -14,5 +14,5 @@ func TestOutputFormat_String(t *testing.T) {
 	expected := `<link rel="alternate" type="text/html" href="https://example.com/">`
 	c.Assert(format.String(), qt.Equals, expected)
 	formats := OutputFormats{format, format}
-	c.Assert(formats.String(), qt.Equals, expected+"\n"+expected+"\n")
+	c.Assert(formats.String(), qt.Equals, expected+"\n"+expected)
 }

--- a/resources/page/page_outputformat_test.go
+++ b/resources/page/page_outputformat_test.go
@@ -1,0 +1,18 @@
+package page
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/gohugoio/hugo/output"
+)
+
+func TestOutputFormat_String(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	format := OutputFormat{Rel: "alternate", Format: output.HTMLFormat, permalink: "https://example.com/"}
+	expected := `<link rel="alternate" type="text/html" href="https://example.com/">`
+	c.Assert(format.String(), qt.Equals, expected)
+	formats := OutputFormats{format, format}
+	c.Assert(formats.String(), qt.Equals, expected+"\n"+expected+"\n")
+}


### PR DESCRIPTION
after [^1]:
```
{{ range .AlternativeOutputFormats -}}
<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
{{ end -}}
```

before (if no special requirements [^2]):

```
{{ range .AlternativeOutputFormats -}}
{{ . }}
{{ end -}}
```

or

```
{{ .AlternativeOutputFormats }}
```

[^1]: https://gohugo.io/templates/output-formats/#list-output-formats
[^2]: for example: [OpenSearch](https://developer.mozilla.org/en-US/docs/Web/OpenSearch#autodiscovery_of_search_plugins) need "title" field