### PR TITLE
docs(Diagrams): Update mermaid to esm

### DIFF
--- a/docs/content/en/content-management/diagrams.md
+++ b/docs/content/en/content-management/diagrams.md
@@ -58,8 +58,8 @@ And then include this snippet at the bottom of the content template (**Note**: b
 
 ```go-html-template
 {{ if .Page.Store.Get "hasMermaid" }}
-  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
-  <script>
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
     mermaid.initialize({ startOnLoad: true });
   </script>
 {{ end }}


### PR DESCRIPTION
I was trying to use hugo in Mermaid's new blog, saw it was using the deprecated method to integrate mermaid to websites. 
I've fixed it to use the new ESM method.