### PR TITLE
hugolib: Formally deprecate .Page.NextPage .Page.PrevPage

### DIFF
--- a/hugolib/page__position.go
+++ b/hugolib/page__position.go
@@ -16,6 +16,7 @@ package hugolib
 import (
 	"context"
 
+	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/lazy"
 	"github.com/gohugoio/hugo/resources/page"
 )
@@ -52,7 +53,9 @@ func (p pagePosition) Next() page.Page {
 	return p.next()
 }
 
+// Deprecated: Use Next instead.
 func (p pagePosition) NextPage() page.Page {
+	hugo.Deprecate(".Page.NextPage", "Use .Page.Next instead.", "v0.123.0")
 	return p.Next()
 }
 
@@ -60,7 +63,9 @@ func (p pagePosition) Prev() page.Page {
 	return p.prev()
 }
 
+// Deprecated: Use Prev instead.
 func (p pagePosition) PrevPage() page.Page {
+	hugo.Deprecate(".Page.PrevPage", "Use .Page.Prev instead.", "v0.123.0")
 	return p.Prev()
 }
 


### PR DESCRIPTION
Use .Page.Next and .Page.Prev instead.

Housecleaning... these were originally deprecated in v0.57.0 according to comments:
https://github.com/gohugoio/hugo/blob/46575baa02562e4ad05c89f4250287413e38627a/resources/page/page.go#L341-L345
