### PR TITLE
Update README.md to use better linode logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ And with [Hugo Modules], you can share content, assets, data, translations, them
 
 <p>&nbsp;</p>
 <p float="left">
-  <a href="https://www.linode.com/?utm_campaign=hugosponsor&utm_medium=banner&utm_source=hugogithub" target="_blank"><img src="https://raw.githubusercontent.com/gohugoio/gohugoioTheme/master/assets/images/sponsors/linode-logo_standard_light_medium.png" width="200" alt="Linode"></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://www.linode.com/?utm_campaign=hugosponsor&utm_medium=banner&utm_source=hugogithub" target="_blank"><img src="https://raw.githubusercontent.com/gohugoio/gohugoioTheme/master/assets/images/sponsors/linode-logo_standard_dark_medium.png" width="200" alt="Linode"></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
   <a href="https://cloudcannon.com/hugo-cms/?utm_campaign=HugoSponsorship&utm_source=sponsor&utm_content=gohugo" target="_blank"><img src="https://raw.githubusercontent.com/gohugoio/gohugoioTheme/master/assets/images/sponsors/cloudcannon-blue.svg" width="220" alt="CloudCannon"></a>
 <p>&nbsp;</p>
 


### PR DESCRIPTION
You cannot read the linode logo in the readme because the text is black and the background is black. I made a pull request on [gohugoio/gohugoioTheme](https://github.com/gohugoio/gohugoioTheme) to add a linode logo optimal for black backgrounds. Once that is approved, the gohugoio/hugo project can start using that image.

You can see the other pull request [here](https://github.com/gohugoio/gohugoioTheme/pull/270)

# Here is the Readme before the fix:
![before](https://github.com/gohugoio/hugo/assets/145078271/0a01cf45-708b-4d91-ae64-bba270f408c6)

# Here is the Readme after the fix:
![after](https://github.com/gohugoio/hugo/assets/145078271/f0851904-3bb3-4409-b571-fe8e1f344b77)