### PR TITLE
tpl: Escape .Title in built-in image and link render hooks

### DIFF
--- a/tpl/tplimpl/embedded/templates/_default/_markup/render-image.html
+++ b/tpl/tplimpl/embedded/templates/_default/_markup/render-image.html
@@ -5,7 +5,7 @@
     {{- $src = .RelPermalink -}}
   {{- end -}}
 {{- end -}}
-{{- $attributes := merge .Attributes (dict "alt" .Text "src" $src "title" .Title) -}}
+{{- $attributes := merge .Attributes (dict "alt" .Text "src" $src "title" (.Title | transform.HTMLEscape)) -}}
 <img
   {{- range $k, $v := $attributes -}}
     {{- if $v -}}

--- a/tpl/tplimpl/embedded/templates/_default/_markup/render-link.html
+++ b/tpl/tplimpl/embedded/templates/_default/_markup/render-link.html
@@ -17,7 +17,7 @@
     {{- end -}}
   {{- end -}}
 {{- end -}}
-{{- $attributes := dict "href" $href "title" .Title -}}
+{{- $attributes := dict "href" $href "title" (.Title | transform.HTMLEscape) -}}
 <a
   {{- range $k, $v := $attributes -}}
     {{- if $v -}}


### PR DESCRIPTION
These templates were added in Hugo v0.123.0, and in the common case disabled by default, see https://gohugo.io/getting-started/configuration-markup/#renderhooksimageenabledefault
