### PR TITLE
deploy: Add stripIndexHtml target option

### DIFF
--- a/deploy/deployconfig/deployConfig.go
+++ b/deploy/deployconfig/deployConfig.go
@@ -69,6 +69,11 @@ type Target struct {
 	// Parsed versions of Include/Exclude.
 	IncludeGlob glob.Glob `json:"-"`
 	ExcludeGlob glob.Glob `json:"-"`
+
+	// If true, any local path matching <dir>/index.html will be mapped to the
+	// remote path <dir>/. This does not affect the top-level index.html file,
+	// since that would result in an empty path.
+	StripIndexHTML bool
 }
 
 func (tgt *Target) ParseIncludeExclude() error {

--- a/docs/content/en/hosting-and-deployment/hugo-deploy.md
+++ b/docs/content/en/hosting-and-deployment/hugo-deploy.md
@@ -186,6 +186,15 @@ URL = "<FILL ME IN>"
 #include = "**.html" # would only include files with ".html" suffix
 #exclude = "**.{jpg, png}" # would exclude files with ".jpg" or ".png" suffix
 
+# Map any file named "<dir>/index.html" to the remote file "<dir>/". This does
+# not affect the root "index.html" file, and it does not affect matchers below.
+# This works when deploying to key-value cloud storage systems, such as Amazon
+# S3 (general purpose buckets, not directory buckets), Google Cloud Storage, and
+# Azure Blob Storage. This makes it so the canonical URL will match the object
+# key in cloud storage, except for the root index.html file.
+#
+#stripIndexHTML = true
+
 
 #######################
 [[deployment.matchers]] 
@@ -195,6 +204,7 @@ URL = "<FILL ME IN>"
 
 # See https://golang.org/pkg/regexp/syntax/ for pattern syntax.
 # Pattern searching is stopped on first match.
+# This is not affected by stripIndexHTML, above.
 pattern = "<FILL ME IN>"
 
 # If true, Hugo will gzip the file before uploading it to the bucket.


### PR DESCRIPTION
This new configuration parameter causes paths matching "<dir>/index.html" to be stored as "<dir>/" remotely. This simplifies the cloud configuration needed for some use cases, such as CloudFront distributions with S3 bucket origins. Before this change, users must configure their S3 buckets as public websites (which is incompatible with certain authentication / authorization schemes), or users must add a CloudFormation function to add index.html to the end of incoming requests. After this change, users can simply use an ordinary CloudFront distribution (no additional code) with an ordinary S3 bucket origin (and not an S3 website).

This adds tests to ensure that functionality like matchers is unaffected by this change. I have also tested that the functionality works as expected when deploying to a real S3 / CloudFront website.

Closes #12607