### PR TITLE
parser/metadecoders: Accumulate org keywords into arrays

### DIFF
--- a/docs/content/en/content-management/front-matter.md
+++ b/docs/content/en/content-management/front-matter.md
@@ -31,7 +31,7 @@ JSON
 
 ORG
 : a group of Org mode keywords in the format '`#+KEY: VALUE`'. Any line that does not start with `#+` ends the front matter section.
-  Keyword values can be either strings (`#+KEY: VALUE`) or a whitespace separated list of strings (`#+KEY[]: VALUE_1 VALUE_2`).
+  Array values can either be separated into multiple lines (`#+KEY: VALUE_1` and `#+KEY: VALUE_2`) or a whitespace separated list of strings (`#+KEY[]: VALUE_1 VALUE_2`).
 
 ### Example
 

--- a/parser/metadecoders/decoder.go
+++ b/parser/metadecoders/decoder.go
@@ -242,9 +242,8 @@ func (d Decoder) unmarshalORG(data []byte, v any) error {
 		k = strings.ToLower(k)
 		if strings.HasSuffix(k, "[]") {
 			frontMatter[k[:len(k)-2]] = strings.Fields(v)
-		} else if k == "tags" || k == "categories" || k == "aliases" {
-			log.Printf("warn: Please use '#+%s[]:' notation, automatic conversion is deprecated.", k)
-			frontMatter[k] = strings.Fields(v)
+		} else if strings.Contains(v, "\n") {
+			frontMatter[k] = strings.Split(v, "\n")
 		} else if k == "date" || k == "lastmod" || k == "publishdate" || k == "expirydate" {
 			frontMatter[k] = parseORGDate(v)
 		} else {

--- a/parser/metadecoders/decoder_test.go
+++ b/parser/metadecoders/decoder_test.go
@@ -125,6 +125,7 @@ func TestUnmarshalToInterface(t *testing.T) {
 		{[]byte(``), JSON, map[string]any{}},
 		{[]byte(nil), JSON, map[string]any{}},
 		{[]byte(`#+a: b`), ORG, expect},
+		{[]byte("#+a: foo bar\n#+a: baz"), ORG, map[string]any{"a": []string{string("foo bar"), string("baz")}}},
 		{[]byte(`#+DATE: <2020-06-26 Fri>`), ORG, map[string]any{"date": "2020-06-26"}},
 		{[]byte(`#+LASTMOD: <2020-06-26 Fri>`), ORG, map[string]any{"lastmod": "2020-06-26"}},
 		{[]byte(`#+PUBLISHDATE: <2020-06-26 Fri>`), ORG, map[string]any{"publishdate": "2020-06-26"}},


### PR DESCRIPTION
Hey all! What are your thoughts on this change?

The [keywords](https://orgmode.org/worg/org-syntax.html#Keywords) definition from the org syntax specification doesn't say we can't repeat keywords. 

This change will also enable terms in org mode to have space. 

Currently, repeated keywords are concatenated: `#+title: foo\n#+title: bar` would render as `foo bar`. With this change, it just doesn't render anything but hugo is not crashing either.