### PR TITLE
resources: Update Dart Sass error message

### DIFF
--- a/resources/resource_transformers/tocss/dartsass/transform.go
+++ b/resources/resource_transformers/tocss/dartsass/transform.go
@@ -39,7 +39,7 @@ import (
 	"github.com/bep/godartsass/v2"
 )
 
-// Supports returns whether dart-sass-embedded is found in $PATH.
+// Supports returns whether sass, dart-sass, or dart-sass-embedded is found in $PATH.
 func Supports() bool {
 	if htesting.SupportsAll() {
 		return true

--- a/resources/transform.go
+++ b/resources/transform.go
@@ -493,7 +493,7 @@ func (r *resourceAdapter) transform(key string, publish, setContent bool) (*reso
 				} else if tr.Key().Name == "tocss" {
 					errMsg = ". Check your Hugo installation; you need the extended version to build SCSS/SASS with transpiler set to 'libsass'."
 				} else if tr.Key().Name == "tocss-dart" {
-					errMsg = ". You need dart-sass-embedded in your system $PATH."
+					errMsg = ". You need to install Dart Sass, see https://gohugo.io/functions/resources/tocss/#dart-sass"
 				} else if tr.Key().Name == "babel" {
 					errMsg = ". You need to install Babel, see https://gohugo.io/hugo-pipes/babel/"
 				}


### PR DESCRIPTION
The migration from Embedded Dart Sass to Sass began a little over a year ago. This updates the "not installed" error message to reflect that change.