### PR TITLE
modules: Make new cache directories read/write

### DIFF
--- a/modules/client.go
+++ b/modules/client.go
@@ -456,7 +456,7 @@ func (c *Client) listGoMods() (goModules, error) {
 	}
 
 	downloadModules := func(modules ...string) error {
-		args := []string{"mod", "download"}
+		args := []string{"mod", "download", "-modcacherw"}
 		args = append(args, modules...)
 		out := io.Discard
 		err := c.runGo(context.Background(), out, args...)


### PR DESCRIPTION
Leave newly-created directories in the module cache read-write instead of making them read-only.

Closes # 11369