### PR TITLE
Fix deploy defaults for non-zero flag values (e.g. maxDeletes, invalidateCDN)

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -63,9 +63,9 @@ documentation.
 			cmd.Flags().Bool("confirm", false, "ask for confirmation before making changes to the target")
 			cmd.Flags().Bool("dryRun", false, "dry run")
 			cmd.Flags().Bool("force", false, "force upload of all files")
-			cmd.Flags().Bool("invalidateCDN", true, "invalidate the CDN cache listed in the deployment target")
-			cmd.Flags().Int("maxDeletes", 256, "maximum # of files to delete, or -1 to disable")
-			cmd.Flags().Int("workers", 10, "number of workers to transfer files. defaults to 10")
+			cmd.Flags().Bool("invalidateCDN", deploy.DefaultConfig.InvalidateCDN, "invalidate the CDN cache listed in the deployment target")
+			cmd.Flags().Int("maxDeletes", deploy.DefaultConfig.MaxDeletes, "maximum # of files to delete, or -1 to disable")
+			cmd.Flags().Int("workers", deploy.DefaultConfig.Workers, "number of workers to transfer files. defaults to 10")
 		},
 	}
 }

--- a/deploy/deployConfig.go
+++ b/deploy/deployConfig.go
@@ -127,11 +127,16 @@ func (m *Matcher) Matches(path string) bool {
 	return m.re.MatchString(path)
 }
 
+var DefaultConfig = DeployConfig{
+	Workers:       10,
+	InvalidateCDN: true,
+	MaxDeletes:    256,
+}
+
 // DecodeConfig creates a config from a given Hugo configuration.
 func DecodeConfig(cfg config.Provider) (DeployConfig, error) {
-	var (
-		dcfg DeployConfig
-	)
+
+	dcfg := DefaultConfig
 
 	if !cfg.IsSet(deploymentConfigKey) {
 		return dcfg, nil

--- a/testscripts/commands/deploy.txt
+++ b/testscripts/commands/deploy.txt
@@ -3,10 +3,10 @@
 hugo deploy -h
 stdout 'Deploy your site to a Cloud provider\.'
 mkdir mybucket
-hugo deploy --target mydeployment
+hugo deploy --target mydeployment --invalidateCDN=false
 grep 'hello' mybucket/index.html
 replace  public/index.html 'hello' 'changed'
-hugo deploy --target mydeployment --invalidateCDN --dryRun
+hugo deploy --target mydeployment --dryRun
 stdout 'Would upload: index.html'
 stdout 'Would invalidate CloudFront CDN with ID foobar'
 -- hugo.toml --


### PR DESCRIPTION
This was broken in the config rewrite in Hugo 0.112.0.

The workaround is to be explicit about setting these flag values (even if just using the defaults), e.g.:

```
hugo deploy --invalidateCDN --maxDeletes 256
```
Fixes https://github.com/gohugoio/hugo/issues/11127