### PR TITLE
cache: Set default cache path based on $USER

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -521,7 +521,7 @@ Complete documentation is available at https://gohugo.io/.`
 func applyLocalFlagsBuildConfig(cmd *cobra.Command, r *rootCommand) {
 	cmd.Flags().StringSliceP("theme", "t", []string{}, "themes to use (located in /themes/THEMENAME/)")
 	cmd.Flags().StringVarP(&r.baseURL, "baseURL", "b", "", "hostname (and path) to the root, e.g. https://spf13.com/")
-	cmd.Flags().StringP("cacheDir", "", "", "filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/")
+	cmd.Flags().StringP("cacheDir", "", "", "filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/")
 	_ = cmd.Flags().SetAnnotation("cacheDir", cobra.BashCompSubdirsInDir, []string{})
 	cmd.Flags().StringP("contentDir", "c", "", "filesystem path to content directory")
 	_ = cmd.Flags().SetAnnotation("theme", cobra.BashCompSubdirsInDir, []string{"themes"})

--- a/docs/content/en/commands/hugo.md
+++ b/docs/content/en/commands/hugo.md
@@ -27,7 +27,7 @@ hugo [flags]
   -D, --buildDrafts                include content marked as draft
   -E, --buildExpired               include expired content
   -F, --buildFuture                include content with publishdate in the future
-      --cacheDir string            filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string            filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
       --cleanDestinationDir        remove files from destination not found in static directories
       --clock string               set the clock used by Hugo, e.g. --clock 2021-11-06T22:30:00.00+09:00
       --config string              config file (default is hugo.yaml|json|toml)

--- a/docs/content/en/commands/hugo_config.md
+++ b/docs/content/en/commands/hugo_config.md
@@ -19,7 +19,7 @@ hugo config [command] [flags]
 
 ```
   -b, --baseURL string      hostname (and path) to the root, e.g. https://spf13.com/
-      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
   -c, --contentDir string   filesystem path to content directory
       --format string       preferred file format (toml, yaml or json) (default "toml")
   -h, --help                help for config

--- a/docs/content/en/commands/hugo_config_mounts.md
+++ b/docs/content/en/commands/hugo_config_mounts.md
@@ -15,7 +15,7 @@ hugo config mounts [flags] [args]
 
 ```
   -b, --baseURL string      hostname (and path) to the root, e.g. https://spf13.com/
-      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
   -c, --contentDir string   filesystem path to content directory
   -h, --help                help for mounts
   -t, --theme strings       themes to use (located in /themes/THEMENAME/)

--- a/docs/content/en/commands/hugo_mod_clean.md
+++ b/docs/content/en/commands/hugo_mod_clean.md
@@ -20,7 +20,7 @@ hugo mod clean [flags] [args]
 ```
       --all                 clean entire module cache
   -b, --baseURL string      hostname (and path) to the root, e.g. https://spf13.com/
-      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
   -c, --contentDir string   filesystem path to content directory
   -h, --help                help for clean
       --pattern string      pattern matching module paths to clean (all if not set), e.g. "**hugo*"

--- a/docs/content/en/commands/hugo_mod_graph.md
+++ b/docs/content/en/commands/hugo_mod_graph.md
@@ -21,7 +21,7 @@ hugo mod graph [flags] [args]
 
 ```
   -b, --baseURL string      hostname (and path) to the root, e.g. https://spf13.com/
-      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
       --clean               delete module cache for dependencies that fail verification
   -c, --contentDir string   filesystem path to content directory
   -h, --help                help for graph

--- a/docs/content/en/commands/hugo_mod_init.md
+++ b/docs/content/en/commands/hugo_mod_init.md
@@ -26,7 +26,7 @@ hugo mod init [flags] [args]
 
 ```
   -b, --baseURL string      hostname (and path) to the root, e.g. https://spf13.com/
-      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
   -c, --contentDir string   filesystem path to content directory
   -h, --help                help for init
   -t, --theme strings       themes to use (located in /themes/THEMENAME/)

--- a/docs/content/en/commands/hugo_mod_npm_pack.md
+++ b/docs/content/en/commands/hugo_mod_npm_pack.md
@@ -29,7 +29,7 @@ hugo mod npm pack [flags] [args]
 
 ```
   -b, --baseURL string      hostname (and path) to the root, e.g. https://spf13.com/
-      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
   -c, --contentDir string   filesystem path to content directory
   -h, --help                help for pack
   -t, --theme strings       themes to use (located in /themes/THEMENAME/)

--- a/docs/content/en/commands/hugo_mod_tidy.md
+++ b/docs/content/en/commands/hugo_mod_tidy.md
@@ -15,7 +15,7 @@ hugo mod tidy [flags] [args]
 
 ```
   -b, --baseURL string      hostname (and path) to the root, e.g. https://spf13.com/
-      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
   -c, --contentDir string   filesystem path to content directory
   -h, --help                help for tidy
   -t, --theme strings       themes to use (located in /themes/THEMENAME/)

--- a/docs/content/en/commands/hugo_mod_vendor.md
+++ b/docs/content/en/commands/hugo_mod_vendor.md
@@ -21,7 +21,7 @@ hugo mod vendor [flags] [args]
 
 ```
   -b, --baseURL string      hostname (and path) to the root, e.g. https://spf13.com/
-      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
   -c, --contentDir string   filesystem path to content directory
   -h, --help                help for vendor
   -t, --theme strings       themes to use (located in /themes/THEMENAME/)

--- a/docs/content/en/commands/hugo_mod_verify.md
+++ b/docs/content/en/commands/hugo_mod_verify.md
@@ -19,7 +19,7 @@ hugo mod verify [flags] [args]
 
 ```
   -b, --baseURL string      hostname (and path) to the root, e.g. https://spf13.com/
-      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
       --clean               delete module cache for dependencies that fail verification
   -c, --contentDir string   filesystem path to content directory
   -h, --help                help for verify

--- a/docs/content/en/commands/hugo_new_content.md
+++ b/docs/content/en/commands/hugo_new_content.md
@@ -26,7 +26,7 @@ hugo new content [path] [flags]
 
 ```
   -b, --baseURL string      hostname (and path) to the root, e.g. https://spf13.com/
-      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
   -c, --contentDir string   filesystem path to content directory
       --editor string       edit new content with this editor, if provided
   -f, --force               overwrite file if it already exists

--- a/docs/content/en/commands/hugo_server.md
+++ b/docs/content/en/commands/hugo_server.md
@@ -33,7 +33,7 @@ hugo server [command] [flags]
   -D, --buildDrafts            include content marked as draft
   -E, --buildExpired           include expired content
   -F, --buildFuture            include content with publishdate in the future
-      --cacheDir string        filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --cacheDir string        filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache_$USER/
       --cleanDestinationDir    remove files from destination not found in static directories
   -c, --contentDir string      filesystem path to content directory
       --disableBrowserError    do not show build errors in the browser

--- a/docs/content/en/getting-started/configuration.md
+++ b/docs/content/en/getting-started/configuration.md
@@ -807,7 +807,7 @@ You can override any of these cache settings in your own `hugo.toml`.
 ### The keywords explained
 
 `:cacheDir`
-: This is the value of the `cacheDir` config option if set (can also be set via OS env variable `HUGO_CACHEDIR`). It will fall back to `/opt/build/cache/hugo_cache/` on Netlify, or a `hugo_cache` directory below the OS temp dir for the others. This means that if you run your builds on Netlify, all caches configured with `:cacheDir` will be saved and restored on the next build. For other CI vendors, please read their documentation. For an CircleCI example, see [this configuration](https://github.com/bep/hugo-sass-test/blob/6c3960a8f4b90e8938228688bc49bdcdd6b2d99e/.circleci/config.yml).
+: This is the value of the `cacheDir` config option if set (can also be set via OS env variable `HUGO_CACHEDIR`). It will fall back to `/opt/build/cache/hugo_cache/` on Netlify, or a `hugo_cache_$USER` directory below the OS temp dir for the others. This means that if you run your builds on Netlify, all caches configured with `:cacheDir` will be saved and restored on the next build. For other CI vendors, please read their documentation. For an CircleCI example, see [this configuration](https://github.com/bep/hugo-sass-test/blob/6c3960a8f4b90e8938228688bc49bdcdd6b2d99e/.circleci/config.yml).
 
 `:project`
 : The base directory name of the current Hugo project. This means that, in its default setting, every project will have separated file caches, which means that when you do `hugo --gc` you will not touch files related to other Hugo projects running on the same PC.

--- a/docs/content/en/templates/data-templates.md
+++ b/docs/content/en/templates/data-templates.md
@@ -209,7 +209,7 @@ The expression `{{ index $r number }}` must be used to output the nth-column fro
 
 ### Cache URLs
 
-Each downloaded URL will be cached in the default folder `$TMPDIR/hugo_cache/`. The variable `$TMPDIR` will be resolved to your system-dependent temporary directory.
+Each downloaded URL will be cached in the default folder `$TMPDIR/hugo_cache_$USER/`. The variable `$TMPDIR` will be resolved to your system-dependent temporary directory.
 
 With the command-line flag `--cacheDir`, you can specify any folder on your system as a caching directory.
 

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -409,7 +409,12 @@ func GetCacheDir(fs afero.Fs, cacheDir string) (string, error) {
 	}
 
 	// Fall back to a cache in /tmp.
-	return GetTempDir("hugo_cache", fs), nil
+	userName := os.Getenv("USER")
+	if userName != "" {
+		return GetTempDir("hugo_cache_"+userName, fs), nil
+	} else {
+		return GetTempDir("hugo_cache", fs), nil
+	}
 }
 
 func cacheDirDefault(cacheDir string) string {


### PR DESCRIPTION
Change the default cache directory to `$TMPDIR/hugo_cache_$USER`, so that multi-user systems do not have caches that interfere with each other.  The other cache-choosing logic (e.g. Netlify exceptions, configuration options) are not affected.

Fixes #7391