### PR TITLE
Fix sample logic when adding content files in server

### DIFF
--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -192,7 +192,7 @@ func (t *pageTrees) collectIdentitiesSurroundingIn(key string, maxSamples int, t
 		level := strings.Count(prefix, "/")
 		tree.WalkPrefixRaw(prefix, func(s string, n contentNodeI) bool {
 			if level != strings.Count(s, "/") {
-				return true
+				return false
 			}
 			n.ForEeachIdentity(func(id identity.Identity) bool {
 				ids = append(ids, id)

--- a/hugolib/rebuild_test.go
+++ b/hugolib/rebuild_test.go
@@ -261,6 +261,29 @@ func TestRebuilErrorRecovery(t *testing.T) {
 	b.EditFileReplaceAll("content/mysection/mysectionbundle/index.md", "{{< foo }}", "{{< foo >}}").Build()
 }
 
+func TestRebuildAddPageListPagesInHome(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com"
+disableLiveReload = true
+-- content/asection/s1.md --
+-- content/p1.md --
+---
+title: "P1"
+weight: 1
+---
+-- layouts/_default/single.html --
+Single: {{ .Title }}|{{ .Content }}|
+-- layouts/index.html --
+Pages: {{ range .RegularPages }}{{ .RelPermalink }}|{{ end }}$
+`
+
+	b := TestRunning(t, files)
+	b.AssertFileContent("public/index.html", "Pages: /p1/|$")
+	b.AddFiles("content/p2.md", ``).Build()
+	b.AssertFileContent("public/index.html", "Pages: /p1/|/p2/|$")
+}
+
 func TestRebuildScopedToOutputFormat(t *testing.T) {
 	files := `
 -- hugo.toml --


### PR DESCRIPTION
The partial rebuilds works by calaulating a baseline from a change set.

For new content, this doesn't work, so to avoid rebuilding everything, we first
try to collect a sample of surrounding identities (e.g. content files in the same section).

This commit fixes a flaw in that logic that in some cases would return a too small sample set.

Fixes #12054
