### PR TITLE
Correctly handle charset parameter to MIME types.

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -397,7 +397,7 @@ func (w *whatChanged) Changes() []identity.Identity {
 func (s *Site) RegisterMediaTypes() {
 	for _, mt := range s.conf.MediaTypes.Config {
 		for _, suffix := range mt.Suffixes() {
-			_ = mime.AddExtensionType(mt.Delimiter+suffix, mt.Type+"; charset=utf-8")
+			_ = mime.AddExtensionType(mt.Delimiter+suffix, mt.Type)
 		}
 	}
 }


### PR DESCRIPTION
The current implementation of Hugo always sets a parameter `charset` to `utf-8` for all MIME types. This is not always correct, as some MIME types are not text-based and do not have a charset paramter.

Why does it matter? Some browsers have strict checking and will throw an error if the `charset` parameter is set to `utf-8` for a non-text MIME type.

For reference see the [RFC2045 Section 5](https://datatracker.ietf.org/doc/html/rfc2045#section-5): `For example, the "charset" parameter is applicable to any subtype of "text"...`, and Mozilla's docs for
[Structure of a MIME Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#structure_of_a_mime_type).

As documented in
[mime/type.go:L110](https://cs.opensource.google/go/go/+/master:src/mime/type.go;l=110),
on the `TypeByExtension` function:
`// Text types have the charset parameter set to "utf-8" by default.`,
the Go standard library already takes care of setting the `charset` parameter to `utf-8` for text-based MIME types, so there is no need to set it manually. For the actual logic that sets the value see
[mime/type.go:L180](https://cs.opensource.google/go/go/+/master:src/mime/type.go;l=180) part of `setExtensionType` function, called by `AddExtensionType`. So there is actually nothing for Hugo to do, to be compliant with the standard.

I came across this issue when trying to serve a WASM file with the MIME type `application/wasm` and the `charset` parameter set to `utf-8`. This caused the browser to throw an error, as the `charset` parameter is not valid for this MIME type.

Actually debugging this issue was non trivial as the Chrome error message was not very helpful, and the Hugo server logs did not show any errors. I had to use `curl` to inspect the headers and see the `charset` parameter being set to `utf-8`.

Chrome Error: `Uncaught (in promise) TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.`

Firefox is a bit more helpful, as it prints the actual MIME type (including paramters).

Firefox Error: `Uncaught (in promise) TypeError: WebAssembly: Response has unsupported MIME type 'application/wasm; charset=utf-8' expected 'application/wasm'`

More than happy to add unit tests for this, if changes are accepted.

Fixes #10734
