### PR TITLE
Fix server rebuilds when adding sub sections especially on Windows

### DIFF
--- a/hugolib/pages_capture.go
+++ b/hugolib/pages_capture.go
@@ -161,7 +161,7 @@ func (c *pagesCollector) Collect() (collectErr error) {
 				// We always start from a directory.
 				collectErr = c.collectDir(id.p, id.isDir, func(fim hugofs.FileMetaInfo) bool {
 					if id.delete || id.isDir {
-						if id.isDir {
+						if id.isDir && fim.Meta().PathInfo.IsLeafBundle() {
 							return strings.HasPrefix(fim.Meta().PathInfo.Path(), paths.AddTrailingSlash(id.p.Path()))
 						}
 


### PR DESCRIPTION
This commit also optimizes for the case where change events for both file (e.g. `_index.md`) and the container directory comes in the same event batch.

While testing this on Windows 11 (ARM64), I notice that Windows behaves a little oddly when dumping a folder of files into the content tree; it works (at least after this commit), but it seems like the event batching behaves differently compared to other OSes (even older Win versions).

A related tip would be to try starting the server with polling, to see if that improves the situation, e.g.:

```
hugo server --poll 700ms
```

Fixes #12230
