### PR TITLE
tpl/tplimpl: Honor markdown attributes in embedded image render hook

### DIFF
--- a/tpl/tplimpl/embedded/templates/_default/_markup/render-image.html
+++ b/tpl/tplimpl/embedded/templates/_default/_markup/render-image.html
@@ -5,7 +5,7 @@
     {{- $src = .RelPermalink -}}
   {{- end -}}
 {{- end -}}
-{{- $attributes := dict "alt" .Text "src" $src "title" .Title -}}
+{{- $attributes := merge .Attributes (dict "alt" .Text "src" $src "title" .Title) -}}
 <img
   {{- range $k, $v := $attributes -}}
     {{- if $v -}}


### PR DESCRIPTION
Fixes #12203