### PR TITLE
hugolib: Add capitalizeListTitles config option

### DIFF
--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -538,6 +538,9 @@ type RootConfig struct {
 	// Note that this currently only works for English, but you can provide your own title in the content file's front matter.
 	PluralizeListTitles bool
 
+	// Whether to capitalize automatic page titles, applicable to section, taxonomy, and term pages.
+	CapitalizeListTitles bool
+
 	// Make all relative URLs absolute using the baseURL.
 	// <docsmeta>{"identifiers": ["baseURL"] }</docsmeta>
 	CanonifyURLs bool

--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -189,6 +189,7 @@ func (l configLoader) applyDefaultConfig() error {
 		"menus":                                maps.Params{},
 		"disableLiveReload":                    false,
 		"pluralizeListTitles":                  true,
+		"CapitalizeListTitles":                 true,
 		"forceSyncStatic":                      false,
 		"footnoteAnchorPrefix":                 "",
 		"footnoteReturnLinkContents":           "",

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -446,7 +446,7 @@ title: "My Title"
 params:
   build: "My Build"
 ---
-´   
+´
 
 `
 		}
@@ -746,15 +746,26 @@ func (p *pageMeta) applyDefaultValues() error {
 			if p.s.conf.PluralizeListTitles {
 				sectionName = flect.Pluralize(sectionName)
 			}
-			p.pageConfig.Title = p.s.conf.C.CreateTitle(sectionName)
+			if p.s.conf.CapitalizeListTitles {
+				sectionName = p.s.conf.C.CreateTitle(sectionName)
+			}
+			p.pageConfig.Title = sectionName
 		case kinds.KindTerm:
 			if p.term != "" {
-				p.pageConfig.Title = p.s.conf.C.CreateTitle(p.term)
+				if p.s.conf.CapitalizeListTitles {
+					p.pageConfig.Title = p.s.conf.C.CreateTitle(p.term)
+				} else {
+					p.pageConfig.Title = p.term
+				}
 			} else {
 				panic("term not set")
 			}
 		case kinds.KindTaxonomy:
-			p.pageConfig.Title = strings.Replace(p.s.conf.C.CreateTitle(p.pathInfo.Unnormalized().BaseNameNoIdentifier()), "-", " ", -1)
+			if p.s.conf.CapitalizeListTitles {
+				p.pageConfig.Title = strings.Replace(p.s.conf.C.CreateTitle(p.pathInfo.Unnormalized().BaseNameNoIdentifier()), "-", " ", -1)
+			} else {
+				p.pageConfig.Title = strings.Replace(p.pathInfo.Unnormalized().BaseNameNoIdentifier(), "-", " ", -1)
+			}
 		case kinds.KindStatus404:
 			p.pageConfig.Title = "404 Page not found"
 		}

--- a/hugolib/page__meta_test.go
+++ b/hugolib/page__meta_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hugolib_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gohugoio/hugo/hugolib"
+)
+
+// Issue 9793
+// Issue 12115
+func TestListTitles(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','sitemap']
+capitalizeListTitles = true
+pluralizeListTitles = true
+[taxonomies]
+tag = 'tags'
+-- content/section-1/page-1.md --
+---
+title: page-1
+tags: 'tag-a'
+---
+-- layouts/_default/list.html --
+{{ .Title }}
+-- layouts/_default/single.html --
+{{ .Title }}
+	`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/section-1/index.html", "Section-1s")
+	b.AssertFileContent("public/tags/index.html", "Tags")
+	b.AssertFileContent("public/tags/tag-a/index.html", "Tag-A")
+
+	files = strings.Replace(files, "true", "false", -1)
+
+	b = hugolib.Test(t, files)
+
+	b.AssertFileContent("public/section-1/index.html", "section-1")
+	b.AssertFileContent("public/tags/index.html", "tags")
+	b.AssertFileContent("public/tags/tag-a/index.html", "tag-a")
+}


### PR DESCRIPTION
Whether to capitalize automatic page titles, applicable to section, taxonomy, and term pages. Default is true.

Closes #9793
Closes #12115