### PR TITLE
Unclosed shortcode with inner content: improved error message

### DIFF
--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -689,7 +689,7 @@ Loop:
 		case currItem.IsDone():
 			if !currItem.IsError() {
 				if !closed && sc.needsInner() {
-					return sc, fmt.Errorf("%s: unclosed shortcode %q", errorPrefix, sc.name)
+					return sc, fmt.Errorf("%s: shortcode %q must be closed or self-closed", errorPrefix, sc.name)
 				}
 			}
 			// handled by caller

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -1274,5 +1274,5 @@ Inner: {{ .Get 0 }}: {{ len .Inner }}
 	).BuildE()
 
 	b.Assert(err, qt.Not(qt.IsNil))
-	b.Assert(err.Error(), qt.Contains, `p1.md:5:1": failed to extract shortcode: unclosed shortcode "sc"`)
+	b.Assert(err.Error(), qt.Contains, `p1.md:5:1": failed to extract shortcode: shortcode "sc" must be closed or self-closed`)
 }


### PR DESCRIPTION
Following up on this [thread](https://discourse.gohugo.io/t/hugo-0-111-2-failure-with-unclosed-shortcodes/43368) in hugo discourse, this PR aims at improving the error message printed out when hugo encounters an unclosed shortcode with inner content. The message is now in line with the [wording](https://gohugo.io/templates/shortcode-templates/#inner) in the official hugo docs.