### PR TITLE
Fix cascade-pattern-with-extension for cascade in site config

### DIFF
--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -671,6 +671,13 @@ type Configs struct {
 	configLangs []config.AllProvider
 }
 
+func (c *Configs) Validate(logger loggers.Logger) error {
+	for p := range c.Base.Cascade.Config {
+		page.CheckCascadePattern(logger, p)
+	}
+	return nil
+}
+
 // transientErr returns the last transient error found during config compilation.
 func (c *Configs) transientErr() error {
 	for _, l := range c.LanguageConfigSlice {
@@ -969,7 +976,7 @@ func decodeConfigFromParams(fs afero.Fs, logger loggers.Logger, bcfg config.Base
 	})
 
 	for _, v := range decoderSetups {
-		p := decodeConfig{p: p, c: target, fs: fs, logger: logger, bcfg: bcfg}
+		p := decodeConfig{p: p, c: target, fs: fs, bcfg: bcfg}
 		if err := v.decode(v, p); err != nil {
 			return fmt.Errorf("failed to decode %q: %w", v.key, err)
 		}

--- a/config/allconfig/alldecoders.go
+++ b/config/allconfig/alldecoders.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/gohugoio/hugo/cache/filecache"
-	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/config"
@@ -43,11 +42,10 @@ import (
 )
 
 type decodeConfig struct {
-	p      config.Provider
-	c      *Config
-	fs     afero.Fs
-	logger loggers.Logger
-	bcfg   config.BaseConfig
+	p    config.Provider
+	c    *Config
+	fs   afero.Fs
+	bcfg config.BaseConfig
 }
 
 type decodeWeight struct {
@@ -293,7 +291,7 @@ var allDecoderSetups = map[string]decodeWeight{
 		key: "cascade",
 		decode: func(d decodeWeight, p decodeConfig) error {
 			var err error
-			p.c.Cascade, err = page.DecodeCascadeConfig(p.logger, p.p.Get(d.key))
+			p.c.Cascade, err = page.DecodeCascadeConfig(nil, p.p.Get(d.key))
 			return err
 		},
 	},

--- a/hugolib/cascade_test.go
+++ b/hugolib/cascade_test.go
@@ -674,6 +674,8 @@ S1|p1:|p2:p2|
 
 // Issue 11977.
 func TestCascadeExtensionInPath(t *testing.T) {
+	t.Parallel()
+
 	files := `
 -- hugo.toml --
 baseURL = "https://example.org"
@@ -699,4 +701,68 @@ title: "Post 1"
 	b, err := TestE(t, files)
 	b.Assert(err, qt.IsNotNil)
 	b.AssertLogContains(`cascade target path "/posts/post-1.de.md" looks like a path with an extension; since Hugo v0.123.0 this will not match anything, see  https://gohugo.io/methods/page/path/`)
+}
+
+func TestCascadeExtensionInPathIgnore(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org"
+ignoreLogs   = ['cascade-pattern-with-extension']
+[languages]
+[languages.en]
+weight = 1
+[languages.de]
+-- content/_index.de.md --
++++
+[[cascade]]
+[cascade.params]
+foo = 'bar'
+[cascade._target]
+path = '/posts/post-1.de.md'
++++
+-- content/posts/post-1.de.md --
+---
+title: "Post 1"
+---
+-- layouts/_default/single.html --
+{{ .Title }}|{{ .Params.foo }}$
+`
+	b := Test(t, files)
+	b.AssertLogNotContains(`looks like a path with an extension`)
+}
+
+func TestCascadConfigExtensionInPath(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org"
+[[cascade]]
+[cascade.params]
+foo = 'bar'
+[cascade._target]
+path = '/p1.md'
+`
+	b, err := TestE(t, files)
+	b.Assert(err, qt.IsNotNil)
+	b.AssertLogContains(`looks like a path with an extension`)
+}
+
+func TestCascadConfigExtensionInPathIgnore(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org"
+ignoreLogs   = ['cascade-pattern-with-extension']
+[[cascade]]
+[cascade.params]
+foo = 'bar'
+[cascade._target]
+path = '/p1.md'
+`
+	b := Test(t, files)
+	b.AssertLogNotContains(`looks like a path with an extension`)
 }

--- a/hugolib/site_new.go
+++ b/hugolib/site_new.go
@@ -127,6 +127,7 @@ func NewHugoSites(cfg deps.DepsCfg) (*HugoSites, error) {
 			SuppressStatements: conf.IgnoredLogs(),
 		}
 		logger = loggers.New(logOpts)
+
 	}
 
 	memCache := dynacache.New(dynacache.Options{Running: conf.Running(), Log: logger})
@@ -145,6 +146,9 @@ func NewHugoSites(cfg deps.DepsCfg) (*HugoSites, error) {
 	}
 
 	confm := cfg.Configs
+	if err := confm.Validate(logger); err != nil {
+		return nil, err
+	}
 	var sites []*Site
 
 	ns := &contentNodeShifter{

--- a/resources/page/page_matcher.go
+++ b/resources/page/page_matcher.go
@@ -98,6 +98,12 @@ func isGlobWithExtension(s string) bool {
 	return strings.Count(last, ".") > 0
 }
 
+func CheckCascadePattern(logger loggers.Logger, m PageMatcher) {
+	if logger != nil && isGlobWithExtension(m.Path) {
+		logger.Erroridf("cascade-pattern-with-extension", "cascade target path %q looks like a path with an extension; since Hugo v0.123.0 this will not match anything, see  https://gohugo.io/methods/page/path/", m.Path)
+	}
+}
+
 func DecodeCascadeConfig(logger loggers.Logger, in any) (*config.ConfigNamespace[[]PageMatcherParamsConfig, map[PageMatcher]maps.Params], error) {
 	buildConfig := func(in any) (map[PageMatcher]maps.Params, any, error) {
 		cascade := make(map[PageMatcher]maps.Params)
@@ -127,9 +133,7 @@ func DecodeCascadeConfig(logger loggers.Logger, in any) (*config.ConfigNamespace
 
 		for _, cfg := range cfgs {
 			m := cfg.Target
-			if isGlobWithExtension(m.Path) {
-				logger.Erroridf("cascade-pattern-with-extension", "cascade target path %q looks like a path with an extension; since Hugo v0.123.0 this will not match anything, see  https://gohugo.io/methods/page/path/", m.Path)
-			}
+			CheckCascadePattern(logger, m)
 			c, found := cascade[m]
 			if found {
 				// Merge


### PR DESCRIPTION
Also clean up the log handling in the integration tester, most notably lost logs during the config loading.

Fixes #12151