### PR TITLE
content_map_page: Ensure homepage exists

### DIFF
--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -487,7 +487,11 @@ func (m *pageMap) assembleSections() error {
 
 		shouldBuild = m.s.shouldBuild(n.p)
 		if !shouldBuild {
-			sectionsToDelete = append(sectionsToDelete, s)
+			if kind == kinds.KindHome {
+				n.p = m.s.newPage(n, parentBucket, kind, "", sections...)
+			} else {
+				sectionsToDelete = append(sectionsToDelete, s)
+			}
 			return false
 		}
 

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -435,7 +435,7 @@ NO HOME FOR YOU
 
 	b.Build(BuildCfg{})
 
-	b.Assert(b.CheckExists("public/index.html"), qt.Equals, false)
+	b.Assert(b.CheckExists("public/index.html"), qt.Equals, true)
 	b.Assert(b.CheckExists("public/categories/index.html"), qt.Equals, false)
 	b.Assert(b.CheckExists("public/posts/index.html"), qt.Equals, false)
 }


### PR DESCRIPTION
Previously, it was possible to create an _index.md, but have it not be built, such as by setting `draft: true`. This would result in there being no homepage, and when e.g. a theme would call `.Site.Home`, this would result in a “runtime error: invalid memory address or nil pointer dereference”. Now, if the homepage does not end up being built, we fall back to creating a default homepage, as if _index.md never exited.

Fixes #11441