### PR TITLE
tpl/lang: Document delimiter option for FormatNumberCustom

### DIFF
--- a/tpl/lang/init.go
+++ b/tpl/lang/init.go
@@ -72,6 +72,7 @@ func init() {
 				{`{{ lang.FormatNumberCustom 2 12345.6789 "- , ." }}`, `12.345,68`},
 				{`{{ lang.FormatNumberCustom 6 -12345.6789 "- ." }}`, `-12345.678900`},
 				{`{{ lang.FormatNumberCustom 0 -12345.6789 "- . ," }}`, `-12,346`},
+				{`{{ lang.FormatNumberCustom 0 -12345.6789 "-|.| " "|" }}`, `-12 346`},
 				{`{{ -98765.4321 | lang.FormatNumberCustom 2 }}`, `-98,765.43`},
 			},
 		)

--- a/tpl/lang/lang.go
+++ b/tpl/lang/lang.go
@@ -133,10 +133,10 @@ func (ns *Namespace) castPrecisionNumber(precision, number any) (uint64, float64
 	return p, n, nil
 }
 
-// FormatNumberCustom formats a number with the given precision using the
-// negative, decimal, and grouping options.  The `options`
-// parameter is a string consisting of `<negative> <decimal> <grouping>`.  The
-// default `options` value is `- . ,`.
+// FormatNumberCustom formats a number with the given precision. The first
+// options parameter is a space-delimited string of characters to represent
+// negativity, the decimal point, and grouping. The default value is `- . ,`.
+// The second options parameter defines an alternate delimiting character.
 //
 // Note that numbers are rounded up at 5 or greater.
 // So, with precision set to 0, 1.5 becomes `2`, and 1.4 becomes `1`.


### PR DESCRIPTION
Closes gohugoio/hugoDocs#1760