### PR TITLE
tpl: Add hasSuffix alias

### DIFF
--- a/docs/content/en/functions/hasPrefix.md
+++ b/docs/content/en/functions/hasPrefix.md
@@ -9,11 +9,11 @@ categories: [functions]
 menu:
   docs:
     parent: "functions"
-keywords: []
+keywords: [strings]
 signature: ["hasPrefix STRING PREFIX"]
 workson: []
 hugoversion:
-relatedfuncs: []
+relatedfuncs: [hasSuffix]
 deprecated: false
 aliases: []
 ---

--- a/docs/content/en/functions/hasSuffix.md
+++ b/docs/content/en/functions/hasSuffix.md
@@ -1,0 +1,21 @@
+---
+title: hassuffix
+linktitle: hasSuffix
+description: Tests whether a string ends with suffix.
+date: 2023-03-01
+publishdate: 2023-03-01
+lastmod: 2023-03-01
+categories: [functions]
+menu:
+docs:
+parent: "functions"
+keywords: [strings]
+signature: ["hasSuffix STRING SUFFIX"]
+workson: []
+hugoversion:
+relatedfuncs: [hasPrefix]
+deprecated: false
+aliases: []
+---
+
+* `{{ hasSuffix "Hugo" "go" }}` → true

--- a/tpl/strings/init.go
+++ b/tpl/strings/init.go
@@ -104,6 +104,14 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.HasSuffix,
+			[]string{"hasSuffix"},
+			[][2]string{
+				{`{{ hasSuffix "Hugo" "go" }}`, `true`},
+				{`{{ hasSuffix "Hugo" "du" }}`, `false`},
+			},
+		)
+
 		ns.AddMethodMapping(ctx.ToLower,
 			[]string{"lower"},
 			[][2]string{


### PR DESCRIPTION
strings.HasPrefix already has an alias of hasPrefix but strings.HasSuffix has no such alias.
This PR adds a hasSuffix alias to the funcs mapping with corresponding documentation.
It also adds a minor update to the hasPrefix function documentation re: keywords and relatedfuncs.

 Completes https://github.com/gohugoio/hugo/issues/10474