### PR TITLE
Fall back to original name in Resources.GetMatch/Match

### DIFF
--- a/hugolib/pagebundler_test.go
+++ b/hugolib/pagebundler_test.go
@@ -876,3 +876,20 @@ RegularPages: {{ range .RegularPages }}{{ .RelPermalink }}|File LogicalName: {{ 
 		"List: |/mysection|File LogicalName: _index.md|/mysection/|section|Resources: sectiondata.json: Secion data JSON.|sectiondata.txt: Section data TXT.|$",
 		"RegularPages: /mysection/foo/p2/|File LogicalName: p2.md|/mysection/mybundle/|File LogicalName: index.md|/mysection/p2/|File LogicalName: p2.md|$")
 }
+
+func TestBundleResourcesGetMatchOriginalName(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com"
+-- content/mybundle/index.md --
+-- content/mybundle/f1.en.txt --
+F1.
+-- layouts/_default/single.html --
+GetMatch: {{ with .Resources.GetMatch "f1.en.*" }}{{ .Name }}: {{ .Content }}|{{ end }}
+Match: {{ range .Resources.Match "f1.en.*" }}{{ .Name }}: {{ .Content }}|{{ end }}
+`
+
+	b := Test(t, files)
+
+	b.AssertFileContent("public/mybundle/index.html", "GetMatch: f1.txt: F1.|", "Match: f1.txt: F1.|")
+}

--- a/resources/resource/resources.go
+++ b/resources/resource/resources.go
@@ -106,6 +106,15 @@ func (r Resources) GetMatch(pattern any) Resource {
 		}
 	}
 
+	// Finally, check the original name.
+	for _, resource := range r {
+		if nop, ok := resource.(NameOriginalProvider); ok {
+			if g.Match(paths.NormalizePathStringBasic(nop.NameOriginal())) {
+				return resource
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -133,6 +142,16 @@ func (r Resources) Match(pattern any) Resources {
 	for _, resource := range r {
 		if g.Match(strings.ToLower(resource.Name())) {
 			matches = append(matches, resource)
+		}
+	}
+	if len(matches) == 0 {
+		// 	Fall back to the original name.
+		for _, resource := range r {
+			if nop, ok := resource.(NameOriginalProvider); ok {
+				if g.Match(strings.ToLower(nop.NameOriginal())) {
+					matches = append(matches, resource)
+				}
+			}
 		}
 	}
 	return matches


### PR DESCRIPTION
Same as we do in .Get.

Fixes #12076