### PR TITLE
Only print the path warnings once

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -110,12 +110,10 @@ type rootCommand struct {
 	environment string
 
 	// Common build flags.
-	baseURL              string
-	gc                   bool
-	poll                 string
-	forceSyncStatic      bool
-	printPathWarnings    bool
-	printUnusedTemplates bool
+	baseURL         string
+	gc              bool
+	poll            string
+	forceSyncStatic bool
 
 	// Profile flags (for debugging of performance problems)
 	cpuprofile   string
@@ -288,7 +286,7 @@ func (r *rootCommand) ConfigFromProvider(key int32, cfg config.Provider) (*commo
 			htime.Clock = clock.Start(configs.Base.C.Clock)
 		}
 
-		if base.LogPathWarnings {
+		if base.PrintPathWarnings {
 			// Note that we only care about the "dynamic creates" here,
 			// so skip the static fs.
 			fs.PublishDir = hugofs.NewCreateCountingFs(fs.PublishDir)
@@ -544,8 +542,8 @@ func applyLocalFlagsBuild(cmd *cobra.Command, r *rootCommand) {
 	cmd.Flags().BoolP("noChmod", "", false, "don't sync permission mode of files")
 	cmd.Flags().BoolP("noBuildLock", "", false, "don't create .hugo_build.lock file")
 	cmd.Flags().BoolP("printI18nWarnings", "", false, "print missing translations")
-	cmd.Flags().BoolVarP(&r.printPathWarnings, "printPathWarnings", "", false, "print warnings on duplicate target paths etc.")
-	cmd.Flags().BoolVarP(&r.printUnusedTemplates, "printUnusedTemplates", "", false, "print warnings on unused templates.")
+	cmd.Flags().BoolP("printPathWarnings", "", false, "print warnings on duplicate target paths etc.")
+	cmd.Flags().BoolP("printUnusedTemplates", "", false, "print warnings on unused templates.")
 	cmd.Flags().StringVarP(&r.cpuprofile, "profile-cpu", "", "", "write cpu profile to `file`")
 	cmd.Flags().StringVarP(&r.memprofile, "profile-mem", "", "", "write memory profile to `file`")
 	cmd.Flags().BoolVarP(&r.printm, "printMemoryUsage", "", false, "print memory usage to screen at intervals")

--- a/commands/helpers.go
+++ b/commands/helpers.go
@@ -79,11 +79,9 @@ func flagsToCfgWithAdditionalConfigBase(cd *simplecobra.Commandeer, cfg config.P
 
 	// Flags with a different name in the config.
 	keyMap := map[string]string{
-		"minify":            "minifyOutput",
-		"destination":       "publishDir",
-		"printI18nWarnings": "logI18nWarnings",
-		"printPathWarnings": "logPathWarnings",
-		"editor":            "newContentEditor",
+		"minify":      "minifyOutput",
+		"destination": "publishDir",
+		"editor":      "newContentEditor",
 	}
 
 	// Flags that we for some reason don't want to expose in the site config.

--- a/commands/hugobuilder.go
+++ b/commands/hugobuilder.go
@@ -43,7 +43,6 @@ import (
 	"github.com/gohugoio/hugo/hugolib/filesystems"
 	"github.com/gohugoio/hugo/livereload"
 	"github.com/gohugoio/hugo/resources/page"
-	"github.com/gohugoio/hugo/tpl"
 	"github.com/gohugoio/hugo/watcher"
 	"github.com/spf13/fsync"
 	"golang.org/x/sync/errgroup"
@@ -416,13 +415,6 @@ func (c *hugoBuilder) build() error {
 		h, err := c.hugo()
 		if err != nil {
 			return err
-		}
-
-		if c.r.printUnusedTemplates {
-			unusedTemplates := h.Tmpl().(tpl.UnusedTemplatesProvider).UnusedTemplates()
-			for _, unusedTemplate := range unusedTemplates {
-				c.r.logger.Warnf("Template %s is unused, source file %s", unusedTemplate.Name(), unusedTemplate.Filename())
-			}
 		}
 
 		h.PrintProcessingStats(os.Stdout)

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -484,12 +484,6 @@ type RootConfig struct {
 	// Enable to print greppable placeholders (on the form "[i18n] TRANSLATIONID") for missing translation strings.
 	EnableMissingTranslationPlaceholders bool
 
-	// Enable to print warnings for missing translation strings.
-	LogI18nWarnings bool
-
-	// ENable to print warnings for multiple files published to the same destination.
-	LogPathWarnings bool
-
 	// Enable to panic on warning log entries. This may make it easier to detect the source.
 	PanicOnWarning bool
 
@@ -524,6 +518,12 @@ type RootConfig struct {
 
 	// Whether to track and print unused templates during the build.
 	PrintUnusedTemplates bool
+
+	// Enable to print warnings for missing translation strings.
+	PrintI18nWarnings bool
+
+	// ENable to print warnings for multiple files published to the same destination.
+	PrintPathWarnings bool
 
 	// URL to be used as a placeholder when a page reference cannot be found in ref or relref. Is used as-is.
 	RefLinksNotFoundURL string

--- a/config/allconfig/configlanguage.go
+++ b/config/allconfig/configlanguage.go
@@ -199,8 +199,8 @@ func (c ConfigLanguage) EnableMissingTranslationPlaceholders() bool {
 	return c.config.EnableMissingTranslationPlaceholders
 }
 
-func (c ConfigLanguage) LogI18nWarnings() bool {
-	return c.config.LogI18nWarnings
+func (c ConfigLanguage) PrintI18nWarnings() bool {
+	return c.config.PrintI18nWarnings
 }
 
 func (c ConfigLanguage) CreateTitle(s string) string {

--- a/config/allconfig/integration_test.go
+++ b/config/allconfig/integration_test.go
@@ -69,3 +69,21 @@ Title: {{ .Title }}
 	b.Assert(modConf.Mounts[1].Lang, qt.Equals, "sv")
 
 }
+
+func TestConfigAliases(t *testing.T) {
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com"
+logI18nWarnings = true
+logPathWarnings = true
+`
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{T: t, TxtarString: files},
+	).Build()
+
+	conf := b.H.Configs.Base
+
+	b.Assert(conf.PrintI18nWarnings, qt.Equals, true)
+	b.Assert(conf.PrintPathWarnings, qt.Equals, true)
+}

--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -139,7 +139,11 @@ type configLoader struct {
 
 // Handle some legacy values.
 func (l configLoader) applyConfigAliases() error {
-	aliases := []types.KeyValueStr{{Key: "taxonomies", Value: "indexes"}}
+	aliases := []types.KeyValueStr{
+		{Key: "indexes", Value: "taxonomies"},
+		{Key: "logI18nWarnings", Value: "printI18nWarnings"},
+		{Key: "logPathWarnings", Value: "printPathWarnings"},
+	}
 
 	for _, alias := range aliases {
 		if l.cfg.IsSet(alias.Key) {

--- a/config/configProvider.go
+++ b/config/configProvider.go
@@ -57,7 +57,7 @@ type AllProvider interface {
 	EnableMissingTranslationPlaceholders() bool
 	TemplateMetrics() bool
 	TemplateMetricsHints() bool
-	LogI18nWarnings() bool
+	PrintI18nWarnings() bool
 	CreateTitle(s string) string
 	IgnoreFile(s string) bool
 	NewContentEditor() string

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -77,6 +77,8 @@ type HugoSites struct {
 	contentInit sync.Once
 	content     *pageMaps
 
+	postRenderInit sync.Once
+
 	// Keeps track of bundle directories and symlinks to enable partial rebuilding.
 	ContentChanges *contentChangeMap
 

--- a/langs/i18n/i18n.go
+++ b/langs/i18n/i18n.go
@@ -119,7 +119,7 @@ func (t Translator) initFuncs(bndl *i18n.Bundle) {
 				t.logger.Warnf("Failed to get translated string for language %q and ID %q: %s", currentLangStr, translationID, err)
 			}
 
-			if t.cfg.LogI18nWarnings() {
+			if t.cfg.PrintI18nWarnings() {
 				t.logger.Warnf("i18n|MISSING_TRANSLATION|%s|%s", currentLangStr, translationID)
 			}
 


### PR DESCRIPTION
We could reset and rerun it on server rebuilds, but that report needs a full build to make sense.

Also clean up the config vs flags in this area: Make all config settings match the flags e.g. `printPathWarnings`, but set up aliases for the
old.

Fixes #11187
