### PR TITLE
docs: Correct spelling of 'GitHub'

### DIFF
--- a/docs/content/en/hosting-and-deployment/hosting-on-azure.md
+++ b/docs/content/en/hosting-and-deployment/hosting-on-azure.md
@@ -1,7 +1,7 @@
 ---
 title: Host on Azure Static Web Apps
 linktitle: Host on Azure Static Web Apps
-description: Deploy Hugo to Azure Static Web Apps and automate the whole process with Github Action Workflow
+description: Deploy Hugo to Azure Static Web Apps and automate the whole process with GitHub Action Workflow
 date: 2021-03-12
 publishdate: 2021-03-12
 categories: [hosting and deployment]

--- a/docs/content/en/hosting-and-deployment/hosting-on-firebase.md
+++ b/docs/content/en/hosting-and-deployment/hosting-on-firebase.md
@@ -51,7 +51,7 @@ From here:
 4. Accept the default for the publish directory, which is `public`
 5. Choose "No" in the question if you are deploying a single-page app
 
-## Using Firebase & Github CI/CD
+## Using Firebase & GitHub CI/CD
 
 In new versions of Firebase, some other questions apply:
 
@@ -62,7 +62,7 @@ Here you will be redirected to login in your GitHub account to get permissions. 
 7. For which GitHub repository would you like to set up a GitHub workflow? (format: user/repository) 
 
 Include the repository you will use in the format above (Account/Repo)
-Firebase script with retrive credentials, create a service account you can later manage in your github settings.
+Firebase script with retrive credentials, create a service account you can later manage in your GitHub settings.
 
 8. Set up the workflow to run a build script before every deploy? 
 
@@ -78,7 +78,7 @@ After that Firebase has been set in your project with CI/CD. After that run:
 hugo && firebase deploy
 ```
 
-With this you will have the app initialized manually. After that you can manage and fix your github workflow from: https://github.com/your-account/yout-repo/actions
+With this you will have the app initialized manually. After that you can manage and fix your GitHub workflow from: https://github.com/your-account/yout-repo/actions
 
 Don't forget to update your static pages before push!
 

--- a/docs/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/docs/content/en/hosting-and-deployment/hosting-on-github.md
@@ -1,7 +1,7 @@
 ---
 title: Host on GitHub
 linktitle: Host on GitHub
-description: Deploy Hugo as a GitHub Pages project or personal/organizational site and automate the whole process with Github Action Workflow
+description: Deploy Hugo as a GitHub Pages project or personal/organizational site and automate the whole process with GitHub Action Workflow
 date: 2014-03-21
 publishdate: 2014-03-21
 categories: [hosting and deployment]
@@ -52,7 +52,7 @@ GitHub executes your software development workflows. Every time you push your co
 Create a file in `.github/workflows/gh-pages.yml` containing the following content (based on [actions-hugo](https://github.com/marketplace/actions/hugo-setup)):
 
 ```yml
-name: github pages
+name: GitHub pages
 
 on:
   push:


### PR DESCRIPTION
This PR modifies `*.md` files to use only `GitHub` word.