### PR TITLE
Typo fixes

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -307,7 +307,7 @@ func (f *fileServer) createEndpoint(i int) (*http.ServeMux, net.Listener, string
 			if redirect := serverConfig.MatchRedirect(requestURI); !redirect.IsZero() {
 				// fullName := filepath.Join(dir, filepath.FromSlash(path.Clean("/"+name)))
 				doRedirect := true
-				// This matches Netlify's behaviour and is needed for SPA behaviour.
+				// This matches Netlify's behavior and is needed for SPA behavior.
 				// See https://docs.netlify.com/routing/redirects/rewrites-proxies/
 				if !redirect.Force {
 					path := filepath.Clean(strings.TrimPrefix(requestURI, baseURL.Path()))

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -374,7 +374,7 @@ func cacheDirDefault(cacheDir string) string {
 	// Turns out that Cloudflare also sets NETLIFY=true in its build environment,
 	// but all of these 3 should not give any false positives.
 	if os.Getenv("NETLIFY") == "true" && os.Getenv("PULL_REQUEST") != "" && os.Getenv("DEPLOY_PRIME_URL") != "" {
-		// Netlify's cache behaviour is not documented, the currently best example
+		// Netlify's cache behavior is not documented, the currently best example
 		// is this project:
 		// https://github.com/philhawksworth/content-shards/blob/master/gulpfile.js
 		return "/opt/build/cache/hugo_cache/"

--- a/hugolib/content_map.go
+++ b/hugolib/content_map.go
@@ -181,7 +181,7 @@ func (m *pageMap) AddFi(fi hugofs.FileMetaInfo) error {
 
 		var rs *resourceSource
 		if pi.IsContent() {
-			// Create the page now as we need it at assemembly time.
+			// Create the page now as we need it at assembly time.
 			// The other resources are created if needed.
 			pageResource, pi, err := m.s.h.newPage(
 				&pageMeta{

--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -133,7 +133,7 @@ type pageTrees struct {
 func (t *pageTrees) collectAndMarkStaleIdentities(p *paths.Path) []identity.Identity {
 	key := p.Base()
 	var ids []identity.Identity
-	// We need only one identity sample per dimensio.
+	// We need only one identity sample per dimension.
 	nCount := 0
 	cb := func(n contentNodeI) bool {
 		if n == nil {

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -676,7 +676,7 @@ params:
 }
 
 // shouldList returns whether this page should be included in the list of pages.
-// glogal indicates site.Pages etc.
+// global indicates site.Pages etc.
 func (p *pageMeta) shouldList(global bool) bool {
 	if p.isStandalone() {
 		// Never list 404, sitemap and similar.

--- a/langs/i18n/i18n.go
+++ b/langs/i18n/i18n.go
@@ -87,7 +87,7 @@ func (t Translator) initFuncs(bndl *i18n.Bundle) {
 						// the context.Context.
 						// A common pattern is to pass Page to i18n, and use .ReadingTime etc.
 						// We need to improve this, but that requires some upstream changes.
-						// For now, just creata a wrepper.
+						// For now, just create a wrapper.
 						templateData = page.PageWithContext{Page: p, Ctx: ctx}
 					}
 				}

--- a/markup/goldmark/goldmark_config/config.go
+++ b/markup/goldmark/goldmark_config/config.go
@@ -217,6 +217,6 @@ type Parser struct {
 type ParserAttribute struct {
 	// Enables custom attributes for titles.
 	Title bool
-	// Enables custom attributeds for blocks.
+	// Enables custom attributes for blocks.
 	Block bool
 }

--- a/resources/errorResource.go
+++ b/resources/errorResource.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	_ error = (*errorResource)(nil)
-	// Imnage covers all current Resource implementations.
+	// Image covers all current Resource implementations.
 	_ images.ImageResource = (*errorResource)(nil)
 	// The list of user facing and exported interfaces in resource.go
 	// Note that if we're missing some interface here, the user will still

--- a/testscripts/commands/server.txt
+++ b/testscripts/commands/server.txt
@@ -9,7 +9,7 @@ httpget $HUGOTEST_BASEURL_0 'Title: Hugo Server Test' $HUGOTEST_BASEURL_0 'Serve
 httpget ${HUGOTEST_BASEURL_0}doesnotexist 'custom 404'
 httpget ${HUGOTEST_BASEURL_0}livereload.js 'function'
 
-# By defauilt, the server renders to memory.
+# By default, the server renders to memory.
 ! exists public/index.html
 
 stopServer


### PR DESCRIPTION
For reference, to find these I used cSpell CLI - running:

`npx cspell \"**/*.*\" --no-progress --quiet`

with the following `.cspell.json` config in the root folder. There are still many false-positives in the comfig I used though.

```json
{
  "version": "0.2",
  "allowCompoundWords": true,
  "flagWords": [
    "alot",
    "hte",
    "langauge",
    "reccommend",
    "seperate",
    "teh"
  ],
  "ignorePaths": [
    "**/*.css",
    "**/*.ics",
    "**/*.jpe",
    "**/*.js",
    "**/*.md",
    "**/*.svg",
    "**/*.yaml"
  ],
  "ignoreRegExpList": [
    "# cspell: ignore fenced code blocks",
    "^(\\s*`{3,}).*[\\s\\S]*?^\\1",
    "# cspell: ignore words joined with dot",
    "\\w+\\.\\w+",
    "# cspell: ignore strings within backticks",
    "`.+`",
    "# cspell: ignore strings within single quotes",
    "'.+'",
    "# cspell: ignore strings within double quotes",
    "\".+\"",
    "# cspell: ignore strings within brackets",
    "\\[.+\\]",
    "# cspell: ignore strings within parentheses",
    "\\(.+\\)",
    "# cspell: ignore words that begin with a slash",
    "/\\w+",
    "# cspell: ignore everything within action delimiters",
    "\\{\\{.+\\}\\}",
    "# cspell: ignore everything after a right arrow",
    "\\s+→\\s+.+"
  ],
  "language": "de,en,en-US,es,fr,it,lorem",
  "words": [
    "# ----------------------------------------------------------------------",
    "# cspell: ignore foreign language words",
    "# cspell: ignore miscellaneous",
    "# cspell: ignore operating systems and software packages",
    "# cspell: ignore proper nouns",
    "abcdefghi",
    "abcdefghijk",
    "abcdefghis",
    "abcdefgs",
    "abcdefs",
    "ABNF",
    "absurlified",
    "absurlify",
    "acfg",
    "Afero",
    "alloc",
    "Anchorize",
    "Andrey",
    "antialiasing",
    "argsv",
    "asciidoctor",
    "attrtp",
    "bcfg",
    "benchcmp",
    "bepsays",
    "bezpieczeństwo",
    "bgcolor",
    "blogm",
    "bofi",
    "boolor",
    "brotli",
    "bydate",
    "bylength",
    "byparam",
    "bypubdate",
    "bytype",
    "canonify",
    "cascadeparam",
    "ccolor",
    "cerr",
    "CLOUDFRONTDISTRIBUTIONID",
    "Cmds",
    "codeowners",
    "composability",
    "concatr",
    "configurators",
    "confmu",
    "contentmemw",
    "Contentr",
    "contentrc",
    "corejs",
    "CPATH",
    "curr",
    "dcfg",
    "Debugf",
    "debugl",
    "defang",
    "defaultv",
    "deindent",
    "deletefd",
    "didn",
    "disqus",
    "Dmitry",
    "dname",
    "doas",
    "dokumentation",
    "dostounix",
    "downscale",
    "downscaled",
    "downscaling",
    "dring",
    "dynacache",
    "Eliott",
    "Emojify",
    "émotion",
    "envtags",
    "eopkg",
    "Eqer",
    "errch",
    "Erroridf",
    "errorl",
    "Errorln",
    "errorsw",
    "esbuild",
    "exif",
    "extj",
    "ferr",
    "ferrors",
    "ferrs",
    "filefs",
    "filterby",
    "fims",
    "Flexi",
    "fname",
    "fromt",
    "fromv",
    "fromvs",
    "fset",
    "fsnotify",
    "fsnotity",
    "gcaws",
    "geolocalized",
    "getenv",
    "gfilters",
    "giph",
    "giphy",
    "gitee",
    "givenv",
    "gobench",
    "GOCACHE",
    "godartsassv",
    "GOEXE",
    "gofmt",
    "gohtml",
    "gohugo",
    "gohugoio",
    "goimports",
    "goldmark",
    "golint",
    "gomod",
    "gomods",
    "graphb",
    "grayscale",
    "Gregor",
    "greppable",
    "Groot",
    "gtag",
    "gzipped",
    "hcontext",
    "hglob",
    "hreflect",
    "htesting",
    "htext",
    "htime",
    "hugio",
    "hugofs",
    "icfg",
    "Idents",
    "idprefix",
    "idseparator",
    "iface",
    "imgconfig",
    "imgs",
    "Infof",
    "infol",
    "Infoln",
    "infow",
    "inor",
    "intelli",
    "iofs",
    "isatty",
    "ishex",
    "istemp",
    "Jaco",
    "jdoe",
    "jmespath",
    "JSHTML",
    "Jsonify",
    "jsons",
    "KaTeX",
    "Keyer",
    "keyt",
    "kubuntu",
    "ldquo",
    "libros",
    "lidx",
    "Linkify",
    "lofi",
    "logln",
    "lrport",
    "lubuntu",
    "Markdownify",
    "marshal",
    "marshaling",
    "MathJax",
    "mconf",
    "memfs",
    "metaw",
    "miesiąc",
    "miesięcy",
    "milli",
    "minifier",
    "minifiers",
    "misérables",
    "Mkcert",
    "monokai",
    "moolor",
    "multihost",
    "myblog",
    "mybucket",
    "mybundle",
    "myclass",
    "myconfigdir",
    "mydata",
    "mydeployment",
    "myenv",
    "myexistingsite",
    "myhugosite",
    "myjekyllsite",
    "myjsoncontent",
    "mymodule",
    "myparam",
    "myposts",
    "mysite",
    "mysource",
    "mystatic",
    "mytemplate",
    "mytheme",
    "mytomlcontent",
    "myworkingdir",
    "myyamlcontent",
    "Netravali",
    "newfd",
    "newp",
    "nfilename",
    "nlocker",
    "noclasses",
    "nofilefilename",
    "nofileslug",
    "nofiletitle",
    "Noll",
    "noshift",
    "nosql",
    "nread",
    "NUMWORKERMULTIPLIER",
    "Octopress",
    "onclick",
    "optionsm",
    "optsm",
    "osfs",
    "pandoc",
    "Pastorius",
    "pathc",
    "Pathify",
    "pcfg",
    "pconf",
    "pdate",
    "performantly",
    "pkcs",
    "pkeys",
    "pkgin",
    "Plainify",
    "preconfigured",
    "prerendering",
    "printm",
    "projekt",
    "proto",
    "publicw",
    "publishw",
    "Querify",
    "rbylength",
    "rbypubdate",
    "rbysection",
    "RCDATA",
    "rclone",
    "rcsources",
    "rdquo",
    "receiverv",
    "redir",
    "redirection",
    "redirections",
    "regexs",
    "régime",
    "Resizer",
    "resolvedm",
    "resultch",
    "resultv",
    "Resumé",
    "resv",
    "rgba",
    "rootv",
    "rsmith",
    "Samsa",
    "sectnocontent",
    "sectnofrontmatter",
    "Sedykh",
    "seqv",
    "setm",
    "shortcode",
    "shortcodes",
    "shouldn",
    "smap",
    "stringifier",
    "struct",
    "stuttery",
    "stype",
    "subexpression",
    "subexpressions",
    "suppressable",
    "Syncer",
    "tableofcontents",
    "Tarantsov",
    "tbody",
    "tctx",
    "tdewolff",
    "Templ",
    "templating",
    "tfoot",
    "THEAD",
    "themeconfigdirparam",
    "tinygo",
    "tjones",
    "tmpbucketdir",
    "tmpfsdir",
    "tmpl",
    "toclevels",
    "Tocs",
    "tomlcontent",
    "tplimpl",
    "tracel",
    "transpile",
    "transpilerv",
    "transpiles",
    "tsti",
    "uncloned",
    "uncomparable",
    "undelimited",
    "Unmarshable",
    "unmarshal",
    "unmarshaled",
    "unmarshaling",
    "unmarshall",
    "unmarshals",
    "unnormalized",
    "unnudged",
    "unorderable",
    "unrendered",
    "Unsharp",
    "Unwrapv",
    "updatefd",
    "upgrader",
    "urlize",
    "vals",
    "varn",
    "Warnf",
    "Warnidf",
    "warnl",
    "Warnln",
    "WEBM",
    "Webp",
    "WHATWG",
    "withc",
    "xfeff",
    "xubuntu",
    "yamlcontent",
    "Zeroer",
    "zgotmplz",
    "zoolor"
  ]
}

```