### PR TITLE
create/skeletons: Improve viewport meta tag

### DIFF
--- a/create/skeletons/theme/layouts/partials/head.html
+++ b/create/skeletons/theme/layouts/partials/head.html
@@ -1,5 +1,5 @@
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0">
+<meta name="viewport" content="width=device-width">
 <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title site.Title }}{{ end }}</title>
 {{ partialCached "head/css.html" . }}
 {{ partialCached "head/js.html" . }}


### PR DESCRIPTION
Remove initial-scale=1.0 (this is the browser default)
Remove minimum-scale=1.0 (opinionated, can throw WCAG warning)