### PR TITLE
commands/mod: update all active modules

### DIFF
--- a/testscripts/commands/mod_get.txt
+++ b/testscripts/commands/mod_get.txt
@@ -1,0 +1,15 @@
+hugo mod get
+stderr 'withhugotoml.*v1.1.0'
+
+-- hugo.toml --
+title = "Hugo Modules Test"
+[module]
+[[module.imports]]
+path="github.com/gohugoio/hugo-mod-integrationtests/withconfigtoml"
+disable = true
+[[module.imports]]
+path="github.com/gohugoio/hugo-mod-integrationtests/withhugotoml"
+-- go.mod --
+module foo
+go 1.20
+

--- a/testscripts/commands/mod_get_u.txt
+++ b/testscripts/commands/mod_get_u.txt
@@ -1,0 +1,20 @@
+hugo mod get -u
+hugo mod graph
+stdout 'commonmod@v1.0.1.*commonmod2@v1.0.2'
+
+-- hugo.toml --
+title = "Hugo Modules Update Test"
+[module]
+[[module.imports]]
+path="github.com/gohugoio/hugo-mod-integrationtests/withconfigtoml"
+disable = true
+[[module.imports]]
+path="github.com/gohugoio/hugo-mod-integrationtests/withhugotoml"
+-- go.mod --
+module foo
+go 1.20
+require (
+  github.com/gohugoio/hugo-mod-integrationtests/withhugotoml v1.1.0 // indirect
+  github.com/gohugoio/hugo-mod-integrationtests/commonmod v0.0.0-20230823103305-919cefe8a425 // indirect
+)
+


### PR DESCRIPTION
Currently, `hugo mod get` won't update indirect import modules.

```toml
// site config
[[module.imports]]
path = "example.org/vendor/foo"
```

```toml
// example.org/vendor/foo module config
[[module.imports]]
path = "example.org/vendor/bar"
```

`hugo mod get` won't update the `example.org/vendor/bar` module.

Related issue/discussion: https://discourse.gohugo.io/t/unable-to-update-modules-those-imported-indirectly/46707.

I'm not sure if this PR is good, or should I create another command instead of overriding the original for this?