### PR TITLE
resources/page: Let GroupByParam return nil instead of error

### DIFF
--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -427,8 +427,8 @@ mainSections=["a", "b"]
 {{/* Behaviour before Hugo 0.112.0. */}}
 MainSections Params: {{ site.Params.mainSections }}|
 MainSections Site method: {{ site.MainSections }}|
-	
-	
+
+
 	`
 
 		b := Test(t, files)
@@ -478,8 +478,8 @@ disableKinds = ['RSS','sitemap','taxonomy','term']
 -- layouts/index.html --
 MainSections Params: {{ site.Params.mainSections }}|
 MainSections Site method: {{ site.MainSections }}|
-	
-	
+
+
 	`
 
 		b := Test(t, files)
@@ -787,9 +787,12 @@ func TestGroupedPages(t *testing.T) {
 		t.Errorf("PageGroup has unexpected number of pages. First group should have '%d' pages, got '%d' pages", 2, len(byparam[0].Pages))
 	}
 
-	_, err = s.RegularPages().GroupByParam("not_exist")
-	if err == nil {
-		t.Errorf("GroupByParam didn't return an expected error")
+	byNonExistentParam, err := s.RegularPages().GroupByParam("not_exist")
+	if err != nil {
+		t.Errorf("GroupByParam returned an error when it shouldn't")
+	}
+	if len(byNonExistentParam) != 0 {
+		t.Errorf("PageGroup array has unexpected elements. Group length should be '%d', got '%d'", 0, len(byNonExistentParam))
 	}
 
 	byOnlyOneParam, err := s.RegularPages().GroupByParam("only_one")

--- a/resources/page/pagegroup.go
+++ b/resources/page/pagegroup.go
@@ -205,7 +205,7 @@ func (p Pages) GroupByParam(key string, order ...string) (PagesGroup, error) {
 		}
 	}
 	if !tmp.IsValid() {
-		return nil, errors.New("there is no such param")
+		return nil, nil
 	}
 
 	for _, e := range p {

--- a/resources/page/pagegroup_test.go
+++ b/resources/page/pagegroup_test.go
@@ -142,15 +142,6 @@ func TestGroupByCalledWithEmptyPages(t *testing.T) {
 	}
 }
 
-func TestGroupByParamCalledWithUnavailableKey(t *testing.T) {
-	t.Parallel()
-	pages := preparePageGroupTestPages(t)
-	_, err := pages.GroupByParam("UnavailableKey")
-	if err == nil {
-		t.Errorf("GroupByParam should return an error but didn't")
-	}
-}
-
 func TestReverse(t *testing.T) {
 	t.Parallel()
 	pages := preparePageGroupTestPages(t)
@@ -256,8 +247,8 @@ func TestGroupByParamCalledWithUnavailableParam(t *testing.T) {
 	t.Parallel()
 	pages := preparePageGroupTestPages(t)
 	_, err := pages.GroupByParam("unavailable_param")
-	if err == nil {
-		t.Errorf("GroupByParam should return an error but didn't")
+	if err != nil {
+		t.Errorf("GroupByParam returned an error when it shouldn't")
 	}
 }
 


### PR DESCRIPTION
Closes #12578