### PR TITLE
GitHub workflows: bump actions to latest versions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@08e671be8ac8944d0e132aa71d0ae8ccfb347675
+      - uses: dessant/lock-threads@v5
         with:
           issue-inactive-days: 21
           add-issue-labels: 'Outdated'
@@ -24,7 +24,7 @@ jobs:
             This pull request has been automatically locked since there
             has not been any recent activity after it was closed.
             Please open a new issue for related bugs.
-      - uses: actions/stale@04a1828bc18ada028d85a0252a47cd2963a91abe
+      - uses: actions/stale@v9
         with:
           operations-per-run: 999
           days-before-issue-stale: 365

--- a/.github/workflows/test-dart-sass-v1.yml
+++ b/.github/workflows/test-dart-sass-v1.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true
@@ -30,18 +30,18 @@ jobs:
           **/go.sum
           **/go.mod
     - name: Install Ruby
-      uses: ruby/setup-ruby@036ef458ddccddb148a2b9fb67e95a22fdbf728b
+      uses: ruby/setup-ruby@v1.171.0
       with:
         ruby-version: '2.7' 
         bundler-cache: true #
     - name: Install Python
-      uses: actions/setup-python@3105fb18c05ddd93efea5f9e0bef7a03a6e9e7df
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install Mage
       run: go install github.com/magefile/mage@v1.15.0
     - name: Install asciidoctor
-      uses: reitzig/actions-asciidoctor@7570212ae20b63653481675fb1ff62d1073632b0
+      uses: reitzig/actions-asciidoctor@v2.0.1
     - name: Install docutils
       run: |
         pip install docutils

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true
@@ -32,18 +32,18 @@ jobs:
           **/go.sum
           **/go.mod
     - name: Install Ruby
-      uses: ruby/setup-ruby@036ef458ddccddb148a2b9fb67e95a22fdbf728b
+      uses: ruby/setup-ruby@v1.171.0
       with:
         ruby-version: '2.7'
         bundler-cache: true #
     - name: Install Python
-      uses: actions/setup-python@3105fb18c05ddd93efea5f9e0bef7a03a6e9e7df
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install Mage
       run: go install github.com/magefile/mage@v1.15.0
     - name: Install asciidoctor
-      uses: reitzig/actions-asciidoctor@7570212ae20b63653481675fb1ff62d1073632b0
+      uses: reitzig/actions-asciidoctor@v2.0.1
     - name: Install docutils
       run: |
         pip install docutils


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions, thus avoiding deprecation warnings as seen e.g. [here](https://github.com/gohugoio/hugo/actions/runs/7803541200).