### PR TITLE
tpl/tplimpl: Update schema template

### DIFF
--- a/hugolib/embedded_templates_test.go
+++ b/hugolib/embedded_templates_test.go
@@ -70,9 +70,9 @@ title: My Site
 <meta property="article:published_time" content="2021-02-26T18:02:00-01:00" />
 <meta property="article:modified_time" content="2021-05-22T19:25:00-01:00" />
 <meta itemprop="name" content="My Bundle">
-<meta itemprop="image" content="https://example.org/mybundle/featured-sunset.jpg" />
-<meta itemprop="datePublished" content="2021-02-26T18:02:00-01:00" />
-<meta itemprop="dateModified" content="2021-05-22T19:25:00-01:00" />
+<meta itemprop="image" content="https://example.org/mybundle/featured-sunset.jpg">
+<meta itemprop="datePublished" content="2021-02-26T18:02:00-01:00">
+<meta itemprop="dateModified" content="2021-05-22T19:25:00-01:00">
 
 `)
 	b.AssertFileContent("public/mypage/index.html", `
@@ -83,17 +83,17 @@ title: My Site
 <meta property="og:image" content="https://example.org/mypage/sample.jpg" />
 <meta property="article:published_time" content="2021-02-26T18:02:00+01:00" />
 <meta property="article:modified_time" content="2021-05-22T19:25:00+01:00" />
-<meta itemprop="image" content="https://example.org/pageimg1.jpg" />
-<meta itemprop="image" content="https://example.org/pageimg2.jpg" />
-<meta itemprop="image" content="https://example.local/logo.png" />
-<meta itemprop="image" content="https://example.org/mypage/sample.jpg" />
-<meta itemprop="datePublished" content="2021-02-26T18:02:00+01:00" />
-<meta itemprop="dateModified" content="2021-05-22T19:25:00+01:00" />
+<meta itemprop="image" content="https://example.org/pageimg1.jpg">
+<meta itemprop="image" content="https://example.org/pageimg2.jpg">
+<meta itemprop="image" content="https://example.local/logo.png">
+<meta itemprop="image" content="https://example.org/mypage/sample.jpg">
+<meta itemprop="datePublished" content="2021-02-26T18:02:00+01:00">
+<meta itemprop="dateModified" content="2021-05-22T19:25:00+01:00">
 `)
 	b.AssertFileContent("public/mysite/index.html", `
 <meta name="twitter:image" content="https://example.org/siteimg1.jpg" />
 <meta property="og:image" content="https://example.org/siteimg1.jpg" />
-<meta itemprop="image" content="https://example.org/siteimg1.jpg" />
+<meta itemprop="image" content="https://example.org/siteimg1.jpg">
 `)
 }
 

--- a/tpl/tplimpl/embedded/templates/schema.html
+++ b/tpl/tplimpl/embedded/templates/schema.html
@@ -1,17 +1,56 @@
-<meta itemprop="name" content="{{ .Title }}">
-<meta itemprop="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
+{{- with or .Title site.Title }}
+  <meta itemprop="name" content="{{ . }}">
+{{- end }}
 
-{{- if .IsPage -}}
-{{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
-{{ with .PublishDate }}<meta itemprop="datePublished" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />{{ end}}
-{{ with .Lastmod }}<meta itemprop="dateModified" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />{{ end}}
-<meta itemprop="wordCount" content="{{ .WordCount }}">
+{{- with or .Description .Summary site.Params.Description }}
+  <meta itemprop="description" content="{{ . }}">
+{{- end }}
 
-{{- $images := partial "_funcs/get-page-images" . -}}
-{{- range first 6 $images -}}
-  <meta itemprop="image" content="{{ .Permalink }}" />
-{{- end -}}
+{{- $ISO8601 := "2006-01-02T15:04:05-07:00" }}
+{{- with .PublishDate }}
+  <meta itemprop="datePublished" {{ .Format $ISO8601 | printf "content=%q" | safeHTMLAttr }}>
+{{- end }}
 
-<!-- Output all taxonomies as schema.org keywords -->
-<meta itemprop="keywords" content="{{ if .IsPage}}{{ range $index, $tag := .Params.tags }}{{ $tag }},{{ end }}{{ else }}{{ range $plural, $terms := .Site.Taxonomies }}{{ range $term, $val := $terms }}{{ printf "%s," $term }}{{ end }}{{ end }}{{ end }}" />
+{{- with .Lastmod }}
+  <meta itemprop="dateModified" {{ .Format $ISO8601 | printf "content=%q" | safeHTMLAttr }}>
+{{- end }}
+
+{{- with .WordCount }}
+  <meta itemprop="wordCount" content="{{ . }}">
+{{- end }}
+
+{{- $images := partial "_funcs/get-page-images" . }}
+{{- range first 6 $images }}
+  <meta itemprop="image" content="{{ .Permalink }}">
+{{- end }}
+
+{{- /*
+Keywords precedence:
+
+1. Use "keywords" term page titles.
+2. Use "keywords" from front matter if "keywords" is not a taxonomy.
+3. Use "tags" term page titles.
+4. Use term page titles from all taxonomies.
+
+*/}}
+{{- $keywords := slice }}
+{{- range .GetTerms "keywords" }}
+  {{- $keywords = $keywords | append .Title }}
+{{- else }}
+  {{- with .Keywords }}
+    {{- $keywords = . }}
+  {{- else }}
+    {{- range .GetTerms "tags" }}
+      {{- $keywords = $keywords | append .Title }}
+    {{- else }}
+      {{- range $taxonomy, $_ := site.Taxonomies }}
+        {{- range $.GetTerms $taxonomy }}
+          {{- $keywords = $keywords | append .Title }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- with $keywords }}
+  <meta itemprop="keywords" content="{{ delimit . `,` }}">
 {{- end -}}


### PR DESCRIPTION
Changes:

- Remove trailing comma from list of keywords.
- Improve keywords precedence:
  1. Use "keywords" term page titles.
  2. Use "keywords" from front matter if "keywords" is not a taxonomy.
  3. Use "tags" term page titles.
  4. Use term page titles from all taxonomies.
- Enable schema for all page kinds, previously limited to kind = page.
- Remove trailing slashes from void elements.
- Improve readability.

Closes #7570

Co-authored by: 0urobor0s <0urobor0s@users.noreply.github.com>