### PR TITLE
Fix it so disable a module does not disable transitive dependency required by others

### DIFF
--- a/config/allconfig/configlanguage.go
+++ b/config/allconfig/configlanguage.go
@@ -140,7 +140,7 @@ func (c ConfigLanguage) GetConfigSection(s string) any {
 		return c.config.Permalinks
 	case "minify":
 		return c.config.Minify
-	case "activeModules":
+	case "allModules":
 		return c.m.Modules
 	case "deployment":
 		return c.config.Deployment

--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -84,7 +84,7 @@ func LoadConfig(d ConfigSourceDescriptor) (*Configs, error) {
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}
 
-	configs.Modules = moduleConfig.ActiveModules
+	configs.Modules = moduleConfig.AllModules
 	configs.ModulesClient = modulesClient
 
 	if err := configs.Init(); err != nil {
@@ -471,7 +471,7 @@ func (l *configLoader) loadModules(configs *Configs) (modules.ModulesConfig, *mo
 	ex := hexec.New(conf.Security)
 
 	hook := func(m *modules.ModulesConfig) error {
-		for _, tc := range m.ActiveModules {
+		for _, tc := range m.AllModules {
 			if len(tc.ConfigFilenames()) > 0 {
 				if tc.Watch() {
 					l.ModulesConfigFiles = append(l.ModulesConfigFiles, tc.ConfigFilenames()...)

--- a/hugolib/paths/paths.go
+++ b/hugolib/paths/paths.go
@@ -83,7 +83,7 @@ func New(fs *hugofs.Fs, cfg config.AllProvider) (*Paths, error) {
 }
 
 func (p *Paths) AllModules() modules.Modules {
-	return p.Cfg.GetConfigSection("activeModules").(modules.Modules)
+	return p.Cfg.GetConfigSection("allModules").(modules.Modules)
 }
 
 // GetBasePath returns any path element in baseURL if needed.

--- a/modules/client.go
+++ b/modules/client.go
@@ -153,10 +153,6 @@ func (c *Client) Graph(w io.Writer) error {
 			continue
 		}
 
-		prefix := ""
-		if module.Disabled() {
-			prefix = "DISABLED "
-		}
 		dep := pathVersion(module.Owner()) + " " + pathVersion(module)
 		if replace := module.Replace(); replace != nil {
 			if replace.Version() != "" {
@@ -166,7 +162,7 @@ func (c *Client) Graph(w io.Writer) error {
 				dep += " => " + replace.Dir()
 			}
 		}
-		fmt.Fprintln(w, prefix+dep)
+		fmt.Fprintln(w, dep)
 	}
 
 	return nil

--- a/modules/module.go
+++ b/modules/module.go
@@ -40,9 +40,6 @@ type Module interface {
 	// Directory holding files for this module.
 	Dir() string
 
-	// This module is disabled.
-	Disabled() bool
-
 	// Returns whether this is a Go Module.
 	IsGoMod() bool
 
@@ -81,7 +78,6 @@ type moduleAdapter struct {
 	dir        string
 	version    string
 	vendor     bool
-	disabled   bool
 	projectMod bool
 	owner      Module
 
@@ -113,10 +109,6 @@ func (m *moduleAdapter) Dir() string {
 		return m.dir
 	}
 	return m.gomod.Dir
-}
-
-func (m *moduleAdapter) Disabled() bool {
-	return m.disabled
 }
 
 func (m *moduleAdapter) IsGoMod() bool {

--- a/testscripts/commands/mod__disable.txt
+++ b/testscripts/commands/mod__disable.txt
@@ -1,0 +1,15 @@
+hugo mod graph
+stdout 'withhugotoml.*commonmod'
+
+-- hugo.toml --
+title = "Hugo Modules Test"
+[module]
+[[module.imports]]
+path="github.com/gohugoio/hugo-mod-integrationtests/withconfigtoml"
+disable = true
+[[module.imports]]
+path="github.com/gohugoio/hugo-mod-integrationtests/withhugotoml"
+-- go.mod --
+module foo
+go 1.19
+

--- a/testscripts/commands/mod_vendor.txt
+++ b/testscripts/commands/mod_vendor.txt
@@ -20,5 +20,6 @@ go 1.19
 
 module github.com/gohugoio/testmod
 -- golden/vendor.txt --
-# github.com/gohugoio/hugo-mod-integrationtests/withconfigtoml v1.0.0
-# github.com/gohugoio/hugo-mod-integrationtests/withhugotoml v1.0.0
+# github.com/gohugoio/hugo-mod-integrationtests/withconfigtoml v1.1.0
+# github.com/gohugoio/hugo-mod-integrationtests/commonmod v0.0.0-20230823103305-919cefe8a425
+# github.com/gohugoio/hugo-mod-integrationtests/withhugotoml v1.1.0


### PR DESCRIPTION
The motivation behind the original implementation was probably to show disabled modules when running `hugo mod graph`.

Fixes #11376
