### PR TITLE
Filter out duplicate content resource files

### DIFF
--- a/hugofs/component_fs.go
+++ b/hugofs/component_fs.go
@@ -147,13 +147,13 @@ func (f *componentFsDir) ReadDir(count int) ([]iofs.DirEntry, error) {
 	})
 
 	if f.fs.opts.Component == files.ComponentFolderContent {
-		// Finally filter out any duplicate content files, e.g. page.md and page.html.
+		// Finally filter out any duplicate content or resource files, e.g. page.md and page.html.
 		n := 0
 		seen := map[hstrings.Tuple]bool{}
 		for _, fi := range fis {
 			fim := fi.(FileMetaInfo)
 			pi := fim.Meta().PathInfo
-			keep := fim.IsDir() || !pi.IsContent()
+			keep := fim.IsDir()
 
 			if !keep {
 				baseLang := hstrings.Tuple{First: pi.Base(), Second: fim.Meta().Lang}


### PR DESCRIPTION
We do a slight normalisation of the content paths (lower case, replacing " " with "-") and remove andy language identifier before inserting them into the content tree.

This means that, given that that the default content language is `en`:

```
index.md
index.html
Foo Bar.txt
foo-bar.txt
foo-bar.en.txt
Foo-Bar.txt
```

The bundle above will be reduced to one content file with one resource (`foo-bar.txt`).

Before this commit, what version of the `foo-bar.txt` you ended up with was undeterministic. No  we pick the first determined by sort order.

Note that the sort order is stable, but we recommend avoiding situations like the above.

Closes #11946
