### PR TITLE
snap: Install dart-sass-embedded for 32-bit ARM (armhf) too

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -144,6 +144,7 @@ parts:
       case "$SNAPCRAFT_TARGET_ARCH" in
         amd64)  arch=x64    ;;
         arm64)  arch=arm64  ;;
+        armhf)  arch=arm    ;;
         i386)   arch=ia32   ;;
         *)      arch=""     ;;
       esac


### PR DESCRIPTION
See https://github.com/sass/dart-sass-embedded/releases/tag/1.54.7 which "Add[ed] support for 32-bit ARM releases on Linux" on 2022-08-30.