### PR TITLE
all: Format files with gofmt

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -927,7 +927,7 @@ func (c *serverCommand) serve() error {
 
 	for i := range baseURLs {
 		mu, listener, serverURL, endpoint, err := srv.createEndpoint(i)
-		var srv *http.Server	
+		var srv *http.Server
 		if c.tlsCertFile != "" && c.tlsKeyFile != "" {
 			srv = &http.Server{
 				Addr:    endpoint,

--- a/common/paths/url.go
+++ b/common/paths/url.go
@@ -51,9 +51,10 @@ var pb pathBridge
 
 // MakePermalink combines base URL with content path to create full URL paths.
 // Example
-//    base:   http://spf13.com/
-//    path:   post/how-i-blog
-//    result: http://spf13.com/post/how-i-blog
+//
+//	base:   http://spf13.com/
+//	path:   post/how-i-blog
+//	result: http://spf13.com/post/how-i-blog
 func MakePermalink(host, plink string) *url.URL {
 	base, err := url.Parse(host)
 	if err != nil {
@@ -117,17 +118,19 @@ func PrettifyURL(in string) string {
 
 // PrettifyURLPath takes a URL path to a content and converts it
 // to enable pretty URLs.
-//     /section/name.html       becomes /section/name/index.html
-//     /section/name/           becomes /section/name/index.html
-//     /section/name/index.html becomes /section/name/index.html
+//
+//	/section/name.html       becomes /section/name/index.html
+//	/section/name/           becomes /section/name/index.html
+//	/section/name/index.html becomes /section/name/index.html
 func PrettifyURLPath(in string) string {
 	return prettifyPath(in, pb)
 }
 
 // Uglify does the opposite of PrettifyURLPath().
-//     /section/name/index.html becomes /section/name.html
-//     /section/name/           becomes /section/name.html
-//     /section/name.html       becomes /section/name.html
+//
+//	/section/name/index.html becomes /section/name.html
+//	/section/name/           becomes /section/name.html
+//	/section/name.html       becomes /section/name.html
 func Uglify(in string) string {
 	if path.Ext(in) == "" {
 		if len(in) < 2 {

--- a/tpl/math/round.go
+++ b/tpl/math/round.go
@@ -20,19 +20,20 @@ const (
 // Round returns the nearest integer, rounding half away from zero.
 //
 // Special cases are:
+//
 //	Round(±0) = ±0
 //	Round(±Inf) = ±Inf
 //	Round(NaN) = NaN
 func _round(x float64) float64 {
 	// Round is a faster implementation of:
 	//
-	// func Round(x float64) float64 {
-	//   t := Trunc(x)
-	//   if Abs(x-t) >= 0.5 {
-	//     return t + Copysign(1, x)
-	//   }
-	//   return t
-	// }
+	//	func Round(x float64) float64 {
+	//		t := Trunc(x)
+	//		if Abs(x-t) >= 0.5 {
+	//			return t + Copysign(1, x)
+	//		}
+	//		return t
+	//	}
 	const (
 		signMask = 1 << 63
 		fracMask = 1<<shift - 1

--- a/tpl/tplimpl/template_ast_transformers.go
+++ b/tpl/tplimpl/template_ast_transformers.go
@@ -213,7 +213,8 @@ func (c *templateContext) hasIdent(idents []string, ident string) bool {
 // collectConfig collects and parses any leading template config variable declaration.
 // This will be the first PipeNode in the template, and will be a variable declaration
 // on the form:
-//    {{ $_hugo_config:= `{ "version": 1 }` }}
+//
+//	{{ $_hugo_config:= `{ "version": 1 }` }}
 func (c *templateContext) collectConfig(n *parse.PipeNode) {
 	if c.t.typ != templateShortcode {
 		return


### PR DESCRIPTION
This PR formats files with `gofmt`. We need this to fix `mage fmt`.

The problem appeared when the PR https://github.com/gohugoio/hugo/pull/11521 had been accepted.