### PR TITLE
config: expand default security.exec.osEnv policy

### DIFF
--- a/config/security/securityConfig.go
+++ b/config/security/securityConfig.go
@@ -42,7 +42,7 @@ var DefaultConfig = Config{
 		),
 		// These have been tested to work with Hugo's external programs
 		// on Windows, Linux and MacOS.
-		OsEnv: MustNewWhitelist(`(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\w+)$`),
+		OsEnv: MustNewWhitelist(`(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\w+|(XDG_CONFIG_)?HOME|USERPROFILE|SSH_AUTH_SOCK|DISPLAY|LANG)$`),
 	},
 	Funcs: Funcs{
 		Getenv: MustNewWhitelist("^HUGO_", "^CI$"),

--- a/config/security/securityConfig_test.go
+++ b/config/security/securityConfig_test.go
@@ -140,7 +140,7 @@ func TestToTOML(t *testing.T) {
 	got := DefaultConfig.ToTOML()
 
 	c.Assert(got, qt.Equals,
-		"[security]\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^(dart-)?sass(-embedded)?$', '^go$', '^npx$', '^postcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\\w+)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_', '^CI$']\n\n  [security.goTemplates]\n    AllowActionJSTmpl = false\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['.*']",
+		"[security]\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^(dart-)?sass(-embedded)?$', '^go$', '^npx$', '^postcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\\w+|(XDG_CONFIG_)?HOME|USERPROFILE|SSH_AUTH_SOCK|DISPLAY|LANG)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_', '^CI$']\n\n  [security.goTemplates]\n    AllowActionJSTmpl = false\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['.*']",
 	)
 }
 
@@ -154,9 +154,6 @@ func TestDecodeConfigDefault(t *testing.T) {
 	c.Assert(pc.Exec.Allow.Accept("a"), qt.IsFalse)
 	c.Assert(pc.Exec.Allow.Accept("npx"), qt.IsTrue)
 	c.Assert(pc.Exec.Allow.Accept("Npx"), qt.IsFalse)
-	c.Assert(pc.Exec.OsEnv.Accept("a"), qt.IsFalse)
-	c.Assert(pc.Exec.OsEnv.Accept("PATH"), qt.IsTrue)
-	c.Assert(pc.Exec.OsEnv.Accept("e"), qt.IsFalse)
 
 	c.Assert(pc.HTTP.URLs.Accept("https://example.org"), qt.IsTrue)
 	c.Assert(pc.HTTP.Methods.Accept("POST"), qt.IsTrue)
@@ -167,6 +164,10 @@ func TestDecodeConfigDefault(t *testing.T) {
 
 	c.Assert(pc.Exec.OsEnv.Accept("PATH"), qt.IsTrue)
 	c.Assert(pc.Exec.OsEnv.Accept("GOROOT"), qt.IsTrue)
+	c.Assert(pc.Exec.OsEnv.Accept("HOME"), qt.IsTrue)
+	c.Assert(pc.Exec.OsEnv.Accept("SSH_AUTH_SOCK"), qt.IsTrue)
+	c.Assert(pc.Exec.OsEnv.Accept("a"), qt.IsFalse)
+	c.Assert(pc.Exec.OsEnv.Accept("e"), qt.IsFalse)
 	c.Assert(pc.Exec.OsEnv.Accept("MYSECRET"), qt.IsFalse)
 
 }


### PR DESCRIPTION
To better support private Hugo modules and automatically
launching a text editor on content creation, this change
adds the following environment variables to the default
security policy:

- HOME
- XDG_CONFIG_HOME
- USERPROFILE
- SSH_AUTH_SOCK
- DISPLAY
- LANG

Fixes https://github.com/gohugoio/hugo/issues/9333

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
