### PR TITLE
Enable cross-site translations

### DIFF
--- a/langs/language.go
+++ b/langs/language.go
@@ -15,6 +15,7 @@
 package langs
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/gohugoio/hugo/common/htime"
 	"github.com/gohugoio/hugo/common/maps"
+
 	"github.com/gohugoio/locales"
 	translators "github.com/gohugoio/localescompressed"
 )
@@ -110,6 +112,12 @@ func (l *Language) LanguageCode() string {
 		return l.LanguageConfig.LanguageCode
 	}
 	return l.Lang
+}
+
+// Translate returns a translated string for id.
+func (l *Language) Translate(ctx context.Context, id string, args ...any) (string, error) {
+	translatedString := "" // TODO (jmm)
+	return translatedString, nil
 }
 
 func (l *Language) loadLocation(tzStr string) error {

--- a/resources/page/site.go
+++ b/resources/page/site.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gohugoio/hugo/config/privacy"
 	"github.com/gohugoio/hugo/config/services"
 	"github.com/gohugoio/hugo/identity"
+	"github.com/spf13/cast"
 
 	"github.com/gohugoio/hugo/config"
 
@@ -145,6 +146,20 @@ func (s Sites) First() Site {
 		return nil
 	}
 	return s[0]
+}
+
+// GetSite returns the site corresponding to the given language.
+func (s Sites) GetSite(lang string) (Site, error) {
+	slang, err := cast.ToStringE(lang)
+	if err != nil {
+		return nil, err
+	}
+	for _, site := range s {
+		if site.Language().Lang == slang {
+			return site, nil
+		}
+	}
+	return nil, nil
 }
 
 // Some additional interfaces implemented by siteWrapper that's not on Site.


### PR DESCRIPTION
This introduces two methods to enable cross-site translations:

- Site.Translate returns a translated string in the language of the given site.

  {{ range .AllTranslations }} {{ .Site.Translate "cat" 6 }} {{ end }}

- Sites.GetSite returns the site corresponding to the given language. This method simplifies cross-site translations.

  {{ with .Sites.GetSite "en" }} {{ .Translate "dog" 7 }} {{ end }}

Closes #7844