### PR TITLE
hugolib: Revert deprecation of .Page.Lang

### DIFF
--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -153,9 +153,7 @@ func (p *pageMeta) Description() string {
 	return p.pageConfig.Description
 }
 
-// Deprecated: use .Page.Language.Lang instead.
 func (p *pageMeta) Lang() string {
-	hugo.Deprecate(".Page.Lang", "Use .Page.Language.Lang instead.", "v0.123.0")
 	return p.s.Lang()
 }
 


### PR DESCRIPTION
Deprecation message was also emitted when calling .Page.Language.Lang. Reverting for now, but will remove all references to .Page.Lang from documentation.