### PR TITLE
hugolib: Remove Site.HomeAbsURL

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -598,18 +598,13 @@ func (h *HugoSites) fileEventsContentPaths(p []pathChange) []pathChange {
 	return keepers
 }
 
-// HomeAbsURL is a convenience method giving the absolute URL to the home page.
-func (s *Site) HomeAbsURL() string {
+// SitemapAbsURL is a convenience method giving the absolute URL to the sitemap.
+func (s *Site) SitemapAbsURL() string {
 	base := ""
 	if len(s.conf.Languages) > 1 || s.Conf.DefaultContentLanguageInSubdir() {
 		base = s.Language().Lang
 	}
-	return s.AbsURL(base, false)
-}
-
-// SitemapAbsURL is a convenience method giving the absolute URL to the sitemap.
-func (s *Site) SitemapAbsURL() string {
-	p := s.HomeAbsURL()
+	p := s.AbsURL(base, false)
 	if !strings.HasSuffix(p, "/") {
 		p += "/"
 	}


### PR DESCRIPTION
It's not in use and after #12266 it's also not corret to use on its own (use .Site.Home.Permalink).
