### PR TITLE
all: Fix comments for exported functions and packages

### DIFF
--- a/common/herrors/errors.go
+++ b/common/herrors/errors.go
@@ -49,7 +49,7 @@ func Recover(args ...any) {
 	}
 }
 
-// Get the current goroutine id. Used only for debugging.
+// GetGID the current goroutine id. Used only for debugging.
 func GetGID() uint64 {
 	b := make([]byte, 64)
 	b = b[:runtime.Stack(b, false)]

--- a/common/herrors/file_error.go
+++ b/common/herrors/file_error.go
@@ -35,7 +35,7 @@ import (
 type FileError interface {
 	error
 
-	// ErroContext holds some context information about the error.
+	// ErrorContext holds some context information about the error.
 	ErrorContext() *ErrorContext
 
 	text.Positioner

--- a/common/maps/params.go
+++ b/common/maps/params.go
@@ -37,7 +37,7 @@ func (p Params) GetNested(indices ...string) any {
 	return v
 }
 
-// Set overwrites values in dst with values in src for common or new keys.
+// SetParams overwrites values in dst with values in src for common or new keys.
 // This is done recursively.
 func SetParams(dst, src Params) {
 	for k, v := range src {
@@ -83,7 +83,7 @@ func MergeParamsWithStrategy(strategy string, dst, src Params) {
 	dst.merge(ParamsMergeStrategy(strategy), src)
 }
 
-// MergeParamsWithStrategy transfers values from src to dst for new keys using the merge encoded in dst.
+// MergeParams transfers values from src to dst for new keys using the merge encoded in dst.
 // This is done recursively.
 func MergeParams(dst, src Params) {
 	ms, _ := dst.GetMergeStrategy()

--- a/config/security/whitelist.go
+++ b/config/security/whitelist.go
@@ -84,7 +84,7 @@ func NewWhitelist(patterns ...string) Whitelist {
 	return Whitelist{patterns: patternsr, patternsStrings: patternsStrings}
 }
 
-// Accepted reports whether name is whitelisted.
+// Accept reports whether name is whitelisted.
 func (w Whitelist) Accept(name string) bool {
 	if w.acceptNone {
 		return false

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -231,7 +231,7 @@ type globalErrHandler struct {
 	quit chan struct{}
 }
 
-// SendErr sends the error on a channel to be handled later.
+// SendError sends the error on a channel to be handled later.
 // This can be used in situations where returning and aborting the current
 // operation isn't practical.
 func (e *globalErrHandler) SendError(err error) {

--- a/helpers/general.go
+++ b/helpers/general.go
@@ -117,7 +117,7 @@ func UniqueStringsReuse(s []string) []string {
 	return result
 }
 
-// UniqueStringsReuse returns a sorted slice with any duplicates removed.
+// UniqueStringsSorted returns a sorted slice with any duplicates removed.
 // It will modify the input slice.
 func UniqueStringsSorted(s []string) []string {
 	if len(s) == 0 {

--- a/hugofs/fs.go
+++ b/hugofs/fs.go
@@ -85,7 +85,7 @@ func NewFromOld(fs afero.Fs, cfg config.Provider) *Fs {
 	return newFs(fs, fs, workingDir, publishDir)
 }
 
-// NewFrom creates a new Fs based on the provided Afero Fss
+// NewFromSourceAndDestination creates a new Fs based on the provided Afero Fss
 // as the source and destination file systems.
 func NewFromSourceAndDestination(source, destination afero.Fs, cfg config.Provider) *Fs {
 	workingDir, publishDir := getWorkingPublishDir(cfg)
@@ -178,7 +178,7 @@ func MakeReadableAndRemoveAllModulePkgDir(fs afero.Fs, dir string) (int, error) 
 	return counter, fs.RemoveAll(dir)
 }
 
-// HasOsFs returns whether fs is an OsFs or if it fs wraps an OsFs.
+// IsOsFs returns whether fs is an OsFs or if it fs wraps an OsFs.
 // TODO(bep) make this nore robust.
 func IsOsFs(fs afero.Fs) bool {
 	var isOsFs bool
@@ -202,7 +202,7 @@ type FilesystemsUnwrapper interface {
 	UnwrapFilesystems() []afero.Fs
 }
 
-// FilesystemsProvider returns the underlying filesystem.
+// FilesystemUnwrapper returns the underlying filesystem.
 type FilesystemUnwrapper interface {
 	UnwrapFilesystem() afero.Fs
 }

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -146,7 +146,7 @@ func (p *pageState) Eq(other any) bool {
 	return p == pp
 }
 
-// GetIdentify is for internal use.
+// GetIdentity is for internal use.
 func (p *pageState) GetIdentity() identity.Identity {
 	return identity.NewPathIdentity(files.ComponentFolderContent, filepath.FromSlash(p.Pathc()))
 }

--- a/hugolib/pagecollections.go
+++ b/hugolib/pagecollections.go
@@ -57,7 +57,7 @@ func (c *PageCollections) AllPages() page.Pages {
 	return c.allPages.get()
 }
 
-// AllPages returns all regular pages for all languages.
+// AllRegularPages returns all regular pages for all languages.
 func (c *PageCollections) AllRegularPages() page.Pages {
 	return c.allRegularPages.get()
 }

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -20,7 +20,7 @@ import (
 	"sync/atomic"
 )
 
-// NewIdentityManager creates a new Manager starting at id.
+// NewManager creates a new Manager starting at id.
 func NewManager(id Provider) Manager {
 	return &identityManager{
 		Provider: id,

--- a/langs/i18n/translationProvider.go
+++ b/langs/i18n/translationProvider.go
@@ -123,7 +123,7 @@ func addTranslationFile(bundle *i18n.Bundle, r source.File) error {
 	return nil
 }
 
-// Clone sets the language func for the new language.
+// CloneResource sets the language func for the new language.
 func (tp *TranslationProvider) CloneResource(dst, src *deps.Deps) error {
 	dst.Translate = tp.t.Func(dst.Conf.Language().Lang)
 	return nil

--- a/lazy/init.go
+++ b/lazy/init.go
@@ -73,7 +73,7 @@ func (ini *Init) Branch(initFn func(context.Context) (any, error)) *Init {
 	return ini.add(true, initFn)
 }
 
-// BranchdWithTimeout is same as Branch, but with a timeout.
+// BranchWithTimeout is same as Branch, but with a timeout.
 func (ini *Init) BranchWithTimeout(timeout time.Duration, f func(ctx context.Context) (any, error)) *Init {
 	return ini.Branch(func(ctx context.Context) (any, error) {
 		return ini.withTimeout(ctx, timeout, f)

--- a/markup/asciidocext/asciidocext_config/config.go
+++ b/markup/asciidocext/asciidocext_config/config.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package asciidoc_config holds asciidoc related configuration.
+// Package asciidocext_config holds asciidoc related configuration.
 package asciidocext_config
 
 var (

--- a/markup/converter/hooks/hooks.go
+++ b/markup/converter/hooks/hooks.go
@@ -121,7 +121,7 @@ type HeadingContext interface {
 
 // HeadingRenderer describes a uniquely identifiable rendering hook.
 type HeadingRenderer interface {
-	// Render writes the rendered content to w using the data in w.
+	// RenderHeading writes the rendered content to w using the data in w.
 	RenderHeading(cctx context.Context, w io.Writer, ctx HeadingContext) error
 	identity.Provider
 }

--- a/markup/goldmark/codeblocks/transform.go
+++ b/markup/goldmark/codeblocks/transform.go
@@ -6,7 +6,7 @@ import (
 	"github.com/yuin/goldmark/text"
 )
 
-// Kind is the kind of an Hugo code block.
+// KindCodeBlock is the kind of an Hugo code block.
 var KindCodeBlock = ast.NewNodeKind("HugoCodeBlock")
 
 // Its raw contents are the plain text of the code block.

--- a/markup/goldmark/goldmark_config/config.go
+++ b/markup/goldmark/goldmark_config/config.go
@@ -20,7 +20,7 @@ const (
 	AutoHeadingIDTypeBlackfriday = "blackfriday"
 )
 
-// DefaultConfig holds the default Goldmark configuration.
+// Default holds the default Goldmark configuration.
 var Default = Config{
 	Extensions: Extensions{
 		Typographer: Typographer{

--- a/markup/highlight/highlight.go
+++ b/markup/highlight/highlight.go
@@ -148,7 +148,7 @@ func (h chromaHighlighter) IsDefaultCodeBlockRenderer() bool {
 
 var id = identity.NewPathIdentity("chroma", "highlight")
 
-// GetIdentify is for internal use.
+// GetIdentity is for internal use.
 func (h chromaHighlighter) GetIdentity() identity.Identity {
 	return id
 }

--- a/markup/internal/attributes/attributes.go
+++ b/markup/internal/attributes/attributes.go
@@ -199,7 +199,7 @@ func RenderASTAttributes(w hugio.FlexiWriter, attributes ...ast.Attribute) {
 	}
 }
 
-// Render writes the attributes to the given as attributes to an HTML element.
+// RenderAttributes Render writes the attributes to the given as attributes to an HTML element.
 // This is used for the default codeblock rendering.
 // This performs HTML escaping of string attributes.
 func RenderAttributes(w hugio.FlexiWriter, skipClass bool, attributes ...Attribute) {

--- a/markup/tableofcontents/tableofcontents.go
+++ b/markup/tableofcontents/tableofcontents.go
@@ -31,7 +31,7 @@ type Builder struct {
 	toc *Fragments
 }
 
-// Add adds the heading to the ToC.
+// AddAt adds the heading to the ToC.
 func (b *Builder) AddAt(h *Heading, row, level int) {
 	if b.toc == nil {
 		b.toc = &Fragments{}

--- a/resources/page/page.go
+++ b/resources/page/page.go
@@ -334,7 +334,7 @@ type PageWithoutContent interface {
 	// Used in change/dependency tracking.
 	identity.Provider
 
-	// Headings returns the headings for this page when a filter is set.
+	// HeadingsFiltered returns the headings for this page when a filter is set.
 	// This is currently only triggered with the Related content feature
 	// and the "fragments" type of index.
 	HeadingsFiltered(context.Context) tableofcontents.Headings
@@ -373,7 +373,7 @@ type RefProvider interface {
 	// RelRef returns a relative URL to a page.
 	RelRef(argsm map[string]any) (string, error)
 
-	// RefFrom is for internal use only.
+	// RelRefFrom is for internal use only.
 	RelRefFrom(argsm map[string]any, source any) (string, error)
 }
 

--- a/resources/page/site.go
+++ b/resources/page/site.go
@@ -128,13 +128,13 @@ type Site interface {
 	// For internal use only.
 	GetPageWithTemplateInfo(info tpl.Info, ref ...string) (Page, error)
 
-	// BuildDraft is deprecated and will be removed in a future release.
+	// BuildDrafts is deprecated and will be removed in a future release.
 	BuildDrafts() bool
 
-	// IsMultilingual reports whether this site is configured with more than one language.
+	// IsMultiLingual reports whether this site is configured with more than one language.
 	IsMultiLingual() bool
 
-	// LanguagePrefi returns the language prefix for this site.
+	// LanguagePrefix returns the language prefix for this site.
 	LanguagePrefix() string
 }
 

--- a/resources/postpub/postpub.go
+++ b/resources/postpub/postpub.go
@@ -55,7 +55,7 @@ func NewPostPublishResource(id int, r resource.Resource) PostPublishedResource {
 	}
 }
 
-// postPublishResource holds a Resource to be transformed post publishing.
+// PostPublishResource holds a Resource to be transformed post publishing.
 type PostPublishResource struct {
 	prefix   string
 	delegate resource.Resource

--- a/resources/resource_transformers/tocss/dartsass/client.go
+++ b/resources/resource_transformers/tocss/dartsass/client.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package godartsass integrates with the Dass Sass Embedded protocol to transpile
+// Package dartsass integrates with the Dass Sass Embedded protocol to transpile
 // SCSS/SASS.
 package dartsass
 

--- a/tpl/compare/compare.go
+++ b/tpl/compare/compare.go
@@ -197,7 +197,7 @@ func (n *Namespace) Le(first any, others ...any) bool {
 	return true
 }
 
-// Lt returns the boolean truth of arg1 < arg2 && arg1 < arg3 && arg1 < arg4.
+// LtCollate returns the boolean truth of arg1 < arg2 && arg1 < arg3 && arg1 < arg4.
 // The provided collator will be used for string comparisons.
 // This is for internal use.
 func (n *Namespace) LtCollate(collator *langs.Collator, first any, others ...any) bool {


### PR DESCRIPTION
This PR changes comments for functions and packages, so that function/package names in comments and code are synchronized.