### PR TITLE
Misc regression fixes

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -108,9 +108,6 @@ type rootCommand struct {
 	buildWatch  bool
 	environment string
 
-	// File format to read or write (TOML, YAML, JSON).
-	format string
-
 	// Common build flags.
 	baseURL              string
 	gc                   bool
@@ -408,12 +405,6 @@ func (r *rootCommand) PreRun(cd, runner *simplecobra.Commandeer) error {
 	if err != nil {
 		return err
 	}
-	switch r.format {
-	case "json", "toml", "yaml":
-		// OK
-	default:
-		return fmt.Errorf("unsupported format %q; must be one of json, toml or yaml", r.format)
-	}
 
 	loggers.PanicOnWarning.Store(r.panicOnWarning)
 	r.commonConfigs = lazycache.New[int32, *commonConfig](lazycache.Options{MaxEntries: 5})
@@ -485,7 +476,6 @@ Complete documentation is available at https://gohugo.io/.`
 
 	// Configure persistent flags
 	cmd.PersistentFlags().StringVarP(&r.source, "source", "s", "", "filesystem path to read files relative from")
-	cmd.PersistentFlags().StringVar(&r.format, "format", "toml", "preferred file format (toml, yaml or json)")
 	cmd.PersistentFlags().SetAnnotation("source", cobra.BashCompSubdirsInDir, []string{})
 	cmd.PersistentFlags().StringP("destination", "d", "", "filesystem path to write files to")
 	cmd.PersistentFlags().SetAnnotation("destination", cobra.BashCompSubdirsInDir, []string{})

--- a/commands/config.go
+++ b/commands/config.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -39,6 +40,8 @@ func newConfigCommand() *configCommand {
 
 type configCommand struct {
 	r *rootCommand
+
+	format string
 
 	commands []simplecobra.Commander
 }
@@ -67,7 +70,7 @@ func (c *configCommand) Run(ctx context.Context, cd *simplecobra.Commandeer, arg
 		return err
 	}
 
-	format := strings.ToLower(c.r.format)
+	format := strings.ToLower(c.format)
 
 	switch format {
 	case "json":
@@ -83,6 +86,8 @@ func (c *configCommand) Run(ctx context.Context, cd *simplecobra.Commandeer, arg
 			return parser.InterfaceToConfig(m, metadecoders.YAML, os.Stdout)
 		case "toml":
 			return parser.InterfaceToConfig(m, metadecoders.TOML, os.Stdout)
+		default:
+			return fmt.Errorf("unsupported format: %q", format)
 		}
 	}
 
@@ -93,6 +98,8 @@ func (c *configCommand) Init(cd *simplecobra.Commandeer) error {
 	cmd := cd.CobraCommand
 	cmd.Short = "Print the site configuration"
 	cmd.Long = `Print the site configuration, both default and custom settings.`
+	cmd.Flags().StringVar(&c.format, "format", "toml", "preferred file format (toml, yaml or json)")
+
 	return nil
 }
 

--- a/commands/hugobuilder.go
+++ b/commands/hugobuilder.go
@@ -1019,6 +1019,10 @@ func (c *hugoBuilder) loadConfig(cd *simplecobra.Commandeer, running bool) error
 		return err
 	}
 
+	if len(conf.configs.LoadingInfo.ConfigFiles) == 0 {
+		return errors.New("Unable to locate config file or config directory. Perhaps you need to create a new site.\nRun `hugo help new` for details.")
+	}
+
 	c.conf = conf
 	if c.onConfigLoaded != nil {
 		if err := c.onConfigLoaded(false); err != nil {

--- a/commands/new.go
+++ b/commands/new.go
@@ -36,6 +36,7 @@ func newNewCommand() *newCommand {
 	var (
 		force       bool
 		contentType string
+		format      string
 	)
 
 	var c *newCommand
@@ -67,6 +68,8 @@ func newNewCommand() *newCommand {
 					cmd.Flags().StringVarP(&contentType, "kind", "k", "", "content type to create")
 					cmd.Flags().String("editor", "", "edit new content with this editor, if provided")
 					cmd.Flags().BoolVarP(&force, "force", "f", false, "overwrite file if it already exists")
+					cmd.Flags().StringVar(&format, "format", "toml", "preferred file format (toml, yaml or json)")
+
 				},
 			},
 			&simpleCommand{
@@ -118,7 +121,7 @@ Use ` + "`hugo new [contentPath]`" + ` to create new content.`,
 							return errors.New(createpath + " already exists and is not empty. See --force.")
 
 						case !isEmpty && force:
-							all := append(dirs, filepath.Join(createpath, "hugo."+r.format))
+							all := append(dirs, filepath.Join(createpath, "hugo."+format))
 							for _, path := range all {
 								if exists, _ := helpers.Exists(path, sourceFs); exists {
 									return errors.New(path + " already exists")
@@ -133,7 +136,7 @@ Use ` + "`hugo new [contentPath]`" + ` to create new content.`,
 						}
 					}
 
-					c.newSiteCreateConfig(sourceFs, createpath, r.format)
+					c.newSiteCreateConfig(sourceFs, createpath, format)
 
 					// Create a default archetype file.
 					helpers.SafeWriteToDisk(filepath.Join(archeTypePath, "default.md"),

--- a/commands/new.go
+++ b/commands/new.go
@@ -148,7 +148,7 @@ Use ` + "`hugo new [contentPath]`" + ` to create new content.`,
 					return nil
 				},
 				withc: func(cmd *cobra.Command) {
-					cmd.Flags().BoolVar(&force, "force", false, "init inside non-empty directory")
+					cmd.Flags().BoolVarP(&force, "force", "f", false, "init inside non-empty directory")
 				},
 			},
 			&simpleCommand{

--- a/commands/server.go
+++ b/commands/server.go
@@ -288,7 +288,7 @@ func (f *fileServer) createEndpoint(i int) (*http.ServeMux, net.Listener, string
 					}
 					var fs afero.Fs
 					f.c.withConf(func(conf *commonConfig) {
-						fs = conf.fs.PublishDir
+						fs = conf.fs.PublishDirServer
 					})
 
 					fi, err := fs.Stat(path)

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -824,6 +824,7 @@ baseURL = "https://example.com"
 disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT"]
 [languages]
 [languages.en]
+languageCode = "en-US"
 title = "English Title"
 [languages.en.params]
 myparam = "enParamValue"
@@ -840,6 +841,7 @@ title: "My English Section"
 title: "My Swedish Section"
 ---
 -- layouts/index.html --
+LanguageCode: {{ eq site.LanguageCode site.Language.LanguageCode }}|{{ site.Language.LanguageCode }}|
 {{ range $i, $e := (slice site .Site) }}
 {{ $i }}|AllPages: {{ len .AllPages }}|Sections: {{ if .Sections }}true{{ end }}| Author: {{ .Authors }}|BuildDrafts: {{ .BuildDrafts }}|IsMultiLingual: {{ .IsMultiLingual }}|Param: {{ .Language.Params.myparam }}|Language string: {{ .Language }}|Languages: {{ .Languages }}
 {{ end }}
@@ -863,10 +865,12 @@ Sections: true|
 Param: enParamValue	
 Param: enParamValue	
 IsMultiLingual: true
+LanguageCode: true|en-US|
 `)
 
 	b.AssertFileContent("public/sv/index.html", `
-Param: svParamValue	
+Param: svParamValue
+LanguageCode: true|sv|
 
 `)
 

--- a/hugolib/site_new.go
+++ b/hugolib/site_new.go
@@ -361,10 +361,7 @@ func (s *Site) Config() page.SiteConfig {
 }
 
 func (s *Site) LanguageCode() string {
-	if s.conf.LanguageCode != "" {
-		return s.conf.LanguageCode
-	}
-	return s.language.Lang
+	return s.Language().LanguageCode()
 }
 
 // Returns all Sites for all languages.

--- a/langs/config.go
+++ b/langs/config.go
@@ -24,6 +24,9 @@ type LanguageConfig struct {
 	// The language name, e.g. "English".
 	LanguageName string
 
+	// The language code, e.g. "en-US".
+	LanguageCode string
+
 	// The language title. When set, this will
 	// override site.Title for this language.
 	Title string

--- a/langs/language.go
+++ b/langs/language.go
@@ -102,6 +102,13 @@ func (l *Language) Params() maps.Params {
 	return l.params
 }
 
+func (l *Language) LanguageCode() string {
+	if l.LanguageConfig.LanguageCode != "" {
+		return l.LanguageConfig.LanguageCode
+	}
+	return l.Lang
+}
+
 func (l *Language) loadLocation(tzStr string) error {
 	location, err := time.LoadLocation(tzStr)
 	if err != nil {

--- a/langs/language.go
+++ b/langs/language.go
@@ -98,7 +98,9 @@ See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
 // Note that this is the same as the Site.Params, but we keep it here for legacy reasons.
 // Deprecated: Use the site.Params instead.
 func (l *Language) Params() maps.Params {
-	DeprecationFunc(".Language.Params", paramsDeprecationWarning, false)
+	// TODO(bep) Remove this for now as it created a little too much noise. Need to think about this.
+	// See https://github.com/gohugoio/hugo/issues/11025
+	//DeprecationFunc(".Language.Params", paramsDeprecationWarning, false)
 	return l.params
 }
 

--- a/resources/page/site.go
+++ b/resources/page/site.go
@@ -65,6 +65,7 @@ type Site interface {
 	Title() string
 
 	// Returns the configured language code for this Site.
+	// Deprecated: Use .Language.LanguageCode instead.
 	LanguageCode() string
 
 	// Returns the configured copyright information for this Site.

--- a/testscripts/commands/hugo__configdir.txt
+++ b/testscripts/commands/hugo__configdir.txt
@@ -1,0 +1,6 @@
+
+hugo
+! stderr .
+
+-- config/_default/hugo.toml --
+baseURL = "https://example.com/"

--- a/testscripts/commands/hugo__flags.txt
+++ b/testscripts/commands/hugo__flags.txt
@@ -11,6 +11,8 @@ grep '<body>Home' newpublic/index.html
 hugo --quiet
 ! stdout .
 
+-- hugo.toml --
+title = "Hugo Test"
 -- myconfig.toml --
 baseURL = "http://example.org/"
 disableKinds = ["RSS", "sitemap", "robotsTXT", "404", "taxonomy", "term"]

--- a/testscripts/commands/hugo__noconfig.txt
+++ b/testscripts/commands/hugo__noconfig.txt
@@ -1,0 +1,4 @@
+
+! hugo
+
+stderr 'Unable to locate config file or config directory'

--- a/testscripts/commands/new.txt
+++ b/testscripts/commands/new.txt
@@ -2,7 +2,7 @@
 
 hugo new site -h
 stdout 'Create a new site in the provided directory'
-hugo new site mysite
+hugo new site mysite -f
 stdout 'Congratulations! Your new Hugo site is created in'
 cd mysite
 checkfile hugo.toml

--- a/testscripts/commands/server_render_static_to_disk.txt
+++ b/testscripts/commands/server_render_static_to_disk.txt
@@ -6,6 +6,7 @@ hugo server --renderStaticToDisk &
 waitServer
 
 httpget $HUGOTEST_BASEURL_0 'Title: Hugo Server Test' $HUGOTEST_BASEURL_0
+httpget ${HUGOTEST_BASEURL_0}mystatic.txt 'This is a static file.'
 
 ! exists public/index.html
 exists public/mystatic.txt


### PR DESCRIPTION
- commands: Move the --format flag to only the commands that support it
- commands: Re-introduce the -f shorthand for hugo new site
- Fix --renderStaticToDisk regression
- Add language.LanguageCode
- langs: Remove the Language.Params deprecation message for now
- commands: Fail the build when no config file or config dir
