### PR TITLE
server: Replace golang.org/x/net/context with context

### DIFF
--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -14,6 +14,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -26,7 +27,6 @@ import (
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/htesting"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 
 	qt "github.com/frankban/quicktest"


### PR DESCRIPTION
This PR changes imports of `golang.org/x/net/context` to `context` by running the command `go fix -fix context ./...`