### PR TITLE
hugolib: Conditionally suppress .Site.Author deprecation notice

### DIFF
--- a/hugolib/site_new.go
+++ b/hugolib/site_new.go
@@ -449,7 +449,9 @@ func (s *Site) Params() maps.Params {
 
 // Deprecated: Use taxonomies instead.
 func (s *Site) Author() map[string]any {
-	hugo.Deprecate(".Site.Author", "Use taxonomies instead.", "v0.124.0")
+	if len(s.conf.Author) != 0 {
+		hugo.Deprecate(".Site.Author", "Use taxonomies instead.", "v0.124.0")
+	}
 	return s.conf.Author
 }
 


### PR DESCRIPTION
Suppress the .Site.Author deprecation notice unless the Author key is present and not empty in the site configuration.

Closes #12297