### PR TITLE
refactor: improve math

### DIFF
--- a/docs/content/en/functions/math.md
+++ b/docs/content/en/functions/math.md
@@ -3,7 +3,7 @@ title: Math
 description: Hugo provides mathematical operators in templates.
 date: 2017-02-01
 publishdate: 2017-02-01
-lastmod: 2020-02-23
+lastmod: 2023-03-11
 keywords: [math, operators]
 categories: [functions]
 menu:
@@ -21,13 +21,13 @@ aliases: []
 
 | Function     | Description                                                                 | Example                          |
 |--------------|-----------------------------------------------------------------------------|----------------------------------|
-| `add`        | Adds two numbers.                                                           | `{{add 1 2}}` &rarr; `3`         |
+| `add`        | Adds multivalued numbers.                                                   | `{{add 1 2}}` &rarr; `3`         |
 |              | *If one of the numbers is a float, the result is a float.*                  | `{{add 1.1 2}}` &rarr; `3.1`     |
-| `sub`        | Subtracts two numbers.                                                      | `{{sub 3 2}}` &rarr; `1`         |
+| `sub`        | Subtracts multivalued numbers.                                              | `{{sub 3 2}}` &rarr; `1`         |
 |              | *If one of the numbers is a float, the result is a float.*                  | `{{sub 3 2.5}}` &rarr; `0.5`     |
-| `mul`        | Multiplies two numbers.                                                     | `{{mul 2 3}}` &rarr; `6`         |
+| `mul`        | Multiplies multivalued numbers.                                             | `{{mul 2 3}}` &rarr; `6`         |
 |              | *If one of the numbers is a float, the result is a float.*                  | `{{mul 2 3.1}}` &rarr; `6.2`     |
-| `div`        | Divides two numbers.                                                        | `{{div 6 3}}` &rarr; `2`         |
+| `div`        | Divides multivalued numbers.                                                | `{{div 6 3}}` &rarr; `2`         |
 |              |                                                                             | `{{div 6 4}}` &rarr; `1`         |
 |              | *If one of the numbers is a float, the result is a float.*                  | `{{div 6 4.0}}` &rarr; `1.5`     |
 | `mod`        | Modulus of two integers.                                                    | `{{mod 15 3}}` &rarr; `0`        |
@@ -35,8 +35,8 @@ aliases: []
 | `math.Ceil`  | Returns the least integer value greater than or equal to the given number.  | `{{math.Ceil 2.1}}` &rarr; `3`   |
 | `math.Floor` | Returns the greatest integer value less than or equal to the given number.  | `{{math.Floor 1.9}}` &rarr; `1`  |
 | `math.Log`   | Returns the natural logarithm of the given number.                          | `{{math.Log 42}}` &rarr; `3.737` |
-| `math.Max`   | Returns the greater of two numbers.                                         | `{{math.Max 1 2}}` &rarr; `2`    |
-| `math.Min`   | Returns the smaller of two numbers.                                         | `{{math.Min 1 2}}` &rarr; `1`    |
+| `math.Max`   | Returns the greater of multivalued numbers.                                 | `{{math.Max 1 2}}` &rarr; `2`    |
+| `math.Min`   | Returns the smaller of multivalued numbers.                                 | `{{math.Min 1 2}}` &rarr; `1`    |
 | `math.Pow`   | Returns the first number raised to the power of the second number.          | `{{math.Pow 2 3}}` &rarr; `8`    |
 | `math.Round` | Returns the nearest integer, rounding half away from zero.                  | `{{math.Round 1.5}}` &rarr; `2`  |
 | `math.Sqrt`  | Returns the square root of the given number.                                | `{{math.Sqrt 81}}` &rarr; `9`    |

--- a/tpl/math/math.go
+++ b/tpl/math/math.go
@@ -31,7 +31,7 @@ func New() *Namespace {
 // Namespace provides template functions for the "math" namespace.
 type Namespace struct{}
 
-// Add adds the two addends n1 and n2.
+// Add adds the multivalued addends n1 and n2 or more values.
 func (ns *Namespace) Add(inputs ...any) (any, error) {
 	return ns.doArithmetic(inputs, '+')
 }
@@ -71,7 +71,7 @@ func (ns *Namespace) Log(n any) (float64, error) {
 	return math.Log(af), nil
 }
 
-// Max returns the greater of the two numbers n1 or n2.
+// Max returns the greater of the multivalued numbers n1 and n2 or more values.
 func (ns *Namespace) Max(inputs ...any) (maximum float64, err error) {
 	var value float64
 	for index, input := range inputs {
@@ -89,7 +89,7 @@ func (ns *Namespace) Max(inputs ...any) (maximum float64, err error) {
 	return
 }
 
-// Min returns the smaller of two numbers n1 or n2.
+// Min returns the smaller of multivalued numbers n1 and n2 or more values.
 func (ns *Namespace) Min(inputs ...any) (minimum float64, err error) {
 	var value float64
 	for index, input := range inputs {
@@ -133,7 +133,7 @@ func (ns *Namespace) ModBool(n1, n2 any) (bool, error) {
 	return res == int64(0), nil
 }
 
-// Mul multiplies the two numbers n1 and n2.
+// Mul multiplies the multivalued numbers n1 and n2 or more values.
 func (ns *Namespace) Mul(inputs ...any) (any, error) {
 	return ns.doArithmetic(inputs, '*')
 }
@@ -170,7 +170,7 @@ func (ns *Namespace) Sqrt(n any) (float64, error) {
 	return math.Sqrt(af), nil
 }
 
-// Sub subtracts n2 from n1.
+// Sub subtracts multivalued.
 func (ns *Namespace) Sub(inputs ...any) (any, error) {
 	return ns.doArithmetic(inputs, '-')
 }

--- a/tpl/math/math.go
+++ b/tpl/math/math.go
@@ -20,7 +20,6 @@ import (
 	"sync/atomic"
 
 	_math "github.com/gohugoio/hugo/common/math"
-
 	"github.com/spf13/cast"
 )
 
@@ -75,11 +74,15 @@ func (ns *Namespace) Log(n any) (float64, error) {
 // Max returns the greater of the two numbers n1 or n2.
 func (ns *Namespace) Max(inputs ...any) (maximum float64, err error) {
 	var value float64
-	for input := range inputs {
+	for index, input := range inputs {
 		value, err = cast.ToFloat64E(input)
 		if err != nil {
 			err = errors.New("Max operator can't be used with non-float value")
 			return
+		}
+		if index == 0 {
+			maximum = value
+			continue
 		}
 		maximum = math.Max(value, maximum)
 	}
@@ -89,11 +92,15 @@ func (ns *Namespace) Max(inputs ...any) (maximum float64, err error) {
 // Min returns the smaller of two numbers n1 or n2.
 func (ns *Namespace) Min(inputs ...any) (minimum float64, err error) {
 	var value float64
-	for input := range inputs {
+	for index, input := range inputs {
 		value, err = cast.ToFloat64E(input)
 		if err != nil {
 			err = errors.New("Max operator can't be used with non-float value")
 			return
+		}
+		if index == 0 {
+			minimum = value
+			continue
 		}
 		minimum = math.Min(value, minimum)
 	}
@@ -171,7 +178,8 @@ func (ns *Namespace) Sub(inputs ...any) (any, error) {
 func (ns *Namespace) doArithmetic(inputs []any, operation rune) (value any, err error) {
 	value = inputs[0]
 	for i := 1; i < len(inputs); i++ {
-		if value, err = _math.DoArithmetic(value, inputs[i], operation); err != nil {
+		value, err = _math.DoArithmetic(value, inputs[i], operation)
+		if err != nil {
 			return
 		}
 	}

--- a/tpl/math/math.go
+++ b/tpl/math/math.go
@@ -33,8 +33,8 @@ func New() *Namespace {
 type Namespace struct{}
 
 // Add adds the two addends n1 and n2.
-func (ns *Namespace) Add(n1, n2 any) (any, error) {
-	return _math.DoArithmetic(n1, n2, '+')
+func (ns *Namespace) Add(inputs ...any) (any, error) {
+	return ns.doArithmetic(inputs, '+')
 }
 
 // Ceil returns the least integer value greater than or equal to n.
@@ -48,8 +48,8 @@ func (ns *Namespace) Ceil(n any) (float64, error) {
 }
 
 // Div divides n1 by n2.
-func (ns *Namespace) Div(n1, n2 any) (any, error) {
-	return _math.DoArithmetic(n1, n2, '/')
+func (ns *Namespace) Div(inputs ...any) (any, error) {
+	return ns.doArithmetic(inputs, '/')
 }
 
 // Floor returns the greatest integer value less than or equal to n.
@@ -73,27 +73,31 @@ func (ns *Namespace) Log(n any) (float64, error) {
 }
 
 // Max returns the greater of the two numbers n1 or n2.
-func (ns *Namespace) Max(n1, n2 any) (float64, error) {
-	af, erra := cast.ToFloat64E(n1)
-	bf, errb := cast.ToFloat64E(n2)
-
-	if erra != nil || errb != nil {
-		return 0, errors.New("Max operator can't be used with non-float value")
+func (ns *Namespace) Max(inputs ...any) (maximum float64, err error) {
+	var value float64
+	for input := range inputs {
+		value, err = cast.ToFloat64E(input)
+		if err != nil {
+			err = errors.New("Max operator can't be used with non-float value")
+			return
+		}
+		maximum = math.Max(value, maximum)
 	}
-
-	return math.Max(af, bf), nil
+	return
 }
 
 // Min returns the smaller of two numbers n1 or n2.
-func (ns *Namespace) Min(n1, n2 any) (float64, error) {
-	af, erra := cast.ToFloat64E(n1)
-	bf, errb := cast.ToFloat64E(n2)
-
-	if erra != nil || errb != nil {
-		return 0, errors.New("Min operator can't be used with non-float value")
+func (ns *Namespace) Min(inputs ...any) (minimum float64, err error) {
+	var value float64
+	for input := range inputs {
+		value, err = cast.ToFloat64E(input)
+		if err != nil {
+			err = errors.New("Max operator can't be used with non-float value")
+			return
+		}
+		minimum = math.Min(value, minimum)
 	}
-
-	return math.Min(af, bf), nil
+	return
 }
 
 // Mod returns n1 % n2.
@@ -123,8 +127,8 @@ func (ns *Namespace) ModBool(n1, n2 any) (bool, error) {
 }
 
 // Mul multiplies the two numbers n1 and n2.
-func (ns *Namespace) Mul(n1, n2 any) (any, error) {
-	return _math.DoArithmetic(n1, n2, '*')
+func (ns *Namespace) Mul(inputs ...any) (any, error) {
+	return ns.doArithmetic(inputs, '*')
 }
 
 // Pow returns n1 raised to the power of n2.
@@ -160,8 +164,18 @@ func (ns *Namespace) Sqrt(n any) (float64, error) {
 }
 
 // Sub subtracts n2 from n1.
-func (ns *Namespace) Sub(n1, n2 any) (any, error) {
-	return _math.DoArithmetic(n1, n2, '-')
+func (ns *Namespace) Sub(inputs ...any) (any, error) {
+	return ns.doArithmetic(inputs, '-')
+}
+
+func (ns *Namespace) doArithmetic(inputs []any, operation rune) (value any, err error) {
+	value = inputs[0]
+	for i := 1; i < len(inputs); i++ {
+		if value, err = _math.DoArithmetic(value, inputs[i], operation); err != nil {
+			return
+		}
+	}
+	return
 }
 
 var counter uint64

--- a/tpl/math/math_test.go
+++ b/tpl/math/math_test.go
@@ -26,23 +26,28 @@ func TestBasicNSArithmetic(t *testing.T) {
 
 	ns := New()
 
-	for _, test := range []struct {
+	type TestCase struct {
 		fn     func(inputs ...any) (any, error)
-		a      any
-		b      any
+		values []any
 		expect any
-	}{
-		{ns.Add, 4, 2, int64(6)},
-		{ns.Add, 1.0, "foo", false},
-		{ns.Sub, 4, 2, int64(2)},
-		{ns.Sub, 1.0, "foo", false},
-		{ns.Mul, 4, 2, int64(8)},
-		{ns.Mul, 1.0, "foo", false},
-		{ns.Div, 4, 2, int64(2)},
-		{ns.Div, 1.0, "foo", false},
+	}
+
+	for _, test := range []TestCase{
+		{ns.Add, []any{4, 2}, int64(6)},
+		{ns.Add, []any{4, 2, 5}, int64(11)},
+		{ns.Add, []any{1.0, "foo"}, false},
+		{ns.Sub, []any{4, 2}, int64(2)},
+		{ns.Sub, []any{4, 2, 5}, int64(-3)},
+		{ns.Sub, []any{1.0, "foo"}, false},
+		{ns.Mul, []any{4, 2}, int64(8)},
+		{ns.Mul, []any{4, 2, 5}, int64(40)},
+		{ns.Mul, []any{1.0, "foo"}, false},
+		{ns.Div, []any{4, 2}, int64(2)},
+		{ns.Div, []any{4, 2, 5}, int64(0)},
+		{ns.Div, []any{1.0, "foo"}, false},
 	} {
 
-		result, err := test.fn(test.a, test.b)
+		result, err := test.fn(test.values...)
 
 		if b, ok := test.expect.(bool); ok && !b {
 			c.Assert(err, qt.Not(qt.IsNil))
@@ -129,11 +134,11 @@ func TestLog(t *testing.T) {
 		a      any
 		expect any
 	}{
-		{1, float64(0)},
-		{3, float64(1.0986)},
-		{0, float64(math.Inf(-1))},
-		{1.0, float64(0)},
-		{3.1, float64(1.1314)},
+		{1, 0.0},
+		{3, 1.0986},
+		{0, math.Inf(-1)},
+		{1.0, 0.0},
+		{3.1, 1.1314},
 		{"abc", false},
 	} {
 
@@ -170,9 +175,9 @@ func TestSqrt(t *testing.T) {
 		a      any
 		expect any
 	}{
-		{81, float64(9)},
-		{0.25, float64(0.5)},
-		{0, float64(0)},
+		{81, 9.0},
+		{0.25, 0.5},
+		{0, 0.0},
 		{"abc", false},
 	} {
 
@@ -329,15 +334,15 @@ func TestPow(t *testing.T) {
 		b      any
 		expect any
 	}{
-		{0, 0, float64(1)},
-		{2, 0, float64(1)},
-		{2, 3, float64(8)},
-		{-2, 3, float64(-8)},
-		{2, -3, float64(0.125)},
-		{-2, -3, float64(-0.125)},
-		{0.2, 3, float64(0.008)},
-		{2, 0.3, float64(1.2311)},
-		{0.2, 0.3, float64(0.617)},
+		{0, 0, 1.0},
+		{2, 0, 1.0},
+		{2, 3, 8.0},
+		{-2, 3, -8.0},
+		{2, -3, 0.125},
+		{-2, -3, -0.125},
+		{0.2, 3, 0.008},
+		{2, 0.3, 1.2311},
+		{0.2, 0.3, 0.617},
 		{"aaa", "3", false},
 		{"2", "aaa", false},
 	} {
@@ -364,28 +369,33 @@ func TestMax(t *testing.T) {
 
 	ns := New()
 
-	for _, test := range []struct {
-		a      any
-		b      any
+	type TestCase struct {
+		values []any
 		expect any
-	}{
-		{-1, -1, float64(-1)},
-		{-1, 0, float64(0)},
-		{-1, 1, float64(1)},
-		{0, -1, float64(0)},
-		{0, 0, float64(0)},
-		{0, 1, float64(1)},
-		{1, -1, float64(1)},
-		{1, 0, float64(1)},
-		{1, 1, float64(1)},
-		{1.2, 1.23, float64(1.23)},
-		{-1.2, -1.23, float64(-1.2)},
-		{0, "a", false},
-		{"a", 0, false},
-		{"a", "b", false},
-	} {
+	}
 
-		result, err := ns.Max(test.a, test.b)
+	for _, test := range []TestCase{
+		// two values
+		{[]any{-1, -1}, -1.0},
+		{[]any{-1, 0}, 0.0},
+		{[]any{-1, 1}, 1.0},
+		{[]any{0, -1}, 0.0},
+		{[]any{0, 0}, 0.0},
+		{[]any{0, 1}, 1.0},
+		{[]any{1, -1}, 1.0},
+		{[]any{1, 0}, 1.0},
+		{[]any{1, 1}, 1.0},
+		{[]any{1.2, 1.23}, 1.23},
+		{[]any{-1.2, -1.23}, -1.2},
+		{[]any{0, "a"}, false},
+		{[]any{"a", 0}, false},
+		{[]any{"a", "b"}, false},
+		// multi values
+		{[]any{-1, -2, -3}, -1.0},
+		{[]any{1, 2, 3}, 3.0},
+		{[]any{"a", 2, 3}, false},
+	} {
+		result, err := ns.Max(test.values...)
 
 		if b, ok := test.expect.(bool); ok && !b {
 			c.Assert(err, qt.Not(qt.IsNil))
@@ -403,28 +413,34 @@ func TestMin(t *testing.T) {
 
 	ns := New()
 
-	for _, test := range []struct {
-		a      any
-		b      any
+	type TestCase struct {
+		values []any
 		expect any
-	}{
-		{-1, -1, float64(-1)},
-		{-1, 0, float64(-1)},
-		{-1, 1, float64(-1)},
-		{0, -1, float64(-1)},
-		{0, 0, float64(0)},
-		{0, 1, float64(0)},
-		{1, -1, float64(-1)},
-		{1, 0, float64(0)},
-		{1, 1, float64(1)},
-		{1.2, 1.23, float64(1.2)},
-		{-1.2, -1.23, float64(-1.23)},
-		{0, "a", false},
-		{"a", 0, false},
-		{"a", "b", false},
+	}
+
+	for _, test := range []TestCase{
+		// two values
+		{[]any{-1, -1}, -1.0},
+		{[]any{-1, 0}, -1.0},
+		{[]any{-1, 1}, -1.0},
+		{[]any{0, -1}, -1.0},
+		{[]any{0, 0}, 0.0},
+		{[]any{0, 1}, 0.0},
+		{[]any{1, -1}, -1.0},
+		{[]any{1, 0}, 0.0},
+		{[]any{1, 1}, 1.0},
+		{[]any{1.2, 1.23}, 1.2},
+		{[]any{-1.2, -1.23}, -1.23},
+		{[]any{0, "a"}, false},
+		{[]any{"a", 0}, false},
+		{[]any{"a", "b"}, false},
+		// multi values
+		{[]any{-1, -2, -3}, -3.0},
+		{[]any{1, 2, 3}, 1.0},
+		{[]any{"a", 2, 3}, false},
 	} {
 
-		result, err := ns.Min(test.a, test.b)
+		result, err := ns.Min(test.values...)
 
 		if b, ok := test.expect.(bool); ok && !b {
 			c.Assert(err, qt.Not(qt.IsNil))

--- a/tpl/math/math_test.go
+++ b/tpl/math/math_test.go
@@ -27,7 +27,7 @@ func TestBasicNSArithmetic(t *testing.T) {
 	ns := New()
 
 	for _, test := range []struct {
-		fn     func(a, b any) (any, error)
+		fn     func(inputs ...any) (any, error)
 		a      any
 		b      any
 		expect any


### PR DESCRIPTION
allow multi numbers of add (`+`) / sub (`-`) / mul (`*`) / div (`/`) / min value / max value

refactor before:

```
add 1 2 | add 3 | add 4 // equivalent to: 1 + 2 + 3 + 4
sub 1 2 | sub 3 | sub 4 // equivalent to: 1 - 2 - 3 - 4
mul 1 2 | mul 3 | mul 4 // equivalent to: 1 * 2 * 3 * 4
div 1 2 | div 3 | div 4 // equivalent to: 1 / 2 / 3 / 4
math.Min 1 2 | math.Min 3 | math.Min 4
math.Max 1 2 | math.Max 3 | math.Max 4
```

refactor after:

```
add 1 2 3 4
sub 1 2 3 4
mul 1 2 3 4
div 1 2 3 4
math.Min 1 2 3 4
math.Max 1 2 3 4
```