### PR TITLE
Set usesFMA as true for riscv64 too

### DIFF
--- a/resources/image_test.go
+++ b/resources/image_test.go
@@ -509,7 +509,8 @@ func BenchmarkImageExif(b *testing.B) {
 var usesFMA = runtime.GOARCH == "s390x" ||
 	runtime.GOARCH == "ppc64" ||
 	runtime.GOARCH == "ppc64le" ||
-	runtime.GOARCH == "arm64"
+	runtime.GOARCH == "arm64" ||
+	runtime.GOARCH == "riscv64"
 
 // goldenEqual compares two NRGBA images.  It is used in golden tests only.
 // A small tolerance is allowed on architectures using "fused multiply and add"


### PR DESCRIPTION
This fixes the following TestImageOperationsGolden "values are not deep equal" error on riscv64 with Go 1.22 and above:

```
=== NAME  TestImageOperationsGolden
    image_test.go:790: expectedly differs from golden due to dithering: giphy_hu3eafc418e52414ace6236bf1d31f82e1_52213_200x0_resize_box_1.gif
    ...
    image_test.go:799: 
        error:
          values are not deep equal
        diff (-got +want):
            (*os.unixDirent)(
          - 	&{
          - 		parent: "/tmp/hugores955611955/resources/_gen/images/a",
          - 		name:   "giphy_hu3eafc418e52414ace6236bf1d31f82e1_52213_200x0_resize_box_1.gif",
          - 	},
          + 	&{
          + 		parent: "testdata/golden",
          + 		name:   "giphy_hu3eafc418e52414ace6236bf1d31f82e1_52213_200x0_resize_box_1.gif",
          + 	},
            )
        got:
          s"- giphy_hu3eafc418e52414ace6236bf1d31f82e1_52213_200x0_resize_box_1.gif"
        want:
          s"- giphy_hu3eafc418e52414ace6236bf1d31f82e1_52213_200x0_resize_box_1.gif"
        stack:
          /<<PKGBUILDDIR>>/_build/src/github.com/gohugoio/hugo/resources/image_test.go:799
            c.Assert(fi1, eq, fi2)
          /<<PKGBUILDDIR>>/_build/src/github.com/gohugoio/hugo/resources/image_test.go:734
            assetGoldenDirs(c, dir1, dir2)

--- FAIL: TestImageOperationsGolden (79.90s)
```

The error was detected on Debian build daemon recently when Go 1.22 became the default version, see the build log at <https://buildd.debian.org/status/fetch.php?pkg=hugo&arch=riscv64&ver=0.123.8-1&stamp=1710487333&raw=0> for example.

It was also reproducible locally on my amd64 machine using the following command:

```console
$ GOARCH=riscv64 CI=true go test -run TestImageOperationsGolden ./resources
```

See also:

- #6396

Thanks!