### PR TITLE
Add mastodon shortcode

### DIFF
--- a/config/privacy/privacyConfig.go
+++ b/config/privacy/privacyConfig.go
@@ -30,6 +30,7 @@ type Config struct {
 	Disqus          Disqus
 	GoogleAnalytics GoogleAnalytics
 	Instagram       Instagram
+	Mastodon        Mastodon
 	Twitter         Twitter
 	Vimeo           Vimeo
 	YouTube         YouTube
@@ -62,6 +63,11 @@ type Instagram struct {
 	// If simple mode is enabled, a static and no-JS version of the Instagram
 	// image card will be built.
 	Simple bool
+}
+
+// Mastodon holds the privacy configuration settings related to the Mastodon template.
+type Mastodon struct {
+	Service `mapstructure:",squash"`
 }
 
 // Twitter holds the privacy configuration settingsrelated to the Twitter shortcode.

--- a/config/privacy/privacyConfig_test.go
+++ b/config/privacy/privacyConfig_test.go
@@ -38,6 +38,8 @@ useSessionStorage = true
 [privacy.instagram]
 disable = true
 simple = true
+[privacy.mastodon]
+disable = true
 [privacy.twitter]
 disable = true
 enableDNT = true
@@ -62,7 +64,7 @@ simple = true
 		pc.Disqus.Disable, pc.GoogleAnalytics.Disable,
 		pc.GoogleAnalytics.RespectDoNotTrack, pc.GoogleAnalytics.AnonymizeIP,
 		pc.GoogleAnalytics.UseSessionStorage, pc.Instagram.Disable,
-		pc.Instagram.Simple, pc.Twitter.Disable, pc.Twitter.EnableDNT,
+		pc.Instagram.Simple, pc.Mastodon.Disable, pc.Twitter.Disable, pc.Twitter.EnableDNT,
 		pc.Twitter.Simple, pc.Vimeo.Disable, pc.Vimeo.EnableDNT, pc.Vimeo.Simple,
 		pc.YouTube.PrivacyEnhanced, pc.YouTube.Disable,
 	}

--- a/tpl/tplimpl/embedded/templates/shortcodes/mastodon.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/mastodon.html
@@ -1,0 +1,32 @@
+{{- $pc := site.Config.Privacy.Mastodon -}}
+{{- if not $pc.Disable -}}
+  {{- $msg1 := "The %q shortcode requires three named parameters: instance, user and id. See %s" -}}
+  {{- $msg2 := "The %q shortcode requires three parameters: instance, user and id. See %s" -}}
+  {{- if .IsNamedParams -}}
+    {{- $id := .Get "id" -}}
+    {{- $user := .Get "user" -}}      
+    {{- $instance := .Get "instance" -}}
+    {{- if and $id $user $instance -}}
+      {{- template "render-toot" (dict "id" $id "user" $user "instance" $instance) -}}
+    {{- else -}}
+      {{- errorf $msg1 .Name .Position -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $id := .Get 2 -}}
+    {{- $user := .Get 1 -}}
+    {{- $instance := .Get 0 -}}
+    {{- if eq 3 (len .Params) -}}
+      {{- template "render-toot" (dict "id" $id "user" $user "instance" $instance) -}}
+    {{- else -}}      
+      {{- errorf $msg2 .Name .Position -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "render-toot" -}}
+  {{- $url := printf "https://%v/@%v/%v" .instance .user .id -}}
+  {{- $query := querify "url" $url -}}
+  {{- $request := printf "https://%v/api/oembed?%s" .instance $query -}}
+  {{- $json := getJSON $request -}}
+  {{- $json.html | safeHTML -}}
+{{- end -}}


### PR DESCRIPTION
Hugo comes with shortcodes for embedding tweets and various other social media posts. This pull request adds the ability to embed Mastodon posts.

Suggestions on how to improve this shortcode are very welcome.