### PR TITLE
tpl/tplimpl: fix dropped error

### DIFF
--- a/tpl/tplimpl/template.go
+++ b/tpl/tplimpl/template.go
@@ -758,6 +758,9 @@ var embeddedTemplatesFs embed.FS
 
 func (t *templateHandler) loadEmbedded() error {
 	return fs.WalkDir(embeddedTemplatesFs, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		if d == nil || d.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
This fixes a dropped `err` variable in `tpl/tplimpl` that is passed into an `fs.WalkDir()` and immediately dropped.