### PR TITLE
Misc fixes and improvements

### DIFF
--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -13,12 +13,14 @@
 
 package constants
 
-// Error IDs.
+// Error/Warning IDs.
 // Do not change these values.
 const (
 	// IDs for remote errors in tpl/data.
 	ErrRemoteGetJSON = "error-remote-getjson"
 	ErrRemoteGetCSV  = "error-remote-getcsv"
+
+	WarnFrontMatterParamsOverrides = "warning-frontmatter-params-overrides"
 )
 
 // Field/method names with special meaning.

--- a/common/loggers/logger.go
+++ b/common/loggers/logger.go
@@ -179,9 +179,9 @@ type Logger interface {
 	Debugln(v ...any)
 	Error() logg.LevelLogger
 	Errorf(format string, v ...any)
+	Erroridf(id, format string, v ...any)
 	Errorln(v ...any)
 	Errors() string
-	Errorsf(id, format string, v ...any)
 	Info() logg.LevelLogger
 	InfoCommand(command string) logg.LevelLogger
 	Infof(format string, v ...any)
@@ -197,6 +197,7 @@ type Logger interface {
 	Warn() logg.LevelLogger
 	WarnCommand(command string) logg.LevelLogger
 	Warnf(format string, v ...any)
+	Warnidf(id, format string, v ...any)
 	Warnln(v ...any)
 	Deprecatef(fail bool, format string, v ...any)
 	Trace(s logg.StringFunc)
@@ -321,8 +322,18 @@ func (l *logAdapter) Errors() string {
 	return l.errors.String()
 }
 
-func (l *logAdapter) Errorsf(id, format string, v ...any) {
+func (l *logAdapter) Erroridf(id, format string, v ...any) {
+	format += l.idfInfoStatement("error", id, format)
 	l.errorl.WithField(FieldNameStatementID, id).Logf(format, v...)
+}
+
+func (l *logAdapter) Warnidf(id, format string, v ...any) {
+	format += l.idfInfoStatement("warning", id, format)
+	l.warnl.WithField(FieldNameStatementID, id).Logf(format, v...)
+}
+
+func (l *logAdapter) idfInfoStatement(what, id, format string) string {
+	return fmt.Sprintf("\nYou can suppress this %s by adding the following to your site configuration:\nignoreLogs = ['%s']", what, id)
 }
 
 func (l *logAdapter) Trace(s logg.StringFunc) {

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -206,7 +206,7 @@ func (c Config) cloneForLang() *Config {
 	x.DisableKinds = copyStringSlice(x.DisableKinds)
 	x.DisableLanguages = copyStringSlice(x.DisableLanguages)
 	x.MainSections = copyStringSlice(x.MainSections)
-	x.IgnoreErrors = copyStringSlice(x.IgnoreErrors)
+	x.IgnoreLogs = copyStringSlice(x.IgnoreLogs)
 	x.IgnoreFiles = copyStringSlice(x.IgnoreFiles)
 	x.Theme = copyStringSlice(x.Theme)
 
@@ -299,9 +299,9 @@ func (c *Config) CompileConfig(logger loggers.Logger) error {
 		}
 	}
 
-	ignoredErrors := make(map[string]bool)
-	for _, err := range c.IgnoreErrors {
-		ignoredErrors[strings.ToLower(err)] = true
+	ignoredLogIDs := make(map[string]bool)
+	for _, err := range c.IgnoreLogs {
+		ignoredLogIDs[strings.ToLower(err)] = true
 	}
 
 	baseURL, err := urls.NewBaseURLFromString(c.BaseURL)
@@ -357,7 +357,7 @@ func (c *Config) CompileConfig(logger loggers.Logger) error {
 		BaseURLLiveReload: baseURL,
 		DisabledKinds:     disabledKinds,
 		DisabledLanguages: disabledLangs,
-		IgnoredErrors:     ignoredErrors,
+		IgnoredLogs:       ignoredLogIDs,
 		KindOutputFormats: kindOutputFormats,
 		CreateTitle:       helpers.GetTitleFunc(c.TitleCaseStyle),
 		IsUglyURLSection:  isUglyURL,
@@ -394,7 +394,7 @@ type ConfigCompiled struct {
 	KindOutputFormats map[string]output.Formats
 	DisabledKinds     map[string]bool
 	DisabledLanguages map[string]bool
-	IgnoredErrors     map[string]bool
+	IgnoredLogs       map[string]bool
 	CreateTitle       func(s string) string
 	IsUglyURLSection  func(section string) bool
 	IgnoreFile        func(filename string) bool
@@ -501,8 +501,8 @@ type RootConfig struct {
 	// Enable to disable the build lock file.
 	NoBuildLock bool
 
-	// A list of error IDs to ignore.
-	IgnoreErrors []string
+	// A list of log IDs to ignore.
+	IgnoreLogs []string
 
 	// A list of regexps that match paths to ignore.
 	// Deprecated: Use the settings on module imports.

--- a/config/allconfig/configlanguage.go
+++ b/config/allconfig/configlanguage.go
@@ -89,8 +89,8 @@ func (c ConfigLanguage) IsLangDisabled(lang string) bool {
 	return c.config.C.DisabledLanguages[lang]
 }
 
-func (c ConfigLanguage) IgnoredErrors() map[string]bool {
-	return c.config.C.IgnoredErrors
+func (c ConfigLanguage) IgnoredLogs() map[string]bool {
+	return c.config.C.IgnoredLogs
 }
 
 func (c ConfigLanguage) NoBuildLock() bool {

--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -141,6 +141,7 @@ func (l configLoader) applyConfigAliases() error {
 		{Key: "indexes", Value: "taxonomies"},
 		{Key: "logI18nWarnings", Value: "printI18nWarnings"},
 		{Key: "logPathWarnings", Value: "printPathWarnings"},
+		{Key: "ignoreErrors", Value: "ignoreLogs"},
 	}
 
 	for _, alias := range aliases {

--- a/config/configProvider.go
+++ b/config/configProvider.go
@@ -67,7 +67,7 @@ type AllProvider interface {
 	NewContentEditor() string
 	Timeout() time.Duration
 	StaticDirs() []string
-	IgnoredErrors() map[string]bool
+	IgnoredLogs() map[string]bool
 	WorkingDir() string
 	EnableEmoji() bool
 }

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/marekm4/color-extractor v1.2.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mitchellh/hashstructure v1.1.0
-	github.com/mitchellh/mapstructure v1.5.0
+	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/muesli/smartcrop v0.3.0
 	github.com/niklasfasching/go-org v1.7.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,8 @@ github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9km
 github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c h1:cqn374mizHuIWj+OSJCajGr/phAmuMug9qIX3l9CflE=
+github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/montanaflynn/stats v0.6.3/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=

--- a/hugolib/content_map.go
+++ b/hugolib/content_map.go
@@ -187,7 +187,7 @@ func (m *pageMap) AddFi(fi hugofs.FileMetaInfo) error {
 		if pi.IsContent() {
 			// Create the page now as we need it at assemembly time.
 			// The other resources are created if needed.
-			pageResource, err := m.s.h.newPage(
+			pageResource, pi, err := m.s.h.newPage(
 				&pageMeta{
 					f:        source.NewFileInfo(fim),
 					pathInfo: pi,
@@ -197,6 +197,8 @@ func (m *pageMap) AddFi(fi hugofs.FileMetaInfo) error {
 			if err != nil {
 				return err
 			}
+			key = pi.Base()
+
 			rs = &resourceSource{r: pageResource}
 		} else {
 			rs = &resourceSource{path: pi, opener: r, fi: fim}
@@ -226,7 +228,7 @@ func (m *pageMap) AddFi(fi hugofs.FileMetaInfo) error {
 			},
 		))
 		// A content file.
-		p, err := m.s.h.newPage(
+		p, pi, err := m.s.h.newPage(
 			&pageMeta{
 				f:        source.NewFileInfo(fi),
 				pathInfo: pi,

--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -1548,7 +1548,7 @@ func (sa *sitePagesAssembler) assembleResources() error {
 						return false, nil
 					}
 
-					relPathOriginal := rs.path.PathRel(ps.m.pathInfo)
+					relPathOriginal := rs.path.Unmormalized().PathRel(ps.m.pathInfo.Unmormalized())
 					relPath := rs.path.BaseRel(ps.m.pathInfo)
 
 					var targetBasePaths []string

--- a/hugolib/content_map_test.go
+++ b/hugolib/content_map_test.go
@@ -280,3 +280,22 @@ P1: {{ $p1.Title }}|{{ $p1.Params.foo }}|{{ $p1.File.Filename }}|
 		filepath.FromSlash("P1: P1 md|md|/content/p1.md|"),
 	)
 }
+
+// Issue #11944
+func TestBundleResourcesGetWithSpacesInFilename(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com"
+disableKinds = ["taxonomy", "term"]
+-- content/bundle/index.md --
+-- content/bundle/data with Spaces.txt --
+Data.
+-- layouts/index.html --
+{{ $bundle := site.GetPage "bundle" }}
+{{ $r := $bundle.Resources.Get "data with Spaces.txt" }}
+R: {{ with $r }}{{ .Content }}{{ end }}|
+`
+	b := Test(t, files)
+
+	b.AssertFileContent("public/index.html", "R: Data.")
+}

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gohugoio/hugo/config/allconfig"
 	"github.com/gohugoio/hugo/hugofs/glob"
 	"github.com/gohugoio/hugo/hugolib/doctree"
+	"github.com/gohugoio/hugo/resources"
 
 	"github.com/fsnotify/fsnotify"
 
@@ -72,6 +73,8 @@ type HugoSites struct {
 
 	// Cache for page listings.
 	cachePages *dynacache.Partition[string, page.Pages]
+	// Cache for content sources.
+	cacheContentSource *dynacache.Partition[string, *resources.StaleValue[[]byte]]
 
 	// Before Hugo 0.122.0 we managed all translations in a map using a translationKey
 	// that could be overridden in front matter.

--- a/hugolib/integrationtest_builder.go
+++ b/hugolib/integrationtest_builder.go
@@ -80,6 +80,15 @@ func Test(t testing.TB, files string, opts ...TestOpt) *IntegrationTestBuilder {
 	return NewIntegrationTestBuilder(cfg).Build()
 }
 
+// TestE is the same as Test, but returns an error instead of failing the test.
+func TestE(t testing.TB, files string, opts ...TestOpt) (*IntegrationTestBuilder, error) {
+	cfg := IntegrationTestConfig{T: t, TxtarString: files}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return NewIntegrationTestBuilder(cfg).BuildE()
+}
+
 // TestRunning is a convenience method to create a new IntegrationTestBuilder from some files with Running set to true and run a build.
 // Deprecated: Use Test with TestOptRunning instead.
 func TestRunning(t testing.TB, files string, opts ...TestOpt) *IntegrationTestBuilder {

--- a/hugolib/integrationtest_builder.go
+++ b/hugolib/integrationtest_builder.go
@@ -57,6 +57,13 @@ func TestOptDebug() TestOpt {
 	}
 }
 
+// TestOptWarn will enable warn logging in integration tests.
+func TestOptWarn() TestOpt {
+	return func(c *IntegrationTestConfig) {
+		c.LogLevel = logg.LevelWarn
+	}
+}
+
 // TestOptWithNFDOnDarwin will normalize the Unicode filenames to NFD on Darwin.
 func TestOptWithNFDOnDarwin() TestOpt {
 	return func(c *IntegrationTestConfig) {
@@ -181,9 +188,18 @@ func (b *lockingBuffer) Write(p []byte) (n int, err error) {
 	return
 }
 
-func (s *IntegrationTestBuilder) AssertLogContains(text string) {
+func (s *IntegrationTestBuilder) AssertLogContains(els ...string) {
 	s.Helper()
-	s.Assert(s.logBuff.String(), qt.Contains, text)
+	for _, el := range els {
+		s.Assert(s.logBuff.String(), qt.Contains, el)
+	}
+}
+
+func (s *IntegrationTestBuilder) AssertLogNotContains(els ...string) {
+	s.Helper()
+	for _, el := range els {
+		s.Assert(s.logBuff.String(), qt.Not(qt.Contains), el)
+	}
 }
 
 func (s *IntegrationTestBuilder) AssertLogMatches(expression string) {

--- a/hugolib/page__common.go
+++ b/hugolib/page__common.go
@@ -91,9 +91,6 @@ type pageCommon struct {
 	layoutDescriptor     layouts.LayoutDescriptor
 	layoutDescriptorInit sync.Once
 
-	// The source and the parsed page content.
-	content *cachedContent
-
 	// Set if feature enabled and this is in a Git repo.
 	gitInfo    source.GitInfo
 	codeowners []string

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gohugoio/hugo/source"
 
+	"github.com/gohugoio/hugo/common/constants"
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
@@ -621,6 +622,9 @@ func (p *pageState) setMetaPostParams() error {
 	}
 
 	for k, v := range userParams {
+		if _, found := params[k]; found {
+			p.s.Log.Warnidf(constants.WarnFrontMatterParamsOverrides, "Hugo front matter key %q is overridden in params section.", k)
+		}
 		params[strings.ToLower(k)] = v
 	}
 

--- a/hugolib/page__paths.go
+++ b/hugolib/page__paths.go
@@ -127,7 +127,7 @@ func createTargetPathDescriptor(p *pageState) (page.TargetPathDescriptor, error)
 		Section:     pageInfoCurrentSection,
 		UglyURLs:    s.h.Conf.IsUglyURLs(p.Section()),
 		ForcePrefix: s.h.Conf.IsMultihost() || alwaysInSubDir,
-		URL:         pm.urlPaths.URL,
+		URL:         pm.pageConfig.URL,
 	}
 
 	if pm.Slug() != "" {

--- a/hugolib/params_test.go
+++ b/hugolib/params_test.go
@@ -133,6 +133,28 @@ RegularPages: {{ range site.RegularPages }}{{ .Path }}|{{ .RelPermalink }}|{{ .T
 	)
 }
 
+func TestFrontMatterTitleOverrideWarn(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+disableKinds = ["taxonomy", "term"]
+-- content/p1.md --
+---
+title: "My title"
+params:
+  title: "My title from params"
+---
+
+
+`
+
+	b := Test(t, files, TestOptWarn())
+
+	b.AssertLogContains("ARN  Hugo front matter key \"title\" is overridden in params section", "You can suppress this warning")
+}
+
 func TestFrontMatterParamsLangNoCascade(t *testing.T) {
 	t.Parallel()
 

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -315,7 +315,7 @@ func prepareShortcode(
 	isRenderString bool,
 ) (shortcodeRenderer, error) {
 	toParseErr := func(err error) error {
-		source := p.content.mustSource()
+		source := p.m.content.mustSource()
 		return p.parseError(fmt.Errorf("failed to render shortcode %q: %w", sc.name, err), source, sc.pos)
 	}
 
@@ -443,7 +443,7 @@ func doRenderShortcode(
 			//     unchanged.
 			// 2   If inner does not have a newline, strip the wrapping <p> block and
 			//     the newline.
-			switch p.m.markup {
+			switch p.m.pageConfig.Markup {
 			case "", "markdown":
 				if match, _ := regexp.MatchString(innerNewlineRegexp, inner); !match {
 					cleaner, err := regexp.Compile(innerCleanupRegexp)

--- a/hugolib/site_new.go
+++ b/hugolib/site_new.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gohugoio/hugo/navigation"
 	"github.com/gohugoio/hugo/output"
 	"github.com/gohugoio/hugo/publisher"
+	"github.com/gohugoio/hugo/resources"
 	"github.com/gohugoio/hugo/resources/page"
 	"github.com/gohugoio/hugo/resources/page/pagemeta"
 	"github.com/gohugoio/hugo/resources/page/siteidentities"
@@ -281,6 +282,7 @@ func newHugoSites(cfg deps.DepsCfg, d *deps.Deps, pageTrees *pageTrees, sites []
 			page.Pages](d.MemCache, "/pags/all",
 			dynacache.OptionsPartition{Weight: 10, ClearWhen: dynacache.ClearOnRebuild},
 		),
+		cacheContentSource:      dynacache.GetOrCreatePartition[string, *resources.StaleValue[[]byte]](d.MemCache, "/cont/src", dynacache.OptionsPartition{Weight: 70, ClearWhen: dynacache.ClearOnChange}),
 		translationKeyPages:     maps.NewSliceCache[page.Page](),
 		currentSite:             sites[0],
 		skipRebuildForFilenames: make(map[string]bool),

--- a/hugolib/site_new.go
+++ b/hugolib/site_new.go
@@ -124,7 +124,7 @@ func NewHugoSites(cfg deps.DepsCfg) (*HugoSites, error) {
 			Stdout:             cfg.LogOut,
 			Stderr:             cfg.LogOut,
 			StoreErrors:        conf.Running(),
-			SuppressStatements: conf.IgnoredErrors(),
+			SuppressStatements: conf.IgnoredLogs(),
 		}
 		logger = loggers.New(logOpts)
 	}

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -129,7 +129,7 @@ func pageRenderer(
 			continue
 		}
 
-		if p.m.buildConfig.PublishResources {
+		if p.m.pageConfig.Build.PublishResources {
 			if err := p.renderResources(); err != nil {
 				s.SendError(p.errorf(err, "failed to render page resources"))
 				continue

--- a/resources/page/pagemeta/page_frontmatter.go
+++ b/resources/page/pagemeta/page_frontmatter.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Hugo Authors. All rights reserved.
+// Copyright 2024 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,14 +19,75 @@ import (
 
 	"github.com/gohugoio/hugo/common/htime"
 	"github.com/gohugoio/hugo/common/loggers"
+	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
+	"github.com/gohugoio/hugo/resources/page"
 
 	"github.com/gohugoio/hugo/helpers"
-	"github.com/gohugoio/hugo/resources/resource"
 
 	"github.com/gohugoio/hugo/config"
 	"github.com/spf13/cast"
 )
+
+type Dates struct {
+	Date        time.Time
+	Lastmod     time.Time
+	PublishDate time.Time
+	ExpiryDate  time.Time
+}
+
+func (d Dates) IsDateOrLastModAfter(in Dates) bool {
+	return d.Date.After(in.Date) || d.Lastmod.After(in.Lastmod)
+}
+
+func (d *Dates) UpdateDateAndLastmodIfAfter(in Dates) {
+	if in.Date.After(d.Date) {
+		d.Date = in.Date
+	}
+	if in.Lastmod.After(d.Lastmod) {
+		d.Lastmod = in.Lastmod
+	}
+}
+
+func (d Dates) IsAllDatesZero() bool {
+	return d.Date.IsZero() && d.Lastmod.IsZero() && d.PublishDate.IsZero() && d.ExpiryDate.IsZero()
+}
+
+// PageConfig configures a Page, typically from front matter.
+// Note that all the top level fields are reserved Hugo keywords.
+// Any custom configuration needs to be set in the Params map.
+type PageConfig struct {
+	Dates                   // Dates holds the fource core dates for this page.
+	Title          string   // The title of the page.
+	LinkTitle      string   // The link title of the page.
+	Type           string   // The content type of the page.
+	Layout         string   // The layout to use for to render this page.
+	Markup         string   // The markup used in the content file.
+	Weight         int      // The weight of the page, used in sorting if set to a non-zero value.
+	Kind           string   // The kind of page, e.g. "page", "section", "home" etc. This is usually derived from the content path.
+	Path           string   // The canonical path to the page, e.g. /sect/mypage. Note: Leading slash, no trailing slash, no extensions or language identifiers.
+	Lang           string   // The language code for this page. This is usually derived from the module mount or filename.
+	Slug           string   // The slug for this page.
+	Description    string   // The description for this page.
+	Summary        string   // The summary for this page.
+	Draft          bool     // Whether or not the content is a draft.
+	Headless       bool     // Whether or not the page should be rendered.
+	IsCJKLanguage  bool     // Whether or not the content is in a CJK language.
+	TranslationKey string   // The translation key for this page.
+	Keywords       []string // The keywords for this page.
+	Aliases        []string // The aliases for this page.
+	Outputs        []string // The output formats to render this page in. If not set, the site's configured output formats for this page kind will be used.
+
+	// These build options are set in the front matter,
+	// but not passed on to .Params.
+	Resources []map[string]any
+	Cascade   map[page.PageMatcher]maps.Params // Only relevant for branch nodes.
+	Sitemap   config.SitemapConfig
+	Build     BuildConfig
+
+	// User defined params.
+	Params maps.Params
+}
 
 // FrontMatterHandler maps front matter into Page fields and .Params.
 // Note that we currently have only extracted the date logic.
@@ -47,9 +108,6 @@ type FrontMatterHandler struct {
 // FrontMatterDescriptor describes how to handle front matter for a given Page.
 // It has pointers to values in the receiving page which gets updated.
 type FrontMatterDescriptor struct {
-	// This is the Page's params.
-	Params map[string]any
-
 	// This is the Page's base filename (BaseFilename), e.g. page.md., or
 	// if page is a leaf bundle, the bundle folder name (ContentBaseName).
 	BaseFilename string
@@ -60,13 +118,8 @@ type FrontMatterDescriptor struct {
 	// May be set from the author date in Git.
 	GitAuthorDate time.Time
 
-	// The below are pointers to values on Page and will be modified.
-
-	// This is the Page's dates.
-	Dates *resource.Dates
-
-	// This is the Page's Slug etc.
-	PageURLs *URLPath
+	// The below will be modified.
+	PageConfig *PageConfig
 
 	// The Location to use to parse dates without time zone info.
 	Location *time.Location
@@ -83,8 +136,8 @@ var dateFieldAliases = map[string][]string{
 // supplied front matter params. Note that this requires all lower-case keys
 // in the params map.
 func (f FrontMatterHandler) HandleDates(d *FrontMatterDescriptor) error {
-	if d.Dates == nil {
-		panic("missing dates")
+	if d.PageConfig == nil {
+		panic("missing pageConfig")
 	}
 
 	if f.dateHandler == nil {
@@ -297,7 +350,7 @@ func (f *FrontMatterHandler) createHandlers() error {
 
 	if f.dateHandler, err = f.createDateHandler(f.fmConfig.Date,
 		func(d *FrontMatterDescriptor, t time.Time) {
-			d.Dates.FDate = t
+			d.PageConfig.Date = t
 			setParamIfNotSet(fmDate, t, d)
 		}); err != nil {
 		return err
@@ -306,7 +359,7 @@ func (f *FrontMatterHandler) createHandlers() error {
 	if f.lastModHandler, err = f.createDateHandler(f.fmConfig.Lastmod,
 		func(d *FrontMatterDescriptor, t time.Time) {
 			setParamIfNotSet(fmLastmod, t, d)
-			d.Dates.FLastmod = t
+			d.PageConfig.Lastmod = t
 		}); err != nil {
 		return err
 	}
@@ -314,7 +367,7 @@ func (f *FrontMatterHandler) createHandlers() error {
 	if f.publishDateHandler, err = f.createDateHandler(f.fmConfig.PublishDate,
 		func(d *FrontMatterDescriptor, t time.Time) {
 			setParamIfNotSet(fmPubDate, t, d)
-			d.Dates.FPublishDate = t
+			d.PageConfig.PublishDate = t
 		}); err != nil {
 		return err
 	}
@@ -322,7 +375,7 @@ func (f *FrontMatterHandler) createHandlers() error {
 	if f.expiryDateHandler, err = f.createDateHandler(f.fmConfig.ExpiryDate,
 		func(d *FrontMatterDescriptor, t time.Time) {
 			setParamIfNotSet(fmExpiryDate, t, d)
-			d.Dates.FExpiryDate = t
+			d.PageConfig.ExpiryDate = t
 		}); err != nil {
 		return err
 	}
@@ -331,10 +384,10 @@ func (f *FrontMatterHandler) createHandlers() error {
 }
 
 func setParamIfNotSet(key string, value any, d *FrontMatterDescriptor) {
-	if _, found := d.Params[key]; found {
+	if _, found := d.PageConfig.Params[key]; found {
 		return
 	}
-	d.Params[key] = value
+	d.PageConfig.Params[key] = value
 }
 
 func (f FrontMatterHandler) createDateHandler(identifiers []string, setter func(d *FrontMatterDescriptor, t time.Time)) (frontMatterFieldHandler, error) {
@@ -361,7 +414,7 @@ type frontmatterFieldHandlers int
 
 func (f *frontmatterFieldHandlers) newDateFieldHandler(key string, setter func(d *FrontMatterDescriptor, t time.Time)) frontMatterFieldHandler {
 	return func(d *FrontMatterDescriptor) (bool, error) {
-		v, found := d.Params[key]
+		v, found := d.PageConfig.Params[key]
 
 		if !found {
 			return false, nil
@@ -377,7 +430,7 @@ func (f *frontmatterFieldHandlers) newDateFieldHandler(key string, setter func(d
 		setter(d, date)
 
 		// This is the params key as set in front matter.
-		d.Params[key] = date
+		d.PageConfig.Params[key] = date
 
 		return true, nil
 	}
@@ -392,9 +445,9 @@ func (f *frontmatterFieldHandlers) newDateFilenameHandler(setter func(d *FrontMa
 
 		setter(d, date)
 
-		if _, found := d.Params["slug"]; !found {
+		if _, found := d.PageConfig.Params["slug"]; !found {
 			// Use slug from filename
-			d.PageURLs.Slug = slug
+			d.PageConfig.Slug = slug
 		}
 
 		return true, nil

--- a/resources/page/pagemeta/page_frontmatter.go
+++ b/resources/page/pagemeta/page_frontmatter.go
@@ -57,7 +57,7 @@ func (d Dates) IsAllDatesZero() bool {
 // Note that all the top level fields are reserved Hugo keywords.
 // Any custom configuration needs to be set in the Params map.
 type PageConfig struct {
-	Dates                   // Dates holds the fource core dates for this page.
+	Dates                   // Dates holds the four core dates for this page.
 	Title          string   // The title of the page.
 	LinkTitle      string   // The link title of the page.
 	Type           string   // The content type of the page.
@@ -66,6 +66,7 @@ type PageConfig struct {
 	Weight         int      // The weight of the page, used in sorting if set to a non-zero value.
 	Kind           string   // The kind of page, e.g. "page", "section", "home" etc. This is usually derived from the content path.
 	Path           string   // The canonical path to the page, e.g. /sect/mypage. Note: Leading slash, no trailing slash, no extensions or language identifiers.
+	URL            string   // The URL to the rendered page, e.g. /sect/mypage.html.
 	Lang           string   // The language code for this page. This is usually derived from the module mount or filename.
 	Slug           string   // The slug for this page.
 	Description    string   // The description for this page.

--- a/resources/page/pagemeta/page_frontmatter_test.go
+++ b/resources/page/pagemeta/page_frontmatter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Hugo Authors. All rights reserved.
+// Copyright 2024 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,16 +22,15 @@ import (
 	"github.com/gohugoio/hugo/config/testconfig"
 
 	"github.com/gohugoio/hugo/resources/page/pagemeta"
-	"github.com/gohugoio/hugo/resources/resource"
 
 	qt "github.com/frankban/quicktest"
 )
 
 func newTestFd() *pagemeta.FrontMatterDescriptor {
 	return &pagemeta.FrontMatterDescriptor{
-		Params:   make(map[string]any),
-		Dates:    &resource.Dates{},
-		PageURLs: &pagemeta.URLPath{},
+		PageConfig: &pagemeta.PageConfig{
+			Params: make(map[string]interface{}),
+		},
 		Location: time.UTC,
 	}
 }
@@ -105,16 +104,16 @@ func TestFrontMatterDatesHandlers(t *testing.T) {
 		case ":git":
 			d.GitAuthorDate = d1
 		}
-		d.Params["date"] = d2
+		d.PageConfig.Params["date"] = d2
 		c.Assert(handler.HandleDates(d), qt.IsNil)
-		c.Assert(d.Dates.FDate, qt.Equals, d1)
-		c.Assert(d.Params["date"], qt.Equals, d2)
+		c.Assert(d.PageConfig.Dates.Date, qt.Equals, d1)
+		c.Assert(d.PageConfig.Params["date"], qt.Equals, d2)
 
 		d = newTestFd()
-		d.Params["date"] = d2
+		d.PageConfig.Params["date"] = d2
 		c.Assert(handler.HandleDates(d), qt.IsNil)
-		c.Assert(d.Dates.FDate, qt.Equals, d2)
-		c.Assert(d.Params["date"], qt.Equals, d2)
+		c.Assert(d.PageConfig.Dates.Date, qt.Equals, d2)
+		c.Assert(d.PageConfig.Params["date"], qt.Equals, d2)
 
 	}
 }
@@ -137,15 +136,15 @@ func TestFrontMatterDatesDefaultKeyword(t *testing.T) {
 
 	testDate, _ := time.Parse("2006-01-02", "2018-02-01")
 	d := newTestFd()
-	d.Params["mydate"] = testDate
-	d.Params["date"] = testDate.Add(1 * 24 * time.Hour)
-	d.Params["mypubdate"] = testDate.Add(2 * 24 * time.Hour)
-	d.Params["publishdate"] = testDate.Add(3 * 24 * time.Hour)
+	d.PageConfig.Params["mydate"] = testDate
+	d.PageConfig.Params["date"] = testDate.Add(1 * 24 * time.Hour)
+	d.PageConfig.Params["mypubdate"] = testDate.Add(2 * 24 * time.Hour)
+	d.PageConfig.Params["publishdate"] = testDate.Add(3 * 24 * time.Hour)
 
 	c.Assert(handler.HandleDates(d), qt.IsNil)
 
-	c.Assert(d.Dates.FDate.Day(), qt.Equals, 1)
-	c.Assert(d.Dates.FLastmod.Day(), qt.Equals, 2)
-	c.Assert(d.Dates.FPublishDate.Day(), qt.Equals, 4)
-	c.Assert(d.Dates.FExpiryDate.IsZero(), qt.Equals, true)
+	c.Assert(d.PageConfig.Dates.Date.Day(), qt.Equals, 1)
+	c.Assert(d.PageConfig.Dates.Lastmod.Day(), qt.Equals, 2)
+	c.Assert(d.PageConfig.Dates.PublishDate.Day(), qt.Equals, 4)
+	c.Assert(d.PageConfig.Dates.ExpiryDate.IsZero(), qt.Equals, true)
 }

--- a/resources/page/pagemeta/pagemeta.go
+++ b/resources/page/pagemeta/pagemeta.go
@@ -17,13 +17,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-type URLPath struct {
-	URL       string
-	Permalink string
-	Slug      string
-	Section   string
-}
-
 const (
 	Never       = "never"
 	Always      = "always"

--- a/resources/resource/dates.go
+++ b/resources/resource/dates.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Hugo Authors. All rights reserved.
+// Copyright 2024 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ import (
 	"github.com/gohugoio/hugo/common/htime"
 )
 
-var _ Dated = Dates{}
-
 // Dated wraps a "dated resource". These are the 4 dates that makes
 // the date logic in Hugo.
 type Dated interface {
@@ -35,27 +33,6 @@ type Dated interface {
 
 	// ExpiryDate returns the expiration date of the resource.
 	ExpiryDate() time.Time
-}
-
-// Dates holds the 4 Hugo dates.
-type Dates struct {
-	FDate        time.Time
-	FLastmod     time.Time
-	FPublishDate time.Time
-	FExpiryDate  time.Time
-}
-
-func (d *Dates) IsDateOrLastModAfter(in Dated) bool {
-	return d.Date().After(in.Date()) || d.Lastmod().After(in.Lastmod())
-}
-
-func (d *Dates) UpdateDateAndLastmodIfAfter(in Dated) {
-	if in.Date().After(d.Date()) {
-		d.FDate = in.Date()
-	}
-	if in.Lastmod().After(d.Lastmod()) {
-		d.FLastmod = in.Lastmod()
-	}
 }
 
 // IsFuture returns whether the argument represents the future.
@@ -78,20 +55,4 @@ func IsExpired(d Dated) bool {
 // IsZeroDates returns true if all of the dates are zero.
 func IsZeroDates(d Dated) bool {
 	return d.Date().IsZero() && d.Lastmod().IsZero() && d.ExpiryDate().IsZero() && d.PublishDate().IsZero()
-}
-
-func (p Dates) Date() time.Time {
-	return p.FDate
-}
-
-func (p Dates) Lastmod() time.Time {
-	return p.FLastmod
-}
-
-func (p Dates) PublishDate() time.Time {
-	return p.FPublishDate
-}
-
-func (p Dates) ExpiryDate() time.Time {
-	return p.FExpiryDate
 }

--- a/tpl/data/data.go
+++ b/tpl/data/data.go
@@ -94,7 +94,7 @@ func (ns *Namespace) GetCSV(sep string, args ...any) (d [][]string, err error) {
 		if security.IsAccessDenied(err) {
 			return nil, err
 		}
-		ns.deps.Log.Errorsf(constants.ErrRemoteGetCSV, "Failed to get CSV resource %q: %s", url, err)
+		ns.deps.Log.Erroridf(constants.ErrRemoteGetCSV, "Failed to get CSV resource %q: %s", url, err)
 		return nil, nil
 	}
 
@@ -132,7 +132,7 @@ func (ns *Namespace) GetJSON(args ...any) (any, error) {
 		if security.IsAccessDenied(err) {
 			return nil, err
 		}
-		ns.deps.Log.Errorsf(constants.ErrRemoteGetJSON, "Failed to get JSON resource %q: %s", url, err)
+		ns.deps.Log.Erroridf(constants.ErrRemoteGetJSON, "Failed to get JSON resource %q: %s", url, err)
 		return nil, nil
 	}
 

--- a/tpl/fmt/fmt.go
+++ b/tpl/fmt/fmt.go
@@ -68,9 +68,7 @@ func (ns *Namespace) Errorf(format string, args ...any) string {
 // an information text that the error with the given id can be suppressed in config.
 // It returns an empty string.
 func (ns *Namespace) Erroridf(id, format string, args ...any) string {
-	format += "\nYou can suppress this error by adding the following to your site configuration:\nignoreErrors = ['%s']"
-	args = append(args, id)
-	ns.logger.Errorsf(id, format, args...)
+	ns.logger.Erroridf(id, format, args...)
 	return ""
 }
 
@@ -78,6 +76,14 @@ func (ns *Namespace) Erroridf(id, format string, args ...any) string {
 // It returns an empty string.
 func (ns *Namespace) Warnf(format string, args ...any) string {
 	ns.logger.Warnf(format, args...)
+	return ""
+}
+
+// Warnidf formats args according to a format specifier and logs an WARNING and
+// an information text that the warning with the given id can be suppressed in config.
+// It returns an empty string.
+func (ns *Namespace) Warnidf(id, format string, args ...any) string {
+	ns.logger.Warnidf(id, format, args...)
 	return ""
 }
 

--- a/tpl/fmt/init.go
+++ b/tpl/fmt/init.go
@@ -66,6 +66,13 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.Warnidf,
+			[]string{"warnidf"},
+			[][2]string{
+				{`{{ warnidf "my-warn-id" "%s." "warning" }}`, ``},
+			},
+		)
+
 		ns.AddMethodMapping(ctx.Warnf,
 			[]string{"warnf"},
 			[][2]string{


### PR DESCRIPTION
This is 4 separate and (mostly) related commits. See the commit messages for details.

The one thing that may need some explaining is the addition of `kind`, `path` and `lang` as front matter keys, and the consolidation of the page configuration into this struct:

```go

type Dates struct {
	Date        time.Time
	Lastmod     time.Time
	PublishDate time.Time
	ExpiryDate  time.Time
}

// PageConfig configures a Page, typically from front matter.
// Note that all the top level fields are reserved Hugo keywords.
// Any custom configuration needs to be set in the Params map.
type PageConfig struct {
	Dates                   // Dates holds the fource core dates for this page.
	Title          string   // The title of the page.
	LinkTitle      string   // The link title of the page.
	Type           string   // The content type of the page.
	Layout         string   // The layout to use for to render this page.
	Markup         string   // The markup used in the content file.
	Weight         int      // The weight of the page, used in sorting if set to a non-zero value.
	Kind           string   // The kind of page, e.g. "page", "section", "home" etc. This is usually derived from the content path.
	Path           string   // The canonical path to the page, e.g. /sect/mypage. Note: Leading slash, no trailing slash, no extensions or language identifiers.
	Lang           string   // The language code for this page. This is usually derived from the module mount or filename.
	Slug           string   // The slug for this page.
	Description    string   // The description for this page.
	Summary        string   // The summary for this page.
	Draft          bool     // Whether or not the content is a draft.
	Headless       bool     // Whether or not the page should be rendered.
	IsCJKLanguage  bool     // Whether or not the content is in a CJK language.
	TranslationKey string   // The translation key for this page.
	Keywords       []string // The keywords for this page.
	Aliases        []string // The aliases for this page.
	Outputs        []string // The output formats to render this page in. If not set, the site's configured output formats for this page kind will be used.

	// These build options are set in the front matter,
	// but not passed on to .Params.
	Resources []map[string]any
	Cascade   map[page.PageMatcher]maps.Params // Only relevant for branch nodes.
	Sitemap   config.SitemapConfig
	Build     BuildConfig

	// User defined params.
	Params maps.Params
}

```

I think the above should be complete. Note that 

1. Use cases for `kind`, `path` and `lang` in front matter may be rare, but this is mostly a preparation for other data formats.
2. None of these can currently be set in `cascade`.
3. I have renamed the `_build` to `build` (but both will work).