### PR TITLE
[Docs] [XS] Replace ignoreErrors in source md to align with new behavior

### DIFF
--- a/docs/content/en/functions/fmt/Erroridf.md
+++ b/docs/content/en/functions/fmt/Erroridf.md
@@ -28,13 +28,13 @@ Produces this console log:
 ```text
 ERROR You should consider fixing this.
 You can suppress this error by adding the following to your site configuration:
-ignoreErrors = ['error-42']
+ignoreLogs = ['error-42']
 ```
 
 To suppress this message:
 
 {{< code-toggle file=hugo >}}
-ignoreErrors = ["error-42"]
+ignoreLogs = ["error-42"]
 {{< /code-toggle >}}
 
 [`errorf`]: /functions/fmt/errorf


### PR DESCRIPTION
Realize that the rendered output is fine, but got confused when searching through y'alls source code.

Think there's also some build logging messages that might need to be improved, but didn't exactly know where to go and update those.

```
[0] ERROR 2024/06/07 13:05:21 You have the value 'taxonomy' in the disabledKinds list. In Hugo 0.73.0 we fixed these to be what most people expect (taxonomy and term).
[0] But this also means that your site configuration may not do what you expect. If it is correct, you can suppress this message by following the instructions below.
[0] If you feel that this should not be logged as an ERROR, you can ignore it by adding this to your site config:
[0] ignoreErrors = ["error-disable-taxonomy"]
[0] Start building sites ...
```