### PR TITLE
markup/goldmark: Render strikethrough and emojis in TOC entries

### DIFF
--- a/markup/goldmark/convert.go
+++ b/markup/goldmark/convert.go
@@ -18,14 +18,14 @@ import (
 	"bytes"
 
 	"github.com/gohugoio/hugo-goldmark-extensions/passthrough"
+	"github.com/yuin/goldmark/util"
+
 	"github.com/gohugoio/hugo/markup/goldmark/codeblocks"
 	"github.com/gohugoio/hugo/markup/goldmark/goldmark_config"
 	"github.com/gohugoio/hugo/markup/goldmark/images"
 	"github.com/gohugoio/hugo/markup/goldmark/internal/extensions/attributes"
 	"github.com/gohugoio/hugo/markup/goldmark/internal/render"
 
-	"github.com/gohugoio/hugo/markup/converter"
-	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/yuin/goldmark"
 	emoji "github.com/yuin/goldmark-emoji"
 	"github.com/yuin/goldmark/ast"
@@ -34,6 +34,9 @@ import (
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
+
+	"github.com/gohugoio/hugo/markup/converter"
+	"github.com/gohugoio/hugo/markup/tableofcontents"
 )
 
 const (
@@ -91,10 +94,17 @@ func newMarkdown(pcfg converter.ProviderConfig) goldmark.Markdown {
 		rendererOptions = append(rendererOptions, html.WithUnsafe())
 	}
 
+	tocRendererOptions := make([]renderer.Option, len(rendererOptions))
+	if rendererOptions != nil {
+		copy(tocRendererOptions, rendererOptions)
+	}
+	tocRendererOptions = append(tocRendererOptions,
+		renderer.WithNodeRenderers(util.Prioritized(extension.NewStrikethroughHTMLRenderer(), 500)),
+		renderer.WithNodeRenderers(util.Prioritized(emoji.NewHTMLRenderer(), 200)))
 	var (
 		extensions = []goldmark.Extender{
 			newLinks(cfg),
-			newTocExtension(rendererOptions),
+			newTocExtension(tocRendererOptions),
 		}
 		parserOptions []parser.Option
 	)

--- a/markup/goldmark/toc.go
+++ b/markup/goldmark/toc.go
@@ -16,6 +16,10 @@ package goldmark
 import (
 	"bytes"
 
+	strikethroughAst "github.com/yuin/goldmark/extension/ast"
+
+	emojiAst "github.com/yuin/goldmark-emoji/ast"
+
 	"github.com/gohugoio/hugo/markup/tableofcontents"
 
 	"github.com/yuin/goldmark"
@@ -86,7 +90,9 @@ func (t *tocTransformer) Transform(n *ast.Document, reader text.Reader, pc parse
 			ast.KindCodeSpan,
 			ast.KindLink,
 			ast.KindImage,
-			ast.KindEmphasis:
+			ast.KindEmphasis,
+			strikethroughAst.KindStrikethrough,
+			emojiAst.KindEmoji:
 			err := t.r.Render(&headingText, reader.Source(), n)
 			if err != nil {
 				return s, err

--- a/markup/goldmark/toc_integration_test.go
+++ b/markup/goldmark/toc_integration_test.go
@@ -253,14 +253,12 @@ title: p7 (emoji)
 `)
 
 	// strikethrough
-	// TODO failing test: Issue #8087
-	// 	b.AssertFileContent("public/p6/index.html", `
-	// <li><a href="#ome-deleted-text">Some <del>deleted</del> text</a></li>
-	// 	`)
+	b.AssertFileContent("public/p6/index.html", `
+<li><a href="#some-deleted-text">Some <del>deleted</del> text</a></li>
+`)
 
 	// emoji
-	// TODO failing test: Issue #12022
-	// 	b.AssertFileContent("public/p7/index.html", `
-	// <li><a href="#a-snake-emoji">A &#x1f40d; emoji</a></li>
-	// 		`)
+	b.AssertFileContent("public/p7/index.html", `
+<li><a href="#a-snake-emoji">A &#x1f40d; emoji</a></li>
+`)
 }


### PR DESCRIPTION
Configure the TOC (table of contents, `toc.go`) goldmark renderer instance to always enable the Strikethrough extension.

This allows handling `ast.KindStrikethrough` within an AST node avoiding a crash.

Fixes #7169
Fixes #8087
Fixes #11783
