### PR TITLE
commands,config: Fix typo in log and error messages

### DIFF
--- a/commands/convert.go
+++ b/commands/convert.go
@@ -140,7 +140,7 @@ func (c *convertCommand) convertAndSavePage(p page.Page, site *hugolib.Site, tar
 
 	errMsg := fmt.Errorf("error processing file %q", p.File().Path())
 
-	site.Log.Infoln("ttempting to convert", p.File().Filename())
+	site.Log.Infoln("attempting to convert", p.File().Filename())
 
 	f := p.File()
 	file, err := f.FileInfo().Meta().Open()

--- a/config/configLoader.go
+++ b/config/configLoader.go
@@ -157,7 +157,7 @@ func LoadConfigFromDir(sourceFs afero.Fs, configDir, environment string) (Provid
 			if err != nil {
 				// This will be used in error reporting, use the most specific value.
 				dirnames = []string{path}
-				return fmt.Errorf("failed to unmarshl config for path %q: %w", path, err)
+				return fmt.Errorf("failed to unmarshal config for path %q: %w", path, err)
 			}
 
 			var keyPath []string


### PR DESCRIPTION
This PR corrects spelling mistakes.