### PR TITLE
Add missing space in documentation

### DIFF
--- a/docs/content/en/content-management/syntax-highlighting.md
+++ b/docs/content/en/content-management/syntax-highlighting.md
@@ -131,7 +131,7 @@ func GetTitleFunc(style string) func(s string) string {
 }
 ```
 
-The options are the same as in the [highlighting shortcode](/content-management/syntax-highlighting/#highlight-shortcode),including `linenos=false`, but note the slightly different Markdown attribute syntax.
+The options are the same as in the [highlighting shortcode](/content-management/syntax-highlighting/#highlight-shortcode), including `linenos=false`, but note the slightly different Markdown attribute syntax.
 
 ## List of Chroma Highlighting Languages
 


### PR DESCRIPTION
This is a minor typo fix.