### PR TITLE
Parse brackets in IPv6 URIs correctly

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -814,13 +814,13 @@ func (c *serverCommand) fixURL(baseURLFromConfig, baseURLFromFlag string, port i
 	}
 
 	if c.serverAppend {
-		if strings.Contains(u.Host, ":") {
-			u.Host, _, err = net.SplitHostPort(u.Host)
-			if err != nil {
-				return "", fmt.Errorf("failed to split baseURL hostport: %w", err)
-			}
+		_, p, e := net.SplitHostPort(u.Host)
+		if e != nil {
+			return "", fmt.Errorf("failed to split baseURL hostport: %w", e)
 		}
-		u.Host += fmt.Sprintf(":%d", port)
+		if p == "" {
+			u.Host = net.JoinHostPort(u.Hostname(), fmt.Sprintf(":%d", port))
+		}
 	}
 
 	return u.String(), nil


### PR DESCRIPTION
There is an issue with how Hugo parses a base URL if it contains an IPv6 address. Such an address is, in a URI, required be surrounded by square brackets. e.g.: `http://[::1]:80`

Given the following command:

```
hugo server --bind '::1' --port 1313 --baseURL 'http://[::1]:1313/'
```

Current behavior:

```
Web Server is available at http://::1:1313/ (bind address ::1) 
```

Desired behavior:

```
Web Server is available at http://[::1]:1313/ (bind address ::1)
```

---

The following PR changes the way that the URL's hostname is generated to properly preserve the brackets that surround an IPv6 address.

This is such a silly thing for me to have wanted to do that I understand why nobody ever caught this small bug 😅