### PR TITLE
markup/tableofcontents: Return template.HTML from .Fragments.ToHTML

### DIFF
--- a/markup/goldmark/convert_test.go
+++ b/markup/goldmark/convert_test.go
@@ -109,7 +109,7 @@ LINE1
 
 * Autolink: https://gohugo.io/
 * Strikethrough:~~Hi~~ Hello, world!
- 
+
 ## Table
 
 | foo | bar |
@@ -137,7 +137,7 @@ That's some text with a footnote.[^1]
 ## Definition Lists
 
 date
-: the datetime assigned to this page. 
+: the datetime assigned to this page.
 
 description
 : the description for the content.
@@ -204,8 +204,8 @@ unsafe = true
 
 	toc, ok := b.(converter.TableOfContentsProvider)
 	c.Assert(ok, qt.Equals, true)
-	tocHTML := toc.TableOfContents().ToHTML(1, 2, false)
-	c.Assert(tocHTML, qt.Contains, "TableOfContents")
+	tocString := string(toc.TableOfContents().ToHTML(1, 2, false))
+	c.Assert(tocString, qt.Contains, "TableOfContents")
 }
 
 func TestConvertAutoIDAsciiOnly(t *testing.T) {

--- a/markup/goldmark/toc_test.go
+++ b/markup/goldmark/toc_test.go
@@ -62,7 +62,8 @@ And then some.
 	c.Assert(err, qt.IsNil)
 	b, err := conv.Convert(converter.RenderContext{Src: []byte(content), RenderTOC: true, GetRenderer: nopGetRenderer})
 	c.Assert(err, qt.IsNil)
-	got := b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(2, 3, false)
+	tocHTML := b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(2, 3, false)
+	got := string(tocHTML)
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#first-h2---now-with-typography">First h2&mdash;now with typography!</a>
@@ -104,7 +105,8 @@ func TestEscapeToc(t *testing.T) {
 	// content := ""
 	b, err := safeConv.Convert(converter.RenderContext{Src: []byte(content), RenderTOC: true, GetRenderer: nopGetRenderer})
 	c.Assert(err, qt.IsNil)
-	got := b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(1, 2, false)
+	tocHTML := b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(1, 2, false)
+	got := string(tocHTML)
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#a--b--c--d">A &lt; B &amp; C &gt; D</a></li>
@@ -116,7 +118,8 @@ func TestEscapeToc(t *testing.T) {
 
 	b, err = unsafeConv.Convert(converter.RenderContext{Src: []byte(content), RenderTOC: true, GetRenderer: nopGetRenderer})
 	c.Assert(err, qt.IsNil)
-	got = b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(1, 2, false)
+	tocHTML = b.(converter.TableOfContentsProvider).TableOfContents().ToHTML(1, 2, false)
+	got = string(tocHTML)
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#a--b--c--d">A &lt; B &amp; C &gt; D</a></li>

--- a/markup/tableofcontents/tableofcontents.go
+++ b/markup/tableofcontents/tableofcontents.go
@@ -14,6 +14,7 @@
 package tableofcontents
 
 import (
+	"html/template"
 	"sort"
 	"strings"
 
@@ -131,7 +132,7 @@ func (toc *Fragments) addAt(h *Heading, row, level int) {
 }
 
 // ToHTML renders the ToC as HTML.
-func (toc *Fragments) ToHTML(startLevel, stopLevel int, ordered bool) string {
+func (toc *Fragments) ToHTML(startLevel, stopLevel int, ordered bool) template.HTML {
 	if toc == nil {
 		return ""
 	}
@@ -143,7 +144,7 @@ func (toc *Fragments) ToHTML(startLevel, stopLevel int, ordered bool) string {
 		ordered:    ordered,
 	}
 	b.Build()
-	return b.s.String()
+	return template.HTML(b.s.String())
 }
 
 func (toc Fragments) walk(fn func(*Heading)) {

--- a/markup/tableofcontents/tableofcontents_test.go
+++ b/markup/tableofcontents/tableofcontents_test.go
@@ -45,7 +45,7 @@ func TestToc(t *testing.T) {
 	toc.addAt(&Heading{Title: "1-H3-1", ID: "1-h2-2"}, 0, 2)
 	toc.addAt(&Heading{Title: "Heading 2", ID: "h1-2"}, 1, 0)
 
-	got := toc.ToHTML(1, -1, false)
+	got := string(toc.ToHTML(1, -1, false))
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#h1-1">Heading 1</a>
@@ -62,7 +62,7 @@ func TestToc(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(1, 1, false)
+	got = string(toc.ToHTML(1, 1, false))
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#h1-1">Heading 1</a></li>
@@ -70,7 +70,7 @@ func TestToc(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(1, 2, false)
+	got = string(toc.ToHTML(1, 2, false))
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#h1-1">Heading 1</a>
@@ -83,7 +83,7 @@ func TestToc(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(2, 2, false)
+	got = string(toc.ToHTML(2, 2, false))
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#1-h2-1">1-H2-1</a></li>
@@ -91,7 +91,7 @@ func TestToc(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(1, -1, true)
+	got = string(toc.ToHTML(1, -1, true))
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ol>
     <li><a href="#h1-1">Heading 1</a>
@@ -118,7 +118,7 @@ func TestTocMissingParent(t *testing.T) {
 	toc.addAt(&Heading{Title: "H3", ID: "h3"}, 1, 2)
 	toc.addAt(&Heading{Title: "H3", ID: "h3"}, 1, 2)
 
-	got := toc.ToHTML(1, -1, false)
+	got := string(toc.ToHTML(1, -1, false))
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li>
@@ -139,7 +139,7 @@ func TestTocMissingParent(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(3, 3, false)
+	got = string(toc.ToHTML(3, 3, false))
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ul>
     <li><a href="#h3">H3</a></li>
@@ -147,7 +147,7 @@ func TestTocMissingParent(t *testing.T) {
   </ul>
 </nav>`, qt.Commentf(got))
 
-	got = toc.ToHTML(1, -1, true)
+	got = string(toc.ToHTML(1, -1, true))
 	c.Assert(got, qt.Equals, `<nav id="TableOfContents">
   <ol>
     <li>


### PR DESCRIPTION
Closes #11545