### PR TITLE
markup/asciidocext: Enable converter templates

### DIFF
--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -1052,6 +1052,8 @@ config:
       preserveTOC: false
       safeMode: unsafe
       sectionNumbers: false
+      templateDirectories: []
+      templateEngine: handlebars
       trace: false
       verbose: false
       workingFolderCurrent: false
@@ -2797,8 +2799,8 @@ tpl:
             {{ $m.Set "Hugo" "Rocks!" }}
             {{ $m.Values | debug.Dump | safeHTML }}
           - |-
-            map[string]interface {}{
-              "Hugo": "Rocks!",
+            {
+              "Hugo": "Rocks!"
             }
       TestDeprecationErr:
         Aliases: null

--- a/markup/asciidocext/asciidocext_config/config.go
+++ b/markup/asciidocext/asciidocext_config/config.go
@@ -28,6 +28,8 @@ var (
 		FailureLevel:         "fatal",
 		WorkingFolderCurrent: false,
 		PreserveTOC:          false,
+		TemplateDirectories:  []string{},
+		TemplateEngine:       "handlebars",
 	}
 
 	// CliDefault holds Asciidoctor CLI defaults (see https://asciidoctor.org/docs/user-manual/)
@@ -58,6 +60,10 @@ var (
 		"manpage":   true,
 	}
 
+	AllowedTemplateEngine = map[string]bool{
+		"handlebars": true,
+	}
+
 	DisallowedAttributes = map[string]bool{
 		"outdir": true,
 	}
@@ -76,4 +82,6 @@ type Config struct {
 	FailureLevel         string
 	WorkingFolderCurrent bool
 	PreserveTOC          bool
+	TemplateDirectories  []string
+	TemplateEngine       string
 }

--- a/markup/asciidocext/asciidocext_integration_test.go
+++ b/markup/asciidocext/asciidocext_integration_test.go
@@ -1,0 +1,135 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package asciidocext_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gohugoio/hugo/common/hexec"
+	"github.com/gohugoio/hugo/hugolib"
+	"github.com/gohugoio/hugo/markup/asciidocext"
+)
+
+func TestAsciiDocConverterTemplates(t *testing.T) {
+	if !asciidocext.Supports() {
+		t.Skip("asciidoctor not installed")
+	}
+	missingGems := listMissingConverterTemplateGems()
+	if len(missingGems) > 0 {
+		t.Skip("these ruby gems, required to use AsciiDoc converter templates, are not installed:", strings.Join(missingGems, ", "))
+	}
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','section','rss','section','sitemap','taxonomy','term']
+[markup.asciidocext]
+templateDirectories = ['a','b']
+templateEngine = 'handlebars'
+[security.exec]
+allow = ['asciidoctor']
+-- content/_index.adoc --
+---
+title: home
+---
+https://gohugo.io[This is a link,title="Hugo rocks!"]
+
+image:a.jpg[alt=A kitten,title=This is my kitten!]
+-- layouts/index.html --
+{{ .Content }}
+-- a/inline_anchor.html.handlebars --
+inline_anchor_html_handlebars
+-- b/inline_image.html.handlebars --
+inline_image_html_handlebars
+`
+
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+			NeedsOsFS:   true,
+		}).Build()
+
+	b.AssertFileContent("public/index.html",
+		`<p>inline_anchor_html_handlebars</p>`,
+		`<p>inline_image_html_handlebars</p>`,
+	)
+}
+
+func TestAsciiDocConverterTemplatesWithDisallowedFile(t *testing.T) {
+	if !asciidocext.Supports() {
+		t.Skip("asciidoctor not installed")
+	}
+	missingGems := listMissingConverterTemplateGems()
+	if len(missingGems) > 0 {
+		t.Skip("these ruby gems, required to use AsciiDoc converter templates, are not installed:", strings.Join(missingGems, ", "))
+	}
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','section','rss','section','sitemap','taxonomy','term']
+[markup.asciidocext]
+templateDirectories = ['a','b']
+templateEngine = 'handlebars'
+[security.exec]
+allow = ['asciidoctor']
+-- content/_index.adoc --
+---
+title: home
+---
+https://gohugo.io[This is a link,title="Hugo rocks!"]
+
+image:a.jpg[alt=A kitten,title=This is my kitten!]
+-- layouts/index.html --
+{{ .Content }}
+-- a/inline_anchor.html.handlebars --
+inline_anchor_html_handlebars
+-- b/inline_image.html.handlebars --
+inline_image_html_handlebars
+-- b/helpers.js --
+I have the potential to execute arbitrary code; skip this directory!
+`
+
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+			NeedsOsFS:   true,
+		}).Build()
+
+	b.AssertFileContent("public/index.html",
+		`<p>inline_anchor_html_handlebars</p>`,
+		`<img src="a.jpg" alt="A kitten" title="This is my kitten!"/>`,
+	)
+}
+
+// converterTemplateGems is a map of the ruby gems required to test AsciiDoc
+// converter templates. The key is the gem name, while the value is the
+// executable name.
+var converterTemplateGems = map[string]string{
+	"tilt":            "tilt",
+	"tilt-handlebars": "handlebars",
+}
+
+// listMissingConverterTemplateGems returns a slice of missing (not installed)
+// ruby gems that are required to test AsciiDoc converter templates.
+func listMissingConverterTemplateGems() []string {
+	var gems []string
+	for name, exec := range converterTemplateGems {
+		if !hexec.InPath(exec) {
+			gems = append(gems, name)
+		}
+	}
+	return gems
+}


### PR DESCRIPTION
Converter templates are the AsciiDoc equivalent of Markdown render hooks: https://docs.asciidoctor.org/asciidoctor/latest/convert/templates/

Requires the following gems: `concurrent-ruby`, `tilt`, and `tilt-handlebars`.

Handlebars is the only allowed template engine, and all files must have the `.handlebars` file extension. Handlebars templates may not be placed within the `layouts` directory.

Supports multiple converter template directories, with left-to-right precedence. The path to each converter template directory must be relative to the project directory.

Hugo will intentionally skip converter template directories that contain files with extensions other than `.handlebars`. For example, Hugo will skip directories that contain a `helpers.js` file.

Example configuration:

```text
[markup.asciidocExt]
extensions = ['tilt-handlebars']
templateDirectories = ['adoc-templates/a','adoc-templates/b']
templateEngine = 'handlebars' # can omit; handlebars is the default
```

Hugo's snap package does not support AsciiDoc converter templates.

Closes #12314