### PR TITLE
Fix "context canceled" with partial

### DIFF
--- a/lazy/init.go
+++ b/lazy/init.go
@@ -180,14 +180,15 @@ func (ini *Init) checkDone() {
 }
 
 func (ini *Init) withTimeout(ctx context.Context, timeout time.Duration, f func(ctx context.Context) (any, error)) (any, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	// Create a new context with a timeout not connected to the incoming context.
+	waitCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	c := make(chan verr, 1)
 
 	go func() {
 		v, err := f(ctx)
 		select {
-		case <-ctx.Done():
+		case <-waitCtx.Done():
 			return
 		default:
 			c <- verr{v: v, err: err}
@@ -195,7 +196,7 @@ func (ini *Init) withTimeout(ctx context.Context, timeout time.Duration, f func(
 	}()
 
 	select {
-	case <-ctx.Done():
+	case <-waitCtx.Done():
 		return nil, errors.New("timed out initializing value. You may have a circular loop in a shortcode, or your site may have resources that take longer to build than the `timeout` limit in your Hugo config file.")
 	case ve := <-c:
 		return ve.v, ve.err

--- a/lazy/init_test.go
+++ b/lazy/init_test.go
@@ -126,12 +126,6 @@ func TestInitAddWithTimeoutTimeout(t *testing.T) {
 
 	init := New().AddWithTimeout(100*time.Millisecond, func(ctx context.Context) (any, error) {
 		time.Sleep(500 * time.Millisecond)
-		select {
-		case <-ctx.Done():
-			return nil, nil
-		default:
-		}
-		t.Fatal("slept")
 		return nil, nil
 	})
 

--- a/resources/transform.go
+++ b/resources/transform.go
@@ -164,12 +164,12 @@ type resourceAdapter struct {
 	*resourceAdapterInner
 }
 
-func (r *resourceAdapter) Content(context.Context) (any, error) {
+func (r *resourceAdapter) Content(ctx context.Context) (any, error) {
 	r.init(false, true)
 	if r.transformationsErr != nil {
 		return nil, r.transformationsErr
 	}
-	return r.target.Content(context.Background())
+	return r.target.Content(ctx)
 }
 
 func (r *resourceAdapter) Err() resource.ResourceError {


### PR DESCRIPTION
Make sure the context used for partial timeouts isn't created based on the incoming
context, as we have cases where this can cancel the context prematurely.

Fixes #10789
