### PR TITLE
Correct typos in Go comments

### DIFF
--- a/cache/filecache/filecache.go
+++ b/cache/filecache/filecache.go
@@ -249,7 +249,7 @@ func (c *Cache) GetBytes(id string) (ItemInfo, []byte, error) {
 	return info, nil, nil
 }
 
-// Get gets the file with the given id from the cahce, nil if none found.
+// Get gets the file with the given id from the cache, nil if none found.
 func (c *Cache) Get(id string) (ItemInfo, io.ReadCloser, error) {
 	id = cleanID(id)
 

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -230,7 +230,7 @@ func TestFlags(t *testing.T) {
 				if cmd.getCommand() == nil {
 					continue
 				}
-				// We are only intereseted in the flag handling here.
+				// We are only interested in the flag handling here.
 				cmd.getCommand().RunE = noOpRunE
 			}
 			rootCmd := root.getCommand()

--- a/commands/server.go
+++ b/commands/server.go
@@ -505,7 +505,7 @@ func removeErrorPrefixFromLog(content string) string {
 }
 
 var logReplacer = strings.NewReplacer(
-	"can't", "can’t", // Chroma lexer does'nt do well with "can't"
+	"can't", "can’t", // Chroma lexer doesn't do well with "can't"
 	"*hugolib.pageState", "page.Page", // Page is the public interface.
 	"Rebuild failed:", "",
 )
@@ -547,7 +547,7 @@ func (c *commandeer) serve(s *serverCmd) error {
 		roots = []string{""}
 	}
 
-	// Cache it here. The HugoSites object may be unavaialble later on due to intermitent configuration errors.
+	// Cache it here. The HugoSites object may be unavailable later on due to intermittent configuration errors.
 	// To allow the en user to change the error template while the server is running, we use
 	// the freshest template we can provide.
 	var (

--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -211,7 +211,7 @@ func TestServerBugs(t *testing.T) {
 			c.Assert(r.err, qt.IsNil)
 			c.Assert(r.homesContent[0], qt.Contains, "PostProcess: /foo.min.css")
 		}},
-		// Isue 9901
+		// Issue 9901
 		{"Multihost", `
 defaultContentLanguage = 'en'
 [languages]

--- a/common/para/para.go
+++ b/common/para/para.go
@@ -27,7 +27,7 @@ type Workers struct {
 
 // Runner wraps the lifecycle methods of a new task set.
 //
-// Run wil block until a worker is available or the context is cancelled,
+// Run will block until a worker is available or the context is cancelled,
 // and then run the given func in a new goroutine.
 // Wait will wait for all the running goroutines to finish.
 type Runner interface {

--- a/config/security/whitelist.go
+++ b/config/security/whitelist.go
@@ -44,7 +44,7 @@ func (w Whitelist) MarshalJSON() ([]byte, error) {
 
 // NewWhitelist creates a new Whitelist from zero or more patterns.
 // An empty patterns list or a pattern with the value 'none' will create
-// a whitelist that will Accept noone.
+// a whitelist that will Accept none.
 func NewWhitelist(patterns ...string) Whitelist {
 	if len(patterns) == 0 {
 		return Whitelist{acceptNone: true}

--- a/helpers/pathspec.go
+++ b/helpers/pathspec.go
@@ -42,7 +42,7 @@ func NewPathSpec(fs *hugofs.Fs, cfg config.Provider, logger loggers.Logger) (*Pa
 	return NewPathSpecWithBaseBaseFsProvided(fs, cfg, logger, nil)
 }
 
-// NewPathSpecWithBaseBaseFsProvided creats a new PathSpec from the given filesystems and language.
+// NewPathSpecWithBaseBaseFsProvided creates a new PathSpec from the given filesystems and language.
 // If an existing BaseFs is provided, parts of that is reused.
 func NewPathSpecWithBaseBaseFsProvided(fs *hugofs.Fs, cfg config.Provider, logger loggers.Logger, baseBaseFs *filesystems.BaseFs) (*PathSpec, error) {
 	p, err := paths.New(fs, cfg)

--- a/hugofs/glob/glob.go
+++ b/hugofs/glob/glob.go
@@ -82,7 +82,7 @@ func (gc *globCache) GetGlob(pattern string) (glob.Glob, error) {
 
 type globDecorator struct {
 	// On Windows we may get filenames with Windows slashes to match,
-	// which wee need to normalize.
+	// which we need to normalize.
 	isWindows bool
 
 	g glob.Glob

--- a/hugolib/content_map.go
+++ b/hugolib/content_map.go
@@ -43,7 +43,7 @@ import (
 //
 // For bundled pages (/mybundle/index.md), we use the folder name.
 //
-// An exmple of a full page key would be "/blog/__hb_page1__hl_"
+// An example of a full page key would be "/blog/__hb_page1__hl_"
 //
 // Bundled resources are stored in the `resources` having their path prefixed
 // with the bundle they belong to, e.g.
@@ -317,7 +317,7 @@ type contentMap struct {
 	// There are currently two cases where this is used:
 	// 1. Short name lookups in ref/relRef, e.g. using only "mypage.md" without a path.
 	// 2. Links resolved from a remounted content directory. These are restricted to the same module.
-	// Both of the above cases can  result in ambigous lookup errors.
+	// Both of the above cases can  result in ambiguous lookup errors.
 	pageReverseIndex *contentTreeReverseIndex
 
 	// Section nodes.

--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -297,7 +297,7 @@ func (s SourceFilesystems) StaticFs(lang string) afero.Fs {
 // StatResource looks for a resource in these filesystems in order: static, assets and finally content.
 // If found in any of them, it returns FileInfo and the relevant filesystem.
 // Any non herrors.IsNotExist error will be returned.
-// An herrors.IsNotExist error wil be returned only if all filesystems return such an error.
+// An herrors.IsNotExist error will be returned only if all filesystems return such an error.
 // Note that if we only wanted to find the file, we could create a composite Afero fs,
 // but we also need to know which filesystem root it lives in.
 func (s SourceFilesystems) StatResource(lang, filename string) (fi os.FileInfo, fs afero.Fs, err error) {

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -723,7 +723,7 @@ type BuildCfg struct {
 // shouldRender is used in the Fast Render Mode to determine if we need to re-render
 // a Page: If it is recently visited (the home pages will always be in this set) or changed.
 // Note that a page does not have to have a content page / file.
-// For regular builds, this will allways return true.
+// For regular builds, this will always return true.
 // TODO(bep) rename/work this.
 func (cfg *BuildCfg) shouldRender(p *pageState) bool {
 	if p == nil {

--- a/hugolib/pagecollections.go
+++ b/hugolib/pagecollections.go
@@ -209,7 +209,7 @@ func (c *PageCollections) getSectionOrPage(ref string) (*contentNode, string) {
 	return m.getPage(s, name), name
 }
 
-// For Ref/Reflink and .Site.GetPage do simple name lookups for the potentially ambigous myarticle.md and /myarticle.md,
+// For Ref/Reflink and .Site.GetPage do simple name lookups for the potentially ambiguous myarticle.md and /myarticle.md,
 // but not when we get ./myarticle*, section/myarticle.
 func shouldDoSimpleLookup(ref string) bool {
 	if ref[0] == '.' {
@@ -325,7 +325,7 @@ func (c *PageCollections) getContentNode(context page.Page, isReflink bool, ref 
 		return nil, nil
 	}
 
-	// Ref/relref supports this potentially ambigous lookup.
+	// Ref/relref supports this potentially ambiguous lookup.
 	return getByName(path.Base(name))
 }
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -426,7 +426,7 @@ func newSite(cfg deps.DepsCfg) (*Site, error) {
 
 		delete(disabledKinds, "taxonomyTerm")
 	} else if disabledKinds[page.KindTaxonomy] && !disabledKinds[page.KindTerm] {
-		// This is a potentially ambigous situation. It may be correct.
+		// This is a potentially ambiguous situation. It may be correct.
 		ignorableLogger.Errorsf(constants.ErrIDAmbigousDisableKindTaxonomy, `You have the value 'taxonomy' in the disabledKinds list. In Hugo 0.73.0 we fixed these to be what most people expect (taxonomy and term).
 But this also means that your site configuration may not do what you expect. If it is correct, you can suppress this message by following the instructions below.`)
 	}
@@ -485,7 +485,7 @@ But this also means that your site configuration may not do what you expect. If 
 			siteOutputs[page.KindTerm] = v2
 			delete(siteOutputs, "taxonomyTerm")
 		} else if hasTaxonomy && !hasTerm {
-			// This is a potentially ambigous situation. It may be correct.
+			// This is a potentially ambiguous situation. It may be correct.
 			ignorableLogger.Errorsf(constants.ErrIDAmbigousOutputKindTaxonomy, `You have configured output formats for 'taxonomy' in your site configuration. In Hugo 0.73.0 we fixed these to be what most people expect (taxonomy and term).
 But this also means that your site configuration may not do what you expect. If it is correct, you can suppress this message by following the instructions below.`)
 		}

--- a/langs/language.go
+++ b/langs/language.go
@@ -92,7 +92,7 @@ type Language struct {
 	collator      *Collator
 	location      *time.Location
 
-	// Error during initialization. Will fail the buld.
+	// Error during initialization. Will fail the build.
 	initErr error
 }
 
@@ -223,7 +223,7 @@ func (l Languages) AsOrdinalSet() map[string]int {
 }
 
 // IsMultihost returns whether there are more than one language and at least one of
-// the languages has baseURL specificed on the language level.
+// the languages has baseURL specified on the language level.
 func (l Languages) IsMultihost() bool {
 	if len(l) <= 1 {
 		return false
@@ -326,7 +326,7 @@ type Collator struct {
 // CompareStrings compares a and b.
 // It returns -1 if a < b, 1 if a > b and 0 if a == b.
 // Note that the Collator is not thread safe, so you may want
-// to aquire a lock on it before calling this method.
+// to acquire a lock on it before calling this method.
 func (c *Collator) CompareStrings(a, b string) int {
 	return c.c.CompareString(a, b)
 }

--- a/markup/goldmark/autoid.go
+++ b/markup/goldmark/autoid.go
@@ -112,7 +112,7 @@ func (ids *idFactory) Generate(value []byte, kind ast.NodeKind) []byte {
 		}
 
 		if _, found := ids.vals[util.BytesToReadOnlyString(buf.Bytes())]; found {
-			// Append a hypen and a number, starting with 1.
+			// Append a hyphen and a number, starting with 1.
 			buf.WriteRune('-')
 			pos := buf.Len()
 			for i := 1; ; i++ {

--- a/markup/internal/attributes/attributes.go
+++ b/markup/internal/attributes/attributes.go
@@ -200,8 +200,8 @@ func RenderASTAttributes(w hugio.FlexiWriter, attributes ...ast.Attribute) {
 }
 
 // Render writes the attributes to the given as attributes to an HTML element.
-// This is used for the default codeblock renderering.
-// This performs HTML esacaping of string attributes.
+// This is used for the default codeblock rendering.
+// This performs HTML escaping of string attributes.
 func RenderAttributes(w hugio.FlexiWriter, skipClass bool, attributes ...Attribute) {
 	for _, attr := range attributes {
 		a := strings.ToLower(string(attr.Name))

--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package media containes Media Type (MIME type) related types and functions.
+// Package media contains Media Type (MIME type) related types and functions.
 package media
 
 import (

--- a/parser/metadecoders/format.go
+++ b/parser/metadecoders/format.go
@@ -23,7 +23,7 @@ import (
 type Format string
 
 const (
-	// These are the supported metdata  formats in Hugo. Most of these are also
+	// These are the supported metadata  formats in Hugo. Most of these are also
 	// supported as /data formats.
 	ORG  Format = "org"
 	JSON Format = "json"

--- a/resources/page/page_kinds.go
+++ b/resources/page/page_kinds.go
@@ -23,7 +23,7 @@ const (
 	KindHome    = "home"
 	KindSection = "section"
 
-	// Note tha before Hugo 0.73 these were confusingly named
+	// Note that before Hugo 0.73 these were confusingly named
 	// taxonomy (now: term)
 	// taxonomyTerm (now: taxonomy)
 	KindTaxonomy = "taxonomy"

--- a/resources/page/pages_prev_next.go
+++ b/resources/page/pages_prev_next.go
@@ -22,7 +22,7 @@ func (p Pages) Next(cur Page) Page {
 	return p[x-1]
 }
 
-// Prev returns the previous page reletive to the given
+// Prev returns the previous page relative to the given
 func (p Pages) Prev(cur Page) Page {
 	x := searchPage(cur, p)
 

--- a/resources/page/site.go
+++ b/resources/page/site.go
@@ -62,7 +62,7 @@ type Site interface {
 	// Returns the BaseURL for this Site.
 	BaseURL() template.URL
 
-	// Retuns a taxonomy map.
+	// Returns a taxonomy map.
 	Taxonomies() TaxonomyList
 
 	// Returns the last modification date of the content.

--- a/resources/resource_transformers/js/options.go
+++ b/resources/resource_transformers/js/options.go
@@ -164,7 +164,7 @@ func resolveComponentInAssets(fs afero.Fs, impPath string) *hugofs.FileMeta {
 	var m *hugofs.FileMeta
 
 	// We need to check if this is a regular file imported without an extension.
-	// There may be ambigous situations where both foo.js and foo/index.js exists.
+	// There may be ambiguous situations where both foo.js and foo/index.js exists.
 	// This import order is in line with both how Node and ESBuild's native
 	// import resolver works.
 

--- a/source/fileInfo.go
+++ b/source/fileInfo.go
@@ -301,7 +301,7 @@ func NewGitInfo(info gitmap.GitInfo) GitInfo {
 	return GitInfo(info)
 }
 
-// GitInfo provides information about a version controled source file.
+// GitInfo provides information about a version controlled source file.
 type GitInfo struct {
 	// Commit hash.
 	Hash string `json:"hash"`

--- a/source/filesystem.go
+++ b/source/filesystem.go
@@ -34,7 +34,7 @@ type Filesystem struct {
 	SourceSpec
 }
 
-// NewFilesystem returns a new filesytem for a given source spec.
+// NewFilesystem returns a new filesystem for a given source spec.
 func (sp SourceSpec) NewFilesystem(base string) *Filesystem {
 	return &Filesystem{SourceSpec: sp, Base: base}
 }

--- a/tpl/internal/go_templates/texttemplate/hugo_template.go
+++ b/tpl/internal/go_templates/texttemplate/hugo_template.go
@@ -71,7 +71,7 @@ const (
 	HasLockContextKey = hasLockContextKeyType("hasLock")
 )
 
-// Note: The context is currently not fully implemeted in Hugo. This is a work in progress.
+// Note: The context is currently not fully implemented in Hugo. This is a work in progress.
 func (t *executer) ExecuteWithContext(ctx context.Context, p Preparer, wr io.Writer, data any) error {
 	tmpl, err := p.Prepare()
 	if err != nil {
@@ -144,7 +144,7 @@ func (t *Template) executeWithState(state *state, value reflect.Value) (err erro
 // can execute in parallel.
 type state struct {
 	tmpl   *Template
-	ctx    context.Context // Added for Hugo. The orignal data context.
+	ctx    context.Context // Added for Hugo. The original data context.
 	prep   Preparer        // Added for Hugo.
 	helper ExecHelper      // Added for Hugo.
 	wr     io.Writer

--- a/tpl/tplimpl/template.go
+++ b/tpl/tplimpl/template.go
@@ -770,8 +770,8 @@ func (t *templateHandler) loadEmbedded() error {
 		name := strings.TrimPrefix(filepath.ToSlash(path), "embedded/templates/")
 		templateName := name
 
-		// For the render hooks and the server templates it does not make sense to preseve the
-		// double _indternal double book-keeping,
+		// For the render hooks and the server templates it does not make sense to preserve the
+		// double _internal double book-keeping,
 		// just add it if its now provided by the user.
 		if !strings.Contains(path, "_default/_markup") && !strings.HasPrefix(name, "_server/") {
 			templateName = internalPathPrefix + name


### PR DESCRIPTION
This PR fixes word typos in comments for the Go code.