### PR TITLE
opengraph template: CJK series meta tag malfunction

### DIFF
--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -35,7 +35,7 @@
 {{- $siteSeries := .Site.Taxonomies.series }}
 {{- if $siteSeries }}
 {{ with .Params.series }}{{- range $name := . }}
-  {{- $series := index $siteSeries ($name | urlize) }}
+  {{- $series := index $siteSeries ((urls.Parse ($name | urlize)).Path) }}
   {{- range $page := first 6 $series.Pages }}
     {{- if ne $page.Permalink $permalink }}<meta property="og:see_also" content="{{ $page.Permalink }}" />{{ end }}
   {{- end }}


### PR DESCRIPTION
The current `opengraph.html` template generate the `og:see_also` meta tags, but it does not work when the `series` front matter includes CJK characters. The root cause is that these characters are being url-encoded after `urlize` filter, while they're not in the `.Site.Taxonomies.series` map.

e.g.
Say I have a tag named `料理`, after `urlize` filter, it becomes `%E6%96%99%E7%90%86`. Meanwhile, the `.Site.Taxonomies.series` looks a bit like:

```
map[料理:[WeightedPage(0,"炒飯") WeightedPage(0,"炒麵")]]
```

which is why it return no series page.

The ideal solution should be removing the `urlize`, but the filter also sanitized other characters (e.g. emojis), so I fix the bug by using the `urls.Parse` function and then take the `Path` attribute, which is roughly URL decode the percentage encoded string back.