### PR TITLE
Avoid escaping HTML chars inside hugo_stats.json

### DIFF
--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -492,10 +492,15 @@ func (h *HugoSites) writeBuildStats() error {
 		HTMLElements: *htmlElements,
 	}
 
-	js, err := json.MarshalIndent(stats, "", "  ")
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	err := enc.Encode(stats)
 	if err != nil {
 		return err
 	}
+	js := buf.Bytes()
 
 	filename := filepath.Join(h.Configs.LoadingInfo.BaseConfig.WorkingDir, files.FilenameHugoStatsJSON)
 

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -1116,7 +1116,7 @@ minify = %t
 
 Some text.
 
-<div class="c d e" id="el2">Foo</div>
+<div class="c d e [&>p]:text-red-600" id="el2">Foo</div>
 
 <span class=z>FOO</span>
 
@@ -1144,6 +1144,7 @@ Some text.
               "d",
               "e",
               "hover:text-gradient",
+			  "[&>p]:text-red-600",
               "inline-block",
               "lowercase",
               "pb-1",


### PR DESCRIPTION
Fixes #11371
