### PR TITLE
Fix setting config from env with complex (e.g. YAML) strings

### DIFF
--- a/config/allconfig/alldecoders.go
+++ b/config/allconfig/alldecoders.go
@@ -150,7 +150,7 @@ var allDecoderSetups = map[string]decodeWeight{
 		key: "outputs",
 		decode: func(d decodeWeight, p decodeConfig) error {
 			defaults := createDefaultOutputFormats(p.c.OutputFormats.Config)
-			m := p.p.GetStringMap("outputs")
+			m := maps.CleanConfigStringMap(p.p.GetStringMap("outputs"))
 			p.c.Outputs = make(map[string][]string)
 			for k, v := range m {
 				s := types.ToStringSlicePreserveString(v)

--- a/parser/metadecoders/decoder.go
+++ b/parser/metadecoders/decoder.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/gohugoio/hugo/common/herrors"
+	"github.com/gohugoio/hugo/common/maps"
 	"github.com/niklasfasching/go-org/org"
 
 	xml "github.com/clbanning/mxj/v2"
@@ -90,7 +91,7 @@ func (d Decoder) UnmarshalStringTo(data string, typ any) (any, error) {
 	switch typ.(type) {
 	case string:
 		return data, nil
-	case map[string]any:
+	case map[string]any, maps.Params:
 		format := d.FormatFromContentString(data)
 		return d.UnmarshalToMap([]byte(data), format)
 	case []any:


### PR DESCRIPTION
So you can do

```
HUGO_OUTPUTS="home: [rss]"  hugo
```

And similar.

Fixes #11249
