### PR TITLE
Remove unused temp directory

### DIFF
--- a/temp/0.86.1-relnotes-ready.md
+++ b/temp/0.86.1-relnotes-ready.md
@@ -1,8 +1,0 @@
-
-
-This is a bug-fix release with one important fix.
-
-* config: Fix a potential deadlock in config reading [94b616bd](https://github.com/gohugoio/hugo/commit/94b616bdfad177daa99f5e87535943f509198f6f) [@bep](https://github.com/bep) [#8791](https://github.com/gohugoio/hugo/issues/8791)
-
-
-


### PR DESCRIPTION
Looks like the `temp` directory is not longer stores release notes and can be removed.