### PR TITLE
hugofs/glob: fix dropped test error

### DIFF
--- a/hugofs/glob/filename_filter_test.go
+++ b/hugofs/glob/filename_filter_test.go
@@ -36,6 +36,7 @@ func TestFilenameFilter(t *testing.T) {
 	c.Assert(excludeAlmostAllJSON.Match("", true), qt.Equals, true)
 
 	excludeAllButFooJSON, err := NewFilenameFilter([]string{"/a/**/foo.json"}, []string{"**.json"})
+	c.Assert(err, qt.IsNil)
 	c.Assert(excludeAllButFooJSON.Match(filepath.FromSlash("/data/my.json"), false), qt.Equals, false)
 	c.Assert(excludeAllButFooJSON.Match(filepath.FromSlash("/a/b/c/d/e/foo.json"), false), qt.Equals, true)
 	c.Assert(excludeAllButFooJSON.Match(filepath.FromSlash("/a/b/c"), true), qt.Equals, true)


### PR DESCRIPTION
Fix dropped `err` variable in the tests for `hugofs/glob`.