### PR TITLE
deps: Update github.com/tdewolff/minify/v2 v2.20.9 => v2.20.13

### DIFF
--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -1265,7 +1265,7 @@ config:
         precision: 0
       html:
         keepComments: false
-        keepConditionalComments: true
+        keepSpecialComments: true
         keepDefaultAttrVals: true
         keepDocumentTags: true
         keepEndTags: true

--- a/go.mod
+++ b/go.mod
@@ -61,8 +61,8 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/fsync v0.9.0
 	github.com/spf13/pflag v1.0.5
-	github.com/tdewolff/minify/v2 v2.20.9
-	github.com/tdewolff/parse/v2 v2.7.6
+	github.com/tdewolff/minify/v2 v2.20.13
+	github.com/tdewolff/parse/v2 v2.7.8
 	github.com/yuin/goldmark v1.6.0
 	github.com/yuin/goldmark-emoji v1.0.2
 	go.uber.org/atomic v1.11.0
@@ -143,7 +143,7 @@ require (
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -328,8 +328,12 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tdewolff/minify/v2 v2.20.9 h1:0RGsL+jBpm77obkuNCjNZ2eiN81CZzTnjeVmTqxCmYk=
 github.com/tdewolff/minify/v2 v2.20.9/go.mod h1:hZnNtFqXVQ5QIAR05tdgvS7h6E80jyRwHSGVmM4jbzQ=
+github.com/tdewolff/minify/v2 v2.20.13 h1:TDWS1orkBJjq6Sz9NjEvHEeUnAvlfU7jgStGQBwBPGM=
+github.com/tdewolff/minify/v2 v2.20.13/go.mod h1:qnIJbnG2dSzk7LIa/UUwgN2OjS8ir6RRlqc0T/1q2xY=
 github.com/tdewolff/parse/v2 v2.7.6 h1:PGZH2b/itDSye9RatReRn4GBhsT+KFEMtAMjHRuY1h8=
 github.com/tdewolff/parse/v2 v2.7.6/go.mod h1:3FbJWZp3XT9OWVN3Hmfp0p/a08v4h8J9W1aghka0soA=
+github.com/tdewolff/parse/v2 v2.7.8 h1:1cnVqa8L63xFkc2vfRsZTM6Qy35nJpTvQ2Uvdv3vbvs=
+github.com/tdewolff/parse/v2 v2.7.8/go.mod h1:3FbJWZp3XT9OWVN3Hmfp0p/a08v4h8J9W1aghka0soA=
 github.com/tdewolff/test v1.0.11-0.20231101010635-f1265d231d52 h1:gAQliwn+zJrkjAHVcBEYW/RFvd2St4yYimisvozAYlA=
 github.com/tdewolff/test v1.0.11-0.20231101010635-f1265d231d52/go.mod h1:6DAvZliBAAnD7rhVgwaM7DE5/d9NMOAJ09SqYqeK4QE=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
@@ -401,6 +405,8 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/minifiers/config.go
+++ b/minifiers/config.go
@@ -28,11 +28,11 @@ import (
 
 var defaultTdewolffConfig = TdewolffConfig{
 	HTML: html.Minifier{
-		KeepDocumentTags:        true,
-		KeepConditionalComments: true,
-		KeepEndTags:             true,
-		KeepDefaultAttrVals:     true,
-		KeepWhitespace:          false,
+		KeepDocumentTags:    true,
+		KeepSpecialComments: true,
+		KeepEndTags:         true,
+		KeepDefaultAttrVals: true,
+		KeepWhitespace:      false,
 	},
 	CSS: css.Minifier{
 		Precision: 0,
@@ -90,17 +90,39 @@ func DecodeConfig(v any) (conf MinifyConfig, err error) {
 	// Handle upstream renames.
 	if td, found := m["tdewolff"]; found {
 		tdm := maps.ToStringMap(td)
+
 		for _, key := range []string{"css", "svg"} {
 			if v, found := tdm[key]; found {
 				vm := maps.ToStringMap(v)
-				if vv, found := vm["decimal"]; found {
-					vvi := cast.ToInt(vv)
-					if vvi > 0 {
-						vm["precision"] = vvi
+				ko := "decimal"
+				kn := "precision"
+				if vv, found := vm[ko]; found {
+					if _, found = vm[kn]; !found {
+						vvi := cast.ToInt(vv)
+						if vvi > 0 {
+							vm[kn] = vvi
+						}
 					}
+					delete(vm, ko)
 				}
 			}
 		}
+
+		// keepConditionalComments was renamed to keepSpecialComments
+		if v, found := tdm["html"]; found {
+			vm := maps.ToStringMap(v)
+			ko := "keepconditionalcomments"
+			kn := "keepspecialcomments"
+			if vv, found := vm[ko]; found {
+				// Set keepspecialcomments, if not already set
+				if _, found := vm[kn]; !found {
+					vm[kn] = cast.ToBool(vv)
+				}
+				// Remove the old key to prevent deprecation warnings
+				delete(vm, ko)
+			}
+		}
+
 	}
 
 	err = mapstructure.WeakDecode(m, &conf)

--- a/minifiers/config_test.go
+++ b/minifiers/config_test.go
@@ -59,3 +59,45 @@ func TestConfigLegacy(t *testing.T) {
 	conf := testconfig.GetTestConfigs(nil, v).Base.Minify
 	c.Assert(conf.MinifyOutput, qt.Equals, true)
 }
+
+func TestConfigNewCommentOptions(t *testing.T) {
+	c := qt.New(t)
+	v := config.New()
+
+	// setting the old options should automatically set the new options
+	v.Set("minify", map[string]any{
+		"tdewolff": map[string]any{
+			"html": map[string]any{
+				"keepConditionalComments": false,
+			},
+			"svg": map[string]any{
+				"decimal": "5",
+			},
+		},
+	})
+
+	conf := testconfig.GetTestConfigs(nil, v).Base.Minify
+
+	c.Assert(conf.Tdewolff.HTML.KeepSpecialComments, qt.Equals, false)
+	c.Assert(conf.Tdewolff.SVG.Precision, qt.Equals, 5)
+
+	// the new values should win, regardless of the contents of the old values
+	v = config.New()
+	v.Set("minify", map[string]any{
+		"tdewolff": map[string]any{
+			"html": map[string]any{
+				"keepConditionalComments": false,
+				"keepSpecialComments":     true,
+			},
+			"svg": map[string]any{
+				"decimal":   "5",
+				"precision": "10",
+			},
+		},
+	})
+
+	conf = testconfig.GetTestConfigs(nil, v).Base.Minify
+
+	c.Assert(conf.Tdewolff.HTML.KeepSpecialComments, qt.Equals, true)
+	c.Assert(conf.Tdewolff.SVG.Precision, qt.Equals, 10)
+}

--- a/minifiers/minifiers_test.go
+++ b/minifiers/minifiers_test.go
@@ -203,13 +203,13 @@ func TestDecodeConfigKeepWhitespace(t *testing.T) {
 
 	c.Assert(conf.Tdewolff.HTML, qt.DeepEquals,
 		html.Minifier{
-			KeepComments:            false,
-			KeepConditionalComments: true,
-			KeepDefaultAttrVals:     true,
-			KeepDocumentTags:        true,
-			KeepEndTags:             false,
-			KeepQuotes:              false,
-			KeepWhitespace:          false},
+			KeepComments:        false,
+			KeepSpecialComments: true,
+			KeepDefaultAttrVals: true,
+			KeepDocumentTags:    true,
+			KeepEndTags:         false,
+			KeepQuotes:          false,
+			KeepWhitespace:      false},
 	)
 
 }


### PR DESCRIPTION
KeepConditionalComments was deprecated in the upstream library and replaced with KeepSpecialComments. This new option reflects that both conditional comments and Server Side Include comments can be optionally stripped by the minifier. As with KeepConditionalComments, the minifier is configured not to strip them by default.