### PR TITLE
WIP: markdownify leaves unclosed paragraph

### DIFF
--- a/tpl/transform/transform_test.go
+++ b/tpl/transform/transform_test.go
@@ -247,3 +247,24 @@ func TestPlainify(t *testing.T) {
 		b.Assert(result, qt.Equals, test.expect)
 	}
 }
+
+// Issue #xxx
+func TestMarkdownifyTitleAndBlock(t *testing.T) {
+	t.Parallel()
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{T: t},
+	).Build()
+
+	ns := transform.New(b.H.Deps)
+
+	text := `
+# My Title
+
+This is some text.
+`
+
+	result, err := ns.Markdownify(context.Background(), text)
+	b.Assert(err, qt.IsNil)
+	b.Assert(result, qt.Equals, template.HTML(
+		"<h1 id=\"my-title\">My Title</h1>\n<p>This is some text.</p>\n"))
+}

--- a/tpl/transform/transform_test.go
+++ b/tpl/transform/transform_test.go
@@ -248,7 +248,7 @@ func TestPlainify(t *testing.T) {
 	}
 }
 
-// Issue #xxx
+// Issue #11698
 func TestMarkdownifyTitleAndBlock(t *testing.T) {
 	t.Parallel()
 	b := hugolib.NewIntegrationTestBuilder(


### PR DESCRIPTION
PR to fix https://github.com/gohugoio/hugo/issues/11698; the issue is that markdownify does not close a paragraph when rendering a title and a paragraph.

NOTE: I wrote a test that needs to pass for the issue to be resolved. Unfortunately, I don't expect to be able to fix the problem myself. Feel free to push to this branch if you have solved the issue.