### PR TITLE
create/skeletons: Fix menu template

### DIFF
--- a/create/skeletons/theme/layouts/partials/menu.html
+++ b/create/skeletons/theme/layouts/partials/menu.html
@@ -27,6 +27,12 @@ Renders a menu for the given menu ID.
     {{- else if $page.HasMenuCurrent .Menu .}}
       {{- $attrs = merge $attrs (dict "class" "ancestor" "aria-current" "true") }}
     {{- end }}
+    {{- $name := .Name }}
+    {{- with .Identifier }}
+      {{- with T . }}
+        {{- $name = . }}
+      {{- end }}
+    {{- end }}
     <li>
       <a
         {{- range $k, $v := $attrs }}
@@ -34,7 +40,7 @@ Renders a menu for the given menu ID.
             {{- printf " %s=%q" $k $v | safeHTMLAttr }}
           {{- end }}
         {{- end -}}
-      >{{ or (T .Identifier) .Name | safeHTML }}</a>
+      >{{ $name }}</a>
       {{- with .Children }}
         <ul>
           {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}


### PR DESCRIPTION
Check identifier existence before calling lang.Translate to prevent empty warnings when using the --printI18nWarnings flag.

Closes #11519