### PR TITLE
all: Deprecate .Page.Lang and .Page.File.Lang

### DIFF
--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -105,6 +105,7 @@ func (p *pageMeta) Aliases() []string {
 	return p.pageConfig.Aliases
 }
 
+// Deprecated: use taxonomies.
 func (p *pageMeta) Author() page.Author {
 	hugo.Deprecate(".Author", "Use taxonomies.", "v0.98.0")
 	authors := p.Authors()
@@ -115,6 +116,7 @@ func (p *pageMeta) Author() page.Author {
 	return page.Author{}
 }
 
+// Deprecated: use taxonomies.
 func (p *pageMeta) Authors() page.AuthorList {
 	hugo.Deprecate(".Author", "Use taxonomies.", "v0.112.0")
 	return nil
@@ -151,7 +153,9 @@ func (p *pageMeta) Description() string {
 	return p.pageConfig.Description
 }
 
+// Deprecated: use .Page.Language.Lang instead.
 func (p *pageMeta) Lang() string {
+	hugo.Deprecate(".Page.Lang", "Use .Page.Language.Lang instead.", "v0.123.0")
 	return p.s.Lang()
 }
 

--- a/source/fileInfo.go
+++ b/source/fileInfo.go
@@ -51,17 +51,19 @@ func (fi *File) Dir() string {
 }
 
 // Extension is an alias to Ext().
+// Deprecated: Use Ext() instead.
 func (fi *File) Extension() string {
 	hugo.Deprecate(".File.Extension", "Use .File.Ext instead.", "v0.96.0")
 	return fi.Ext()
 }
 
 // Ext returns a file's extension without the leading period (e.g. "md").
-// Deprecated: Use Extension() instead.
 func (fi *File) Ext() string { return fi.p().Ext() }
 
 // Lang returns a file's language (e.g. "sv").
+// Deprecated: use .Page.Language.Lang instead.
 func (fi *File) Lang() string {
+	hugo.Deprecate(".Page.File.Lang", "Use .Page.Language.Lang instead.", "v0.123.0")
 	return fi.fim.Meta().Lang
 }
 


### PR DESCRIPTION
Use .Page.Language.Lang instead.