### PR TITLE
Rename DefaultPageSize => PagerSize

### DIFF
--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -374,8 +374,8 @@ func (c *Config) CompileConfig(logger loggers.Logger) error {
 
 	// Legacy paginate values.
 	if c.Paginate != 0 {
-		hugo.Deprecate("site config key paginate", "Use paginator.defaultPageSize instead.", "v0.128.0")
-		c.Pagination.DefaultPageSize = c.Paginate
+		hugo.Deprecate("site config key paginate", "Use paginator.pagerSize instead.", "v0.128.0")
+		c.Pagination.PagerSize = c.Paginate
 	}
 
 	if c.PaginatePath != "" {

--- a/config/allconfig/allconfig_integration_test.go
+++ b/config/allconfig/allconfig_integration_test.go
@@ -122,9 +122,9 @@ func TestPaginationConfigOld(t *testing.T) {
 	confDe := b.H.Sites[1].Conf.Pagination()
 
 	b.Assert(confEn.Path, qt.Equals, "page-en")
-	b.Assert(confEn.DefaultPageSize, qt.Equals, 10)
+	b.Assert(confEn.PagerSize, qt.Equals, 10)
 	b.Assert(confDe.Path, qt.Equals, "page-de")
-	b.Assert(confDe.DefaultPageSize, qt.Equals, 20)
+	b.Assert(confDe.PagerSize, qt.Equals, 20)
 }
 
 func TestPaginationConfigNew(t *testing.T) {
@@ -133,7 +133,7 @@ func TestPaginationConfigNew(t *testing.T) {
  [languages.en]
  weight = 1
  [languages.en.pagination]
- defaultPageSize = 20
+ pagerSize = 20
  [languages.de]
  weight = 2
  [languages.de.pagination]
@@ -147,9 +147,9 @@ func TestPaginationConfigNew(t *testing.T) {
 	confDe := b.H.Sites[1].Conf.Pagination()
 
 	b.Assert(confEn.Path, qt.Equals, "page")
-	b.Assert(confEn.DefaultPageSize, qt.Equals, 20)
+	b.Assert(confEn.PagerSize, qt.Equals, 20)
 	b.Assert(confDe.Path, qt.Equals, "page-de")
-	b.Assert(confDe.DefaultPageSize, qt.Equals, 10)
+	b.Assert(confDe.PagerSize, qt.Equals, 10)
 }
 
 func TestPaginationConfigDisableAliases(t *testing.T) {
@@ -158,7 +158,7 @@ func TestPaginationConfigDisableAliases(t *testing.T) {
 disableKinds = ["taxonomy", "term"]
 [pagination]
 disableAliases = true
-defaultPageSize = 2
+pagerSize = 2
 -- layouts/_default/list.html --
 {{ $paginator := .Paginate  site.RegularPages }}
 {{ template "_internal/pagination.html" . }}

--- a/config/allconfig/alldecoders.go
+++ b/config/allconfig/alldecoders.go
@@ -331,8 +331,8 @@ var allDecoderSetups = map[string]decodeWeight{
 		key: "pagination",
 		decode: func(d decodeWeight, p decodeConfig) error {
 			p.c.Pagination = config.Pagination{
-				DefaultPageSize: 10,
-				Path:            "page",
+				PagerSize: 10,
+				Path:      "page",
 			}
 			if p.p.IsSet(d.key) {
 				if err := mapstructure.WeakDecode(p.p.Get(d.key), &p.c.Pagination); err != nil {

--- a/config/commonConfig.go
+++ b/config/commonConfig.go
@@ -413,8 +413,8 @@ func DecodeServer(cfg Provider) (Server, error) {
 
 // Pagination configures the pagination behavior.
 type Pagination struct {
-	//  Default number of elements per page in pagination.
-	DefaultPageSize int
+	//  Default number of elements per pager in pagination.
+	PagerSize int
 
 	// The path element used during pagination.
 	Path string

--- a/resources/page/pagination.go
+++ b/resources/page/pagination.go
@@ -263,7 +263,7 @@ func splitPageGroups(pageGroups PagesGroup, size int) []paginatedElement {
 
 func ResolvePagerSize(conf config.AllProvider, options ...any) (int, error) {
 	if len(options) == 0 {
-		return conf.Pagination().DefaultPageSize, nil
+		return conf.Pagination().PagerSize, nil
 	}
 
 	if len(options) > 1 {

--- a/resources/page/pagination.go
+++ b/resources/page/pagination.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"reflect"
 
+	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/config"
 
 	"github.com/spf13/cast"
@@ -194,7 +195,14 @@ func (p *Paginator) Pagers() pagers {
 }
 
 // PageSize returns the size of each paginator page.
+// Deprecated: Use PagerSize instead.
 func (p *Paginator) PageSize() int {
+	hugo.Deprecate("PageSize", "Use PagerSize instead.", "v0.128.0")
+	return p.size
+}
+
+// PagerSize returns the size of each paginator page.
+func (p *Paginator) PagerSize() int {
 	return p.size
 }
 

--- a/resources/page/pagination_test.go
+++ b/resources/page/pagination_test.go
@@ -114,7 +114,7 @@ func doTestPages(t *testing.T, paginator *Paginator) {
 
 	c.Assert(len(paginatorPages), qt.Equals, 5)
 	c.Assert(paginator.TotalNumberOfElements(), qt.Equals, 21)
-	c.Assert(paginator.PageSize(), qt.Equals, 5)
+	c.Assert(paginator.PagerSize(), qt.Equals, 5)
 	c.Assert(paginator.TotalPages(), qt.Equals, 5)
 
 	first := paginatorPages[0]
@@ -172,7 +172,7 @@ func doTestPagerNoPages(t *testing.T, paginator *Paginator) {
 	c := qt.New(t)
 	c.Assert(len(paginatorPages), qt.Equals, 1)
 	c.Assert(paginator.TotalNumberOfElements(), qt.Equals, 0)
-	c.Assert(paginator.PageSize(), qt.Equals, 5)
+	c.Assert(paginator.PagerSize(), qt.Equals, 5)
 	c.Assert(paginator.TotalPages(), qt.Equals, 0)
 
 	// pageOne should be nothing but the first
@@ -187,7 +187,7 @@ func doTestPagerNoPages(t *testing.T, paginator *Paginator) {
 	c.Assert(pageOne.TotalNumberOfElements(), qt.Equals, 0)
 	c.Assert(pageOne.TotalPages(), qt.Equals, 0)
 	c.Assert(pageOne.PageNumber(), qt.Equals, 1)
-	c.Assert(pageOne.PageSize(), qt.Equals, 5)
+	c.Assert(pageOne.PagerSize(), qt.Equals, 5)
 }
 
 func TestProbablyEqualPageLists(t *testing.T) {


### PR DESCRIPTION
This was recently introduced. so no breaking change.

The thing is:

* We do not commonly use the prefix Default* even if it can be overridden in the templates.
* PagerSize makes more sense and is also the term used in the code.
