### PR TITLE
PoC: hugo.mod as module file

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/gohugoio/hugo/hugofs/files"
+	"github.com/gohugoio/hugo/modules"
 	"github.com/gohugoio/hugo/tpl"
 
 	"github.com/gohugoio/hugo/common/herrors"
@@ -942,7 +943,7 @@ func (c *commandeer) handleEvents(watcher *watcher.Batcher,
 		isConfig := configSet[ev.Name]
 		configChangeType := configChangeConfig
 		if isConfig {
-			if strings.Contains(ev.Name, "go.mod") {
+			if modules.IsGoMod(ev.Name) {
 				configChangeType = configChangeGoMod
 			}
 			if strings.Contains(ev.Name, ".work") {

--- a/modules/client.go
+++ b/modules/client.go
@@ -68,6 +68,12 @@ const (
 	goSumFilename = "go.sum"
 )
 
+var isGoModRe = regexp.MustCompile(`(hu)?go\.mod$`)
+
+func IsGoMod(filename string) bool {
+	return isGoModRe.MatchString(filename)
+}
+
 // NewClient creates a new Client that can be used to manage the Hugo Components
 // in a given workingDir.
 // The Client will resolve the dependencies recursively, but needs the top

--- a/modules/client_test.go
+++ b/modules/client_test.go
@@ -211,3 +211,13 @@ func TestGetModlineSplitter(t *testing.T) {
 	gosumSplitter := getModlineSplitter(false)
 	c.Assert(gosumSplitter("github.com/BurntSushi/toml v0.3.1"), qt.DeepEquals, []string{"github.com/BurntSushi/toml", "v0.3.1"})
 }
+
+func TestIsGoMod(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(IsGoMod("go.mod"), qt.IsTrue)
+	c.Assert(IsGoMod("a/b/go.mod"), qt.IsTrue)
+	c.Assert(IsGoMod("hugo.mod"), qt.IsTrue)
+	c.Assert(IsGoMod("go.sum"), qt.IsFalse)
+	c.Assert(IsGoMod("go.mod.go"), qt.IsFalse)
+}

--- a/modules/integration_test.go
+++ b/modules/integration_test.go
@@ -1,0 +1,53 @@
+// Copyright 2023 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules_test
+
+import (
+	"testing"
+
+	"github.com/gohugoio/hugo/hugolib"
+)
+
+func TestHugoModFile(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com"
+disableKinds = ["taxonomy", "term"]
+[module]
+[[module.imports]]
+path = "github.com/bep/hugo-mod-with-hugodotmod/v5"
+-- layouts/_default/index.html --
+// This comes from the module imported.
+{{ $foo := resources.Get "foo.txt" }}
+Foo: {{ with $foo }}{{ .Content }}{{ end }}|
+-- go.mod --
+module github.com/gohugoio/testmod
+
+go 1.20
+
+`
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+			NeedsOsFS:   true,
+			Verbose:     true,
+		},
+	).Build()
+
+	b.AssertFileContent("public/index.html", "Foo: bar")
+
+}

--- a/modules/integration_test.go
+++ b/modules/integration_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gohugoio/hugo/hugolib"
 )
 
-func TestHugoModFile(t *testing.T) {
+func TestHugoModFileV5(t *testing.T) {
 	t.Parallel()
 
 	files := `
@@ -49,5 +49,105 @@ go 1.20
 	).Build()
 
 	b.AssertFileContent("public/index.html", "Foo: bar")
+
+}
+
+func TestHugoModWithGoModFileV5(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com"
+disableKinds = ["taxonomy", "term"]
+[module]
+[[module.imports]]
+path = "github.com/bep/hugo-mod-with-hugodotmod/v5"
+-- layouts/_default/index.html --
+// This comes from the module imported.
+{{ $foo := resources.Get "foo.txt" }}
+Foo: {{ with $foo }}{{ .Content }}{{ end }}|
+-- go.mod --
+module github.com/gohugoio/testmod
+
+go 1.20
+
+`
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+			NeedsOsFS:   true,
+			Verbose:     true,
+		},
+	).Build()
+
+	b.AssertFileContent("public/index.html", "Foo: bar")
+
+}
+
+func TestHugoModFileV6(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com"
+disableKinds = ["taxonomy", "term"]
+[module]
+[[module.imports]]
+path = "github.com/bep/hugo-mod-with-hugodotmod/v6"
+-- layouts/_default/index.html --
+// This comes from the module imported.
+{{ $foo := resources.Get "foo.txt" }}
+Foo: {{ with $foo }}{{ .Content }}{{ end }}|
+-- hugo.mod --
+module github.com/gohugoio/testmod
+
+go 1.20
+
+`
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+			NeedsOsFS:   true,
+			Verbose:     true,
+		},
+	).Build()
+
+	b.AssertFileContent("public/index.html", "Foo: baz")
+
+}
+
+// same as above but no /v6, just directly to the repo
+func TestHugoModFileV6WithoutPackage(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com"
+disableKinds = ["taxonomy", "term"]
+[module]
+[[module.imports]]
+path = "github.com/bep/hugo-mod-with-hugodotmod"
+-- layouts/_default/index.html --
+// This comes from the module imported.
+{{ $foo := resources.Get "foo.txt" }}
+Foo: {{ with $foo }}{{ .Content }}{{ end }}|
+-- hugo.mod --
+module github.com/gohugoio/testmod
+
+go 1.20
+
+`
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+			NeedsOsFS:   true,
+			Verbose:     true,
+		},
+	).Build()
+
+	b.AssertFileContent("public/index.html", "Foo: baz")
 
 }

--- a/modules/integration_test.go
+++ b/modules/integration_test.go
@@ -33,7 +33,7 @@ path = "github.com/bep/hugo-mod-with-hugodotmod/v5"
 // This comes from the module imported.
 {{ $foo := resources.Get "foo.txt" }}
 Foo: {{ with $foo }}{{ .Content }}{{ end }}|
--- go.mod --
+-- hugo.mod --
 module github.com/gohugoio/testmod
 
 go 1.20


### PR DESCRIPTION
- Works with hugo.mod and go.mod as in `TestHugoModFileV5` and `TestHugoModWithGoModFileV5`
- `TestHugoModFileV6` fails because of the `/v6` "package version suffix" and go does some extra checks, that it probably can find such a module exactly as written in the go.mod file. If such suffix is omitted, the download works, as shown in `TestHugoModFileV6WithoutPackage`
```
go get --modfile=hugo.mod github.com/bep/hugo-mod-with-hugodotmod
go: added github.com/bep/hugo-mod-with-hugodotmod v5.1.1-0.20230308145733-c3e39ab6de5b+incompatible
```
- There will still be some more work needed to continue this path of reading hugo.mod from transitive packages
- `c.GoModulesFilename` should probably be used without the full path. I used this one to check for the "current active module" and whether I need to append `-modfile` to go commands or hacking a temporary go.mod file.
