### PR TITLE
fix: dotpath for Hugo modules mounted as data

### DIFF
--- a/hugolib/hugo_modules_test.go
+++ b/hugolib/hugo_modules_test.go
@@ -1178,3 +1178,32 @@ target = "content/resources-b"
 	b.AssertFileContent("public/resources-a/subdir/about/index.html", "Single")
 	b.AssertFileContent("public/resources-b/subdir/about/index.html", "Single")
 }
+
+func TestMountData(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = 'https://example.org/'
+disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "page", "section"]
+
+[[module.mounts]]
+source = "data"
+target = "data"
+
+[[module.mounts]]
+source = "extra-data"
+target = "data/extra"
+-- extra-data/test.yaml --
+message: Hugo Rocks
+-- layouts/index.html --
+{{ site.Data.extra.test.message }}
+`
+
+	b := NewIntegrationTestBuilder(
+		IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+		},
+	).Build()
+
+	b.AssertFileContent("public/index.html", "Hugo Rocks")
+}

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -555,13 +555,14 @@ func (h *HugoSites) loadData(fis []hugofs.FileMetaInfo) (err error) {
 
 	h.data = make(map[string]any)
 	for _, fi := range fis {
+		basePath := fi.Meta().Path
 		fileSystem := spec.NewFilesystemFromFileMetaInfo(fi)
 		files, err := fileSystem.Files()
 		if err != nil {
 			return err
 		}
 		for _, r := range files {
-			if err := h.handleDataFile(r); err != nil {
+			if err := h.handleDataFile(basePath, r); err != nil {
 				return err
 			}
 		}
@@ -570,7 +571,7 @@ func (h *HugoSites) loadData(fis []hugofs.FileMetaInfo) (err error) {
 	return
 }
 
-func (h *HugoSites) handleDataFile(r source.File) error {
+func (h *HugoSites) handleDataFile(basePath string, r source.File) error {
 	var current map[string]any
 
 	f, err := r.FileInfo().Meta().Open()
@@ -581,7 +582,8 @@ func (h *HugoSites) handleDataFile(r source.File) error {
 
 	// Crawl in data tree to insert data
 	current = h.data
-	keyParts := strings.Split(r.Dir(), helpers.FilePathSeparator)
+	dataPath := filepath.Join(basePath, r.Dir())
+	keyParts := strings.Split(dataPath, helpers.FilePathSeparator)
 
 	for _, key := range keyParts {
 		if key != "" {


### PR DESCRIPTION
Fixes #10681

Before this change, data files from Hugo modules were always mounted at the
root of the `data` directory. The File and FileMetaInfo structs for modules
are different from 'native' data directories.

This changes how the keyParts for data files are generated so that data
from modules or native directories are treated the same.

> **Note**
>
> This might not be the best way of solving this issue. Perhaps it's preferred
> to change how file metadata gets created, so that the properties for native
> and module data directories are the same. I just couldn't figure out how to
> do that.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
