### PR TITLE
Fixed/Updated Github Profile URL of Bjørn Erik Pedersen (bep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[bep]: https://github.com/spf13
+[bep]: https://github.com/bep
 [bugs]: https://github.com/gohugoio/hugo/issues?q=is%3Aopen+is%3Aissue+label%3ABug
 [contributing]: CONTRIBUTING.md
 [create a proposal]: https://github.com/gohugoio/hugo/issues/new?labels=Proposal%2C+NeedsTriage&template=feature_request.md


### PR DESCRIPTION
bep's github profile url was set to spf13's.