### PR TITLE
modules: Print required Hugo version for incompatible modules

### DIFF
--- a/modules/collect.go
+++ b/modules/collect.go
@@ -125,7 +125,7 @@ func (m ModulesConfig) HasConfigFile() bool {
 func (m *ModulesConfig) setActiveMods(logger loggers.Logger) error {
 	for _, mod := range m.AllModules {
 		if !mod.Config().HugoVersion.IsValid() {
-			logger.Warnf(`Module %q is not compatible with this Hugo version; run "hugo mod graph" for more information.`, mod.Path())
+			logger.Warnf(`Module %q is not compatible with this Hugo version: %s; run "hugo mod graph" for more information.`, mod.Path(), mod.Config().HugoVersion)
 		}
 	}
 


### PR DESCRIPTION
This PR prints more info about required Hugo version.

```sh
$ hugo | grep compatible                           
WARN  Module "a" is not compatible with this Hugo version; run "hugo mod graph" for more information.

$ hugo-dev | grep compatible
WARN  Module "a" is not compatible with this Hugo version: Min 0.130.0; run "hugo mod graph" for more information.
```