### PR TITLE
deploy: Create AWS session for CloudFront invalidation via Go CDK

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -271,7 +271,7 @@ func (d *Deployer) Deploy(ctx context.Context) error {
 				}
 			} else {
 				d.logger.Println("Invalidating CloudFront CDN...")
-				if err := InvalidateCloudFront(ctx, d.target.CloudFrontDistributionID); err != nil {
+				if err := InvalidateCloudFront(ctx, d.target); err != nil {
 					d.logger.Printf("Failed to invalidate CloudFront CDN: %v\n", err)
 					return err
 				}


### PR DESCRIPTION
This allows the AWS credentials to be picked up from the configured target URL (like blob does) rather than the current behaviour of only relying on the defaults.

Relying on the defaults here means having to specify credentials twice (once in the URL for the blob, once in the environment for this code path) when non-default AWS credentials are in used (e.g. via a profile).