### PR TITLE
Fix `<!--<!--more-->` caused rendering issue #12426

### DIFF
--- a/parser/pageparser/pagelexer_intro.go
+++ b/parser/pageparser/pagelexer_intro.go
@@ -15,6 +15,7 @@ package pageparser
 
 func lexIntroSection(l *pageLexer) stateFunc {
 	l.summaryDivider = summaryDivider
+	l.summaryDividerReg = summaryDividerReg
 
 LOOP:
 	for {
@@ -94,6 +95,7 @@ func lexFrontMatterOrgMode(l *pageLexer) stateFunc {
 	*/
 
 	l.summaryDivider = summaryDividerOrg
+	l.summaryDividerReg = summaryDividerReg
 
 	l.backup()
 


### PR DESCRIPTION
Fix a rendering issue when "<!--<!--more-->"

There should not use a simple `string.find()` when handling `<!--more-->`.

This commit improves robust for hugo to handle the nested `<!--` situation.

Fixes #12426