### PR TITLE
Misc fixes

### DIFF
--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -1814,6 +1814,14 @@ func (sa *sitePagesAssembler) addMissingRootSections() error {
 				return false, nil
 			}
 
+			switch ps.Kind() {
+			case kinds.KindPage, kinds.KindSection:
+				// OK
+			default:
+				// Skip taxonomy nodes etc.
+				return false, nil
+			}
+
 			p := ps.m.pathInfo
 			section := p.Section()
 			if section == "" || seen[section] {

--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -485,7 +485,7 @@ func (m *pageMap) forEachResourceInPage(
 	rw.Handle = func(resourceKey string, n contentNodeI, match doctree.DimensionFlag) (bool, error) {
 		if isBranch {
 			ownerKey, _ := m.treePages.LongestPrefixAll(resourceKey)
-			if ownerKey != keyPage {
+			if ownerKey != keyPage && path.Dir(ownerKey) != path.Dir(resourceKey) {
 				// Stop walking downwards, someone else owns this resource.
 				rw.SkipPrefix(ownerKey + "/")
 				return false, nil

--- a/hugolib/content_map_test.go
+++ b/hugolib/content_map_test.go
@@ -326,3 +326,35 @@ R: {{ with $r }}{{ .Content }}{{ end }}|Len: {{ len $bundle.Resources }}|$
 		b.AssertFileContent("public/index.html", "R: Data 1.txt|", "Len: 1|")
 	}
 }
+
+func TestBundleResourcesNoPublishedIssue12198(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','sitemap','taxonomy','term']
+-- content/s1/p1.md --
+---
+title: p1
+---
+-- content/s1/foo.txt --
+foo.txt
+-- content/s1/p1.txt --
+p1.txt
+-- content/s1/p1-foo.txt --
+p1-foo.txt
+-- layouts/_default/list.html --
+{{.Title }}|
+-- layouts/_default/single.html --
+{{.Title }}|
+	`
+
+	b := Test(t, files)
+	b.Build()
+
+	b.AssertFileExists("public/s1/index.html", true)
+	b.AssertFileExists("public/s1/foo.txt", true)
+	b.AssertFileExists("public/s1/p1.txt", true)     // failing test
+	b.AssertFileExists("public/s1/p1-foo.txt", true) // failing test
+	b.AssertFileExists("public/s1/p1/index.html", true)
+}

--- a/hugolib/mount_filters_test.go
+++ b/hugolib/mount_filters_test.go
@@ -112,6 +112,6 @@ Template: false
 Resource1: /js/include.js:END
 Resource2: :END
 Resource3: :END
-Resources: [/js/include.js]
+Resources: [include.js]
 `)
 }

--- a/hugolib/page__new.go
+++ b/hugolib/page__new.go
@@ -145,9 +145,11 @@ func (h *HugoSites) newPage(m *pageMeta) (*pageState, *paths.Path, error) {
 					// Either a taxonomy or a term.
 					if tc.pluralTreeKey == m.Path() {
 						m.pageConfig.Kind = kinds.KindTaxonomy
+						m.singular = tc.singular
 					} else {
 						m.pageConfig.Kind = kinds.KindTerm
 						m.term = m.pathInfo.Unnormalized().BaseNameNoIdentifier()
+						m.singular = tc.singular
 					}
 				}
 			} else if m.f != nil {

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -911,3 +911,28 @@ title: tag-a-title-override
 
 	b.AssertFileContent("public/tags/a/index.html", "Tag: tag-a-title-override|")
 }
+
+func TestTaxonomyLookupIssue12193(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','rss','section','sitemap']
+[taxonomies]
+author = 'authors'
+-- layouts/_default/list.html --
+{{ .Title }}|
+-- layouts/_default/author.terms.html --
+layouts/_default/author.terms.html
+-- content/authors/_index.md --
+---
+title: Authors Page
+---
+`
+
+	b := Test(t, files)
+
+	b.AssertFileExists("public/index.html", true)
+	b.AssertFileExists("public/authors/index.html", true)
+	b.AssertFileContent("public/authors/index.html", "layouts/_default/author.terms.html") // failing test
+}

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -936,3 +936,37 @@ title: Authors Page
 	b.AssertFileExists("public/authors/index.html", true)
 	b.AssertFileContent("public/authors/index.html", "layouts/_default/author.terms.html") // failing test
 }
+
+func TestTaxonomyNestedEmptySectionsIssue12188(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['rss','sitemap']
+defaultContentLanguage = 'en'
+defaultContentLanguageInSubdir = true
+[languages.en]
+weight = 1
+[languages.ja]
+weight = 2
+[taxonomies]
+'s1/category' = 's1/category'
+-- layouts/_default/single.html --
+{{ .Title }}|
+-- layouts/_default/list.html --
+{{ .Title }}|
+-- content/s1/p1.en.md --
+---
+title: p1
+---
+`
+
+	b := Test(t, files)
+
+	b.AssertFileExists("public/en/s1/index.html", true)
+	b.AssertFileExists("public/en/s1/p1/index.html", true)
+	b.AssertFileExists("public/en/s1/category/index.html", true)
+
+	b.AssertFileExists("public/ja/s1/index.html", false) // failing test
+	b.AssertFileExists("public/ja/s1/category/index.html", true)
+}

--- a/resources/resource_factories/create/create.go
+++ b/resources/resource_factories/create/create.go
@@ -128,13 +128,16 @@ func (c *Client) match(name, pattern string, matchFunc func(r resource.Resource)
 
 		handle := func(info hugofs.FileMetaInfo) (bool, error) {
 			meta := info.Meta()
+
 			r, err := c.rs.NewResource(resources.ResourceSourceDescriptor{
 				LazyPublish: true,
 				OpenReadSeekCloser: func() (hugio.ReadSeekCloser, error) {
 					return meta.Open()
 				},
-				GroupIdentity: meta.PathInfo,
-				TargetPath:    meta.PathInfo.Unnormalized().Path(),
+				NameNormalized: meta.PathInfo.Name(),
+				NameOriginal:   meta.PathInfo.Unnormalized().Name(),
+				GroupIdentity:  meta.PathInfo,
+				TargetPath:     meta.PathInfo.Unnormalized().Path(),
 			})
 			if err != nil {
 				return true, err

--- a/tpl/resources/resources_integration_test.go
+++ b/tpl/resources/resources_integration_test.go
@@ -155,6 +155,7 @@ I am a.txt
 -- assets/b.txt --
 I am b.txt
 -- layouts/index.html --
+Home.
 {{ with resources.ByType "text" }}
   {{ with .Get "a.txt" }}
     {{ .Publish }}
@@ -167,7 +168,6 @@ I am b.txt
 
 	b := hugolib.Test(t, files)
 
-	b.AssertFileExists("public/index.html", true)
 	b.AssertFileExists("public/a.txt", true) // failing test
 	b.AssertFileExists("public/b.txt", true) // failing test
 }


### PR DESCRIPTION
- **Fix taxonomy kind template lookup issue**
- **Fix section page resource not published if resource filename partially matches content file name**
- **Fix global resource isn't published when using an uncommon code construct**
- **Fix resource name in resources.ByType**
- **Don't auto-create empty sections for nested taxonomies**
