### PR TITLE
Implement defer

### DIFF
--- a/cache/httpcache/httpcache.go
+++ b/cache/httpcache/httpcache.go
@@ -83,7 +83,6 @@ func (c *Config) Compile() (ConfigCompiled, error) {
 }
 
 // PollConfig holds the configuration for polling remote resources to detect changes in watch mode.
-// TODO1 make sure this enabled only in watch mode.
 type PollConfig struct {
 	// What remote resources to apply this configuration to.
 	For GlobMatcher

--- a/common/collections/stack.go
+++ b/common/collections/stack.go
@@ -65,3 +65,16 @@ func (s *Stack[T]) Drain() []T {
 	s.items = nil
 	return items
 }
+
+func (s *Stack[T]) DrainMatching(predicate func(T) bool) []T {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var items []T
+	for i := len(s.items) - 1; i >= 0; i-- {
+		if predicate(s.items[i]) {
+			items = append(items, s.items[i])
+			s.items = append(s.items[:i], s.items[i+1:]...)
+		}
+	}
+	return items
+}

--- a/common/hugio/hasBytesWriter.go
+++ b/common/hugio/hasBytesWriter.go
@@ -17,15 +17,26 @@ import (
 	"bytes"
 )
 
-// HasBytesWriter is a writer that will set Match to true if the given pattern
-// is found in the stream.
+// HasBytesWriter is a writer will match against a slice of patterns.
 type HasBytesWriter struct {
-	Match   bool
-	Pattern []byte
+	Patterns []*HasBytesPattern
 
 	i    int
 	done bool
 	buff []byte
+}
+
+type HasBytesPattern struct {
+	Match   bool
+	Pattern []byte
+}
+
+func (h *HasBytesWriter) patternLen() int {
+	l := 0
+	for _, p := range h.Patterns {
+		l += len(p.Pattern)
+	}
+	return l
 }
 
 func (h *HasBytesWriter) Write(p []byte) (n int, err error) {
@@ -34,7 +45,7 @@ func (h *HasBytesWriter) Write(p []byte) (n int, err error) {
 	}
 
 	if len(h.buff) == 0 {
-		h.buff = make([]byte, len(h.Pattern)*2)
+		h.buff = make([]byte, h.patternLen()*2)
 	}
 
 	for i := range p {
@@ -46,11 +57,23 @@ func (h *HasBytesWriter) Write(p []byte) (n int, err error) {
 			h.i = len(h.buff) / 2
 		}
 
-		if bytes.Contains(h.buff, h.Pattern) {
-			h.Match = true
-			h.done = true
-			return len(p), nil
+		for _, pp := range h.Patterns {
+			if bytes.Contains(h.buff, pp.Pattern) {
+				pp.Match = true
+				done := true
+				for _, ppp := range h.Patterns {
+					if !ppp.Match {
+						done = false
+						break
+					}
+				}
+				if done {
+					h.done = true
+				}
+				return len(p), nil
+			}
 		}
+
 	}
 
 	return len(p), nil

--- a/common/hugio/hasBytesWriter_test.go
+++ b/common/hugio/hasBytesWriter_test.go
@@ -34,8 +34,11 @@ func TestHasBytesWriter(t *testing.T) {
 		var b bytes.Buffer
 
 		h := &HasBytesWriter{
-			Pattern: []byte("__foo"),
+			Patterns: []*HasBytesPattern{
+				{Pattern: []byte("__foo")},
+			},
 		}
+
 		return h, io.MultiWriter(&b, h)
 	}
 
@@ -46,19 +49,19 @@ func TestHasBytesWriter(t *testing.T) {
 	for i := 0; i < 22; i++ {
 		h, w := neww()
 		fmt.Fprintf(w, rndStr()+"abc __foobar"+rndStr())
-		c.Assert(h.Match, qt.Equals, true)
+		c.Assert(h.Patterns[0].Match, qt.Equals, true)
 
 		h, w = neww()
 		fmt.Fprintf(w, rndStr()+"abc __f")
 		fmt.Fprintf(w, "oo bar"+rndStr())
-		c.Assert(h.Match, qt.Equals, true)
+		c.Assert(h.Patterns[0].Match, qt.Equals, true)
 
 		h, w = neww()
 		fmt.Fprintf(w, rndStr()+"abc __moo bar")
-		c.Assert(h.Match, qt.Equals, false)
+		c.Assert(h.Patterns[0].Match, qt.Equals, false)
 	}
 
 	h, w := neww()
 	fmt.Fprintf(w, "__foo")
-	c.Assert(h.Match, qt.Equals, true)
+	c.Assert(h.Patterns[0].Match, qt.Equals, true)
 }

--- a/common/maps/cache.go
+++ b/common/maps/cache.go
@@ -74,6 +74,26 @@ func (c *Cache[K, T]) ForEeach(f func(K, T)) {
 	}
 }
 
+func (c *Cache[K, T]) Drain() map[K]T {
+	c.Lock()
+	m := c.m
+	c.m = make(map[K]T)
+	c.Unlock()
+	return m
+}
+
+func (c *Cache[K, T]) Len() int {
+	c.RLock()
+	defer c.RUnlock()
+	return len(c.m)
+}
+
+func (c *Cache[K, T]) Reset() {
+	c.Lock()
+	c.m = make(map[K]T)
+	c.Unlock()
+}
+
 // SliceCache is a simple thread safe cache backed by a map.
 type SliceCache[T any] struct {
 	m map[string][]T

--- a/common/paths/path.go
+++ b/common/paths/path.go
@@ -237,11 +237,16 @@ func prettifyPath(in string, b filepathPathBridge) string {
 	return b.Join(b.Dir(in), name, "index"+ext)
 }
 
-// CommonDir returns the common directory of the given paths.
-func CommonDir(path1, path2 string) string {
+// CommonDirPath returns the common directory of the given paths.
+func CommonDirPath(path1, path2 string) string {
 	if path1 == "" || path2 == "" {
 		return ""
 	}
+
+	hadLeadingSlash := strings.HasPrefix(path1, "/") || strings.HasPrefix(path2, "/")
+
+	path1 = TrimLeading(path1)
+	path2 = TrimLeading(path2)
 
 	p1 := strings.Split(path1, "/")
 	p2 := strings.Split(path2, "/")
@@ -256,7 +261,13 @@ func CommonDir(path1, path2 string) string {
 		}
 	}
 
-	return strings.Join(common, "/")
+	s := strings.Join(common, "/")
+
+	if hadLeadingSlash && s != "" {
+		s = "/" + s
+	}
+
+	return s
 }
 
 // Sanitize sanitizes string to be used in Hugo's file paths and URLs, allowing only
@@ -384,16 +395,36 @@ func PathEscape(pth string) string {
 
 // ToSlashTrimLeading is just a filepath.ToSlash with an added / prefix trimmer.
 func ToSlashTrimLeading(s string) string {
-	return strings.TrimPrefix(filepath.ToSlash(s), "/")
+	return TrimLeading(filepath.ToSlash(s))
+}
+
+// TrimLeading trims the leading slash from the given string.
+func TrimLeading(s string) string {
+	return strings.TrimPrefix(s, "/")
 }
 
 // ToSlashTrimTrailing is just a filepath.ToSlash with an added / suffix trimmer.
 func ToSlashTrimTrailing(s string) string {
-	return strings.TrimSuffix(filepath.ToSlash(s), "/")
+	return TrimTrailing(filepath.ToSlash(s))
+}
+
+// TrimTrailing trims the trailing slash from the given string.
+func TrimTrailing(s string) string {
+	return strings.TrimSuffix(s, "/")
+}
+
+// ToSlashTrim trims any leading and trailing slashes from the given string and converts it to a forward slash separated path.
+func ToSlashTrim(s string) string {
+	return strings.Trim(filepath.ToSlash(s), "/")
 }
 
 // ToSlashPreserveLeading converts the path given to a forward slash separated path
 // and preserves the leading slash if present trimming any trailing slash.
 func ToSlashPreserveLeading(s string) string {
 	return "/" + strings.Trim(filepath.ToSlash(s), "/")
+}
+
+// IsSameFilePath checks if s1 and s2 are the same file path.
+func IsSameFilePath(s1, s2 string) bool {
+	return path.Clean(ToSlashTrim(s1)) == path.Clean(ToSlashTrim(s2))
 }

--- a/common/paths/path_test.go
+++ b/common/paths/path_test.go
@@ -262,3 +262,52 @@ func TestFieldsSlash(t *testing.T) {
 	c.Assert(FieldsSlash("/"), qt.DeepEquals, []string{})
 	c.Assert(FieldsSlash(""), qt.DeepEquals, []string{})
 }
+
+func TestCommonDirPath(t *testing.T) {
+	c := qt.New(t)
+
+	for _, this := range []struct {
+		a, b, expected string
+	}{
+		{"/a/b/c", "/a/b/d", "/a/b"},
+		{"/a/b/c", "a/b/d", "/a/b"},
+		{"a/b/c", "/a/b/d", "/a/b"},
+		{"a/b/c", "a/b/d", "a/b"},
+		{"/a/b/c", "/a/b/c", "/a/b/c"},
+		{"/a/b/c", "/a/b/c/d", "/a/b/c"},
+		{"/a/b/c", "/a/b", "/a/b"},
+		{"/a/b/c", "/a", "/a"},
+		{"/a/b/c", "/d/e/f", ""},
+	} {
+		c.Assert(CommonDirPath(this.a, this.b), qt.Equals, this.expected, qt.Commentf("a: %s b: %s", this.a, this.b))
+	}
+}
+
+func TestIsSameFilePath(t *testing.T) {
+	c := qt.New(t)
+
+	for _, this := range []struct {
+		a, b     string
+		expected bool
+	}{
+		{"/a/b/c", "/a/b/c", true},
+		{"/a/b/c", "/a/b/c/", true},
+		{"/a/b/c", "/a/b/d", false},
+		{"/a/b/c", "/a/b", false},
+		{"/a/b/c", "/a/b/c/d", false},
+		{"/a/b/c", "/a/b/cd", false},
+		{"/a/b/c", "/a/b/cc", false},
+		{"/a/b/c", "/a/b/c/", true},
+		{"/a/b/c", "/a/b/c//", true},
+		{"/a/b/c", "/a/b/c/.", true},
+		{"/a/b/c", "/a/b/c/./", true},
+		{"/a/b/c", "/a/b/c/./.", true},
+		{"/a/b/c", "/a/b/c/././", true},
+		{"/a/b/c", "/a/b/c/././.", true},
+		{"/a/b/c", "/a/b/c/./././", true},
+		{"/a/b/c", "/a/b/c/./././.", true},
+		{"/a/b/c", "/a/b/c/././././", true},
+	} {
+		c.Assert(IsSameFilePath(filepath.FromSlash(this.a), filepath.FromSlash(this.b)), qt.Equals, this.expected, qt.Commentf("a: %s b: %s", this.a, this.b))
+	}
+}

--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -458,6 +458,7 @@ func (l *configLoader) loadModules(configs *Configs) (modules.ModulesConfig, *mo
 	conf := configs.Base
 	workingDir := bcfg.WorkingDir
 	themesDir := bcfg.ThemesDir
+	publishDir := bcfg.PublishDir
 
 	cfg := configs.LoadingInfo.Cfg
 
@@ -492,6 +493,7 @@ func (l *configLoader) loadModules(configs *Configs) (modules.ModulesConfig, *mo
 		HookBeforeFinalize: hook,
 		WorkingDir:         workingDir,
 		ThemesDir:          themesDir,
+		PublishDir:         publishDir,
 		Environment:        l.Environment,
 		CacheDir:           conf.Caches.CacheDirModules(),
 		ModuleConfig:       conf.Module,

--- a/hugofs/rootmapping_fs.go
+++ b/hugofs/rootmapping_fs.go
@@ -323,6 +323,7 @@ type ComponentPath struct {
 	Component string
 	Path      string
 	Lang      string
+	Watch     bool
 }
 
 func (c ComponentPath) ComponentPathJoined() string {
@@ -376,6 +377,7 @@ func (fs *RootMappingFs) ReverseLookupComponent(component, filename string) ([]C
 			Component: first.FromBase,
 			Path:      paths.ToSlashTrimLeading(filename),
 			Lang:      first.Meta.Lang,
+			Watch:     first.Meta.Watch,
 		})
 	}
 

--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -720,7 +720,7 @@ func (b *sourceFilesystemsBuilder) createOverlayFs(
 				ModuleOrdinal: md.ordinal,
 				IsProject:     md.isMainProject,
 				Meta: &hugofs.FileMeta{
-					Watch:           md.Watch(),
+					Watch:           !mount.DisableWatch && md.Watch(),
 					Weight:          mountWeight,
 					InclusionFilter: inclusionFilter,
 				},

--- a/hugolib/hugo_sites_build_errors_test.go
+++ b/hugolib/hugo_sites_build_errors_test.go
@@ -628,3 +628,20 @@ title: "A page"
 
 	b.CreateSites().BuildFail(BuildCfg{})
 }
+
+func TestErrorTemplateRuntime(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+-- layouts/index.html --
+Home.
+{{ .ThisDoesNotExist }}
+ `
+
+	b, err := TestE(t, files)
+
+	b.Assert(err, qt.Not(qt.IsNil))
+	b.Assert(err.Error(), qt.Contains, filepath.FromSlash(`/layouts/index.html:2:3`))
+	b.Assert(err.Error(), qt.Contains, `can't evaluate field ThisDoesNotExist`)
+}

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -62,7 +62,7 @@ import (
 )
 
 func (s *Site) Taxonomies() page.TaxonomyList {
-	s.checkReady()
+	s.CheckReady()
 	s.init.taxonomies.Do(context.Background())
 	return s.taxonomies
 }
@@ -200,12 +200,8 @@ func (s *Site) prepareInits() {
 	})
 }
 
-type siteRenderingContext struct {
-	output.Format
-}
-
 func (s *Site) Menus() navigation.Menus {
-	s.checkReady()
+	s.CheckReady()
 	s.init.menus.Do(context.Background())
 	return s.menus
 }
@@ -810,7 +806,7 @@ func (s *Site) errorCollator(results <-chan error, errs chan<- error) {
 // as possible for existing sites. Most sites will use {{ .Site.GetPage "section" "my/section" }},
 // i.e. 2 arguments, so we test for that.
 func (s *Site) GetPage(ref ...string) (page.Page, error) {
-	s.checkReady()
+	s.CheckReady()
 	p, err := s.s.getPageForRefs(ref...)
 
 	if p == nil {

--- a/hugolib/site_new.go
+++ b/hugolib/site_new.go
@@ -88,10 +88,6 @@ type Site struct {
 	publisher          publisher.Publisher
 	frontmatterHandler pagemeta.FrontMatterHandler
 
-	// We render each site for all the relevant output formats in serial with
-	// this rendering context pointing to the current one.
-	rc *siteRenderingContext
-
 	// The output formats that we need to render this site in. This slice
 	// will be fixed once set.
 	// This will be the union of Site.Pages' outputFormats.
@@ -439,7 +435,7 @@ func (s *Site) Current() page.Site {
 
 // MainSections returns the list of main sections.
 func (s *Site) MainSections() []string {
-	s.checkReady()
+	s.CheckReady()
 	return s.conf.C.MainSections
 }
 
@@ -458,7 +454,7 @@ func (s *Site) BaseURL() string {
 
 // Deprecated: Use .Site.Lastmod instead.
 func (s *Site) LastChange() time.Time {
-	s.checkReady()
+	s.CheckReady()
 	hugo.Deprecate(".Site.LastChange", "Use .Site.Lastmod instead.", "v0.123.0")
 	return s.lastmod
 }
@@ -547,7 +543,7 @@ func (s *Site) ForEeachIdentityByName(name string, f func(identity.Identity) boo
 // Pages returns all pages.
 // This is for the current language only.
 func (s *Site) Pages() page.Pages {
-	s.checkReady()
+	s.CheckReady()
 	return s.pageMap.getPagesInSection(
 		pageMapQueryPagesInSection{
 			pageMapQueryPagesBelowPath: pageMapQueryPagesBelowPath{
@@ -564,7 +560,7 @@ func (s *Site) Pages() page.Pages {
 // RegularPages returns all the regular pages.
 // This is for the current language only.
 func (s *Site) RegularPages() page.Pages {
-	s.checkReady()
+	s.CheckReady()
 	return s.pageMap.getPagesInSection(
 		pageMapQueryPagesInSection{
 			pageMapQueryPagesBelowPath: pageMapQueryPagesBelowPath{
@@ -579,17 +575,17 @@ func (s *Site) RegularPages() page.Pages {
 
 // AllPages returns all pages for all sites.
 func (s *Site) AllPages() page.Pages {
-	s.checkReady()
+	s.CheckReady()
 	return s.h.Pages()
 }
 
 // AllRegularPages returns all regular pages for all sites.
 func (s *Site) AllRegularPages() page.Pages {
-	s.checkReady()
+	s.CheckReady()
 	return s.h.RegularPages()
 }
 
-func (s *Site) checkReady() {
+func (s *Site) CheckReady() {
 	if s.state != siteStateReady {
 		panic("this method cannot be called before the site is fully initialized")
 	}

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -111,7 +111,7 @@ func (s *Site) renderPages(ctx *siteRenderContext) error {
 
 	err := <-errs
 	if err != nil {
-		return fmt.Errorf("failed to render pages: %w", herrors.ImproveIfNilPointer(err))
+		return fmt.Errorf("failed to render pages: %w", herrors.ImproveRenderErr(err))
 	}
 	return nil
 }
@@ -226,7 +226,7 @@ func (s *Site) renderPaginator(p *pageState, templ tpl.Template) error {
 	paginatePath := s.Conf.Pagination().Path
 
 	d := p.targetPathDescriptor
-	f := p.s.rc.Format
+	f := p.outputFormat()
 	d.Type = f
 
 	if p.paginator.current == nil || p.paginator.current != p.paginator.current.First() {

--- a/hugolib/site_sections.go
+++ b/hugolib/site_sections.go
@@ -19,12 +19,12 @@ import (
 
 // Sections returns the top level sections.
 func (s *Site) Sections() page.Pages {
-	s.checkReady()
+	s.CheckReady()
 	return s.Home().Sections()
 }
 
 // Home is a shortcut to the home page, equivalent to .Site.GetPage "home".
 func (s *Site) Home() page.Page {
-	s.checkReady()
+	s.CheckReady()
 	return s.s.home
 }

--- a/modules/client.go
+++ b/modules/client.go
@@ -760,6 +760,9 @@ type ClientConfig struct {
 	// Absolute path to the project's themes dir.
 	ThemesDir string
 
+	// The publish dir.
+	PublishDir string
+
 	// Eg. "production"
 	Environment string
 

--- a/modules/client_test.go
+++ b/modules/client_test.go
@@ -51,12 +51,16 @@ github.com/gohugoio/hugoTestModules1_darwin/modh2_2@v1.4.0 github.com/gohugoio/h
 		themesDir := filepath.Join(workingDir, "themes")
 		err = os.Mkdir(themesDir, 0o777)
 		c.Assert(err, qt.IsNil)
+		publishDir := filepath.Join(workingDir, "public")
+		err = os.Mkdir(publishDir, 0o777)
+		c.Assert(err, qt.IsNil)
 
 		ccfg := ClientConfig{
 			Fs:         hugofs.Os,
-			WorkingDir: workingDir,
 			CacheDir:   filepath.Join(workingDir, "modcache"),
+			WorkingDir: workingDir,
 			ThemesDir:  themesDir,
+			PublishDir: publishDir,
 			Exec:       hexec.New(security.DefaultConfig),
 		}
 

--- a/modules/config.go
+++ b/modules/config.go
@@ -402,6 +402,9 @@ type Mount struct {
 
 	// Exclude all files matching the given Glob patterns (string or slice).
 	ExcludeFiles any
+
+	// Disable watching in watch mode for this mount.
+	DisableWatch bool
 }
 
 // Used as key to remove duplicates.

--- a/resources/page/site.go
+++ b/resources/page/site.go
@@ -134,6 +134,12 @@ type Site interface {
 
 	// Deprecated: Use .Site.Home.OutputFormats.Get "rss" instead.
 	RSSLink() template.URL
+
+	// For internal use only.
+	// This will panic if the site is not fully initialized.
+	// This is typically used to inform the user in the content adapter templates,
+	// as these are executed before all the page collections etc. are ready to use.
+	CheckReady()
 }
 
 // Sites represents an ordered list of sites (languages).
@@ -326,6 +332,11 @@ func (s *siteWrapper) ForEeachIdentityByName(name string, f func(identity.Identi
 	s.s.(identity.ForEeachIdentityByNameProvider).ForEeachIdentityByName(name, f)
 }
 
+// For internal use only.
+func (s *siteWrapper) CheckReady() {
+	s.s.CheckReady()
+}
+
 type testSite struct {
 	h hugo.HugoInfo
 	l *langs.Language
@@ -478,6 +489,9 @@ func (s testSite) Param(key any) (any, error) {
 // Deprecated: Use .Site.Home.OutputFormats.Get "rss" instead.
 func (s testSite) RSSLink() template.URL {
 	return ""
+}
+
+func (s testSite) CheckReady() {
 }
 
 // NewDummyHugoSite creates a new minimal test site.

--- a/tpl/templates/defer_integration_test.go
+++ b/tpl/templates/defer_integration_test.go
@@ -1,0 +1,202 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/gohugoio/hugo/hugolib"
+)
+
+const deferFilesCommon = `
+-- hugo.toml --
+disableLiveReload = true
+disableKinds = ["taxonomy", "term", "rss", "sitemap", "robotsTXT", "404", "section"]
+[languages]
+[languages.en]
+weight = 1
+[languages.nn]
+weight = 2
+-- i18n/en.toml --
+[hello]
+other = "Hello"
+-- i18n/nn.toml --
+[hello]
+other = "Hei"
+-- content/_index.en.md --
+---
+title: "Home"
+outputs: ["html", "amp"]
+---
+-- content/_index.nn.md --
+---
+title: "Heim"
+outputs: ["html", "amp"]
+---
+-- assets/mytext.txt --
+Hello.
+-- layouts/baseof.html --
+HTML|{{ block "main" . }}{{ end }}$
+-- layouts/index.html --
+{{ define "main" }}
+EDIT_COUNTER_OUTSIDE_0
+{{ .Store.Set "hello" "Hello" }}
+{{ $data := dict "page" . }}
+{{ with (templates.Defer (dict "data" $data) ) }}
+{{ $mytext := resources.Get "mytext.txt" }}
+REPLACE_ME|Title: {{ .page.Title }}|{{ .page.RelPermalink }}|Hello: {{ T "hello" }}|Hello Store: {{ .page.Store.Get "hello" }}|Mytext: {{ $mytext.Content }}|
+EDIT_COUNTER_DEFER_0
+{{ end }}$
+{{ end }}
+-- layouts/index.amp.html --
+AMP.
+{{ $data := dict "page" . }}
+{{ with (templates.Defer (dict "data" $data) ) }}Title AMP: {{ .page.Title }}|{{ .page.RelPermalink }}|Hello: {{ T "hello" }}{{ end }}$
+
+`
+
+func TestDeferBasic(t *testing.T) {
+	t.Parallel()
+
+	b := hugolib.Test(t, deferFilesCommon)
+
+	b.AssertFileContent("public/index.html", "Title: Home|/|Hello: Hello|Hello Store: Hello|Mytext: Hello.|")
+	b.AssertFileContent("public/amp/index.html", "Title AMP: Home|/amp/|Hello: Hello")
+	b.AssertFileContent("public/nn/index.html", "Title: Heim|/nn/|Hello: Hei")
+	b.AssertFileContent("public/nn/amp/index.html", "Title AMP: Heim|/nn/amp/|Hello: Hei")
+}
+
+func TestDeferRepeatedBuildsEditOutside(t *testing.T) {
+	t.Parallel()
+
+	b := hugolib.TestRunning(t, deferFilesCommon)
+
+	for i := 0; i < 5; i++ {
+		old := fmt.Sprintf("EDIT_COUNTER_OUTSIDE_%d", i)
+		new := fmt.Sprintf("EDIT_COUNTER_OUTSIDE_%d", i+1)
+		b.EditFileReplaceAll("layouts/index.html", old, new).Build()
+		b.AssertFileContent("public/index.html", new)
+	}
+}
+
+func TestDeferRepeatedBuildsEditDefer(t *testing.T) {
+	t.Parallel()
+
+	b := hugolib.TestRunning(t, deferFilesCommon)
+
+	for i := 0; i < 8; i++ {
+		old := fmt.Sprintf("EDIT_COUNTER_DEFER_%d", i)
+		new := fmt.Sprintf("EDIT_COUNTER_DEFER_%d", i+1)
+		b.EditFileReplaceAll("layouts/index.html", old, new).Build()
+		b.AssertFileContent("public/index.html", new)
+	}
+}
+
+func TestDeferErrorParse(t *testing.T) {
+	t.Parallel()
+
+	b, err := hugolib.TestE(t, strings.ReplaceAll(deferFilesCommon, "Title AMP: {{ .page.Title }}", "{{ .page.Title }"))
+
+	b.Assert(err, qt.Not(qt.IsNil))
+	b.Assert(err.Error(), qt.Contains, `index.amp.html:3: unexpected "}" in operand`)
+}
+
+func TestDeferErrorRuntime(t *testing.T) {
+	t.Parallel()
+
+	b, err := hugolib.TestE(t, strings.ReplaceAll(deferFilesCommon, "Title AMP: {{ .page.Title }}", "{{ .page.Titles }}"))
+
+	b.Assert(err, qt.Not(qt.IsNil))
+	b.Assert(err.Error(), qt.Contains, filepath.FromSlash(`/layouts/index.amp.html:3:57`))
+	b.Assert(err.Error(), qt.Contains, `execute of template failed: template: index.amp.html:3:57: executing at <.page.Titles>: can't evaluate field Titles`)
+}
+
+func TestDeferEditDeferBlock(t *testing.T) {
+	t.Parallel()
+
+	b := hugolib.TestRunning(t, deferFilesCommon)
+	b.AssertRenderCountPage(4)
+	b.EditFileReplaceAll("layouts/index.html", "REPLACE_ME", "Edited.").Build()
+	b.AssertFileContent("public/index.html", "Edited.")
+	b.AssertRenderCountPage(2)
+}
+
+//
+
+func TestDeferEditResourceUsedInDeferBlock(t *testing.T) {
+	t.Parallel()
+
+	b := hugolib.TestRunning(t, deferFilesCommon)
+	b.AssertRenderCountPage(4)
+	b.EditFiles("assets/mytext.txt", "Mytext Hello Edited.").Build()
+	b.AssertFileContent("public/index.html", "Mytext Hello Edited.")
+	b.AssertRenderCountPage(2)
+}
+
+func TestDeferMountPublic(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+[module]
+[[module.mounts]]
+source = "content"
+target = "content"
+[[module.mounts]]
+source = "layouts"
+target = "layouts"
+[[module.mounts]]
+source = 'public'
+target = 'assets/public'
+disableWatch = true
+-- layouts/index.html --
+Home.
+{{ $mydata := dict "v1" "v1value" }}
+{{ $json := resources.FromString "mydata/data.json" ($mydata | jsonify ) }}
+{{ $nop := $json.RelPermalink }}
+{{ with (templates.Defer (dict "key" "foo")) }}
+	  {{ $jsonFilePublic := resources.Get "public/mydata/data.json" }}
+	  {{ with  $jsonFilePublic }}
+      {{ $m := $jsonFilePublic | transform.Unmarshal }}
+	  v1: {{ $m.v1 }}
+	  {{ end }}
+{{ end }}
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/index.html", "v1: v1value")
+}
+
+func TestDeferFromContentAdapterShouldFail(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+-- content/_content.gotmpl --
+{{ with (templates.Defer (dict "key" "foo")) }}
+ Foo.
+{{ end }}
+`
+
+	b, err := hugolib.TestE(t, files)
+
+	b.Assert(err, qt.Not(qt.IsNil))
+	b.Assert(err.Error(), qt.Contains, "error calling Defer: this method cannot be called before the site is fully initialized")
+}

--- a/tpl/templates/init.go
+++ b/tpl/templates/init.go
@@ -39,6 +39,16 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.Defer,
+			nil, // No aliases to keep the AST parsing simple.
+			[][2]string{},
+		)
+
+		ns.AddMethodMapping(ctx.DoDefer,
+			[]string{"doDefer"},
+			[][2]string{},
+		)
+
 		return ns
 	}
 

--- a/tpl/templates/templates.go
+++ b/tpl/templates/templates.go
@@ -15,14 +15,24 @@
 package templates
 
 import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync/atomic"
+
 	"github.com/gohugoio/hugo/deps"
+	"github.com/gohugoio/hugo/helpers"
+	"github.com/gohugoio/hugo/tpl"
+	"github.com/mitchellh/mapstructure"
 )
 
 // New returns a new instance of the templates-namespaced template functions.
 func New(deps *deps.Deps) *Namespace {
-	return &Namespace{
+	ns := &Namespace{
 		deps: deps,
 	}
+
+	return ns
 }
 
 // Namespace provides template functions for the "templates" namespace.
@@ -35,4 +45,60 @@ type Namespace struct {
 // e.g. partials/header.html
 func (ns *Namespace) Exists(name string) bool {
 	return ns.deps.Tmpl().HasTemplate(name)
+}
+
+// Defer defers the execution of a template block.
+func (ns *Namespace) Defer(args ...any) (bool, error) {
+	// Prevent defer from being used in content adapters,
+	// that just doesn't work.
+	ns.deps.Site.CheckReady()
+
+	if len(args) != 0 {
+		return false, fmt.Errorf("Defer does not take any arguments")
+	}
+	return true, nil
+}
+
+var defferedIDCounter atomic.Uint64
+
+type DeferOpts struct {
+	// Optional cache key. If set, the deferred block will be executed
+	// once per unique key.
+	Key string
+
+	// Optional data context to use when executing the deferred block.
+	Data any
+}
+
+// DoDefer defers the execution of a template block.
+// For internal use only.
+func (ns *Namespace) DoDefer(ctx context.Context, id string, optsv any) string {
+	var opts DeferOpts
+	if optsv != nil {
+		if err := mapstructure.WeakDecode(optsv, &opts); err != nil {
+			panic(err)
+		}
+	}
+
+	templateName := id
+	var key string
+	if opts.Key != "" {
+		key = helpers.MD5String(opts.Key)
+	} else {
+		key = strconv.FormatUint(defferedIDCounter.Add(1), 10)
+	}
+
+	id = fmt.Sprintf("%s_%s%s", id, key, tpl.HugoDeferredTemplateSuffix)
+
+	_ = ns.deps.BuildState.DeferredExecutions.Executions.GetOrCreate(id,
+		func() *tpl.DeferredExecution {
+			return &tpl.DeferredExecution{
+				TemplateName: templateName,
+				Ctx:          ctx,
+				Data:         opts.Data,
+				Executed:     false,
+			}
+		})
+
+	return id
 }

--- a/tpl/tplimpl/template_ast_transformers.go
+++ b/tpl/tplimpl/template_ast_transformers.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/gohugoio/hugo/helpers"
 	htmltemplate "github.com/gohugoio/hugo/tpl/internal/go_templates/htmltemplate"
 	texttemplate "github.com/gohugoio/hugo/tpl/internal/go_templates/texttemplate"
 
@@ -38,6 +39,7 @@ const (
 type templateContext struct {
 	visited          map[string]bool
 	templateNotFound map[string]bool
+	deferNodes       map[string]*parse.ListNode
 	lookupFn         func(name string) *templateState
 
 	// The last error encountered.
@@ -77,6 +79,7 @@ func newTemplateContext(
 		lookupFn:         lookupFn,
 		visited:          make(map[string]bool),
 		templateNotFound: make(map[string]bool),
+		deferNodes:       make(map[string]*parse.ListNode),
 	}
 }
 
@@ -116,9 +119,14 @@ const (
 	// "range" over a one-element slice so we can shift dot to the
 	// partial's argument, Arg, while allowing Arg to be falsy.
 	partialReturnWrapperTempl = `{{ $_hugo_dot := $ }}{{ $ := .Arg }}{{ range (slice .Arg) }}{{ $_hugo_dot.Set ("PLACEHOLDER") }}{{ end }}`
+
+	doDeferTempl = `{{ doDefer ("PLACEHOLDER1") ("PLACEHOLDER2") }}`
 )
 
-var partialReturnWrapper *parse.ListNode
+var (
+	partialReturnWrapper *parse.ListNode
+	doDefer              *parse.ListNode
+)
 
 func init() {
 	templ, err := texttemplate.New("").Parse(partialReturnWrapperTempl)
@@ -126,6 +134,12 @@ func init() {
 		panic(err)
 	}
 	partialReturnWrapper = templ.Tree.Root
+
+	templ, err = texttemplate.New("").Funcs(texttemplate.FuncMap{"doDefer": func(string, string) string { return "" }}).Parse(doDeferTempl)
+	if err != nil {
+		panic(err)
+	}
+	doDefer = templ.Tree.Root
 }
 
 // wrapInPartialReturnWrapper copies and modifies the parsed nodes of a
@@ -158,6 +172,7 @@ func (c *templateContext) applyTransformations(n parse.Node) (bool, error) {
 	case *parse.IfNode:
 		c.applyTransformationsToNodes(x.Pipe, x.List, x.ElseList)
 	case *parse.WithNode:
+		c.handleDefer(x)
 		c.applyTransformationsToNodes(x.Pipe, x.List, x.ElseList)
 	case *parse.RangeNode:
 		c.applyTransformationsToNodes(x.Pipe, x.List, x.ElseList)
@@ -189,6 +204,58 @@ func (c *templateContext) applyTransformations(n parse.Node) (bool, error) {
 	}
 
 	return true, c.err
+}
+
+func (c *templateContext) handleDefer(withNode *parse.WithNode) {
+	if len(withNode.Pipe.Cmds) != 1 {
+		return
+	}
+	cmd := withNode.Pipe.Cmds[0]
+	if len(cmd.Args) != 1 {
+		return
+	}
+	idArg := cmd.Args[0]
+
+	p, ok := idArg.(*parse.PipeNode)
+	if !ok {
+		return
+	}
+
+	if len(p.Cmds) != 1 {
+		return
+	}
+
+	cmd = p.Cmds[0]
+
+	if len(cmd.Args) != 2 {
+		return
+	}
+
+	idArg = cmd.Args[0]
+
+	id, ok := idArg.(*parse.ChainNode)
+	if !ok || len(id.Field) != 1 || id.Field[0] != "Defer" {
+		return
+	}
+	if id2, ok := id.Node.(*parse.IdentifierNode); !ok || id2.Ident != "templates" {
+		return
+	}
+
+	deferArg := cmd.Args[1]
+	cmd.Args = []parse.Node{idArg}
+
+	l := doDefer.CopyList()
+	n := l.Nodes[0].(*parse.ActionNode)
+
+	inner := withNode.List.CopyList()
+	innerHash := helpers.MD5String(inner.String())
+	deferredID := tpl.HugoDeferredTemplatePrefix + innerHash
+
+	c.deferNodes[deferredID] = inner
+	withNode.List = l
+
+	n.Pipe.Cmds[0].Args[1].(*parse.PipeNode).Cmds[0].Args[0].(*parse.StringNode).Text = deferredID
+	n.Pipe.Cmds[0].Args[2] = deferArg
 }
 
 func (c *templateContext) applyTransformationsToNodes(nodes ...parse.Node) {

--- a/tpl/tplimpl/template_ast_transformers_test.go
+++ b/tpl/tplimpl/template_ast_transformers_test.go
@@ -47,7 +47,7 @@ func TestTransformRecursiveTemplate(t *testing.T) {
 }
 
 func newTestTemplate(templ tpl.Template) *templateState {
-	return newTemplateState(
+	return newTemplateState(nil,
 		templ,
 		templateInfo{
 			name: templ.Name(),


### PR DESCRIPTION
Closes #8086

My motivation for taking on this now is that I want to try to support [JS code splitting](https://esbuild.github.io/api/#splitting), and that would need some more powerful "post build" synchronization than what we have today. This PR would eventually, I guess, replace `resources.PostProcess`. This PR needs more testing/polishing, but on the technical level this is simpler and without the many restrictions of `resources.PostProcess`.

A typical use case for `resources.PostProcess` is TailwindCSS where we need to know the CSS classes etc. in use before we can build the CSS. 

Written using the new `defer` keyword, the TailwindCSS setup could look something like this:

```handlebars
 {{ with (templates.Defer (dict "key" "styles" "data" "foo")) }}
      {{ $options := dict "inlineImports" true }}
      {{ $styles := resources.Get "css/styles.css" }}
      {{ $styles = $styles | resources.PostCSS $options }}
      {{ if hugo.IsProduction }}
        {{ $styles = $styles | minify | fingerprint }}
      {{ end }}
      <link href="{{ $styles.RelPermalink }}" rel="stylesheet" />
 {{ end }}
```
* `defer` only works with `with`
* It takes an option map as its argument. Options:
    * `key`: This is optional and can be thought about as being part of the cache key. In the example above, the `defer` block will be executed exactly once and then reused.
    * `data`: This becomes the "dot" in the `defer` block.

Note that variables defined on the outside are not visible on the inside and vice versa. Any data must be passed in the `data` option, e.g.:

```handlebars
{{ $data := dict "page" . }}
{{ with (defer (dict "data" $data)) }}
   Page: {{ .page.Title }}
{{ end }}
```


