### PR TITLE
Fix panic with debug.Dump with Page when running the server

### DIFF
--- a/tpl/debug/debug.go
+++ b/tpl/debug/debug.go
@@ -15,12 +15,12 @@
 package debug
 
 import (
+	"encoding/json"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/bep/logg"
-	"github.com/sanity-io/litter"
 	"github.com/spf13/cast"
 	"github.com/yuin/goldmark/util"
 
@@ -108,7 +108,11 @@ type Namespace struct {
 // Also note that the output from Dump may change from Hugo version to the next,
 // so don't depend on a specific output.
 func (ns *Namespace) Dump(val any) string {
-	return litter.Sdump(val)
+	b, err := json.MarshalIndent(val, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 // VisualizeSpaces returns a string with spaces replaced by a visible string.

--- a/tpl/debug/debug_integration_test.go
+++ b/tpl/debug/debug_integration_test.go
@@ -43,3 +43,33 @@ disableKinds = ["taxonomy", "term"]
 
 	b.AssertLogContains("timer:  name foo count 5 duration")
 }
+
+func TestDebugDumpPage(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+disableLiveReload = true
+[taxonomies]
+tag = "tags"
+-- content/_index.md --
+---
+title: "The Index"
+date: 2012-03-15
+---
+-- content/p1.md --
+---
+title: "The First"
+tags: ["a", "b"]
+---
+-- layouts/_default/list.html --
+Dump: {{ debug.Dump . | safeHTML }}
+Dump Site: {{ debug.Dump site }}
+Dum site.Taxonomies: {{ debug.Dump site.Taxonomies | safeHTML }}
+-- layouts/_default/single.html --
+Dump: {{ debug.Dump . | safeHTML }}
+
+
+`
+	b := hugolib.TestRunning(t, files)
+	b.AssertFileContent("public/index.html", "Dump: {\n  \"Date\": \"2012-03-15T00:00:00Z\"")
+}

--- a/tpl/debug/init.go
+++ b/tpl/debug/init.go
@@ -36,7 +36,7 @@ func init() {
 			[][2]string{
 				{`{{ $m := newScratch }}
 {{ $m.Set "Hugo" "Rocks!" }}
-{{ $m.Values | debug.Dump | safeHTML }}`, "map[string]interface {}{\n  \"Hugo\": \"Rocks!\",\n}"},
+{{ $m.Values | debug.Dump | safeHTML }}`, "{\n  \"Hugo\": \"Rocks!\"\n}"},
 			},
 		)
 


### PR DESCRIPTION
This replaces the current implementation with `json.MarshalIndent` which doesn't produce the same output, but at least it doesn't crash.

There's a bug in the upstream `litter` library. This can probably be fixed, but that needs to wait.

I have tested `go-spew` which does not crash, but it is very data racy in this context.

FIxes #12309
