### PR TITLE
Fix and add integration test for the Bootstrap SCSS module for both Dart Sass and Libsass

### DIFF
--- a/hugofs/rootmapping_fs_test.go
+++ b/hugofs/rootmapping_fs_test.go
@@ -276,20 +276,20 @@ func TestRootMappingFsMount(t *testing.T) {
 
 	// Test ReverseLookup.
 	// Single file mounts.
-	cps, err := rfs.ReverseLookup(filepath.FromSlash("singlefiles/no.txt"), true)
+	cps, err := rfs.ReverseLookup(filepath.FromSlash("singlefiles/no.txt"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(cps, qt.DeepEquals, []ComponentPath{
 		{Component: "content", Path: "singles/p1.md", Lang: "no"},
 	})
 
-	cps, err = rfs.ReverseLookup(filepath.FromSlash("singlefiles/sv.txt"), true)
+	cps, err = rfs.ReverseLookup(filepath.FromSlash("singlefiles/sv.txt"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(cps, qt.DeepEquals, []ComponentPath{
 		{Component: "content", Path: "singles/p1.md", Lang: "sv"},
 	})
 
 	// File inside directory mount.
-	cps, err = rfs.ReverseLookup(filepath.FromSlash("mynoblogcontent/test.txt"), true)
+	cps, err = rfs.ReverseLookup(filepath.FromSlash("mynoblogcontent/test.txt"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(cps, qt.DeepEquals, []ComponentPath{
 		{Component: "content", Path: "blog/test.txt", Lang: "no"},

--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -656,7 +656,7 @@ func (h *HugoSites) processPartial(ctx context.Context, l logg.LevelLogger, conf
 
 		isChangedDir := statErr == nil && fi.IsDir()
 
-		cpss := h.BaseFs.ResolvePaths(ev.Name, !removed)
+		cpss := h.BaseFs.ResolvePaths(ev.Name)
 		pss := make([]*paths.Path, len(cpss))
 		for i, cps := range cpss {
 			p := cps.Path

--- a/hugolib/integrationtest_builder.go
+++ b/hugolib/integrationtest_builder.go
@@ -183,6 +183,13 @@ type lockingBuffer struct {
 	bytes.Buffer
 }
 
+func (b *lockingBuffer) ReadFrom(r io.Reader) (n int64, err error) {
+	b.Lock()
+	n, err = b.Buffer.ReadFrom(r)
+	b.Unlock()
+	return
+}
+
 func (b *lockingBuffer) Write(p []byte) (n int, err error) {
 	b.Lock()
 	n, err = b.Buffer.Write(p)


### PR DESCRIPTION
This fixes the reverse filesystem lookup (absolute filename to path relative to the composite filesystem).

The old logic had some assumptions about the locality of the actual files that didn't work in more complex scenarios.

This commit now also adds the popular Bootstrap SCSS Hugo module to the CI build (both for libsass and dartsass transpiler), so we can hopefully avoid similar future breakage.

Fixes #12178