### PR TITLE
js: Support JSX and JSXImportSourceOptions

### DIFF
--- a/docs/content/en/functions/js/Build.md
+++ b/docs/content/en/functions/js/Build.md
@@ -111,6 +111,29 @@ format
 sourceMap
 : (`string`) Whether to generate `inline` or `external` source maps from esbuild. External source maps will be written to the target with the output file name + ".map". Input source maps can be read from js.Build and node modules and combined into the output source maps. By default, source maps are not created.
 
+JSX {{< new-in 0.124.0 >}}
+: (`string`) How to handle/transform JSX syntax. One of: `transform`, `preserve`, `automatic`. Default is `transform`. Notably, the `automatic` transform was introduced in React 17+ and will cause the necessary JSX helper functions to be imported automatically. See https://esbuild.github.io/api/#jsx
+
+JSXImportSource {{< new-in 0.124.0 >}}
+: (`string`) Which library to use to automatically import its JSX helper functions from. This only works if `JSX` is set to `automatic`. The specified library needs to be installed through NPM and expose certain exports. See https://esbuild.github.io/api/#jsx-import-source
+
+The combination of `JSX` and `JSXImportSource` is helpful if you want to use a non-React JSX library like Preact, e.g.:
+
+```go-html-template
+{{ $js := resources.Get "js/main.jsx" | js.Build (dict "JSX" "automatic" "JSXImportSource" "preact") }}
+```
+
+With the above, you can use Preact components and JSX without having to manually import `h` and `Fragment` every time:
+
+```jsx
+import { render } from 'preact';
+
+const App = () => <>Hello world!</>;
+
+const container = document.getElementById('app');
+if (container) render(<App />, container);
+```
+
 ### Import JS code from /assets
 
 `js.Build` has full support for the virtual union file system in [Hugo Modules](/hugo-modules/). You can see some simple examples in this [test project](https://github.com/gohugoio/hugoTestProjectJSModImports), but in short this means that you can do this:

--- a/docs/content/en/hugo-pipes/js.md
+++ b/docs/content/en/hugo-pipes/js.md
@@ -95,6 +95,29 @@ format
 sourceMap
 : (`string`) Whether to generate `inline` or `external` source maps from esbuild. External source maps will be written to the target with the output file name + ".map". Input source maps can be read from js.Build and node modules and combined into the output source maps. By default, source maps are not created.
 
+JSX {{< new-in 0.124.0 >}}
+: (`string`) How to handle/transform JSX syntax. One of: `transform`, `preserve`, `automatic`. Default is `transform`. Notably, the `automatic` transform was introduced in React 17+ and will cause the necessary JSX helper functions to be imported automatically. See https://esbuild.github.io/api/#jsx
+
+JSXImportSource {{< new-in 0.124.0 >}}
+: (`string`) Which library to use to automatically import its JSX helper functions from. This only works if `JSX` is set to `automatic`. The specified library needs to be installed through NPM and expose certain exports. See https://esbuild.github.io/api/#jsx-import-source
+
+The combination of `JSX` and `JSXImportSource` is helpful if you want to use a non-React JSX library like Preact, e.g.:
+
+```go-html-template
+{{ $js := resources.Get "js/main.jsx" | js.Build (dict "JSX" "automatic" "JSXImportSource" "preact") }}
+```
+
+With the above, you can use Preact components and JSX without having to manually import `h` and `Fragment` every time:
+
+```jsx
+import { render } from 'preact';
+
+const App = () => <>Hello world!</>;
+
+const container = document.getElementById('app');
+if (container) render(<App />, container);
+```
+
 ### Import JS code from /assets
 
 `js.Build` has full support for the virtual union file system in [Hugo Modules](/hugo-modules/). You can see some simple examples in this [test project](https://github.com/gohugoio/hugoTestProjectJSModImports), but in short this means that you can do this:

--- a/resources/resource_transformers/js/options.go
+++ b/resources/resource_transformers/js/options.go
@@ -86,6 +86,14 @@ type Options struct {
 	// What to use instead of React.Fragment.
 	JSXFragment string
 
+	// What to do about JSX syntax.
+	// See https://esbuild.github.io/api/#jsx
+	JSX string
+
+	// Which library to use to automatically import JSX helper functions from. Only works if JSX is set to automatic.
+	// See https://esbuild.github.io/api/#jsx-import-source
+	JSXImportSource string
+
 	// There is/was a bug in WebKit with severe performance issue with the tracking
 	// of TDZ checks in JavaScriptCore.
 	//
@@ -375,6 +383,19 @@ func toBuildOptions(opts Options) (buildOptions api.BuildOptions, err error) {
 		return
 	}
 
+	var jsx api.JSX
+	switch opts.JSX {
+	case "", "transform":
+		jsx = api.JSXTransform
+	case "preserve":
+		jsx = api.JSXPreserve
+	case "automatic":
+		jsx = api.JSXAutomatic
+	default:
+		err = fmt.Errorf("unsupported jsx type: %q", opts.JSX)
+		return
+	}
+
 	var defines map[string]string
 	if opts.Defines != nil {
 		defines = maps.ToStringMapString(opts.Defines)
@@ -415,6 +436,9 @@ func toBuildOptions(opts Options) (buildOptions api.BuildOptions, err error) {
 
 		JSXFactory:  opts.JSXFactory,
 		JSXFragment: opts.JSXFragment,
+
+		JSX:             jsx,
+		JSXImportSource: opts.JSXImportSource,
 
 		Tsconfig: opts.tsConfig,
 

--- a/resources/resource_transformers/js/options_test.go
+++ b/resources/resource_transformers/js/options_test.go
@@ -135,6 +135,20 @@ func TestToBuildOptions(t *testing.T) {
 			Loader: api.LoaderJS,
 		},
 	})
+
+	opts, err = toBuildOptions(Options{mediaType: media.Builtin.JavascriptType,
+		JSX: "automatic", JSXImportSource: "preact"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(opts, qt.DeepEquals, api.BuildOptions{
+		Bundle: true,
+		Target: api.ESNext,
+		Format: api.FormatIIFE,
+		Stdin: &api.StdinOptions{
+			Loader: api.LoaderJS,
+		},
+		JSX:             api.JSXAutomatic,
+		JSXImportSource: "preact",
+	})
 }
 
 func TestResolveComponentInAssets(t *testing.T) {


### PR DESCRIPTION
As discussed in #12118, these two options make it easier to have React and non-React libraries automatically imported when using JSX.

When running `mage -v check`, I get an error in `TestImageOperationsGolden`. However, I get the same problem on `master`, so I'm assuming it isn't related to my changes.

<details>
<summary>Test error</summary>

```
panic: test timed out after 1m0s
running tests:
	TestImageOperationsGolden (34s)

goroutine 11105 [running]:
testing.(*M).startAlarm.func1()
	/usr/lib/go-1.21/src/testing/testing.go:2259 +0x1fc
created by time.goFunc
	/usr/lib/go-1.21/src/time/sleep.go:176 +0x45

goroutine 1 [chan receive]:
testing.tRunner.func1()
	/usr/lib/go-1.21/src/testing/testing.go:1561 +0x8cc
testing.tRunner(0xc0000e4b60, 0xc000629b08)
	/usr/lib/go-1.21/src/testing/testing.go:1601 +0x26c
testing.runTests(0xc0004f5400?, {0x62298a0, 0x15, 0x15}, {0x1c?, 0x4bfc59?, 0x6420180?})
	/usr/lib/go-1.21/src/testing/testing.go:2052 +0x897
testing.(*M).Run(0xc0004f5400)
	/usr/lib/go-1.21/src/testing/testing.go:1925 +0xb58
main.main()
	_testmain.go:93 +0x2be

goroutine 2240 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 2239
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 3741 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 3357
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 3779 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 3355
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 1078 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 900
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 3778 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 2238
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 3459 [runnable]:
image/draw.drawPaletted({0x55e6e48?, 0xc0012303c0?}, {{0xc00113e400?, 0xc0013e6178?}, {0x0?, 0x0?}}, {0x55e40c8?, 0xc00113e400?}, {0x0, 0x0}, ...)
	/usr/lib/go-1.21/src/image/draw/draw.go:1019 +0x12a5
image/draw.floydSteinberg.Draw({}, {0x55e6e48, 0xc0012303c0}, {{0x0, 0x0}, {0x190, 0xc8}}, {0x55e40c8, 0xc00113e400}, {0x0, ...})
	/usr/lib/go-1.21/src/image/draw/draw.go:77 +0x106
github.com/gohugoio/hugo/resources.(*imageResource).doWithImageConfig.func1()
	/home/benni/coding/rnd-stuff/hugo/resources/image.go:408 +0xf02
github.com/gohugoio/hugo/resources.(*ImageCache).getOrCreate.func1.2({{0xc001e23ec1?, 0xc0002faae0?}}, {0x7fbd75124f60?, 0xc00160a4c0})
	/home/benni/coding/rnd-stuff/hugo/resources/image_cache.go:73 +0x115
github.com/gohugoio/hugo/cache/filecache.(*Cache).ReadOrCreate(0xc000a5c910, {0xc001e23ec0, 0x5a}, 0xc0013e6d88, 0xc0013e6d08)
	/home/benni/coding/rnd-stuff/hugo/cache/filecache/filecache.go:180 +0x473
github.com/gohugoio/hugo/resources.(*ImageCache).getOrCreate.func1({0xc0008498c8?, 0x5607220?})
	/home/benni/coding/rnd-stuff/hugo/resources/image_cache.go:93 +0x25a
github.com/bep/lazycache.(*Cache[...]).GetOrCreate(0x5600f80, {0xc001e23f20, 0x5a}, 0xc0013e70d0)
	/home/benni/go/pkg/mod/github.com/bep/lazycache@v0.4.0/lazycache.go:125 +0x302
github.com/gohugoio/hugo/cache/dynacache.(*Partition[...]).GetOrCreate(...)
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:376
github.com/gohugoio/hugo/resources.(*ImageCache).getOrCreate(0xc0003c5320, 0xc000160a80, {0x2, {0x2b4130d, 0x6}, {0xc000f20018, 0x14}, 0x4b, 0x0, 0x0, ...}, ...)
	/home/benni/coding/rnd-stuff/hugo/resources/image_cache.go:44 +0x294
github.com/gohugoio/hugo/resources.(*imageResource).doWithImageConfig(0xc000160a80, {0x2, {0x2b4130d, 0x6}, {0xc000f20018, 0x14}, 0x4b, 0x0, 0x0, {0x0, ...}, ...}, ...)
	/home/benni/coding/rnd-stuff/hugo/resources/image.go:366 +0x128
github.com/gohugoio/hugo/resources.(*imageResource).Filter(0xc000160a80, {0xc00063e870, 0x1, 0xc00063e870?})
	/home/benni/coding/rnd-stuff/hugo/resources/image.go:281 +0x805
github.com/gohugoio/hugo/resources.(*resourceAdapter).Filter(0xc0003c2780?, {0xc00063e870, 0x1, 0x1})
	/home/benni/coding/rnd-stuff/hugo/resources/transform.go:255 +0x51
github.com/gohugoio/hugo/resources_test.TestImageOperationsGolden(0xc0009f71e0)
	/home/benni/coding/rnd-stuff/hugo/resources/image_test.go:708 +0x29d7
testing.tRunner(0xc0009f71e0, 0x2e0c720)
	/usr/lib/go-1.21/src/testing/testing.go:1595 +0x239
created by testing.(*T).Run in goroutine 1
	/usr/lib/go-1.21/src/testing/testing.go:1648 +0x82b

goroutine 3604 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 3356
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 5621 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 3357
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 2141 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 2140
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 1267 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 1266
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 3398 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 2237
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 5488 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 3357
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 3742 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 3458
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145

goroutine 3334 [select]:
github.com/gohugoio/hugo/cache/dynacache.(*Cache).start.func1()
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:295 +0xb0
created by github.com/gohugoio/hugo/cache/dynacache.(*Cache).start in goroutine 3459
	/home/benni/coding/rnd-stuff/hugo/cache/dynacache/dynacache.go:293 +0x145
FAIL	github.com/gohugoio/hugo/resources	60.171s
```

</details>

Fixes #12118