### PR TITLE
[editorial] google_analytics.html: trim trailing whitespace from tpl actions

### DIFF
--- a/tpl/tplimpl/embedded/templates/google_analytics.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics.html
@@ -1,8 +1,8 @@
-{{ if not site.Config.Privacy.GoogleAnalytics.Disable }}
-  {{ with site.Config.Services.GoogleAnalytics.ID }}
-    {{ if strings.HasPrefix (lower .) "ua-" }}
-      {{ warnf "Google Analytics 4 (GA4) replaced Google Universal Analytics (UA) effective 1 July 2023. See https://support.google.com/analytics/answer/11583528. Create a GA4 property and data stream, then replace the Google Analytics ID in your site configuration with the new value." }}
-    {{ else }}
+{{ if not site.Config.Privacy.GoogleAnalytics.Disable -}}
+  {{ with site.Config.Services.GoogleAnalytics.ID -}}
+    {{ if strings.HasPrefix (lower .) "ua-" -}}
+      {{ warnf "Google Analytics 4 (GA4) replaced Google Universal Analytics (UA) effective 1 July 2023. See https://support.google.com/analytics/answer/11583528. Create a GA4 property and data stream, then replace the Google Analytics ID in your site configuration with the new value." -}}
+    {{ else -}}
       <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
       <script>
         var doNotTrack = false;
@@ -17,6 +17,6 @@
           gtag('config', '{{ . }}');
         }
       </script>
-    {{ end }}
-  {{ end }}
-{{ end }}
+    {{ end -}}
+  {{ end -}}
+{{ end -}}

--- a/tpl/tplimpl/embedded/templates/google_analytics.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics.html
@@ -3,7 +3,7 @@
     {{- if strings.HasPrefix (lower .) "ua-" }}
       {{- warnf "Google Analytics 4 (GA4) replaced Google Universal Analytics (UA) effective 1 July 2023. See https://support.google.com/analytics/answer/11583528. Create a GA4 property and data stream, then replace the Google Analytics ID in your site configuration with the new value." }}
     {{- else }}
-      <script async src="https://www.googletagmanager.com/gtag/js?id={{- . }}"></script>
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
       <script>
         var doNotTrack = false;
         if ({{ site.Config.Privacy.GoogleAnalytics.RespectDoNotTrack }}) {

--- a/tpl/tplimpl/embedded/templates/google_analytics.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics.html
@@ -14,7 +14,7 @@
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
-          gtag('config', '{{- . }}');
+          gtag('config', '{{ . }}');
         }
       </script>
     {{- end }}

--- a/tpl/tplimpl/embedded/templates/google_analytics.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics.html
@@ -1,12 +1,12 @@
-{{ if not site.Config.Privacy.GoogleAnalytics.Disable -}}
-  {{ with site.Config.Services.GoogleAnalytics.ID -}}
-    {{ if strings.HasPrefix (lower .) "ua-" -}}
-      {{ warnf "Google Analytics 4 (GA4) replaced Google Universal Analytics (UA) effective 1 July 2023. See https://support.google.com/analytics/answer/11583528. Create a GA4 property and data stream, then replace the Google Analytics ID in your site configuration with the new value." -}}
-    {{ else -}}
-      <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+{{ if not site.Config.Privacy.GoogleAnalytics.Disable }}
+  {{- with site.Config.Services.GoogleAnalytics.ID }}
+    {{- if strings.HasPrefix (lower .) "ua-" }}
+      {{- warnf "Google Analytics 4 (GA4) replaced Google Universal Analytics (UA) effective 1 July 2023. See https://support.google.com/analytics/answer/11583528. Create a GA4 property and data stream, then replace the Google Analytics ID in your site configuration with the new value." }}
+    {{- else }}
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{- . }}"></script>
       <script>
         var doNotTrack = false;
-        if ({{ site.Config.Privacy.GoogleAnalytics.RespectDoNotTrack }}) {
+        if ({{- site.Config.Privacy.GoogleAnalytics.RespectDoNotTrack }}) {
           var dnt = (navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack);
           var doNotTrack = (dnt == "1" || dnt == "yes");
         }
@@ -14,9 +14,9 @@
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
-          gtag('config', '{{ . }}');
+          gtag('config', '{{- . }}');
         }
       </script>
-    {{ end -}}
-  {{ end -}}
-{{ end -}}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/tpl/tplimpl/embedded/templates/google_analytics.html
+++ b/tpl/tplimpl/embedded/templates/google_analytics.html
@@ -6,7 +6,7 @@
       <script async src="https://www.googletagmanager.com/gtag/js?id={{- . }}"></script>
       <script>
         var doNotTrack = false;
-        if ({{- site.Config.Privacy.GoogleAnalytics.RespectDoNotTrack }}) {
+        if ({{ site.Config.Privacy.GoogleAnalytics.RespectDoNotTrack }}) {
           var dnt = (navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack);
           var doNotTrack = (dnt == "1" || dnt == "yes");
         }


### PR DESCRIPTION
"Editorial" change only: from `{{ ... }}` to `{{- ... }}`, to trim template action trailing whitespace.