### PR TITLE
commands: Fix webserver available at url

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -954,7 +954,7 @@ func (c *serverCommand) serve() error {
 			mu.HandleFunc(u.Path+"/livereload.js", livereload.ServeJS)
 			mu.HandleFunc(u.Path+"/livereload", livereload.Handler)
 		}
-		c.r.Printf("Web Server is available at %s (bind address %s) %s\n", serverURL, c.serverInterface, roots[i])
+		c.r.Printf("Web Server is available at http:%s (bind address %s) %s\n", serverURL, c.serverInterface, roots[i])
 		wg1.Go(func() error {
 			if c.tlsCertFile != "" && c.tlsKeyFile != "" {
 				err = srv.ServeTLS(listener, c.tlsCertFile, c.tlsKeyFile)


### PR DESCRIPTION
Running `hugo serve` yielded the following message: `Web Server is available at //localhost:1313/` The url was missing http.

Prepended the baseURL with http: to correct this issue.

Before:
```
Web Server is available at //localhost:1313/ (bind address 127.0.0.1)
```

After
```
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
```

This is a small issue, but adding `http:` makes the URL clickable from the terminal which is nice