### PR TITLE
Add $image.Process

### DIFF
--- a/common/hstrings/strings.go
+++ b/common/hstrings/strings.go
@@ -99,3 +99,26 @@ var reCache = regexpCache{re: make(map[string]*regexp.Regexp)}
 func GetOrCompileRegexp(pattern string) (re *regexp.Regexp, err error) {
 	return reCache.getOrCompileRegexp(pattern)
 }
+
+// InSlice checks if a string is an element of a slice of strings
+// and returns a boolean value.
+func InSlice(arr []string, el string) bool {
+	for _, v := range arr {
+		if v == el {
+			return true
+		}
+	}
+	return false
+}
+
+// InSlicEqualFold checks if a string is an element of a slice of strings
+// and returns a boolean value.
+// It uses strings.EqualFold to compare.
+func InSlicEqualFold(arr []string, el string) bool {
+	for _, v := range arr {
+		if strings.EqualFold(v, el) {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/content/en/content-management/image-processing/index.md
+++ b/docs/content/en/content-management/image-processing/index.md
@@ -101,11 +101,40 @@ Example 4: Skips rendering if there's problem accessing a remote resource.
 
 ## Image processing methods
 
-The `image` resource implements the  [`Resize`], [`Fit`], [`Fill`], [`Crop`], [`Filter`], [`Colors`] and [`Exif`] methods.
+The `image` resource implements the  [`Process`],  [`Resize`], [`Fit`], [`Fill`], [`Crop`], [`Filter`], [`Colors`] and [`Exif`] methods.
 
 {{% note %}}
 Metadata (EXIF, IPTC, XMP, etc.) is not preserved during image transformation. Use the [`Exif`] method with the _original_ image to extract EXIF metadata from JPEG or TIFF images.
 {{% /note %}}
+
+### Process
+
+{{< new-in "0.119.0" >}}
+
+Process processes the image with the given specification. The specification can contain an optional action, one of `resize`, `crop`, `fit` or `fill`. This means that you can use this method instead of [`Resize`], [`Fit`], [`Fill`], or [`Crop`]. 
+
+See [Options](#image-processing-options) for available options.
+
+You can also use this method apply image processing that does not need any scaling, e.g. format conversions:
+
+```go-html-template
+{{/* Convert the image from JPG to PNG. */}}
+{{ $png := $jpg.Process "png" }}
+```
+
+Some more examples:
+
+```go-html-template
+{{/* Rotate the image 90 degrees counter-clockwise. */}}
+{{ $image := $image.Process "r90" }}
+
+{{/* Scaling actions. */}}
+{{ $image := $image.Process "resize 600x" }}
+{{ $image := $image.Process "crop 600x400" }}
+{{ $image := $image.Process "fit 600x400" }}
+{{ $image := $image.Process "fill 600x400" }}
+```
+
 
 ### Resize
 
@@ -477,6 +506,7 @@ hugo --gc
 [github.com/disintegration/imaging]: <https://github.com/disintegration/imaging#image-resizing>
 [Smartcrop]: <https://github.com/muesli/smartcrop#smartcrop>
 [Exif]: <https://en.wikipedia.org/wiki/Exif>
+[`Process`]: #process
 [`Colors`]: #colors
 [`Crop`]: #crop
 [`Exif`]: #exif

--- a/docs/content/en/functions/images/index.md
+++ b/docs/content/en/functions/images/index.md
@@ -12,6 +12,28 @@ toc: true
 
 See [images.Filter](#filter) for how to apply these filters to an image.
 
+## Process
+
+{{< new-in "0.119.0" >}}
+
+{{% funcsig %}}
+images.Overlay SRC SPEC
+{{% /funcsig %}}
+
+A general purpose image processing function.
+
+This filter has all the same options as the [Process](/content-management/image-processing/#process) method, but using it as a filter may be more effective if you need to apply multiple filters to an image:
+
+```go-html-template
+{{ $filters := slice 
+  images.Grayscale
+  (images.GaussianBlur 8)
+  (images.Process "resize 200x jpg q30") 
+}}
+{{ $img = $img | images.Filter $filters }}
+```
+
+
 ## Overlay
 
 {{% funcsig %}}
@@ -36,6 +58,8 @@ The above will overlay `$logo` in the upper left corner of `$img` (at position `
 
 ## Opacity
 
+{{< new-in "0.119.0" >}}
+
 {{% funcsig %}}
 images.Opacity SRC OPACITY
 {{% /funcsig %}}
@@ -45,6 +69,15 @@ The OPACITY parameter must be in range (0, 1).
 
 ```go-html-template
 {{ $img := $img.Filter (images.Opacity 0.5 )}}
+```
+
+Note that target format must support transparency, e.g. PNG. If the source image is e.g. JPG, the most effective way would be to combine it with the [`Process`] filter:
+
+```go-html-template
+{{ $png := $jpg.Filter 
+  (images.Opacity 0.5)
+  (images.Process "png") 
+}}
 ```
 
 ## Text
@@ -237,3 +270,5 @@ images.ImageConfig PATH
 favicon.ico: {{ .Width }} x {{ .Height }}
 {{ end }}
 ```
+
+[`Process`]: #process

--- a/helpers/general.go
+++ b/helpers/general.go
@@ -53,18 +53,6 @@ func TCPListen() (net.Listener, *net.TCPAddr, error) {
 	}
 	l.Close()
 	return nil, nil, fmt.Errorf("unable to obtain a valid tcp port: %v", addr)
-
-}
-
-// InStringArray checks if a string is an element of a slice of strings
-// and returns a boolean value.
-func InStringArray(arr []string, el string) bool {
-	for _, v := range arr {
-		if v == el {
-			return true
-		}
-	}
-	return false
 }
 
 // FirstUpper returns a string with the first character as upper case.

--- a/hugolib/site_output_test.go
+++ b/hugolib/site_output_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/resources/kinds"
 
 	"github.com/spf13/afero"
 
-	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/output"
 )
 
@@ -152,7 +152,7 @@ Len Pages: {{ .Kind }} {{ len .Site.RegularPages }} Page Number: {{ .Paginator.P
 
 	// There is currently always a JSON output to make it simpler ...
 	altFormats := lenOut - 1
-	hasHTML := helpers.InStringArray(outputs, "html")
+	hasHTML := hstrings.InSlice(outputs, "html")
 	b.AssertFileContent("public/index.json",
 		"List JSON",
 		fmt.Sprintf("Alt formats: %d", altFormats),
@@ -205,7 +205,7 @@ Len Pages: {{ .Kind }} {{ len .Site.RegularPages }} Page Number: {{ .Paginator.P
 	b.Assert(json.RelPermalink(), qt.Equals, "/blog/index.json")
 	b.Assert(json.Permalink(), qt.Equals, "http://example.com/blog/index.json")
 
-	if helpers.InStringArray(outputs, "cal") {
+	if hstrings.InSlice(outputs, "cal") {
 		cal := of.Get("calendar")
 		b.Assert(cal, qt.Not(qt.IsNil))
 		b.Assert(cal.RelPermalink(), qt.Equals, "/blog/index.ics")

--- a/resources/errorResource.go
+++ b/resources/errorResource.go
@@ -100,6 +100,10 @@ func (e *errorResource) Width() int {
 	panic(e.ResourceError)
 }
 
+func (e *errorResource) Process(spec string) (images.ImageResource, error) {
+	panic(e.ResourceError)
+}
+
 func (e *errorResource) Crop(spec string) (images.ImageResource, error) {
 	panic(e.ResourceError)
 }

--- a/resources/image.go
+++ b/resources/image.go
@@ -31,6 +31,7 @@ import (
 
 	color_extractor "github.com/marekm4/color-extractor"
 
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/identity"
 
@@ -198,75 +199,49 @@ func (i *imageResource) cloneWithUpdates(u *transformationUpdate) (baseResource,
 	}, nil
 }
 
+var imageActions = []string{images.ActionResize, images.ActionCrop, images.ActionFit, images.ActionFill}
+
+// Process processes the image with the given spec.
+// The spec can contain an optional action, one of "resize", "crop", "fit" or "fill".
+// This makes this method a more flexible version that covers all of Resize, Crop, Fit and Fill,
+// but it also supports e.g. format conversions without any resize action.
+func (i *imageResource) Process(spec string) (images.ImageResource, error) {
+	var action string
+	options := strings.Fields(spec)
+	for i, p := range options {
+		if hstrings.InSlicEqualFold(imageActions, p) {
+			action = p
+			options = append(options[:i], options[i+1:]...)
+			break
+		}
+	}
+	return i.processActionOptions(action, options)
+}
+
 // Resize resizes the image to the specified width and height using the specified resampling
 // filter and returns the transformed image. If one of width or height is 0, the image aspect
 // ratio is preserved.
 func (i *imageResource) Resize(spec string) (images.ImageResource, error) {
-	conf, err := i.decodeImageConfig("resize", spec)
-	if err != nil {
-		return nil, err
-	}
-
-	return i.doWithImageConfig(conf, func(src image.Image) (image.Image, error) {
-		return i.Proc.ApplyFiltersFromConfig(src, conf)
-	})
+	return i.processActionSpec(images.ActionResize, spec)
 }
 
 // Crop the image to the specified dimensions without resizing using the given anchor point.
 // Space delimited config, e.g. `200x300 TopLeft`.
 func (i *imageResource) Crop(spec string) (images.ImageResource, error) {
-	conf, err := i.decodeImageConfig("crop", spec)
-	if err != nil {
-		return nil, err
-	}
-
-	return i.doWithImageConfig(conf, func(src image.Image) (image.Image, error) {
-		return i.Proc.ApplyFiltersFromConfig(src, conf)
-	})
+	return i.processActionSpec(images.ActionCrop, spec)
 }
 
 // Fit scales down the image using the specified resample filter to fit the specified
 // maximum width and height.
 func (i *imageResource) Fit(spec string) (images.ImageResource, error) {
-	conf, err := i.decodeImageConfig("fit", spec)
-	if err != nil {
-		return nil, err
-	}
-
-	return i.doWithImageConfig(conf, func(src image.Image) (image.Image, error) {
-		return i.Proc.ApplyFiltersFromConfig(src, conf)
-	})
+	return i.processActionSpec(images.ActionFit, spec)
 }
 
 // Fill scales the image to the smallest possible size that will cover the specified dimensions,
 // crops the resized image to the specified dimensions using the given anchor point.
 // Space delimited config, e.g. `200x300 TopLeft`.
 func (i *imageResource) Fill(spec string) (images.ImageResource, error) {
-	conf, err := i.decodeImageConfig("fill", spec)
-	if err != nil {
-		return nil, err
-	}
-
-	img, err := i.doWithImageConfig(conf, func(src image.Image) (image.Image, error) {
-		return i.Proc.ApplyFiltersFromConfig(src, conf)
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	if conf.Anchor == 0 && img.Width() == 0 || img.Height() == 0 {
-		// See https://github.com/gohugoio/hugo/issues/7955
-		// Smartcrop fails silently in some rare cases.
-		// Fall back to a center fill.
-		conf.Anchor = gift.CenterAnchor
-		conf.AnchorStr = "center"
-		return i.doWithImageConfig(conf, func(src image.Image) (image.Image, error) {
-			return i.Proc.ApplyFiltersFromConfig(src, conf)
-		})
-	}
-
-	return img, err
+	return i.processActionSpec(images.ActionFill, spec)
 }
 
 func (i *imageResource) Filter(filters ...any) (images.ImageResource, error) {
@@ -284,6 +259,39 @@ func (i *imageResource) Filter(filters ...any) (images.ImageResource, error) {
 	return i.doWithImageConfig(conf, func(src image.Image) (image.Image, error) {
 		return i.Proc.Filter(src, gfilters...)
 	})
+}
+
+func (i *imageResource) processActionSpec(action, spec string) (images.ImageResource, error) {
+	return i.processActionOptions(action, strings.Fields(spec))
+}
+
+func (i *imageResource) processActionOptions(action string, options []string) (images.ImageResource, error) {
+	conf, err := images.DecodeImageConfig(action, options, i.Proc.Cfg, i.Format)
+	if err != nil {
+		return nil, err
+	}
+
+	img, err := i.doWithImageConfig(conf, func(src image.Image) (image.Image, error) {
+		return i.Proc.ApplyFiltersFromConfig(src, conf)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if action == images.ActionFill {
+		if conf.Anchor == 0 && img.Width() == 0 || img.Height() == 0 {
+			// See https://github.com/gohugoio/hugo/issues/7955
+			// Smartcrop fails silently in some rare cases.
+			// Fall back to a center fill.
+			conf.Anchor = gift.CenterAnchor
+			conf.AnchorStr = "center"
+			return i.doWithImageConfig(conf, func(src image.Image) (image.Image, error) {
+				return i.Proc.ApplyFiltersFromConfig(src, conf)
+			})
+		}
+	}
+
+	return img, nil
 }
 
 // Serialize image processing. The imaging library spins up its own set of Go routines,
@@ -362,7 +370,8 @@ func (i *imageResource) doWithImageConfig(conf images.ImageConfig, f func(src im
 }
 
 func (i *imageResource) decodeImageConfig(action, spec string) (images.ImageConfig, error) {
-	conf, err := images.DecodeImageConfig(action, spec, i.Proc.Cfg, i.Format)
+	options := strings.Fields(spec)
+	conf, err := images.DecodeImageConfig(action, options, i.Proc.Cfg, i.Format)
 	if err != nil {
 		return conf, err
 	}

--- a/resources/images/config_test.go
+++ b/resources/images/config_test.go
@@ -106,7 +106,7 @@ func TestDecodeImageConfig(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		result, err := DecodeImageConfig(this.action, this.in, cfg, PNG)
+		result, err := DecodeImageConfig(this.action, strings.Fields(this.in), cfg, PNG)
 		if b, ok := this.expect.(bool); ok && !b {
 			if err == nil {
 				t.Errorf("[%d] parseImageConfig didn't return an expected error", i)

--- a/resources/images/filters.go
+++ b/resources/images/filters.go
@@ -30,6 +30,15 @@ const filterAPIVersion = 0
 
 type Filters struct{}
 
+func (*Filters) Process(spec any) gift.Filter {
+	return filter{
+		Options: newFilterOpts(spec),
+		Filter: processFilter{
+			spec: cast.ToString(spec),
+		},
+	}
+}
+
 // Overlay creates a filter that overlays src at position x y.
 func (*Filters) Overlay(src ImageSource, x, y any) gift.Filter {
 	return filter{

--- a/resources/images/image_resource.go
+++ b/resources/images/image_resource.go
@@ -33,6 +33,9 @@ type ImageResourceOps interface {
 	// Width returns the width of the Image.
 	Width() int
 
+	// Process applies the given image processing options to the image.
+	Process(spec string) (ImageResource, error)
+
 	// Crop an image to match the given dimensions without resizing.
 	// You must provide both width and height.
 	// Use the anchor option to change the crop box anchor point.

--- a/resources/images/process.go
+++ b/resources/images/process.go
@@ -1,0 +1,43 @@
+// Copyright 2023 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package images
+
+import (
+	"image"
+	"image/draw"
+
+	"github.com/disintegration/gift"
+)
+
+var _ ImageProcessSpecProvider = (*processFilter)(nil)
+
+type ImageProcessSpecProvider interface {
+	ImageProcessSpec() string
+}
+
+type processFilter struct {
+	spec string
+}
+
+func (f processFilter) Draw(dst draw.Image, src image.Image, options *gift.Options) {
+	panic("not supported")
+}
+
+func (f processFilter) Bounds(srcBounds image.Rectangle) image.Rectangle {
+	panic("not supported")
+}
+
+func (f processFilter) ImageProcessSpec() string {
+	return f.spec
+}

--- a/resources/page/permalinks.go
+++ b/resources/page/permalinks.go
@@ -14,6 +14,7 @@
 package page
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -23,8 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"errors"
-
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/resources/kinds"
@@ -396,7 +396,6 @@ func (l PermalinkExpander) toSliceFunc(cut string) func(s []string) []string {
 		}
 		return s[n1:n2]
 	}
-
 }
 
 var permalinksKindsSupport = []string{kinds.KindPage, kinds.KindSection, kinds.KindTaxonomy, kinds.KindTerm}
@@ -425,7 +424,7 @@ func DecodePermalinksConfig(m map[string]any) (map[string]map[string]string, err
 			// [permalinks.key]
 			//   xyz = ???
 
-			if helpers.InStringArray(permalinksKindsSupport, k) {
+			if hstrings.InSlice(permalinksKindsSupport, k) {
 				// TODO: warn if we overwrite an already set value
 				for k2, v2 := range v {
 					switch v2 := v2.(type) {

--- a/resources/transform.go
+++ b/resources/transform.go
@@ -195,6 +195,10 @@ func (r resourceAdapter) cloneTo(targetPath string) resource.Resource {
 	return &r
 }
 
+func (r *resourceAdapter) Process(spec string) (images.ImageResource, error) {
+	return r.getImageOps().Process(spec)
+}
+
 func (r *resourceAdapter) Crop(spec string) (images.ImageResource, error) {
 	return r.getImageOps().Crop(spec)
 }
@@ -287,7 +291,6 @@ func (r resourceAdapter) Transform(t ...ResourceTransformation) (ResourceTransfo
 }
 
 func (r resourceAdapter) TransformWithContext(ctx context.Context, t ...ResourceTransformation) (ResourceTransformer, error) {
-
 	r.resourceTransformations = &resourceTransformations{
 		transformations: append(r.transformations, t...),
 	}
@@ -459,7 +462,6 @@ func (r *resourceAdapter) transform(publish, setContent bool) error {
 					errMsg = ". Check your Hugo installation; you need the extended version to build SCSS/SASS with transpiler set to 'libsass'."
 				} else if tr.Key().Name == "tocss-dart" {
 					errMsg = ". You need dart-sass-embedded in your system $PATH."
-
 				} else if tr.Key().Name == "babel" {
 					errMsg = ". You need to install Babel, see https://gohugo.io/hugo-pipes/babel/"
 				}


### PR DESCRIPTION
Which supports all the existing actions: resize, crop, fit, fill-

But it also allows plain format conversions:

```
{{ $img = $img.Process "webp" }}
```

Which will be a simple re-encoding of the source image.

Fixes #11483
