### PR TITLE
Extend Documentation for `hugo config`

### DIFF
--- a/docs/content/en/commands/hugo_config.md
+++ b/docs/content/en/commands/hugo_config.md
@@ -9,7 +9,7 @@ Print the site configuration
 
 ### Synopsis
 
-Print the site configuration, both default and custom settings.
+Print the site configuration, both default and custom settings, and install modules from "go.mod".
 
 ```
 hugo config [command] [flags]

--- a/docs/content/en/commands/hugo_mod_get.md
+++ b/docs/content/en/commands/hugo_mod_get.md
@@ -40,6 +40,7 @@ Go Modules, or a folder inside the themes directory, in that order.
 
 See https://gohugo.io/hugo-modules/ for more information.
 
+To install Hugo modules from "go.mod" without updating them, run [hugo config](/commands/hugo_config/).
 
 
 ```


### PR DESCRIPTION
Related to #11857.

This PR documents that the `hugo config` command downloads Hugo modules without updating them.

To my knowledge, this information isn't documented anywhere currently.