### PR TITLE
postCSS: Improve validation of option 'config'

### DIFF
--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -188,19 +188,19 @@ func (b *BaseFs) AbsProjectContentDir(filename string) (string, string, error) {
 
 // ResolveJSConfigFile resolves the JS-related config file to a absolute
 // filename. One example of such would be postcss.config.js.
-func (fs *BaseFs) ResolveJSConfigFile(name string) string {
+func (fs *BaseFs) ResolveJSConfigFile(name string) (string, bool) {
 	// First look in assets/_jsconfig
 	fi, err := fs.Assets.Fs.Stat(filepath.Join(files.FolderJSConfig, name))
 	if err == nil {
-		return fi.(hugofs.FileMetaInfo).Meta().Filename
+		return fi.(hugofs.FileMetaInfo).Meta().Filename, fi.IsDir()
 	}
 	// Fall back to the work dir.
 	fi, err = fs.Work.Stat(name)
 	if err == nil {
-		return fi.(hugofs.FileMetaInfo).Meta().Filename
+		return fi.(hugofs.FileMetaInfo).Meta().Filename, fi.IsDir()
 	}
 
-	return ""
+	return "", false
 }
 
 // MakePathRelative creates a relative path from the given filename.

--- a/resources/resource_transformers/babel/babel.go
+++ b/resources/resource_transformers/babel/babel.go
@@ -134,13 +134,19 @@ func (t *babelTransformation) Transform(ctx *resources.ResourceTransformationCtx
 	}
 
 	configFile = filepath.Clean(configFile)
+	isConfigFileDir := false
 
 	// We need an absolute filename to the config file.
 	if !filepath.IsAbs(configFile) {
-		configFile = t.rs.BaseFs.ResolveJSConfigFile(configFile)
-		if configFile == "" && t.options.Config != "" {
-			// Only fail if the user specified config file is not found.
-			return fmt.Errorf("babel config %q not found:", configFile)
+		configFile, isConfigFileDir = t.rs.BaseFs.ResolveJSConfigFile(configFile)
+		if t.options.Config != "" {
+			if configFile == "" {
+				// Only fail if the user specified config file is not found.
+				return fmt.Errorf("babel config file %q not found", configFile)
+			}
+			if isConfigFileDir {
+				loggers.Log().Warnf("babel config %q must be a file, not a directory", configFile)
+			}
 		}
 	}
 

--- a/resources/resource_transformers/postcss/postcss.go
+++ b/resources/resource_transformers/postcss/postcss.go
@@ -173,13 +173,19 @@ func (t *postcssTransformation) Transform(ctx *resources.ResourceTransformationC
 	}
 
 	configFile = filepath.Clean(configFile)
+	isConfigFileDir := false
 
 	// We need an absolute filename to the config file.
 	if !filepath.IsAbs(configFile) {
-		configFile = t.rs.BaseFs.ResolveJSConfigFile(configFile)
-		if configFile == "" && options.Config != "" {
-			// Only fail if the user specified config file is not found.
-			return fmt.Errorf("postcss config %q not found:", options.Config)
+		configFile, isConfigFileDir = t.rs.BaseFs.ResolveJSConfigFile(configFile)
+		if options.Config != "" {
+			if configFile == "" {
+				// Only fail if the user specified config file is not found.
+				return fmt.Errorf("postcss config directory %q not found", options.Config)
+			}
+			if !isConfigFileDir {
+				loggers.Log().Warnf("postcss config %q must be a directory", options.Config)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR follows up on #10846. It adds validation for the `config` option: if the value given for `config` is not a directory, a warning is emitted.

**With this patch applied:**

```
git clone --single-branch -b hugo-github-issue-10846 https://github.com/jmooring/hugo-testing hugo-github-issue-10846
cd hugo-github-issue-10846
npm ci
hugo_0.115.dev
Start building sites …
hugo v0.115.0-DEV-8ff4385708a6c19e6f7fb2cb9394eb0cb9c3f2fa windows/amd64 BuildDate=2023-06-28T14:51:41Z

WARN  postcss config "foo/bar.config.js" must be a directory

                   | EN
-------------------+-----
  Pages            |  1
  Paginator pages  |  0
  Non-page files   |  0
  Static files     |  0
  Processed images |  0
  Aliases          |  0
  Sitemaps         |  0
  Cleaned          |  0

Total in 3217 ms

```

Note the line in the middel emitting a warning.
