### PR TITLE
Add `rss.disableKinds` configuration

### DIFF
--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -182,6 +182,9 @@ type Config struct {
 
 	// UglyURLs configuration. Either a boolean or a sections map.
 	UglyURLs any `mapstructure:"-"`
+
+    // RSS configuration
+    Rss config.Rss `mapstructure:"-"`
 }
 
 type configCompiler interface {

--- a/config/allconfig/alldecoders.go
+++ b/config/allconfig/alldecoders.go
@@ -363,6 +363,14 @@ var allDecoderSetups = map[string]decodeWeight{
 			return nil
 		},
 	},
+	"rss": {
+		key: "rss",
+		decode: func(d decodeWeight, p decodeConfig) error {
+			var err error
+			p.c.Rss, err = config.DecodeRss(p.p)
+			return err
+		},
+	},
 	"internal": {
 		key: "internal",
 		decode: func(d decodeWeight, p decodeConfig) error {

--- a/config/commonConfig.go
+++ b/config/commonConfig.go
@@ -421,3 +421,15 @@ func DecodeServer(cfg Provider) (Server, error) {
 
 	return *s, nil
 }
+
+type Rss struct {
+    DisableKinds []string
+}
+
+func DecodeRss(cfg Provider) (Rss, error) {
+    r := &Rss{}
+
+    _ = mapstructure.WeakDecode(cfg.GetStringMap("rss"), r)
+
+    return *r, nil
+}

--- a/docs/content/en/templates/rss.md
+++ b/docs/content/en/templates/rss.md
@@ -47,6 +47,16 @@ copyright = "This work is licensed under a Creative Commons Attribution-ShareAli
     name = "My Name Here"
 {{< /code-toggle >}}
 
+You can opt-out RSS generation for some kinds of content:
+
+
+{{< code-toggle file="hugo" >}}
+[rss]
+    disableKinds = ["taxonomy", "term"]
+{{< /code-toggle >}}
+
+The folowing values didn't produce `public/<TAXONOMY>/index.xml` and `public/<TAXONOMY>/<TERM>/index.xml` files.
+
 ## The Embedded rss.xml
 
 This is the default RSS template that ships with Hugo:

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1048,6 +1048,10 @@ func (s *Site) renderAndWritePage(statCounter *uint64, name string, targetPath s
 	isHTML := of.IsHTML
 	isRSS := of.Name == "rss"
 
+	if isRSS && stringSliceContains(p.Kind(), s.conf.Rss.DisableKinds...) {
+		return nil
+	}
+
 	pd := publisher.Descriptor{
 		Src:          renderBuffer,
 		TargetPath:   targetPath,


### PR DESCRIPTION
This commit will allow users to disable generation of `index.xml` files for some kinds of content.

For example, with this config:

```toml
[rss]
    disableKinds = ["taxonomy", "term"]
```

Hugo will not produce `public/<TAXONOMY>/index.xml` and `public/<TAXONOMY>/<TERM>/index.xml` files.