### PR TITLE
postCSS: improve validation of option 'config'

### DIFF
--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -188,19 +188,19 @@ func (b *BaseFs) AbsProjectContentDir(filename string) (string, string, error) {
 
 // ResolveJSConfigFile resolves the JS-related config file to a absolute
 // filename. One example of such would be postcss.config.js.
-func (fs *BaseFs) ResolveJSConfigFile(name string) string {
+func (fs *BaseFs) ResolveJSConfigFile(name string) (string, bool) {
 	// First look in assets/_jsconfig
 	fi, err := fs.Assets.Fs.Stat(filepath.Join(files.FolderJSConfig, name))
 	if err == nil {
-		return fi.(hugofs.FileMetaInfo).Meta().Filename
+		return fi.(hugofs.FileMetaInfo).Meta().Filename, fi.IsDir()
 	}
 	// Fall back to the work dir.
 	fi, err = fs.Work.Stat(name)
 	if err == nil {
-		return fi.(hugofs.FileMetaInfo).Meta().Filename
+		return fi.(hugofs.FileMetaInfo).Meta().Filename, fi.IsDir()
 	}
 
-	return ""
+	return "", false
 }
 
 // MakePathRelative creates a relative path from the given filename.

--- a/resources/resource_transformers/babel/babel.go
+++ b/resources/resource_transformers/babel/babel.go
@@ -134,13 +134,17 @@ func (t *babelTransformation) Transform(ctx *resources.ResourceTransformationCtx
 	}
 
 	configFile = filepath.Clean(configFile)
+	isConfigFileDir := false
 
 	// We need an absolute filename to the config file.
 	if !filepath.IsAbs(configFile) {
-		configFile = t.rs.BaseFs.ResolveJSConfigFile(configFile)
+		configFile, isConfigFileDir = t.rs.BaseFs.ResolveJSConfigFile(configFile)
+		if isConfigFileDir {
+			logger.Warnf("babel config %q must be a file, not a directory", configFile)
+		}
 		if configFile == "" && t.options.Config != "" {
 			// Only fail if the user specified config file is not found.
-			return fmt.Errorf("babel config %q not found:", configFile)
+			return fmt.Errorf("babel config file %q not found", configFile)
 		}
 	}
 

--- a/resources/resource_transformers/postcss/postcss.go
+++ b/resources/resource_transformers/postcss/postcss.go
@@ -172,13 +172,17 @@ func (t *postcssTransformation) Transform(ctx *resources.ResourceTransformationC
 	}
 
 	configFile = filepath.Clean(configFile)
+	isConfigFileDir := false
 
 	// We need an absolute filename to the config file.
 	if !filepath.IsAbs(configFile) {
-		configFile = t.rs.BaseFs.ResolveJSConfigFile(configFile)
+		configFile, isConfigFileDir = t.rs.BaseFs.ResolveJSConfigFile(configFile)
 		if configFile == "" && options.Config != "" {
 			// Only fail if the user specified config file is not found.
-			return fmt.Errorf("postcss config %q not found:", options.Config)
+			return fmt.Errorf("postcss config directory %q not found", options.Config)
+		}
+		if !isConfigFileDir {
+			logger.Warnf("postcss config %q must be a directory", options.Config)
 		}
 	}
 


### PR DESCRIPTION
This PR follows up on #10846. It adds validation for the `config` option: if the value given for 'config` is not a directory, a warning is emitted.

**With this patch applied:**

```
git clone --single-branch -b hugo-github-issue-10846 https://github.com/jmooring/hugo-testing hugo-github-issue-10846
cd hugo-github-issue-10846
npm ci
hugo_0.112.dev
Start building sites … 
hugo v0.112.0-DEV-720f41aab4fa9185957be65c5c7a92261715e297+extended linux/amd64 BuildDate=2023-03-25T20:05:11Z
WARN 2023/03/25 21:35:33 found no layout file for "HTML" for kind "home": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
WARN 2023/03/25 21:35:33 found no layout file for "HTML" for kind "taxonomy": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
WARN 2023/03/25 21:35:33 found no layout file for "HTML" for kind "taxonomy": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
WARN 2023/03/25 21:35:33 postcss config "mydir/postcss.config.js" must be a directory
```

Note the last line with the warning.

**Without this patch:**

No warning is emitted / no error is thrown.

 