### PR TITLE
magefile: Update isGoLatest to check for Go 1.21

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -329,7 +329,7 @@ func runCmd(env map[string]string, cmd string, args ...any) error {
 }
 
 func isGoLatest() bool {
-	return strings.Contains(runtime.Version(), "1.14")
+	return strings.Contains(runtime.Version(), "1.21")
 }
 
 func isCI() bool {


### PR DESCRIPTION
Updated the `isGoLatest` function to check for the latest Go version `1.21` instead of `1.14`