### PR TITLE
watcher/filenotify: Remove redundant duplicated comments

### DIFF
--- a/watcher/filenotify/fsnotify.go
+++ b/watcher/filenotify/fsnotify.go
@@ -1,5 +1,3 @@
-// Package filenotify is adapted from https://github.com/moby/moby/tree/master/pkg/filenotify, Apache-2.0 License.
-// Hopefully this can be replaced with an external package sometime in the future, see https://github.com/fsnotify/fsnotify/issues/9
 package filenotify
 
 import "github.com/fsnotify/fsnotify"

--- a/watcher/filenotify/poller.go
+++ b/watcher/filenotify/poller.go
@@ -1,5 +1,3 @@
-// Package filenotify is adapted from https://github.com/moby/moby/tree/master/pkg/filenotify, Apache-2.0 License.
-// Hopefully this can be replaced with an external package sometime in the future, see https://github.com/fsnotify/fsnotify/issues/9
 package filenotify
 
 import (

--- a/watcher/filenotify/poller_test.go
+++ b/watcher/filenotify/poller_test.go
@@ -1,5 +1,3 @@
-// Package filenotify is adapted from https://github.com/moby/moby/tree/master/pkg/filenotify, Apache-2.0 License.
-// Hopefully this can be replaced with an external package sometime in the future, see https://github.com/fsnotify/fsnotify/issues/9
 package filenotify
 
 import (


### PR DESCRIPTION
The PR fixes docs for the [`filenotify`](https://pkg.go.dev/github.com/gohugoio/hugo/watcher/filenotify).

Before:
<img width="1036" alt="image" src="https://github.com/gohugoio/hugo/assets/3228886/d1d09c26-7521-4d22-b102-53807266d092">

After:
<img width="1053" alt="image" src="https://github.com/gohugoio/hugo/assets/3228886/0d244abe-9295-4323-94f7-5395fef7548e">

