### PR TITLE
Print help message when command is triggered with no flags

### DIFF
--- a/commands/convert.go
+++ b/commands/convert.go
@@ -110,6 +110,7 @@ See convert's subcommands toJSON, toTOML and toYAML for more information.`
 	cmd.PersistentFlags().StringVarP(&c.outputDir, "output", "o", "", "filesystem path to write files to")
 	cmd.PersistentFlags().BoolVar(&c.unsafe, "unsafe", false, "enable less safe operations, please backup first")
 
+	cmd.RunE = nil
 	return nil
 }
 

--- a/commands/gen.go
+++ b/commands/gen.go
@@ -243,6 +243,8 @@ func (c *genCommand) Run(ctx context.Context, cd *simplecobra.Commandeer, args [
 func (c *genCommand) Init(cd *simplecobra.Commandeer) error {
 	cmd := cd.CobraCommand
 	cmd.Short = "A collection of several useful generators."
+
+	cmd.RunE = nil
 	return nil
 }
 

--- a/commands/import.go
+++ b/commands/import.go
@@ -96,6 +96,7 @@ func (c *importCommand) Init(cd *simplecobra.Commandeer) error {
 
 Import requires a subcommand, e.g. ` + "`hugo import jekyll jekyll_root_path target_path`."
 
+	cmd.RunE = nil
 	return nil
 }
 

--- a/commands/list.go
+++ b/commands/list.go
@@ -182,6 +182,7 @@ func (c *listCommand) Init(cd *simplecobra.Commandeer) error {
 
 List requires a subcommand, e.g. hugo list drafts`
 
+	cmd.RunE = nil
 	return nil
 }
 

--- a/commands/new.go
+++ b/commands/new.go
@@ -285,6 +285,8 @@ You can also specify the kind with ` + "`-k KIND`" + `.
 If archetypes are provided in your theme or site, they will be used.
 
 Ensure you run this within the root directory of your site.`
+
+	cmd.RunE = nil
 	return nil
 }
 


### PR DESCRIPTION
This PR aims to fix [this](https://github.com/gohugoio/hugo/issues/11165) issue.

Starting from release [v0.112.0](https://github.com/gohugoio/hugo/releases/tag/v0.112.0) and via this [commit](https://github.com/gohugoio/hugo/commit/241b21b0fd34d91fccb2ce69874110dceae6f926), `import`, `new`, `convert`, `list` and `gen` commands produce no output when triggered with no flags.

This PR reverts to the old behaviour by printing the help message by default.

