### PR TITLE
Support for .textbundle leaf nodes

### DIFF
--- a/hugofs/files/classifier.go
+++ b/hugofs/files/classifier.go
@@ -77,7 +77,7 @@ func IsIndexContentFile(filename string) bool {
 
 	base := filepath.Base(filename)
 
-	return strings.HasPrefix(base, "index.") || strings.HasPrefix(base, "_index.")
+	return strings.HasPrefix(base, "index.") || strings.HasPrefix(base, "_index.") || strings.HasPrefix(base, "text.")
 }
 
 func IsHTMLFile(filename string) bool {
@@ -132,7 +132,7 @@ func ClassifyContentFile(filename string, open func() (afero.File, error)) Conte
 		return ContentClassBranch
 	}
 
-	if strings.HasPrefix(filename, "index.") {
+	if strings.HasPrefix(filename, "index.") || strings.HasPrefix(filename, "text.") {
 		return ContentClassLeaf
 	}
 

--- a/hugolib/fileInfo.go
+++ b/hugolib/fileInfo.go
@@ -94,7 +94,7 @@ func classifyBundledFile(name string) (bundleDirType, bool) {
 		return bundleBranch, true
 	}
 
-	if strings.HasPrefix(name, "index.") {
+	if strings.HasPrefix(name, "index.") || strings.HasPrefix(name, "text.") {
 		return bundleLeaf, true
 	}
 


### PR DESCRIPTION
I use Ulysses external folder support for my writing, and they use textbundle format for their "posts" -- https://textbundle.org/

The spec uses `text.md` as the markdown container within the `.textbundle` directory and `assets/*` for relative images. With this change, hugo recognizes the `text.md` leaf inside the textbundle and the paths to relative images work correctly.

If there are any tests that should be updated for this, I'd be happy to update them (but some help find where would be appreciated).