### PR TITLE
Support for textbundle leaf nodes

### DIFF
--- a/common/paths/pathparser.go
+++ b/common/paths/pathparser.go
@@ -198,6 +198,7 @@ func (pp *PathParser) doParse(component, s string, p *Path) (*Path, error) {
 		if isContent {
 			switch b {
 			case "index":
+			case "text":
 				p.bundleType = PathTypeLeaf
 			case "_index":
 				p.bundleType = PathTypeBranch

--- a/media/config.go
+++ b/media/config.go
@@ -117,7 +117,7 @@ func (t ContentTypes) IsIndexContentFile(filename string) bool {
 
 	base := filepath.Base(filename)
 
-	return strings.HasPrefix(base, "index.") || strings.HasPrefix(base, "_index.")
+	return strings.HasPrefix(base, "index.") || strings.HasPrefix(base, "_index.") || strings.HasPrefix(base, "text.")
 }
 
 // IsHTMLSuffix returns whether the given suffix is a HTML media type.


### PR DESCRIPTION
Recognize the `text.md` inside a `.textbundle` file as a leaf node so the relative images in the `assets/` directory are correctly handled.

textbundle spec: https://textbundle.org/

There are probably some tests that I need to update, but if someone can direct me in the right direction that would be appreciated.