### PR TITLE
all: Fix typos in function names, tests and comments

### DIFF
--- a/cache/docs.go
+++ b/cache/docs.go
@@ -1,2 +1,2 @@
-// Package cache contains the differenct cache implementations.
+// Package cache contains the different cache implementations.
 package cache

--- a/cache/filecache/filecache_config.go
+++ b/cache/filecache/filecache_config.go
@@ -81,7 +81,7 @@ type FileCacheConfig struct {
 	// Max age of cache entries in this cache. Any items older than this will
 	// be removed and not returned from the cache.
 	// A negative value means forever, 0 means cache is disabled.
-	// Hugo is leninent with what types it accepts here, but we recommend using
+	// Hugo is lenient with what types it accepts here, but we recommend using
 	// a duration string, a sequence of  decimal numbers, each with optional fraction and a unit suffix,
 	// such as "300ms", "1.5h" or "2h45m".
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".

--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -239,11 +239,11 @@ func (r *rootCommand) ConfigFromProvider(key int32, cfg config.Provider) (*commo
 		renderStaticToDisk := cfg.GetBool("renderStaticToDisk")
 
 		sourceFs := hugofs.Os
-		var desinationFs afero.Fs
+		var destinationFs afero.Fs
 		if cfg.GetBool("renderToDisk") {
-			desinationFs = hugofs.Os
+			destinationFs = hugofs.Os
 		} else {
-			desinationFs = afero.NewMemMapFs()
+			destinationFs = afero.NewMemMapFs()
 			if renderStaticToDisk {
 				// Hybrid, render dynamic content to Root.
 				cfg.Set("publishDirDynamic", "/")
@@ -254,7 +254,7 @@ func (r *rootCommand) ConfigFromProvider(key int32, cfg config.Provider) (*commo
 			}
 		}
 
-		fs := hugofs.NewFromSourceAndDestination(sourceFs, desinationFs, cfg)
+		fs := hugofs.NewFromSourceAndDestination(sourceFs, destinationFs, cfg)
 
 		if renderStaticToDisk {
 			dynamicFs := fs.PublishDir

--- a/commands/convert.go
+++ b/commands/convert.go
@@ -84,7 +84,7 @@ type convertCommand struct {
 	r *rootCommand
 	h *hugolib.HugoSites
 
-	// Commmands.
+	// Commands.
 	commands []simplecobra.Commander
 }
 

--- a/common/herrors/error_locator.go
+++ b/common/herrors/error_locator.go
@@ -33,7 +33,7 @@ type LineMatcher struct {
 }
 
 // LineMatcherFn is used to match a line with an error.
-// It returns the column number or 0 if the line was found, but column could not be determinde. Returns -1 if no line match.
+// It returns the column number or 0 if the line was found, but column could not be determined. Returns -1 if no line match.
 type LineMatcherFn func(m LineMatcher) int
 
 // SimpleLineMatcher simply matches by line number.

--- a/common/herrors/file_error.go
+++ b/common/herrors/file_error.go
@@ -292,7 +292,7 @@ func extractFileTypePos(err error) (string, text.Position) {
 	}
 
 	// The error type from the minifier contains line number and column number.
-	if line, col := exctractLineNumberAndColumnNumber(err); line >= 0 {
+	if line, col := extractLineNumberAndColumnNumber(err); line >= 0 {
 		pos.LineNumber = line
 		pos.ColumnNumber = col
 		return fileType, pos
@@ -364,7 +364,7 @@ func extractOffsetAndType(e error) (int, string) {
 	}
 }
 
-func exctractLineNumberAndColumnNumber(e error) (int, int) {
+func extractLineNumberAndColumnNumber(e error) (int, int) {
 	switch v := e.(type) {
 	case *parse.Error:
 		return v.Line, v.Column

--- a/common/hexec/exec.go
+++ b/common/hexec/exec.go
@@ -118,7 +118,7 @@ func SafeCommand(name string, arg ...string) (*exec.Cmd, error) {
 	return exec.Command(bin, arg...), nil
 }
 
-// Exec encorces a security policy for commands run via os/exec.
+// Exec enforces a security policy for commands run via os/exec.
 type Exec struct {
 	sc security.Config
 

--- a/common/paths/path.go
+++ b/common/paths/path.go
@@ -209,7 +209,7 @@ func extractFilename(in, ext, base, pathSeparator string) (name string) {
 		// return the filename minus the extension (and the ".")
 		name = base[:strings.LastIndex(base, ".")]
 	} else {
-		// no extension case so just return base, which willi
+		// no extension case so just return base, which will
 		// be the filename
 		name = base
 	}

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -408,10 +408,10 @@ type RootConfig struct {
 	// Copyright information.
 	Copyright string
 
-	// The language to apply to content without any Clolanguage indicator.
+	// The language to apply to content without any language indicator.
 	DefaultContentLanguage string
 
-	// By defefault, we put the default content language in the root and the others below their language ID, e.g. /no/.
+	// By default, we put the default content language in the root and the others below their language ID, e.g. /no/.
 	// Set this to true to put all languages below their language ID.
 	DefaultContentLanguageInSubdir bool
 

--- a/config/commonConfig.go
+++ b/config/commonConfig.go
@@ -96,7 +96,7 @@ var defaultBuild = BuildConfig{
 			Source: `(postcss|tailwind)\.config\.js`,
 			Target: cssTargetCachebusterRe,
 		},
-		// This is deliberatly coarse grained; it will cache bust resources with "json" in the cache key when js files changes, which is good.
+		// This is deliberately coarse grained; it will cache bust resources with "json" in the cache key when js files changes, which is good.
 		{
 			Source: `assets/.*\.(.*)$`,
 			Target: `$1`,
@@ -112,7 +112,7 @@ type BuildConfig struct {
 	// related aggregated data (e.g. CSS class names).
 	WriteStats bool
 
-	// Can be used to toggle off writing of the intellinsense /assets/jsconfig.js
+	// Can be used to toggle off writing of the IntelliSense /assets/jsconfig.js
 	// file.
 	NoJSConfigInAssets bool
 

--- a/helpers/emoji.go
+++ b/helpers/emoji.go
@@ -30,7 +30,7 @@ var (
 	emojiMaxSize   int
 )
 
-// Emoji returns the emojy given a key, e.g. ":smile:", nil if not found.
+// Emoji returns the emoji given a key, e.g. ":smile:", nil if not found.
 func Emoji(key string) []byte {
 	emojiInit.Do(initEmoji)
 	return emojis[key]

--- a/helpers/emoji_test.go
+++ b/helpers/emoji_test.go
@@ -41,7 +41,7 @@ func TestEmojiCustom(t *testing.T) {
 		{" :beer: :", []byte(" 🍺 :")},
 		{":beer: and :smile: and another :beer:!", []byte("🍺 and 😄 and another 🍺!")},
 		{" :beer: : ", []byte(" 🍺 : ")},
-		{"No smilies for you!", []byte("No smilies for you!")},
+		{"No smiles for you!", []byte("No smiles for you!")},
 		{" The motto: no smiles! ", []byte(" The motto: no smiles! ")},
 		{":hugo_is_the_best_static_gen:", []byte(":hugo_is_the_best_static_gen:")},
 		{"은행 :smile: 은행", []byte("은행 😄 은행")},

--- a/htesting/test_helpers.go
+++ b/htesting/test_helpers.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 // CreateTempDir creates a temp dir in the given filesystem and
-// returns the dirnam and a func that removes it when done.
+// returns the dirname and a func that removes it when done.
 func CreateTempDir(fs afero.Fs, prefix string) (string, func(), error) {
 	tempDir, err := afero.TempDir(fs, "", prefix)
 	if err != nil {

--- a/hugofs/filter_fs.go
+++ b/hugofs/filter_fs.go
@@ -92,7 +92,7 @@ func NewLanguageFs(langs map[string]int, fs afero.Fs) (afero.Fs, error) {
 			fim := fi.(FileMetaInfo)
 			langs := translations[fim.Meta().TranslationBaseNameWithExt]
 			if len(langs) > 0 {
-				fim.Meta().Translations = sortAndremoveStringDuplicates(langs)
+				fim.Meta().Translations = sortAndRemoveStringDuplicates(langs)
 			}
 		}
 	}
@@ -328,7 +328,7 @@ func printFs(fs afero.Fs, path string, w io.Writer) {
 	})
 }
 
-func sortAndremoveStringDuplicates(s []string) []string {
+func sortAndRemoveStringDuplicates(s []string) []string {
 	ss := sort.StringSlice(s)
 	ss.Sort()
 	i := 0

--- a/hugofs/fs.go
+++ b/hugofs/fs.go
@@ -179,7 +179,7 @@ func MakeReadableAndRemoveAllModulePkgDir(fs afero.Fs, dir string) (int, error) 
 }
 
 // IsOsFs returns whether fs is an OsFs or if it fs wraps an OsFs.
-// TODO(bep) make this nore robust.
+// TODO(bep) make this more robust.
 func IsOsFs(fs afero.Fs) bool {
 	var isOsFs bool
 	WalkFilesystems(fs, func(fs afero.Fs) bool {

--- a/hugofs/glob/filename_filter_test.go
+++ b/hugofs/glob/filename_filter_test.go
@@ -59,11 +59,11 @@ func TestFilenameFilter(t *testing.T) {
 	c.Assert(includeOnlyFilter.Match("ab.jpg", false), qt.Equals, true)
 	c.Assert(includeOnlyFilter.Match("ab.gif", false), qt.Equals, false)
 
-	exlcudeOnlyFilter, err := NewFilenameFilter(nil, []string{"**.json", "**.jpg"})
+	excludeOnlyFilter, err := NewFilenameFilter(nil, []string{"**.json", "**.jpg"})
 	c.Assert(err, qt.IsNil)
-	c.Assert(exlcudeOnlyFilter.Match("ab.json", false), qt.Equals, false)
-	c.Assert(exlcudeOnlyFilter.Match("ab.jpg", false), qt.Equals, false)
-	c.Assert(exlcudeOnlyFilter.Match("ab.gif", false), qt.Equals, true)
+	c.Assert(excludeOnlyFilter.Match("ab.json", false), qt.Equals, false)
+	c.Assert(excludeOnlyFilter.Match("ab.jpg", false), qt.Equals, false)
+	c.Assert(excludeOnlyFilter.Match("ab.gif", false), qt.Equals, true)
 
 	var nilFilter *FilenameFilter
 	c.Assert(nilFilter.Match("ab.gif", false), qt.Equals, true)

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -34,7 +34,7 @@ func TestLoadConfigLanguageParamsOverrideIssue10620(t *testing.T) {
 	files := `
 -- hugo.toml --
 baseURL = "https://example.com"
-disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "setion"]
+disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "section"]
 title = "Base Title"
 staticDir = "mystatic"
 [params]
@@ -78,7 +78,7 @@ func TestLoadConfig(t *testing.T) {
 		files := `
 -- hugo.toml --
 baseURL = "https://example.com"
-disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "setion"]
+disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "section"]
 title = "Base Title"
 staticDir = "mystatic"
 [params]
@@ -130,7 +130,7 @@ myparam = "svParamValue"
 		files := `
 -- hugo.toml --
 baseURL = "https://example.com"
-disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "setion"]
+disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "section"]
 title = "Base Title"
 defaultContentLanguage = "sv"
 disableLanguages = ["sv"]
@@ -177,7 +177,7 @@ running = true
 		files := `
 -- hugo.toml --
 baseURL = "https://example.com"
-disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "setion"]
+disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "section"]
 title = "Base Title"
 [params]
 p1 = "p1base"

--- a/hugolib/configdir_test.go
+++ b/hugolib/configdir_test.go
@@ -30,7 +30,7 @@ b = "bc1"
 
 -- hugo.toml --
 baseURL = "https://example.com"
-disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "setion"]
+disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "section"]
 ignoreErrors = ["error-missing-instagram-accesstoken"]
 [params]
 a = "a1"

--- a/hugolib/datafiles_test.go
+++ b/hugolib/datafiles_test.go
@@ -25,7 +25,7 @@ func TestData(t *testing.T) {
 		files := `
 -- hugo.toml --
 baseURL = "https://example.com"
-disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "setion"]
+disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "section"]
 theme = "mytheme"
 -- data/a.toml --
 v1 = "a_v1"

--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -30,7 +30,7 @@ func TestEmbeddedShortcodes(t *testing.T) {
 		files := `
 -- hugo.toml --
 baseURL = "https://example.com"
-disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "setion"]
+disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "section"]
 ignoreErrors = ["error-missing-instagram-accesstoken"]
 [params]
 foo = "bar"

--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -324,7 +324,7 @@ func (h *HugoSites) postProcess() error {
 	// This will only be set when js.Build have been triggered with
 	// imports that resolves to the project or a module.
 	// Write a jsconfig.json file to the project's /asset directory
-	// to help JS intellisense in VS Code etc.
+	// to help JS IntelliSense in VS Code etc.
 	if !h.ResourceSpec.BuildConfig().NoJSConfigInAssets && h.BaseFs.Assets.Dirs != nil {
 		fi, err := h.BaseFs.Assets.Fs.Stat("")
 		if err != nil {

--- a/hugolib/pagecollections_test.go
+++ b/hugolib/pagecollections_test.go
@@ -235,7 +235,7 @@ func TestGetPage(t *testing.T) {
 		{"Root relative, no slash, root page", page.KindPage, nil, []string{"about.md", "ABOUT.md"}, "about page"},
 		{"Root relative, no slash, section", page.KindSection, nil, []string{"sect3"}, "section 3"},
 		{"Root relative, no slash, section page", page.KindPage, nil, []string{"sect3/page1.md"}, "Title3_1"},
-		{"Root relative, no slash, sub setion", page.KindSection, nil, []string{"sect3/sect7"}, "another sect7"},
+		{"Root relative, no slash, sub section", page.KindSection, nil, []string{"sect3/sect7"}, "another sect7"},
 		{"Root relative, no slash, nested page", page.KindPage, nil, []string{"sect3/subsect/deep.md"}, "deep page"},
 		{"Root relative, no slash, OS slashes", page.KindPage, nil, []string{filepath.FromSlash("sect5/page3.md")}, "Title5_3"},
 
@@ -247,7 +247,7 @@ func TestGetPage(t *testing.T) {
 		// content root relative paths without a leading slash, the lookup
 		// returns /sect7. This undermines ambiguity detection, but we have no choice.
 		//{"Ambiguous", nil, []string{"sect7"}, ""},
-		{"Section, ambigous", page.KindSection, nil, []string{"sect7"}, "Sect7s"},
+		{"Section, ambiguous", page.KindSection, nil, []string{"sect7"}, "Sect7s"},
 
 		{"Absolute, home", page.KindHome, nil, []string{"/", ""}, "home page"},
 		{"Absolute, page", page.KindPage, nil, []string{"/about.md", "/about"}, "about page"},

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -886,7 +886,7 @@ func (s *Site) getLanguageTargetPathLang(alwaysInSubDir bool) string {
 	return s.getLanguagePermalinkLang(alwaysInSubDir)
 }
 
-// get any lanaguagecode to prefix the relative permalink with.
+// get any language code to prefix the relative permalink with.
 func (s *Site) getLanguagePermalinkLang(alwaysInSubDir bool) string {
 	if !s.h.isMultiLingual() || s.h.Conf.IsMultihost() {
 		return ""

--- a/langs/language.go
+++ b/langs/language.go
@@ -82,7 +82,7 @@ func NewLanguage(lang, defaultContentLanguage, timeZone string, languageConfig L
 	return l, l.loadLocation(timeZone)
 }
 
-// This is injected from hugolib to avoid cirular dependencies.
+// This is injected from hugolib to avoid circular dependencies.
 var DeprecationFunc = func(item, alternative string, err bool) {}
 
 const paramsDeprecationWarning = `.Language.Params is deprecated and will be removed in a future release. Use site.Params instead.

--- a/livereload/livereload.go
+++ b/livereload/livereload.go
@@ -143,7 +143,7 @@ func refreshPathForPort(s string, port int) {
 	wsHub.broadcast <- []byte(msg)
 }
 
-// ServeJS serves the liverreload.js who's reference is injected into the page.
+// ServeJS serves the livereload.js who's reference is injected into the page.
 func ServeJS(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", media.Builtin.JavascriptType.Type)
 	w.Write(liveReloadJS())

--- a/resources/jsconfig/jsconfig.go
+++ b/resources/jsconfig/jsconfig.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Builder builds a jsconfig.json file that, currently, is used only to assist
-// intellinsense in editors.
+// IntelliSense in editors.
 type Builder struct {
 	sourceRootsMu sync.RWMutex
 	sourceRoots   map[string]bool

--- a/resources/resource_transformers/js/options.go
+++ b/resources/resource_transformers/js/options.go
@@ -239,7 +239,7 @@ func createBuildPlugins(c *Client, opts Options) ([]api.Plugin, error) {
 
 		if m != nil {
 			// Store the source root so we can create a jsconfig.json
-			// to help intellisense when the build is done.
+			// to help IntelliSense when the build is done.
 			// This should be a small number of elements, and when
 			// in server mode, we may get stale entries on renames etc.,
 			// but that shouldn't matter too much.


### PR DESCRIPTION
This PR corrects typos in unexported function names, variable names, testcase names, and comments.