### PR TITLE
docs: Add Comentario to available comment engines

### DIFF
--- a/docs/content/en/content-management/comments.md
+++ b/docs/content/en/content-management/comments.md
@@ -48,6 +48,7 @@ Disqus has its own [internal template](/templates/internal/#disqus) available, t
 These are some alternatives to Disqus:
 
 * [Cactus Comments](https://cactus.chat/docs/integrations/hugo/) (Open Source, Matrix appservice, Docker install)
+* [Comentario](https://gitlab.com/comentario/comentario) (Open Source, self-hosted, Go/Angular, run locally, in Docker or Kubernetes)
 * [Commento](https://commento.io/) (Open Source, available as a service, local install, or docker image)
 * [Giscus](https://giscus.app/) (Open source, comments system powered by GitHub Discussions)
 * [Graph Comment](https://graphcomment.com/)


### PR DESCRIPTION
Comentario is an actively maintained fork of (now abandoned) Commento