### PR TITLE
docs: Modify hosting on github document

### DIFF
--- a/docs/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/docs/content/en/hosting-and-deployment/hosting-on-github.md
@@ -59,7 +59,8 @@ on:
     branches:
       - main  # Set a branch that will trigger a deployment
   pull_request:
-
+permissions:
+  contents: write
 jobs:
   deploy:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## What
Modify hosting-on-github.md, add content writing permission to example github action file from 'Build Hugo With GitHub Action' section
## Why
I tried to host a hugo project on github page with this [workflow](https://github.com/peaceiris/actions-hugo#%EF%B8%8F-create-your-workflow) but it didn't work
I found a issue because the default permission for GITHUB_TOKEN was [changed](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions) from “read and write” to “read only”
so github action cannot write static files to `gh-pages` branch
## Expected
Update hugo offical document and update README of https://github.com/peaceiris/actions-hugo
