### PR TITLE
common/loggers: Fix typo in log option name

### DIFF
--- a/common/loggers/logger.go
+++ b/common/loggers/logger.go
@@ -37,13 +37,13 @@ var (
 
 // Options defines options for the logger.
 type Options struct {
-	Level               logg.Level
-	Stdout              io.Writer
-	Stderr              io.Writer
-	Distinct            bool
-	StoreErrors         bool
-	HandlerPost         func(e *logg.Entry) error
-	SuppresssStatements map[string]bool
+	Level              logg.Level
+	Stdout             io.Writer
+	Stderr             io.Writer
+	Distinct           bool
+	StoreErrors        bool
+	HandlerPost        func(e *logg.Entry) error
+	SuppressStatements map[string]bool
 }
 
 // New creates a new logger with the given options.
@@ -97,8 +97,8 @@ func New(opts Options) Logger {
 		logHandler = newStopHandler(logOnce, logHandler)
 	}
 
-	if opts.SuppresssStatements != nil && len(opts.SuppresssStatements) > 0 {
-		logHandler = newStopHandler(newSuppressStatementsHandler(opts.SuppresssStatements), logHandler)
+	if opts.SuppressStatements != nil && len(opts.SuppressStatements) > 0 {
+		logHandler = newStopHandler(newSuppressStatementsHandler(opts.SuppressStatements), logHandler)
 	}
 
 	logger := logg.New(

--- a/common/loggers/logger_test.go
+++ b/common/loggers/logger_test.go
@@ -110,7 +110,7 @@ func TestSuppressStatements(t *testing.T) {
 
 	opts := loggers.Options{
 		StoreErrors: true,
-		SuppresssStatements: map[string]bool{
+		SuppressStatements: map[string]bool{
 			"error-1": true,
 		},
 	}

--- a/hugolib/site_new.go
+++ b/hugolib/site_new.go
@@ -119,13 +119,13 @@ func NewHugoSites(cfg deps.DepsCfg) (*HugoSites, error) {
 		}
 
 		logOpts := loggers.Options{
-			Level:               cfg.LogLevel,
-			Distinct:            true, // This will drop duplicate log warning and errors.
-			HandlerPost:         logHookLast,
-			Stdout:              cfg.LogOut,
-			Stderr:              cfg.LogOut,
-			StoreErrors:         conf.Running(),
-			SuppresssStatements: conf.IgnoredErrors(),
+			Level:              cfg.LogLevel,
+			Distinct:           true, // This will drop duplicate log warning and errors.
+			HandlerPost:        logHookLast,
+			Stdout:             cfg.LogOut,
+			Stderr:             cfg.LogOut,
+			StoreErrors:        conf.Running(),
+			SuppressStatements: conf.IgnoredErrors(),
 		}
 		logger = loggers.New(logOpts)
 	}

--- a/resources/page/permalinks.go
+++ b/resources/page/permalinks.go
@@ -399,7 +399,7 @@ func (l PermalinkExpander) toSliceFunc(cut string) func(s []string) []string {
 
 }
 
-var permalinksKindsSuppurt = []string{kinds.KindPage, kinds.KindSection, kinds.KindTaxonomy, kinds.KindTerm}
+var permalinksKindsSupport = []string{kinds.KindPage, kinds.KindSection, kinds.KindTaxonomy, kinds.KindTerm}
 
 // DecodePermalinksConfig decodes the permalinks configuration in the given map
 func DecodePermalinksConfig(m map[string]any) (map[string]map[string]string, error) {
@@ -425,7 +425,7 @@ func DecodePermalinksConfig(m map[string]any) (map[string]map[string]string, err
 			// [permalinks.key]
 			//   xyz = ???
 
-			if helpers.InStringArray(permalinksKindsSuppurt, k) {
+			if helpers.InStringArray(permalinksKindsSupport, k) {
 				// TODO: warn if we overwrite an already set value
 				for k2, v2 := range v {
 					switch v2 := v2.(type) {
@@ -437,7 +437,7 @@ func DecodePermalinksConfig(m map[string]any) (map[string]map[string]string, err
 					}
 				}
 			} else {
-				return nil, fmt.Errorf("permalinks configuration not supported for kind %q, supported kinds are %v", k, permalinksKindsSuppurt)
+				return nil, fmt.Errorf("permalinks configuration not supported for kind %q, supported kinds are %v", k, permalinksKindsSupport)
 			}
 
 		default:


### PR DESCRIPTION
This PR fixes typos in the struct field and variable names.