### PR TITLE
cache: Fix --gc failure on Windows 

### DIFF
--- a/cache/filecache/filecache_pruner.go
+++ b/cache/filecache/filecache_pruner.go
@@ -17,8 +17,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
-	"strings"
 
 	"github.com/gohugoio/hugo/common/herrors"
 	"github.com/gohugoio/hugo/hugofs"
@@ -73,8 +71,8 @@ func (c *Cache) Prune(force bool) (int, error) {
 				// This cache dir may not exist.
 				return nil
 			}
-			defer f.Close()
 			_, err = f.Readdirnames(1)
+			f.Close()
 			if err == io.EOF {
 				// Empty dir.
 				if name == "." {
@@ -82,18 +80,6 @@ func (c *Cache) Prune(force bool) (int, error) {
 					err = nil
 				} else {
 					err = c.Fs.Remove(name)
-					if err != nil {
-						if runtime.GOOS == "windows" {
-							if strings.Contains(err.Error(), "used by another process") {
-								// See https://github.com/gohugoio/hugo/issues/10781
-								// This is a known issue on Windows with Go 1.20.
-								// There's not much we can do about it.
-								// So just return nil.
-								err = nil
-
-							}
-						}
-					}
 				}
 			}
 

--- a/cache/filecache/integration_test.go
+++ b/cache/filecache/integration_test.go
@@ -15,7 +15,6 @@ package filecache_test
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -90,12 +89,8 @@ iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAA
 	b.Assert(b.GCCount, qt.Equals, 1)
 	// Build it again to GC the empty a dir.
 	b.Build()
-	if runtime.GOOS != "windows" {
-		// See issue #58860 -- this sometimes fails on Windows,
-		// but the empty directory will be removed on the next run.
-		_, err = b.H.BaseFs.ResourcesCache.Stat(filepath.Join(imagesCacheDir, "a"))
-		b.Assert(err, qt.Not(qt.IsNil))
-	}
+	_, err = b.H.BaseFs.ResourcesCache.Stat(filepath.Join(imagesCacheDir, "a"))
+	b.Assert(err, qt.Not(qt.IsNil))
 	_, err = b.H.BaseFs.ResourcesCache.Stat(imagesCacheDir)
 	b.Assert(err, qt.IsNil)
 


### PR DESCRIPTION
On Windows, we must close the directory before removing it. This fixes
```
Error: failed to prune cache "getjson": remove
C:\Users\photo\AppData\Local\Temp\hugo_cache\quickstart\filecache\getjson:
The process cannot access the file because it is being used by another
process.
```
