### PR TITLE
markup: fixes regression for linenos codeblock hl option

### DIFF
--- a/markup/highlight/config.go
+++ b/markup/highlight/config.go
@@ -198,7 +198,7 @@ func parseHightlightOptions(in string) (map[string]any, error) {
 
 	for _, v := range strings.Split(in, ",") {
 		keyVal := strings.Split(v, "=")
-		key := strings.ToLower(strings.Trim(keyVal[0], " "))
+		key := strings.Trim(keyVal[0], " ")
 		if len(keyVal) != 2 {
 			return opts, fmt.Errorf("invalid Highlight option: %s", key)
 		}
@@ -214,6 +214,12 @@ func parseHightlightOptions(in string) (map[string]any, error) {
 func normalizeHighlightOptions(m map[string]any) {
 	if m == nil {
 		return
+	}
+
+	// lowercase all keys
+	for k, v := range m {
+		delete(m, k)
+		m[strings.ToLower(k)] = v
 	}
 
 	baseLineNumber := 1
@@ -232,7 +238,6 @@ func normalizeHighlightOptions(m map[string]any) {
 			if vs, ok := v.(string); ok {
 				m[k] = vs != "false"
 			}
-
 		case hlLinesKey:
 			if hlRanges, ok := v.([][2]int); ok {
 				for i := range hlRanges {

--- a/markup/highlight/config_test.go
+++ b/markup/highlight/config_test.go
@@ -53,4 +53,21 @@ func TestConfig(t *testing.T) {
 		c.Assert(cfg.LineNoStart, qt.Equals, 32)
 		c.Assert(cfg.Hl_Lines, qt.Equals, "3-8 10-20")
 	})
+
+	c.Run("applyOptionsFromMap", func(c *qt.C) {
+		cfg := DefaultConfig
+		err := applyOptionsFromMap(map[string]any{
+			"noclasses":   true,
+			"lineNos":     "inline", // mixed case key, should work after normalization
+			"linenostart": 32,
+			"hl_lines":    "3-8 10-20",
+		}, &cfg)
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(cfg.NoClasses, qt.Equals, true)
+		c.Assert(cfg.LineNos, qt.Equals, true)
+		c.Assert(cfg.LineNumbersInTable, qt.Equals, false)
+		c.Assert(cfg.LineNoStart, qt.Equals, 32)
+		c.Assert(cfg.Hl_Lines, qt.Equals, "3-8 10-20")
+	})
 }


### PR DESCRIPTION
This fixes a regression introduced in v0.93.0 where previously, a
mixed-case key for lineNos would be successfully parsed. This change
moves the configuration key lowercasing step into the configuration
normalization stage, which is called whether the highlighting config
is being parsed from a `string` or a `map`.

Fixes #10682
