### PR TITLE
deploy: Update InvalidateCloudFront to use Go CDK helper

### DIFF
--- a/deploy/cloudfront.go
+++ b/deploy/cloudfront.go
@@ -21,21 +21,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
+	gcaws "gocloud.dev/aws"
 )
 
 // InvalidateCloudFront invalidates the CloudFront cache for distributionID.
 // It uses the default AWS credentials from the environment.
 func InvalidateCloudFront(ctx context.Context, distributionID string) error {
-	// SharedConfigEnable enables loading "shared config (~/.aws/config) and
-	// shared credentials (~/.aws/credentials) files".
-	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more
-	// details.
-	// This is the same codepath used by Go CDK when creating an s3 URL.
-	// TODO: Update this to a Go CDK helper once available
-	// (https://github.com/google/go-cloud/issues/2003).
-	sess, err := session.NewSessionWithOptions(session.Options{SharedConfigState: session.SharedConfigEnable})
+	sess, err := gcaws.NewDefaultSession()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR refactors `InvalidateCloudFront` by replacing `session.NewSessionWithOptions` with `gcaws.NewDefaultSession`.