### PR TITLE
snap: Add read access for ~/.gitconfig.local and ~/.config/git/* too

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,8 @@ plugs:
     interface: personal-files
     read:
       - $HOME/.gitconfig
-      - $HOME/.config/git/config
+      - $HOME/.config/git       # Allows $HOME/.config/git/config and more
+      - $HOME/.gitconfig.local  # See #10337
 
 environment:
   HOME: $SNAP_REAL_HOME


### PR DESCRIPTION
Besides the `$HOME/.gitconfig` and `$HOME/.config/git/config` files that git reads by default, grant read access for `$HOME/.gitconfig.local` file and `$HOME/.config/git` directory too, in `hugo:gitconfig` plug (`personal-files` interface), for the end users who need the flexibility of using (somewhat arbitrary named) additional custom git config files.

Fixes #10337