### PR TITLE
hugolib: Fix regression in summary generation behavior since v0.123

### DIFF
--- a/hugolib/page__content.go
+++ b/hugolib/page__content.go
@@ -770,7 +770,7 @@ func (c *cachedContent) contentPlain(ctx context.Context, cp *pageContentOutput)
 			result.readingTime = (result.wordCount + 212) / 213
 		}
 
-		if rendered.summary != "" {
+		if c.pi.hasSummaryDivider || rendered.summary != "" {
 			result.summary = rendered.summary
 			result.summaryTruncated = rendered.summaryTruncated
 		} else if cp.po.p.m.pageConfig.Summary != "" {

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -65,6 +65,15 @@ Summary Next Line
 Some more text
 `
 
+	simplePageWithBlankSummary = `---
+title: SimpleWithBlankSummary
+---
+
+<!--more-->
+
+Some text.
+`
+
 	simplePageWithSummaryParameter = `---
 title: SimpleWithSummaryParameter
 summary: "Page with summary parameter and [a link](http://www.example.com/)"
@@ -351,6 +360,9 @@ func normalizeExpected(ext, str string) string {
 
 		return expected
 	case "rst":
+		if str == "" {
+			return "<div class=\"document\"></div>"
+		}
 		return fmt.Sprintf("<div class=\"document\">\n\n\n%s</div>", str)
 	}
 }
@@ -628,6 +640,19 @@ func TestPageWithDelimiter(t *testing.T) {
 	}
 
 	testAllMarkdownEnginesForPages(t, assertFunc, nil, simplePageWithSummaryDelimiter)
+}
+
+func TestPageWithBlankSummary(t *testing.T) {
+	t.Parallel()
+	assertFunc := func(t *testing.T, ext string, pages page.Pages) {
+		p := pages[0]
+		checkPageTitle(t, p, "SimpleWithBlankSummary")
+		checkPageContent(t, p, normalizeExpected(ext, "<p>Some text.</p>\n"), ext)
+		checkPageSummary(t, p, normalizeExpected(ext, ""), ext)
+		checkPageType(t, p, "page")
+	}
+
+	testAllMarkdownEnginesForPages(t, assertFunc, nil, simplePageWithBlankSummary)
 }
 
 func TestPageWithSummaryParameter(t *testing.T) {


### PR DESCRIPTION
Since v0.123, Hugo will use the automatic summary generation when the manual summary results in an empty string, even if there is a `<!--more-->` summary divider.

This PR fixes that regression to allow empty summary, restoring the intended functionality and flexibility provided by the manual summary divider.

Note about implementation in v0.122:
<https://github.com/gohugoio/hugo/blob/v0.122.0/hugolib/page__per_output.go#L791>