### PR TITLE
markup/goldmark: update the CJK extension to allow specifying line break styles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tdewolff/minify/v2 v2.12.9
 	github.com/tdewolff/parse/v2 v2.6.8
-	github.com/yuin/goldmark v1.5.6
+	github.com/yuin/goldmark v1.6.0
 	github.com/yuin/goldmark-emoji v1.0.2
 	go.uber.org/atomic v1.11.0
 	go.uber.org/automaxprocs v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.3.7/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuin/goldmark v1.5.6 h1:COmQAWTCcGetChm3Ig7G/t8AFAN00t+o8Mt4cf7JpwA=
-github.com/yuin/goldmark v1.5.6/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.6.0 h1:boZcn2GTjpsynOsC0iJHnBWa4Bi0qzfJjthwauItG68=
+github.com/yuin/goldmark v1.6.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark-emoji v1.0.2 h1:c/RgTShNgHTtc6xdz2KKI74jJr6rWi7FPgnP9GAsO5s=
 github.com/yuin/goldmark-emoji v1.0.2/go.mod h1:RhP/RWpexdp+KHs7ghKnifRoIs/Bq4nDS7tRbCkOwKY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/markup/goldmark/convert.go
+++ b/markup/goldmark/convert.go
@@ -140,7 +140,11 @@ func newMarkdown(pcfg converter.ProviderConfig) goldmark.Markdown {
 	if cfg.Extensions.CJK.Enable {
 		opts := []extension.CJKOption{}
 		if cfg.Extensions.CJK.EastAsianLineBreaks {
-			opts = append(opts, extension.WithEastAsianLineBreaks())
+			if cfg.Extensions.CJK.EastAsianLineBreaksStyle == "css3draft" {
+				opts = append(opts, extension.WithEastAsianLineBreaks(extension.EastAsianLineBreaksCSS3Draft))
+			} else {
+				opts = append(opts, extension.WithEastAsianLineBreaks())
+			}
 		}
 
 		if cfg.Extensions.CJK.EscapedSpace {

--- a/markup/goldmark/convert_test.go
+++ b/markup/goldmark/convert_test.go
@@ -675,6 +675,60 @@ eastAsianLineBreaks=true
 	c.Assert(got, qt.Contains, "<p>私は太郎です。プログラミングが好きで、運動が苦手です。</p>\n")
 }
 
+func TestConvertCJKWithExtensionWithEastAsianLineBreaksOptionWithSimple(t *testing.T) {
+	c := qt.New(t)
+
+	content := `
+私は太郎です。
+Programming が好きで、
+運動が苦手です。
+`
+
+	confStr := `
+[markup]
+[markup.goldmark]
+[markup.goldmark.extensions.CJK]
+enable=true
+eastAsianLineBreaks=true
+eastAsianLineBreaksStyle="simple"
+`
+
+	cfg := config.FromTOMLConfigString(confStr)
+	conf := testconfig.GetTestConfig(nil, cfg)
+
+	b := convert(c, conf, content)
+	got := string(b.Bytes())
+
+	c.Assert(got, qt.Contains, "<p>私は太郎です。\nProgramming が好きで、運動が苦手です。</p>\n")
+}
+
+func TestConvertCJKWithExtensionWithEastAsianLineBreaksOptionWithStyle(t *testing.T) {
+	c := qt.New(t)
+
+	content := `
+私は太郎です。
+Programming が好きで、
+運動が苦手です。
+`
+
+	confStr := `
+[markup]
+[markup.goldmark]
+[markup.goldmark.extensions.CJK]
+enable=true
+eastAsianLineBreaks=true
+eastAsianLineBreaksStyle="css3draft"
+`
+
+	cfg := config.FromTOMLConfigString(confStr)
+	conf := testconfig.GetTestConfig(nil, cfg)
+
+	b := convert(c, conf, content)
+	got := string(b.Bytes())
+
+	c.Assert(got, qt.Contains, "<p>私は太郎です。Programming が好きで、運動が苦手です。</p>\n")
+}
+
 func TestConvertCJKWithExtensionWithEscapedSpaceOption(t *testing.T) {
 	c := qt.New(t)
 

--- a/markup/goldmark/goldmark_config/config.go
+++ b/markup/goldmark/goldmark_config/config.go
@@ -44,9 +44,10 @@ var Default = Config{
 		LinkifyProtocol: "https",
 		TaskList:        true,
 		CJK: CJK{
-			Enable:              false,
-			EastAsianLineBreaks: false,
-			EscapedSpace:        false,
+			Enable:                   false,
+			EastAsianLineBreaks:      false,
+			EastAsianLineBreaksStyle: "simple",
+			EscapedSpace:             false,
 		},
 	},
 	Renderer: Renderer{
@@ -117,6 +118,9 @@ type CJK struct {
 
 	// Whether softline breaks between east asian wide characters should be ignored.
 	EastAsianLineBreaks bool
+
+	// Styles of Line Breaking of EastAsianLineBreaks: "simple" or "css3draft"
+	EastAsianLineBreaksStyle string
 
 	// Whether a '\' escaped half-space(0x20) should not be rendered.
 	EscapedSpace bool


### PR DESCRIPTION
This commit follows https://github.com/yuin/goldmark/pull/411