### PR TITLE
Keep (but do not render) terms with render = 'link'

### DIFF
--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -441,6 +441,9 @@ func (m *pageMap) getTermsForPageInTaxonomy(path, taxonomy string) page.Pages {
 			doctree.LockTypeNone,
 			paths.AddTrailingSlash(prefix),
 			func(s string, n *weightedContentNode) (bool, error) {
+				if !n.term.m.shouldList(false) {
+					return false, nil
+				}
 				if strings.HasSuffix(s, path) {
 					pas = append(pas, n.term)
 				}
@@ -1932,7 +1935,7 @@ func (m *pageMap) CreateSiteTaxonomies(ctx context.Context) error {
 
 				switch p.Kind() {
 				case kinds.KindTerm:
-					if !p.m.shouldList(true) {
+					if !(p.m.linkOnly() || p.m.shouldList(true)) {
 						return false, nil
 					}
 					taxonomy := m.s.taxonomies[viewName.plural]

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -718,6 +718,10 @@ func (p *pageMeta) noLink() bool {
 	return p.pageConfig.Build.Render == pagemeta.Never
 }
 
+func (p *pageMeta) linkOnly() bool {
+	return p.pageConfig.Build.Render == pagemeta.Link
+}
+
 func (p *pageMeta) applyDefaultValues() error {
 	if p.pageConfig.Build.IsZero() {
 		p.pageConfig.Build, _ = pagemeta.DecodeBuildConfig(nil)

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -970,3 +970,34 @@ title: p1
 	b.AssertFileExists("public/ja/s1/index.html", false) // failing test
 	b.AssertFileExists("public/ja/s1/category/index.html", true)
 }
+
+func TestTermBuildRenderLinkListNever(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- layouts/index.html --
+Tags: {{ len site.Taxonomies.tags }}|
+a: {{with site.GetPage "tags/a" }}{{ .Title }}:{{ .RelPermalink }}{{ end }}|
+{{ $p1 := site.GetPage "p1" }}
+p1.GetTerms.tags: {{ range $p1.GetTerms "tags" }}{{ .Title }}|{{ end }}$
+tags.Pages: {{ with site.GetPage "tags"}}{{ range .Pages }}{{ .Title }}{{end }}{{ end }}$
+-- content/p1.md --
+---
+title: p1
+tags: [a]
+---
+-- content/tags/a/_index.md --
+---
+title: A
+build:
+  render: link
+  list: never
+---
+
+  `
+
+	b := Test(t, files)
+
+	b.AssertFileExists("public/tags/a/index.html", false)
+	b.AssertFileContent("public/index.html", "Tags: 1|\na: A:/tags/a/|\n\np1.GetTerms.tags: $\ntags.Pages: $")
+}


### PR DESCRIPTION
 list = 'never',Fixes #12131