### PR TITLE
tpl/tplimpl: Fix double-escaping in opengraph template

### DIFF
--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -4,11 +4,11 @@
   <meta property="og:site_name" content="{{ . }}">
 {{- end }}
 
-{{- with or .Title site.Title site.Params.title | plainify}}
+{{- with or .Title site.Title site.Params.title | plainify }}
   <meta property="og:title" content="{{ . }}">
 {{- end }}
 
-{{- with or .Description .Summary site.Params.description | plainify }}
+{{- with or .Description .Summary site.Params.description | plainify | htmlUnescape | chomp }}
   <meta property="og:description" content="{{ . }}">
 {{- end }}
 
@@ -18,7 +18,9 @@
 
 {{- if .IsPage }}
   <meta property="og:type" content="article">
-  <meta property="article:section" content="{{ .Section }}">
+  {{- with .Section }}
+    <meta property="article:section" content="{{ . }}">
+  {{- end }}
   {{- $ISO8601 := "2006-01-02T15:04:05-07:00" }}
   {{- with .PublishDate }}
     <meta property="article:published_time" {{ .Format $ISO8601 | printf "content=%q" | safeHTMLAttr }}>


### PR DESCRIPTION
- Do not escape HTML entities
- Use consistent formatting for title and description with opengraph, schema, and twitter_cards
- Improve readability of twitter_cards

Closes #12418