### PR TITLE
markup: Fix typo in function and struct names

### DIFF
--- a/markup/highlight/config.go
+++ b/markup/highlight/config.go
@@ -136,7 +136,7 @@ func applyOptions(opts any, cfg *Config) error {
 }
 
 func applyOptionsFromString(opts string, cfg *Config) error {
-	optsm, err := parseHightlightOptions(opts)
+	optsm, err := parseHighlightOptions(opts)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func ApplyLegacyConfig(cfg config.Provider, conf *Config) error {
 	return nil
 }
 
-func parseHightlightOptions(in string) (map[string]any, error) {
+func parseHighlightOptions(in string) (map[string]any, error) {
 	in = strings.Trim(in, " ")
 	opts := make(map[string]any)
 

--- a/markup/highlight/highlight.go
+++ b/markup/highlight/highlight.go
@@ -33,8 +33,8 @@ import (
 	"github.com/gohugoio/hugo/markup/internal/attributes"
 )
 
-// Markdown attributes used by the Chroma hightlighter.
-var chromaHightlightProcessingAttributes = map[string]bool{
+// Markdown attributes used by the Chroma highlighter.
+var chromaHighlightProcessingAttributes = map[string]bool{
 	"anchorLineNos":      true,
 	"guessSyntax":        true,
 	"hl_Lines":           true,
@@ -48,8 +48,8 @@ var chromaHightlightProcessingAttributes = map[string]bool{
 }
 
 func init() {
-	for k, v := range chromaHightlightProcessingAttributes {
-		chromaHightlightProcessingAttributes[strings.ToLower(k)] = v
+	for k, v := range chromaHighlightProcessingAttributes {
+		chromaHighlightProcessingAttributes[strings.ToLower(k)] = v
 	}
 }
 
@@ -61,7 +61,7 @@ func New(cfg Config) Highlighter {
 
 type Highlighter interface {
 	Highlight(code, lang string, opts any) (string, error)
-	HighlightCodeBlock(ctx hooks.CodeblockContext, opts any) (HightlightResult, error)
+	HighlightCodeBlock(ctx hooks.CodeblockContext, opts any) (HighlightResult, error)
 	hooks.CodeBlockRenderer
 	hooks.IsDefaultCodeBlockRendererProvider
 }
@@ -84,7 +84,7 @@ func (h chromaHighlighter) Highlight(code, lang string, opts any) (string, error
 	return b.String(), nil
 }
 
-func (h chromaHighlighter) HighlightCodeBlock(ctx hooks.CodeblockContext, opts any) (HightlightResult, error) {
+func (h chromaHighlighter) HighlightCodeBlock(ctx hooks.CodeblockContext, opts any) (HighlightResult, error) {
 	cfg := h.cfg
 
 	var b strings.Builder
@@ -94,21 +94,21 @@ func (h chromaHighlighter) HighlightCodeBlock(ctx hooks.CodeblockContext, opts a
 	options := ctx.Options()
 
 	if err := applyOptionsFromMap(options, &cfg); err != nil {
-		return HightlightResult{}, err
+		return HighlightResult{}, err
 	}
 
 	// Apply these last so the user can override them.
 	if err := applyOptions(opts, &cfg); err != nil {
-		return HightlightResult{}, err
+		return HighlightResult{}, err
 	}
 
 	if err := applyOptionsFromCodeBlockContext(ctx, &cfg); err != nil {
-		return HightlightResult{}, err
+		return HighlightResult{}, err
 	}
 
 	low, high, err := highlight(&b, ctx.Inner(), ctx.Type(), attributes, cfg)
 	if err != nil {
-		return HightlightResult{}, err
+		return HighlightResult{}, err
 	}
 
 	highlighted := b.String()
@@ -116,7 +116,7 @@ func (h chromaHighlighter) HighlightCodeBlock(ctx hooks.CodeblockContext, opts a
 		high = len(highlighted)
 	}
 
-	return HightlightResult{
+	return HighlightResult{
 		highlighted: template.HTML(highlighted),
 		innerLow:    low,
 		innerHigh:   high,
@@ -153,20 +153,20 @@ func (h chromaHighlighter) GetIdentity() identity.Identity {
 	return id
 }
 
-// HightlightResult holds the result of an highlighting operation.
-type HightlightResult struct {
+// HighlightResult holds the result of an highlighting operation.
+type HighlightResult struct {
 	innerLow    int
 	innerHigh   int
 	highlighted template.HTML
 }
 
 // Wrapped returns the highlighted code wrapped in a <div>, <pre> and <code> tag.
-func (h HightlightResult) Wrapped() template.HTML {
+func (h HighlightResult) Wrapped() template.HTML {
 	return h.highlighted
 }
 
 // Inner returns the highlighted code without the wrapping <div>, <pre> and <code> tag, suitable for inline use.
-func (h HightlightResult) Inner() template.HTML {
+func (h HighlightResult) Inner() template.HTML {
 	return h.highlighted[h.innerLow:h.innerHigh]
 }
 

--- a/markup/internal/attributes/attributes.go
+++ b/markup/internal/attributes/attributes.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Markdown attributes used as options by the Chroma highlighter.
-var chromaHightlightProcessingAttributes = map[string]bool{
+var chromaHighlightProcessingAttributes = map[string]bool{
 	"anchorLineNos":      true,
 	"guessSyntax":        true,
 	"hl_Lines":           true,
@@ -42,8 +42,8 @@ var chromaHightlightProcessingAttributes = map[string]bool{
 }
 
 func init() {
-	for k, v := range chromaHightlightProcessingAttributes {
-		chromaHightlightProcessingAttributes[strings.ToLower(k)] = v
+	for k, v := range chromaHighlightProcessingAttributes {
+		chromaHighlightProcessingAttributes[strings.ToLower(k)] = v
 	}
 }
 
@@ -101,7 +101,7 @@ func New(astAttributes []ast.Attribute, ownerType AttributesOwnerType) *Attribut
 			panic(fmt.Sprintf("not implemented: %T", vvv))
 		}
 
-		if ownerType == AttributesOwnerCodeBlockChroma && chromaHightlightProcessingAttributes[nameLower] {
+		if ownerType == AttributesOwnerCodeBlockChroma && chromaHighlightProcessingAttributes[nameLower] {
 			attr := Attribute{Name: string(v.Name), Value: vv}
 			opts = append(opts, attr)
 		} else {

--- a/tpl/transform/transform.go
+++ b/tpl/transform/transform.go
@@ -81,7 +81,7 @@ func (ns *Namespace) Highlight(s any, lang string, opts ...any) (template.HTML, 
 }
 
 // HighlightCodeBlock highlights a code block on the form received in the codeblock render hooks.
-func (ns *Namespace) HighlightCodeBlock(ctx hooks.CodeblockContext, opts ...any) (highlight.HightlightResult, error) {
+func (ns *Namespace) HighlightCodeBlock(ctx hooks.CodeblockContext, opts ...any) (highlight.HighlightResult, error) {
 	var optsv any
 	if len(opts) > 0 {
 		optsv = opts[0]


### PR DESCRIPTION
This PR renames `hightlight` to `highlight`.