### PR TITLE
Make language merging of markup etc. config without values in the root

### DIFF
--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -748,8 +748,13 @@ func FromLoadConfigResult(fs afero.Fs, res config.LoadConfigResult) (*Configs, e
 						}
 					}
 				} else {
-					// Apply new values to the root.
-					differentRootKeys = append(differentRootKeys, "")
+					switch vv.(type) {
+					case maps.Params:
+						differentRootKeys = append(differentRootKeys, kk)
+					default:
+						// Apply new values to the root.
+						differentRootKeys = append(differentRootKeys, "")
+					}
 				}
 			}
 			differentRootKeys = helpers.UniqueStringsSorted(differentRootKeys)

--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -214,22 +214,6 @@ func (l configLoader) normalizeCfg(cfg config.Provider) error {
 		cfg.Set("minify", maps.Params{"minifyOutput": true})
 	}
 
-	// Simplify later merge.
-	languages := cfg.GetStringMap("languages")
-	for _, v := range languages {
-		switch m := v.(type) {
-		case maps.Params:
-			// params have merge strategy deep by default.
-			// The languages config key has strategy none by default.
-			// This means that if these two sections does not exist on the left side,
-			// they will not get merged in, so just create some empty maps.
-			if _, ok := m["params"]; !ok {
-				m["params"] = maps.Params{}
-			}
-		}
-
-	}
-
 	return nil
 }
 

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -898,6 +898,59 @@ mainSections: []
 
 }
 
+func TestConfigMergeLanguageDeepEmptyLefSide(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+[params]
+p1 = "p1base"
+[languages.en]
+languageCode = 'en-US'
+languageName = 'English'
+weight = 1
+[languages.en.markup.goldmark.extensions.typographer]
+leftDoubleQuote = '&ldquo;'   # default &ldquo;
+rightDoubleQuote = '&rdquo;'  # default &rdquo;
+
+[languages.de]
+languageCode = 'de-DE'
+languageName = 'Deutsch'
+weight = 2
+[languages.de.params]
+p1 = "p1de"
+[languages.de.markup.goldmark.extensions.typographer]
+leftDoubleQuote = '&laquo;'   # default &ldquo;
+rightDoubleQuote = '&raquo;'  # default &rdquo;
+-- layouts/index.html --
+{{ .Content }}
+p1: {{ site.Params.p1 }}|
+-- content/_index.en.md --
+---
+title: "English Title"
+---
+A "quote" in English.
+-- content/_index.de.md --
+---
+title: "Deutsch Title"
+---
+Ein "Zitat" auf Deutsch.
+
+
+
+`
+	b := NewIntegrationTestBuilder(
+		IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+		},
+	).Build()
+
+	b.AssertFileContent("public/index.html", "p1: p1base", "<p>A &ldquo;quote&rdquo; in English.</p>")
+	b.AssertFileContent("public/de/index.html", "p1: p1de", "<p>Ein &laquo;Zitat&raquo; auf Deutsch.</p>")
+
+}
+
 func TestConfigLegacyValues(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Updates #10953
