### PR TITLE
Hugo deploy customize parallel transfer count

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -31,7 +31,7 @@ type deployCmd struct {
 
 	invalidateCDN bool
 	maxDeletes    int
-	transfers     int
+	workers       int
 }
 
 // TODO: In addition to the "deploy" command, consider adding a "--deploy"
@@ -60,7 +60,7 @@ documentation.
 			cfgInit := func(c *commandeer) error {
 				c.Set("invalidateCDN", cc.invalidateCDN)
 				c.Set("maxDeletes", cc.maxDeletes)
-				c.Set("transfers", cc.transfers)
+				c.Set("workers", cc.workers)
 				return nil
 			}
 			comm, err := initializeConfig(true, true, false, &cc.hugoBuilderCommon, cc, cfgInit)
@@ -81,7 +81,7 @@ documentation.
 	cmd.Flags().Bool("force", false, "force upload of all files")
 	cmd.Flags().BoolVar(&cc.invalidateCDN, "invalidateCDN", true, "invalidate the CDN cache listed in the deployment target")
 	cmd.Flags().IntVar(&cc.maxDeletes, "maxDeletes", 256, "maximum # of files to delete, or -1 to disable")
-	cmd.Flags().IntVar(&cc.transfers, "transfers", 10, "number of file transfers to run in parallel. defaults to 10")
+	cmd.Flags().IntVar(&cc.workers, "workers", 10, "number of workers to transfer files. defaults to 10")
 
 	cc.baseBuilderCmd = b.newBuilderBasicCmd(cmd)
 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -31,6 +31,7 @@ type deployCmd struct {
 
 	invalidateCDN bool
 	maxDeletes    int
+	transfers     int
 }
 
 // TODO: In addition to the "deploy" command, consider adding a "--deploy"
@@ -59,6 +60,7 @@ documentation.
 			cfgInit := func(c *commandeer) error {
 				c.Set("invalidateCDN", cc.invalidateCDN)
 				c.Set("maxDeletes", cc.maxDeletes)
+				c.Set("transfers", cc.transfers)
 				return nil
 			}
 			comm, err := initializeConfig(true, true, false, &cc.hugoBuilderCommon, cc, cfgInit)
@@ -79,6 +81,7 @@ documentation.
 	cmd.Flags().Bool("force", false, "force upload of all files")
 	cmd.Flags().BoolVar(&cc.invalidateCDN, "invalidateCDN", true, "invalidate the CDN cache listed in the deployment target")
 	cmd.Flags().IntVar(&cc.maxDeletes, "maxDeletes", 256, "maximum # of files to delete, or -1 to disable")
+	cmd.Flags().IntVar(&cc.transfers, "transfers", 10, "number of file transfers to run in parallel. defaults to 10")
 
 	cc.baseBuilderCmd = b.newBuilderBasicCmd(cmd)
 

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -236,9 +236,9 @@ func initializeFlags(cmd *cobra.Command, cfg config.Provider) {
 		"target",
 		"theme",
 		"themesDir",
-		"transfers",
 		"verbose",
 		"verboseLog",
+		"workers",
 		"duplicateTargetPaths",
 	}
 

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -236,6 +236,7 @@ func initializeFlags(cmd *cobra.Command, cfg config.Provider) {
 		"target",
 		"theme",
 		"themesDir",
+		"transfers",
 		"verbose",
 		"verboseLog",
 		"duplicateTargetPaths",

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -65,6 +65,7 @@ type Deployer struct {
 	force         bool             // true forces upload of all files
 	invalidateCDN bool             // true enables invalidate CDN cache (if possible)
 	maxDeletes    int              // caps the # of files to delete; -1 to disable
+	transfers     int              // The number of file transfers to run in parallel
 
 	// For tests...
 	summary deploySummary // summary of latest Deploy results
@@ -118,6 +119,7 @@ func New(cfg config.Provider, localFs afero.Fs) (*Deployer, error) {
 		force:         cfg.GetBool("force"),
 		invalidateCDN: cfg.GetBool("invalidateCDN"),
 		maxDeletes:    cfg.GetInt("maxDeletes"),
+		transfers:     cfg.GetInt("transfers"),
 	}, nil
 }
 
@@ -189,7 +191,7 @@ func (d *Deployer) Deploy(ctx context.Context) error {
 	// Apply the changes in parallel, using an inverted worker
 	// pool (https://www.youtube.com/watch?v=5zXAHh5tJqQ&t=26m58s).
 	// sem prevents more than nParallel concurrent goroutines.
-	const nParallel = 10
+	nParallel := d.transfers
 	var errs []error
 	var errMu sync.Mutex // protects errs
 

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -191,6 +191,9 @@ func (d *Deployer) Deploy(ctx context.Context) error {
 	// Apply the changes in parallel, using an inverted worker
 	// pool (https://www.youtube.com/watch?v=5zXAHh5tJqQ&t=26m58s).
 	// sem prevents more than nParallel concurrent goroutines.
+	if d.workers <= 0 {
+		d.workers = 10
+	}
 	nParallel := d.workers
 	var errs []error
 	var errMu sync.Mutex // protects errs

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -65,7 +65,7 @@ type Deployer struct {
 	force         bool             // true forces upload of all files
 	invalidateCDN bool             // true enables invalidate CDN cache (if possible)
 	maxDeletes    int              // caps the # of files to delete; -1 to disable
-	transfers     int              // The number of file transfers to run in parallel
+	workers       int              // The number of workers to transfer files
 
 	// For tests...
 	summary deploySummary // summary of latest Deploy results
@@ -119,7 +119,7 @@ func New(cfg config.Provider, localFs afero.Fs) (*Deployer, error) {
 		force:         cfg.GetBool("force"),
 		invalidateCDN: cfg.GetBool("invalidateCDN"),
 		maxDeletes:    cfg.GetInt("maxDeletes"),
-		transfers:     cfg.GetInt("transfers"),
+		workers:       cfg.GetInt("workers"),
 	}, nil
 }
 
@@ -191,7 +191,7 @@ func (d *Deployer) Deploy(ctx context.Context) error {
 	// Apply the changes in parallel, using an inverted worker
 	// pool (https://www.youtube.com/watch?v=5zXAHh5tJqQ&t=26m58s).
 	// sem prevents more than nParallel concurrent goroutines.
-	nParallel := d.transfers
+	nParallel := d.workers
 	var errs []error
 	var errMu sync.Mutex // protects errs
 

--- a/docs/content/en/commands/hugo_deploy.md
+++ b/docs/content/en/commands/hugo_deploy.md
@@ -31,7 +31,7 @@ hugo deploy [flags]
       --ignoreVendorPaths string   ignores any _vendor for module paths matching the given Glob pattern
       --invalidateCDN              invalidate the CDN cache listed in the deployment target (default true)
       --maxDeletes int             maximum # of files to delete, or -1 to disable (default 256)
-      --transfers int              number of file transfers to run in parallel (default 10)
+      --workers int                number of workers to transfer files. (default 10)
   -s, --source string              filesystem path to read files relative from
       --target string              target deployment from deployments section in config file; defaults to the first one
       --themesDir string           filesystem path to themes directory

--- a/docs/content/en/commands/hugo_deploy.md
+++ b/docs/content/en/commands/hugo_deploy.md
@@ -31,6 +31,7 @@ hugo deploy [flags]
       --ignoreVendorPaths string   ignores any _vendor for module paths matching the given Glob pattern
       --invalidateCDN              invalidate the CDN cache listed in the deployment target (default true)
       --maxDeletes int             maximum # of files to delete, or -1 to disable (default 256)
+      --transfers int              number of file transfers to run in parallel (default 10)
   -s, --source string              filesystem path to read files relative from
       --target string              target deployment from deployments section in config file; defaults to the first one
       --themesDir string           filesystem path to themes directory


### PR DESCRIPTION
### What is the purpose?

The current hugo deploy limits the number of parallel requests by 10 with `nParallel = 10`
This PR allows customization of this value by providing another flag called transfers

### Why?

It can sometimes be useful to set this to a smaller number if the remote is giving a lot of timeouts or bigger if you have lots of bandwidth and a fast remote.

In my testing setting this to 100 in one of our bigger deployment runners reduced our time to deploy to s3 from `1min 50s` to `32s`

### Existing users

Exiting users should see no change as it will default to 10

### Example Usage

```bash
hugo deploy --target foo --workers 20
```

