### PR TITLE
Fix handling of draft term pages

### DIFF
--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -1415,8 +1415,10 @@ func (sa *sitePagesAssembler) applyAggregatesToTaxonomiesAndTerms() error {
 					if err := p.setMetaPost(cascade); err != nil {
 						return false, err
 					}
-
-					if err := sa.pageMap.treeTaxonomyEntries.WalkPrefix(
+					if !p.s.shouldBuild(p) {
+						sa.pageMap.treePages.Delete(s)
+						sa.pageMap.treeTaxonomyEntries.DeletePrefix(paths.AddTrailingSlash(s))
+					} else if err := sa.pageMap.treeTaxonomyEntries.WalkPrefix(
 						doctree.LockTypeRead,
 						paths.AddTrailingSlash(s),
 						func(ss string, wn *weightedContentNode) (bool, error) {

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -835,3 +835,26 @@ tags: ["hellO world"]
 
 	b.AssertFileContent("public/tags/hello-world/index.html", "HellO World|term|tag|tags|hellO world|")
 }
+
+func TestTermDraft(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- layouts/_default/list.html --
+|{{ .Title }}|
+-- content/p1.md --
+---
+title: p1
+tags: [a]
+---
+-- content/tags/a/_index.md --
+---
+title: tag-a-title-override
+draft: true
+---
+  `
+
+	b := Test(t, files)
+
+	b.AssertFileExists("public/tags/a/index.html", false)
+}


### PR DESCRIPTION
By just removing the term page and all of its page entries.

Which is a little of a coin flip, we could possibley also do like we handle the taxonomy nodes, e.g. disable them.

The reason this didn't just work is the way we need to wait until the end of the chain before we can apply the fully cascaded metadata to these nodes (e.g. the draft flag).

Fixes #12055
