### PR TITLE
ci: add image build

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,127 @@
+name: Build Docker image
+
+on:
+  push:
+
+  # Run on pull requests to verify that the image still builds correctly
+  # The image is not pushed on pull requests
+  pull_request:
+    paths:
+      - Dockerfile
+      - .github/workflows/image.yml
+
+permissions:
+  packages: write
+
+env:
+  REGISTRY_IMAGE: ghcr.io/gohugoio/hugo
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4.1.6
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
+
+      - name: Login to GHCR
+        # Login is only needed when the image is pushed
+        if: ${{ startsWith(github.ref, 'refs/tags') }}
+        uses: docker/login-action@v3.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    if: ${{ startsWith(github.ref, 'refs/tags') }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4.1.7
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+          flavor: |
+            latest=false
+
+          # Tag the image with the v-prefixed semver version on tags, tag with the ref on PRs
+          tags: |
+            type=semver,pattern={{raw}}
+            type=ref,event=pr
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Description

This adds a Docker image build running in GitHub actions for `linux/amd64` and `linux/arm64` images.

The build runs for every PR that changes either the workflow or the Dockerfile to verify the image still can be built correctly, but does not push the image for these runs.

For every tag, the images are built and pushed to the GitHub OCI registry.

Resolves #10760.

## Testing

I have run tests with a slightly modified version (to enable testing) in my fork, see the [test-add-image-build](https://github.com/morremeyer/hugo/tree/ci/test-add-image-build) branch.

This builds the image with [this workflow](https://github.com/morremeyer/hugo/actions/runs/9416950944) and results in the package being pushed to https://github.com/morremeyer/hugo/pkgs/container/hugo.

## Continuous testing

I am aware of https://github.com/gohugoio/hugo/pull/8700#issuecomment-869981438 and happy to add automated testing of the images if there is a clear requirement for what should be tested.

However, as with the Dockerfile being a convenience, the same could also be applied to the resulting image in terms of guarantees.