### PR TITLE
parser/metadecoders: Add CSV lazyQuotes option to transform.Unmarshal

### DIFF
--- a/docs/content/en/functions/transform/Unmarshal.md
+++ b/docs/content/en/functions/transform/Unmarshal.md
@@ -125,6 +125,9 @@ delimiter
 comment
 : (`string`) The comment character used in the CSV. If set, lines beginning with the comment character without preceding whitespace are ignored.
 
+lazyQuotes
+: (`bool`) If true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field. Default is `false`.
+
 ```go-html-template
 {{ $csv := "a;b;c" | transform.Unmarshal (dict "delimiter" ";") }}
 ```

--- a/parser/metadecoders/decoder.go
+++ b/parser/metadecoders/decoder.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/gohugoio/hugo/common/herrors"
@@ -41,6 +42,10 @@ type Decoder struct {
 	// Comment, if not 0, is the comment character used in the CSV decoder. Lines beginning with the
 	// Comment character without preceding whitespace are ignored.
 	Comment rune
+
+	// If true, a quote may appear in an unquoted field and a non-doubled quote
+	// may appear in a quoted field. It defaults to false.
+	LazyQuotes bool
 }
 
 // OptionsKey is used in cache keys.
@@ -48,6 +53,7 @@ func (d Decoder) OptionsKey() string {
 	var sb strings.Builder
 	sb.WriteRune(d.Delimiter)
 	sb.WriteRune(d.Comment)
+	sb.WriteString(strconv.FormatBool(d.LazyQuotes))
 	return sb.String()
 }
 
@@ -205,6 +211,7 @@ func (d Decoder) unmarshalCSV(data []byte, v any) error {
 	r := csv.NewReader(bytes.NewReader(data))
 	r.Comma = d.Delimiter
 	r.Comment = d.Comment
+	r.LazyQuotes = d.LazyQuotes
 
 	records, err := r.ReadAll()
 	if err != nil {


### PR DESCRIPTION
If true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field. It defaults to false.

Closes #11884