### PR TITLE
Fix regression on handling of overlapping file mounts

### DIFF
--- a/helpers/general.go
+++ b/helpers/general.go
@@ -328,7 +328,14 @@ func PrintFs(fs afero.Fs, path string, w io.Writer) {
 	}
 
 	afero.Walk(fs, path, func(path string, info os.FileInfo, err error) error {
-		fmt.Fprintln(w, filepath.ToSlash(path))
+		if err != nil {
+			panic(fmt.Sprintf("error: path %q: %s", path, err))
+		}
+		path = filepath.ToSlash(path)
+		if path == "" {
+			path = "."
+		}
+		fmt.Fprintln(w, path, info.IsDir())
 		return nil
 	})
 }

--- a/hugolib/integrationtest_builder.go
+++ b/hugolib/integrationtest_builder.go
@@ -275,9 +275,13 @@ func (s *IntegrationTestBuilder) AssertFileContentExact(filename string, matches
 }
 
 func (s *IntegrationTestBuilder) AssertPublishDir(matches ...string) {
+	s.AssertFs(s.fs.PublishDir, matches...)
+}
+
+func (s *IntegrationTestBuilder) AssertFs(fs afero.Fs, matches ...string) {
 	s.Helper()
 	var buff bytes.Buffer
-	helpers.PrintFs(s.H.Fs.PublishDir, "", &buff)
+	helpers.PrintFs(fs, "", &buff)
 	printFsLines := strings.Split(buff.String(), "\n")
 	sort.Strings(printFsLines)
 	content := strings.TrimSpace((strings.Join(printFsLines, "\n")))

--- a/testscripts/commands/hugo__static_composite.txt
+++ b/testscripts/commands/hugo__static_composite.txt
@@ -1,0 +1,27 @@
+hugo
+ls public/files
+checkfile public/files/f1.txt
+checkfile public/files/f2.txt
+checkfile public/f3.txt
+
+-- hugo.toml --
+disableKinds = ["taxonomy", "term"]
+[module]
+[[module.mounts]]
+source = "myfiles/f1.txt"
+target = "static/files/f1.txt"
+[[module.mounts]]
+source = "f3.txt"
+target = "static/f3.txt"
+[[module.mounts]]
+source = "static"
+target = "static"
+-- static/files/f2.txt --
+f2
+-- myfiles/f1.txt --
+f1
+-- f3.txt --
+f3
+-- layouts/home.html --
+Home.
+


### PR DESCRIPTION
But note that the overlay file system is set up horizontally (project -> module1 -> module2), so I would not recommend too complex overlapping mount setups within the same module.

But this worked in v0.122.0, so we should fix it.

Fixes #12103