### PR TITLE
Fix multilingual plus relativeURL removing the language URL section

### DIFF
--- a/helpers/path.go
+++ b/helpers/path.go
@@ -141,7 +141,13 @@ var isFileRe = regexp.MustCompile(`.*\..{1,6}$`)
 
 // GetDottedRelativePath expects a relative path starting after the content directory.
 // It returns a relative path with dots ("..") navigating up the path structure.
-func GetDottedRelativePath(inPath string) string {
+// Optionally handling MultiLingual sites with an extra prefix
+func GetDottedRelativePath(inPath string, possiblyMultiLingual ...bool) string {
+	isMultiLingual := false
+	if len(possiblyMultiLingual) > 0 {
+		isMultiLingual = possiblyMultiLingual[0]
+	}
+
 	inPath = path.Clean(filepath.ToSlash(inPath))
 
 	if inPath == "." {
@@ -159,6 +165,10 @@ func GetDottedRelativePath(inPath string) string {
 	dir, _ := path.Split(inPath)
 
 	sectionCount := strings.Count(dir, "/")
+
+	if isMultiLingual {
+		sectionCount++
+	}
 
 	if sectionCount == 0 || dir == "/" {
 		return "./"

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -142,8 +142,11 @@ func TestGetDottedRelativePath(t *testing.T) {
 
 func doTestGetDottedRelativePath(urlFixer func(string) string, t *testing.T) {
 	type test struct {
-		input string, isMultiLingual bool, expected string
+		input string
+		isMultiLingual bool
+		expected string
 	}
+
 	data := []test{
 		{"", "./"},
 		{urlFixer("/"), false, "./"},
@@ -174,7 +177,7 @@ func doTestGetDottedRelativePath(urlFixer func(string) string, t *testing.T) {
 		{urlFixer("/en/foo/bar/foo/"), true, "../../../"},
 		{urlFixer("/en/foo/bar/foo"), true, "../../../"},
 		{urlFixer("en/foo/bar/foo/"), true, "../../../"},
-		{urlFixer("en/foo/bar/foo/bar"), true, "../../../../"},
+		{urlFixer("en/foo/bar/foo/bar"), true, "../../../../"}
 	}
 	for i, d := range data {
 		output := helpers.GetDottedRelativePath(d.input)

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -142,26 +142,39 @@ func TestGetDottedRelativePath(t *testing.T) {
 
 func doTestGetDottedRelativePath(urlFixer func(string) string, t *testing.T) {
 	type test struct {
-		input, expected string
+		input string, isMultiLingual bool, expected string
 	}
 	data := []test{
 		{"", "./"},
-		{urlFixer("/"), "./"},
-		{urlFixer("post"), "../"},
-		{urlFixer("/post"), "../"},
-		{urlFixer("post/"), "../"},
-		{urlFixer("tags/foo.html"), "../"},
-		{urlFixer("/tags/foo.html"), "../"},
-		{urlFixer("/post/"), "../"},
-		{urlFixer("////post/////"), "../"},
-		{urlFixer("/foo/bar/index.html"), "../../"},
-		{urlFixer("/foo/bar/foo/"), "../../../"},
-		{urlFixer("/foo/bar/foo"), "../../../"},
-		{urlFixer("foo/bar/foo/"), "../../../"},
-		{urlFixer("foo/bar/foo/bar"), "../../../../"},
-		{"404.html", "./"},
-		{"404.xml", "./"},
-		{"/404.html", "./"},
+		{urlFixer("/"), false, "./"},
+		{urlFixer("post"), false, "../"},
+		{urlFixer("/post"), false, "../"},
+		{urlFixer("post/"), false, "../"},
+		{urlFixer("tags/foo.html"), false, "../"},
+		{urlFixer("/tags/foo.html"), false, "../"},
+		{urlFixer("/post/"), false, "../"},
+		{urlFixer("////post/////"), false, "../"},
+		{urlFixer("/foo/bar/index.html"), false, "../../"},
+		{urlFixer("/foo/bar/foo/"), false, "../../../"},
+		{urlFixer("/foo/bar/foo"), false, "../../../"},
+		{urlFixer("foo/bar/foo/"), false, "../../../"},
+		{urlFixer("foo/bar/foo/bar"), false, "../../../../"},
+		{"404.html", false, "./"},
+		{"404.xml", false, "./"},
+		{"/404.html", false, "./"},
+		{urlFixer("/en/"), true, "./"},
+		{urlFixer("en/post"), true, "../"},
+		{urlFixer("/en/post"), true, "../"},
+		{urlFixer("en/post/"), true, "../"},
+		{urlFixer("en/tags/foo.html"), true, "../"},
+		{urlFixer("/en/tags/foo.html"), true, "../"},
+		{urlFixer("/en/post/"), true, "../"},
+		{urlFixer("////en/post/////"), true, "../"},
+		{urlFixer("/en/foo/bar/index.html"), true, "../../"},
+		{urlFixer("/en/foo/bar/foo/"), true, "../../../"},
+		{urlFixer("/en/foo/bar/foo"), true, "../../../"},
+		{urlFixer("en/foo/bar/foo/"), true, "../../../"},
+		{urlFixer("en/foo/bar/foo/bar"), true, "../../../../"},
 	}
 	for i, d := range data {
 		output := helpers.GetDottedRelativePath(d.input)

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -979,7 +979,7 @@ func (s *Site) permalink(link string) string {
 func (s *Site) absURLPath(targetPath string) string {
 	var path string
 	if s.conf.RelativeURLs {
-		path = helpers.GetDottedRelativePath(targetPath)
+		path = helpers.GetDottedRelativePath(targetPath, s.h.Conf.IsMultiLingual())
 	} else {
 		url := s.PathSpec.Cfg.BaseURL().String()
 		if !strings.HasSuffix(url, "/") {


### PR DESCRIPTION
Fix #7805 

Add an optional param to `GetDottedRelativePath` to remove language prefix in URL if multilingual is enabled