### PR TITLE
Refactor to use strings.ReplaceAll and bytes.ReplaceAll

### DIFF
--- a/cache/filecache/filecache_test.go
+++ b/cache/filecache/filecache_test.go
@@ -79,7 +79,7 @@ dir = ":cacheDir/c"
 		replacer := strings.NewReplacer("CACHEDIR", test.cacheDir, "WORKING_DIR", test.workingDir)
 
 		configStr = replacer.Replace(configStr)
-		configStr = strings.Replace(configStr, "\\", winPathSep, -1)
+		configStr = strings.ReplaceAll(configStr, "\\", winPathSep)
 
 		p := newPathsSpec(t, osfs, configStr)
 

--- a/commands/gendoc.go
+++ b/commands/gendoc.go
@@ -74,7 +74,7 @@ for rendering in Hugo.`,
 				name := filepath.Base(filename)
 				base := strings.TrimSuffix(name, path.Ext(name))
 				url := "/commands/" + strings.ToLower(base) + "/"
-				return fmt.Sprintf(gendocFrontmatterTemplate, strings.Replace(base, "_", " ", -1), base, url)
+				return fmt.Sprintf(gendocFrontmatterTemplate, strings.ReplaceAll(base, "_", " "), base, url)
 			}
 
 			linkHandler := func(name string) string {

--- a/commands/import_jekyll.go
+++ b/commands/import_jekyll.go
@@ -133,9 +133,9 @@ func (i *importCmd) importFromJekyll(cmd *cobra.Command, args []string) error {
 
 		switch {
 		case strings.Contains(relPath, "_posts/"):
-			relPath = filepath.Join("content/post", strings.Replace(relPath, "_posts/", "", -1))
+			relPath = filepath.Join("content/post", strings.ReplaceAll(relPath, "_posts/", ""))
 		case strings.Contains(relPath, "_drafts/"):
-			relPath = filepath.Join("content/draft", strings.Replace(relPath, "_drafts/", "", -1))
+			relPath = filepath.Join("content/draft", strings.ReplaceAll(relPath, "_drafts/", ""))
 			draft = true
 		default:
 			return nil
@@ -484,7 +484,7 @@ func convertJekyllContent(m any, content string) (string, error) {
 	excerptSep := "<!--more-->"
 	if value, ok := metadata["excerpt_separator"]; ok {
 		if str, strOk := value.(string); strOk {
-			content = strings.Replace(content, strings.TrimSpace(str), excerptSep, -1)
+			content = strings.ReplaceAll(content, strings.TrimSpace(str), excerptSep)
 		}
 	}
 
@@ -551,7 +551,7 @@ func replaceHighlightTag(match string) string {
 	result.WriteString(items[0]) // language
 	options := items[1:]
 	for i, opt := range options {
-		opt = strings.Replace(opt, "\"", "", -1)
+		opt = strings.ReplaceAll(opt, "\"", "")
 		if opt == "linenos" {
 			opt = "linenos=table"
 		}

--- a/common/paths/path.go
+++ b/common/paths/path.go
@@ -75,7 +75,7 @@ func AbsPathify(workingDir, inPath string) string {
 // MakeTitle converts the path given to a suitable title, trimming whitespace
 // and replacing hyphens with whitespace.
 func MakeTitle(inpath string) string {
-	return strings.Replace(strings.TrimSpace(inpath), "-", " ", -1)
+	return strings.ReplaceAll(strings.TrimSpace(inpath), "-", " ")
 }
 
 // ReplaceExtension takes a path and an extension, strips the old extension

--- a/common/terminal/colors.go
+++ b/common/terminal/colors.go
@@ -71,9 +71,9 @@ func colorize(s, color string) string {
 }
 
 func doublePercent(str string) string {
-	return strings.Replace(str, "%", "%%", -1)
+	return strings.ReplaceAll(str, "%", "%%")
 }
 
 func singlePercent(str string) string {
-	return strings.Replace(str, "%%", "%", -1)
+	return strings.ReplaceAll(str, "%%", "%")
 }

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -105,7 +105,7 @@ func NewContentSpec(cfg config.Provider, logger loggers.Logger, contentFs afero.
 
 // stripEmptyNav strips out empty <nav> tags from content.
 func stripEmptyNav(in []byte) []byte {
-	return bytes.Replace(in, []byte("<nav>\n</nav>\n\n"), []byte(``), -1)
+	return bytes.ReplaceAll(in, []byte("<nav>\n</nav>\n\n"), []byte(``))
 }
 
 // BytesToHTML converts bytes to type template.HTML.

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -68,7 +68,7 @@ func ToSlashTrimLeading(s string) string {
 // MakeTitle converts the path given to a suitable title, trimming whitespace
 // and replacing hyphens with whitespace.
 func MakeTitle(inpath string) string {
-	return strings.Replace(strings.TrimSpace(inpath), "-", " ", -1)
+	return strings.ReplaceAll(strings.TrimSpace(inpath), "-", " ")
 }
 
 // From https://golang.org/src/net/url/url.go

--- a/hugolib/hugo_modules_test.go
+++ b/hugolib/hugo_modules_test.go
@@ -963,7 +963,7 @@ workingDir = %q
 
 `
 		tomlConfig := fmt.Sprintf(configTemplate, workingDir, mounts)
-		tomlConfig = strings.Replace(tomlConfig, "WORKING_DIR", workingDir, -1)
+		tomlConfig = strings.ReplaceAll(tomlConfig, "WORKING_DIR", workingDir)
 
 		b := newTestSitesBuilder(c).Running()
 

--- a/hugolib/hugo_sites_build_test.go
+++ b/hugolib/hugo_sites_build_test.go
@@ -41,7 +41,7 @@ func doTestMultiSitesMainLangInRoot(t *testing.T, defaultInSubDir bool) {
 
 	if !defaultInSubDir {
 		pathMod = func(s string) string {
-			return strings.Replace(s, "/fr/", "/", -1)
+			return strings.ReplaceAll(s, "/fr/", "/")
 		}
 	}
 

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -710,7 +710,7 @@ func (p *pageMeta) applyDefaultValues(n *contentNode) error {
 		case page.KindTerm:
 			// TODO(bep) improve
 			key := p.sections[len(p.sections)-1]
-			p.title = strings.Replace(p.s.titleFunc(key), "-", " ", -1)
+			p.title = strings.ReplaceAll(p.s.titleFunc(key), "-", " ")
 		case page.KindTaxonomy:
 			p.title = p.s.titleFunc(p.sections[0])
 		case kind404:

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -301,12 +301,12 @@ func checkPageContent(t *testing.T, page page.Page, expected string, msg ...any)
 
 func normalizeContent(c string) string {
 	norm := c
-	norm = strings.Replace(norm, "\n", " ", -1)
-	norm = strings.Replace(norm, "    ", " ", -1)
-	norm = strings.Replace(norm, "   ", " ", -1)
-	norm = strings.Replace(norm, "  ", " ", -1)
-	norm = strings.Replace(norm, "p> ", "p>", -1)
-	norm = strings.Replace(norm, ">  <", "> <", -1)
+	norm = strings.ReplaceAll(norm, "\n", " ")
+	norm = strings.ReplaceAll(norm, "    ", " ")
+	norm = strings.ReplaceAll(norm, "   ", " ")
+	norm = strings.ReplaceAll(norm, "  ", " ")
+	norm = strings.ReplaceAll(norm, "p> ", "p>")
+	norm = strings.ReplaceAll(norm, ">  <", "> <")
 	return strings.TrimSpace(norm)
 }
 

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -583,7 +583,7 @@ weight: %d
 
 	for i := 1; i <= 5; i++ {
 		sc := fmt.Sprintf(shortcodeTemplate, i)
-		sc = strings.Replace(sc, "%%", "%", -1)
+		sc = strings.ReplaceAll(sc, "%%", "%")
 		shortcodes = append(shortcodes, []string{fmt.Sprintf("shortcodes/s%d.html", i), sc}...)
 	}
 

--- a/hugolib/site_benchmark_new_test.go
+++ b/hugolib/site_benchmark_new_test.go
@@ -189,7 +189,7 @@ Some content.
 			
 `
 				for i := 1; i <= 100; i++ {
-					content := strings.Replace(pageTemplate, "GR", strconv.Itoa(i/3), -1)
+					content := strings.ReplaceAll(pageTemplate, "GR", strconv.Itoa(i/3))
 					sb.WithContent(fmt.Sprintf("content/page%d.md", i), content)
 				}
 

--- a/hugolib/site_output_test.go
+++ b/hugolib/site_output_test.go
@@ -39,7 +39,7 @@ func TestSiteWithPageOutputs(t *testing.T) {
 }
 
 func doTestSiteWithPageOutputs(t *testing.T, outputs []string) {
-	outputsStr := strings.Replace(fmt.Sprintf("%q", outputs), " ", ", ", -1)
+	outputsStr := strings.ReplaceAll(fmt.Sprintf("%q", outputs), " ", ", ")
 
 	siteConfig := `
 baseURL = "http://example.com/blog"

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -527,7 +527,7 @@ func TestAbsURLify(t *testing.T) {
 				}
 
 				if !canonify {
-					expected = strings.Replace(expected, baseURL, "", -1)
+					expected = strings.ReplaceAll(expected, baseURL, "")
 				}
 
 				th.assertFileContent(test.file, expected)

--- a/markup/goldmark/convert_test.go
+++ b/markup/goldmark/convert_test.go
@@ -139,7 +139,7 @@ description
 `
 
 	// Code fences
-	content = strings.Replace(content, "§§§", "```", -1)
+	content = strings.ReplaceAll(content, "§§§", "```")
 	mconf := markup_config.Default
 	mconf.Highlight.NoClasses = false
 	mconf.Goldmark.Renderer.Unsafe = true

--- a/markup/internal/external.go
+++ b/markup/internal/external.go
@@ -56,7 +56,7 @@ func ExternallyRenderContent(
 
 // Strips carriage returns from third-party / external processes (useful for Windows)
 func normalizeExternalHelperLineFeeds(content []byte) []byte {
-	return bytes.Replace(content, []byte("\r"), []byte(""), -1)
+	return bytes.ReplaceAll(content, []byte("\r"), []byte(""))
 }
 
 var pythonBinaryCandidates = []string{"python", "python.exe"}

--- a/resources/resource_metadata.go
+++ b/resources/resource_metadata.go
@@ -140,5 +140,5 @@ func AssignMetadata(metadata []map[string]any, resources ...resource.Resource) e
 }
 
 func replaceResourcePlaceholders(in string, counter int) string {
-	return strings.Replace(in, counterPlaceHolder, strconv.Itoa(counter), -1)
+	return strings.ReplaceAll(in, counterPlaceHolder, strconv.Itoa(counter))
 }

--- a/transform/chain_test.go
+++ b/transform/chain_test.go
@@ -32,20 +32,20 @@ func TestChainZeroTransformers(t *testing.T) {
 
 func TestChainingMultipleTransformers(t *testing.T) {
 	f1 := func(ct FromTo) error {
-		_, err := ct.To().Write(bytes.Replace(ct.From().Bytes(), []byte("f1"), []byte("f1r"), -1))
+		_, err := ct.To().Write(bytes.ReplaceAll(ct.From().Bytes(), []byte("f1"), []byte("f1r")))
 		return err
 	}
 	f2 := func(ct FromTo) error {
-		_, err := ct.To().Write(bytes.Replace(ct.From().Bytes(), []byte("f2"), []byte("f2r"), -1))
+		_, err := ct.To().Write(bytes.ReplaceAll(ct.From().Bytes(), []byte("f2"), []byte("f2r")))
 		return err
 	}
 	f3 := func(ct FromTo) error {
-		_, err := ct.To().Write(bytes.Replace(ct.From().Bytes(), []byte("f3"), []byte("f3r"), -1))
+		_, err := ct.To().Write(bytes.ReplaceAll(ct.From().Bytes(), []byte("f3"), []byte("f3r")))
 		return err
 	}
 
 	f4 := func(ct FromTo) error {
-		_, err := ct.To().Write(bytes.Replace(ct.From().Bytes(), []byte("f4"), []byte("f4r"), -1))
+		_, err := ct.To().Write(bytes.ReplaceAll(ct.From().Bytes(), []byte("f4"), []byte("f4r")))
 		return err
 	}
 


### PR DESCRIPTION
Use [strings.ReplaceAll](https://pkg.go.dev/strings#ReplaceAll) instead of `strings.Replace` with `-1` as the last argument. Do the same for [`bytes.ReplaceAll`](https://pkg.go.dev/bytes#ReplaceAll).

`strings.ReplaceAll` available since Go 1.12.