### PR TITLE
markup/goldmark: Add the Hugo Goldmark Extras "delete" extension

### DIFF
--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -1082,6 +1082,8 @@ config:
           escapedSpace: false
         definitionList: true
         extras:
+          delete:
+            enable: false
           insert:
             enable: false
           mark:
@@ -1589,8 +1591,8 @@ config:
   paginate: 0
   paginatePath: ""
   pagination:
-    defaultPageSize: 10
     disableAliases: false
+    pagerSize: 10
     path: page
   panicOnWarning: false
   params: {}

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gohugoio/go-i18n/v2 v2.1.3-0.20230805085216-e63c13218d0e
 	github.com/gohugoio/httpcache v0.7.0
-	github.com/gohugoio/hugo-goldmark-extensions/extras v0.1.0
+	github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0
 	github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.2.0
 	github.com/gohugoio/locales v0.14.0
 	github.com/gohugoio/localescompressed v1.0.1
@@ -68,7 +68,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tdewolff/minify/v2 v2.20.20
 	github.com/tdewolff/parse/v2 v2.7.13
-	github.com/yuin/goldmark v1.7.1
+	github.com/yuin/goldmark v1.7.2
 	github.com/yuin/goldmark-emoji v1.0.2
 	go.uber.org/automaxprocs v1.5.3
 	gocloud.dev v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/gohugoio/go-i18n/v2 v2.1.3-0.20230805085216-e63c13218d0e h1:QArsSubW7
 github.com/gohugoio/go-i18n/v2 v2.1.3-0.20230805085216-e63c13218d0e/go.mod h1:3Ltoo9Banwq0gOtcOwxuHG6omk+AwsQPADyw2vQYOJQ=
 github.com/gohugoio/httpcache v0.7.0 h1:ukPnn04Rgvx48JIinZvZetBfHaWE7I01JR2Q2RrQ3Vs=
 github.com/gohugoio/httpcache v0.7.0/go.mod h1:fMlPrdY/vVJhAriLZnrF5QpN3BNAcoBClgAyQd+lGFI=
-github.com/gohugoio/hugo-goldmark-extensions/extras v0.1.0 h1:YhxZNU8y2vxV6Ibr7QJzzUlpr8oHHWX/l+Q1R/a5Zao=
-github.com/gohugoio/hugo-goldmark-extensions/extras v0.1.0/go.mod h1:0cuvOnGKW7WeXA3i7qK6IS07FH1bgJ2XzOjQ7BMJYH4=
+github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0 h1:MNdY6hYCTQEekY0oAfsxWZU1CDt6iH+tMLgyMJQh/sg=
+github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0/go.mod h1:oBdBVuiZ0fv9xd8xflUgt53QxW5jOCb1S+xntcN4SKo=
 github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.2.0 h1:PCtO5l++psZf48yen2LxQ3JiOXxaRC6v0594NeHvGZg=
 github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.2.0/go.mod h1:g9CCh+Ci2IMbPUrVJuXbBTrA+rIIx5+hDQ4EXYaQDoM=
 github.com/gohugoio/locales v0.14.0 h1:Q0gpsZwfv7ATHMbcTNepFd59H7GoykzWJIxi113XGDc=
@@ -447,8 +447,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.3.7/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuin/goldmark v1.7.1 h1:3bajkSilaCbjdKVsKdZjZCLBNPL9pYzrCakKaf4U49U=
-github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
+github.com/yuin/goldmark v1.7.2 h1:NjGd7lO7zrUn/A7eKwn5PEOt4ONYGqpxSEeZuduvgxc=
+github.com/yuin/goldmark v1.7.2/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
 github.com/yuin/goldmark-emoji v1.0.2 h1:c/RgTShNgHTtc6xdz2KKI74jJr6rWi7FPgnP9GAsO5s=
 github.com/yuin/goldmark-emoji v1.0.2/go.mod h1:RhP/RWpexdp+KHs7ghKnifRoIs/Bq4nDS7tRbCkOwKY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/markup/goldmark/convert.go
+++ b/markup/goldmark/convert.go
@@ -116,6 +116,7 @@ func newMarkdown(pcfg converter.ProviderConfig) goldmark.Markdown {
 
 	extensions = append(extensions, extras.New(
 		extras.Config{
+			Delete:      extras.DeleteConfig{Enable: cfg.Extensions.Extras.Delete.Enable},
 			Insert:      extras.InsertConfig{Enable: cfg.Extensions.Extras.Insert.Enable},
 			Mark:        extras.MarkConfig{Enable: cfg.Extensions.Extras.Mark.Enable},
 			Subscript:   extras.SubscriptConfig{Enable: cfg.Extensions.Extras.Subscript.Enable},

--- a/markup/goldmark/goldmark_config/config.go
+++ b/markup/goldmark/goldmark_config/config.go
@@ -50,16 +50,19 @@ var Default = Config{
 			EscapedSpace:             false,
 		},
 		Extras: Extras{
-			Superscript: Superscript{
-				Enable: false,
-			},
-			Subscript: Subscript{
+			Delete: Delete{
 				Enable: false,
 			},
 			Insert: Insert{
 				Enable: false,
 			},
 			Mark: Mark{
+				Enable: false,
+			},
+			Subscript: Subscript{
+				Enable: false,
+			},
+			Superscript: Superscript{
 				Enable: false,
 			},
 		},
@@ -168,10 +171,15 @@ type Typographer struct {
 // Extras holds extras configuration.
 // github.com/hugoio/hugo-goldmark-extensions/extras
 type Extras struct {
+	Delete      Delete
 	Insert      Insert
 	Mark        Mark
 	Subscript   Subscript
 	Superscript Superscript
+}
+
+type Delete struct {
+	Enable bool
 }
 
 type Insert struct {

--- a/markup/goldmark/goldmark_integration_test.go
+++ b/markup/goldmark/goldmark_integration_test.go
@@ -751,6 +751,10 @@ func TestExtrasExtension(t *testing.T) {
 	files := `
 -- hugo.toml --
 disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+[markup.goldmark.extensions]
+strikethrough = false
+[markup.goldmark.extensions.extras.delete]
+enable = false
 [markup.goldmark.extensions.extras.insert]
 enable = false
 [markup.goldmark.extensions.extras.mark]
@@ -765,6 +769,8 @@ enable = false
 ---
 title: home
 ---
+~~delete~~
+
 ++insert++
 
 ==mark==
@@ -777,6 +783,7 @@ H~2~0
 	b := hugolib.Test(t, files)
 
 	b.AssertFileContent("public/index.html",
+		"<p>~~delete~~</p>",
 		"<p>++insert++</p>",
 		"<p>==mark==</p>",
 		"<p>H~2~0</p>",
@@ -788,6 +795,7 @@ H~2~0
 	b = hugolib.Test(t, files)
 
 	b.AssertFileContent("public/index.html",
+		"<p><del>delete</del></p>",
 		"<p><ins>insert</ins></p>",
 		"<p><mark>mark</mark></p>",
 		"<p>H<sub>2</sub>0</p>",


### PR DESCRIPTION
With Goldmark v1.7.1 and earlier, the Goldmark "strikethrough" extension was triggered by wrapping text within a pair of double-tilde characters. With Goldmark v1.7.2 and later, to provide full GFM compatibility, the Goldmark "strikethrough" extension is triggered by wrapping text within a pair of single- or double-tilde characters.

This change created a conflict with the Hugo Goldmark Extras "subscript" extension.

When enabling the Hugo Goldmark Extras "subscript" extension, if you want to render subscript and strikethrough text concurrently, you must:

1. Disable the Goldmark "strikethrough" extension
2. Enable the Hugo Goldmark Extras "delete" extension

Closes #12597