### PR TITLE
Change fsnotify event operation check

### DIFF
--- a/commands/hugobuilder.go
+++ b/commands/hugobuilder.go
@@ -681,11 +681,11 @@ func (c *hugoBuilder) handleEvents(watcher *watcher.Batcher,
 		if isConfig {
 			isHandled = true
 
-			if ev.Op&fsnotify.Chmod == fsnotify.Chmod {
+			if ev.Has(fsnotify.Chmod) {
 				continue
 			}
 
-			if ev.Op&fsnotify.Remove == fsnotify.Remove || ev.Op&fsnotify.Rename == fsnotify.Rename {
+			if ev.Has(fsnotify.Remove) || ev.Has(fsnotify.Rename) {
 				c.withConf(func(conf *commonConfig) {
 					for _, configFile := range conf.configs.LoadingInfo.ConfigFiles {
 						counter := 0
@@ -807,7 +807,7 @@ func (c *hugoBuilder) handleEvents(watcher *watcher.Batcher,
 		// We do have to check for WRITE though. On slower laptops a Chmod
 		// could be aggregated with other important events, and we still want
 		// to rebuild on those
-		if ev.Op&(fsnotify.Chmod|fsnotify.Write|fsnotify.Create) == fsnotify.Chmod {
+		if ev.Has(fsnotify.Chmod) && !ev.Has(fsnotify.Write) && !ev.Has(fsnotify.Create) {
 			continue
 		}
 
@@ -828,7 +828,7 @@ func (c *hugoBuilder) handleEvents(watcher *watcher.Batcher,
 
 		// recursively add new directories to watch list
 		// When mkdir -p is used, only the top directory triggers an event (at least on OSX)
-		if ev.Op&fsnotify.Create == fsnotify.Create {
+		if ev.Has(fsnotify.Create) {
 			c.withConf(func(conf *commonConfig) {
 				if s, err := conf.fs.Source.Stat(ev.Name); err == nil && s.Mode().IsDir() {
 					_ = helpers.SymbolicWalk(conf.fs.Source, ev.Name, walkAdder)

--- a/commands/server.go
+++ b/commands/server.go
@@ -1103,7 +1103,7 @@ func (s *staticSyncer) syncsStaticEvents(staticEvents []fsnotify.Event) error {
 			// This assumes that Hugo has not generated content on top of a static file and then removed
 			// the source of that static file. In this case Hugo will incorrectly remove that file
 			// from the published directory.
-			if ev.Op&fsnotify.Rename == fsnotify.Rename || ev.Op&fsnotify.Remove == fsnotify.Remove {
+			if ev.Has(fsnotify.Rename) || ev.Has(fsnotify.Remove) {
 				if _, err := sourceFs.Fs.Stat(relPath); herrors.IsNotExist(err) {
 					// If file doesn't exist in any static dir, remove it
 					logger.Println("File no longer exists in static dir, removing", relPath)
@@ -1190,7 +1190,7 @@ func pickOneWriteOrCreatePath(events []fsnotify.Event) string {
 	name := ""
 
 	for _, ev := range events {
-		if ev.Op&fsnotify.Write == fsnotify.Write || ev.Op&fsnotify.Create == fsnotify.Create {
+		if ev.Has(fsnotify.Write) || ev.Has(fsnotify.Create) {
 			if files.IsIndexContentFile(ev.Name) {
 				return ev.Name
 			}

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -423,7 +423,7 @@ func (s *Site) filterFileEvents(events []fsnotify.Event) []fsnotify.Event {
 
 		// Throw away any directories
 		isRegular, err := s.SourceSpec.IsRegularSourceFile(ev.Name)
-		if err != nil && herrors.IsNotExist(err) && (ev.Op&fsnotify.Remove == fsnotify.Remove || ev.Op&fsnotify.Rename == fsnotify.Rename) {
+		if err != nil && herrors.IsNotExist(err) && (ev.Has(fsnotify.Remove) || ev.Has(fsnotify.Rename)) {
 			// Force keep of event
 			isRegular = true
 		}
@@ -463,12 +463,12 @@ func (s *Site) translateFileEvents(events []fsnotify.Event) []fsnotify.Event {
 				kept = ev2
 			}
 
-			if ev2.Op&fsnotify.Write == fsnotify.Write {
+			if ev2.Has(fsnotify.Write) {
 				kept = ev2
 				found = true
 			}
 
-			if !found && ev2.Op&fsnotify.Create == fsnotify.Create {
+			if !found && ev2.Has(fsnotify.Create) {
 				kept = ev2
 			}
 		}
@@ -598,14 +598,14 @@ func (s *Site) processPartial(config *BuildCfg, init func(config *BuildCfg) erro
 	for _, ev := range sourceChanged {
 		removed := false
 
-		if ev.Op&fsnotify.Remove == fsnotify.Remove {
+		if ev.Has(fsnotify.Remove) {
 			removed = true
 		}
 
 		// Some editors (Vim) sometimes issue only a Rename operation when writing an existing file
 		// Sometimes a rename operation means that file has been renamed other times it means
 		// it's been updated
-		if ev.Op&fsnotify.Rename == fsnotify.Rename {
+		if ev.Has(fsnotify.Rename) {
 			// If the file is still on disk, it's only been updated, if it's not, it's been moved
 			if ex, err := afero.Exists(s.Fs.Source, ev.Name); !ex || err != nil {
 				removed = true


### PR DESCRIPTION
This pull request takes advantage of a [new feature] added to fsnotify v1.6.0 that allows for checking event operations using the [Has] method instead of direct bitwise operations. The former may be clearer for most developers.

I'm not sure if the overhead of calling the Has method would be significant. While it seems like a good candidate for inlining by the Go compiler, I haven't been able to prove that is happening at all. Let me know your thoughts!

[new feature]: https://github.com/fsnotify/fsnotify/pull/477
[Has]: https://pkg.go.dev/github.com/fsnotify/fsnotify@v1.6.0#Event.Has
