### PR TITLE
Fix slow HTML elements collector for the pre case

### DIFF
--- a/publisher/htmlElementsCollector_test.go
+++ b/publisher/htmlElementsCollector_test.go
@@ -155,6 +155,34 @@ func TestClassCollector(t *testing.T) {
 
 }
 
+func TestEndsWithTag(t *testing.T) {
+	c := qt.New((t))
+
+	for _, test := range []struct {
+		name    string
+		s       string
+		tagName string
+		expect  bool
+	}{
+		{"empty", "", "div", false},
+		{"no match", "foo", "div", false},
+		{"no close", "foo<div>", "div", false},
+		{"no close 2", "foo/div>", "div", false},
+		{"no close 2", "foo//div>", "div", false},
+		{"no tag", "foo</>", "div", false},
+		{"match", "foo</div>", "div", true},
+		{"match space", "foo<  / div>", "div", true},
+		{"match space 2", "foo<  / div   \n>", "div", true},
+		{"match case", "foo</DIV>", "div", true},
+	} {
+		c.Run(test.name, func(c *qt.C) {
+			got := isClosedByTag([]byte(test.s), []byte(test.tagName))
+			c.Assert(got, qt.Equals, test.expect)
+		})
+	}
+
+}
+
 func BenchmarkElementsCollectorWriter(b *testing.B) {
 	const benchHTML = `
 <!DOCTYPE html>


### PR DESCRIPTION
```
name                           old time/op    new time/op    delta
ElementsCollectorWriterPre-10    25.2µs ± 1%     3.4µs ± 0%  -86.54%  (p=0.029 n=4+4)

name                           old alloc/op   new alloc/op   delta
ElementsCollectorWriterPre-10      624B ± 0%      142B ± 0%  -77.18%  (p=0.029 n=4+4)

name                           old allocs/op  new allocs/op  delta
ElementsCollectorWriterPre-10      16.0 ± 0%       6.0 ± 0%  -62.50%  (p=0.029 n=4+4)
```

Fixes #10698
