### PR TITLE
tpl/tplimpl: Deprecate .Site.Social usage with internal templates

### DIFF
--- a/docs/content/en/templates/internal.md
+++ b/docs/content/en/templates/internal.md
@@ -184,11 +184,11 @@ If no images are found at all, then an image-less Twitter `summary` card is used
 
 Hugo uses the page title and description for the card's title and description fields. The page summary is used if no description is given.
 
-The `.Site.Social.twitter` variable is exposed from the configuration as the value for `twitter:site`.
+Set the value of `twitter:site` in your site configuration:
 
-{{< code-toggle file="hugo" >}}
-[social]
-  twitter = "GoHugoIO"
+{{< code-toggle file="hugo" copy=false >}}
+[params.social]
+twitter = "GoHugoIO"
 {{</ code-toggle >}}
 
 NOTE: The `@` will be added for you

--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -42,5 +42,16 @@
 {{ end }}{{ end }}
 {{- end }}
 
+{{- /* Deprecate site.Social.facebook_admin in favor of site.Params.social.facebook_admin */}}
+{{- $facebookAdmin := "" }}
+{{- with site.Params.social.facebook_admin }}
+  {{- $facebookAdmin = . }}
+{{- else }}
+  {{- with site.Social.facebook_admin }}
+    {{- $facebookAdmin = . }}
+    {{- warnf "The social key in site configuration is deprecated. Use params.social.facebook_admin instead." }}
+  {{- end }}
+{{- end }}
+
 {{- /* Facebook Page Admin ID for Domain Insights */}}
-{{- with .Site.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}
+{{ with $facebookAdmin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}

--- a/tpl/tplimpl/embedded/templates/twitter_cards.html
+++ b/tpl/tplimpl/embedded/templates/twitter_cards.html
@@ -19,6 +19,18 @@
 {{- end }}
 <meta name="twitter:title" content="{{ .Title }}"/>
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
-{{ with .Site.Social.twitter -}}
+
+{{- /* Deprecate site.Social.twitter in favor of site.Params.social.twitter */}}
+{{- $twitterSite := "" }}
+{{- with site.Params.social.twitter }}
+  {{- $twitterSite = . }}
+{{- else }}
+  {{- with site.Social.twitter }}
+    {{- $twitterSite = . }}
+    {{- warnf "The social key in site configuration is deprecated. Use params.social.twitter instead." }}
+  {{- end }}
+{{- end }}
+
+{{- with $twitterSite }}
 <meta name="twitter:site" content="@{{ . }}"/>
-{{ end -}}
+{{- end }}


### PR DESCRIPTION
This is the first step in deprecating the `social` key in site configuration. Our internal exposure is limited to the opengraph and twitter_cards templates. Site authors will receive a warning, generated by the relevant internal template, if they are using:

```
[social]
facebook_admin= 'foo'
```

or 

```
[social]
twitter = 'bar'
```

They will be instructed to change these to:

```
[params.social]
facebook_admin= 'foo'
```

and 

```
[params.social]
twitter = 'bar'
```

After this has been running in the field for a while, and site authors have made the change, we can:

1. Deprecate `func (s *Site) Social()`, and simultaneously
2. Remove `site.Social.facebook_admin` and `site.Social.twitter` from the affected templates

The `social` key in site configuration is not documented[^1], so, other than its usage in the internal templates, our external exposure should be limited.

[^1]: With one minor exception, which is addressed with this PR.