### PR TITLE
tests: Refine test cases for BenchmarkTaxonomiesGetTerms

### DIFF
--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -986,19 +986,8 @@ GetTerms.tags: {{ range .GetTerms "tags" }}{{ .Title }}|{{ end }}
 -- content/_index.md --
 `
 
-		tagsVariants := []string{
-			"tags: ['a']",
-			"tags: ['a', 'b']",
-			"tags: ['a', 'b', 'c']",
-			"tags: ['a', 'b', 'c', 'd']",
-			"tags: ['a', 'b',  'd', 'e']",
-			"tags: ['a', 'b', 'c', 'd', 'e']",
-			"tags: ['a', 'd']",
-			"tags: ['a',  'f']",
-		}
-
 		for i := 1; i < numPages; i++ {
-			tags := tagsVariants[i%len(tagsVariants)]
+			tags := fmt.Sprintf("tags: ['a', 'b%d', 'c%d']", i+1, i+1)
 			files += fmt.Sprintf("\n-- content/posts/p%d.md --\n---\n%s\n---", i+1, tags)
 		}
 		cfg := IntegrationTestConfig{


### PR DESCRIPTION
The tag terms on PR #12611 seems too small (`[a,b,c,d,e,f]`), this PR will create a large number of tags to cover more situations. However I just modified the test cases, since I don't have much ability/knowledge to improve it.

The result of benchmark on my laptop as follows.

```text
Running tool: /usr/bin/go test -benchmem -run=^$ -bench ^BenchmarkTaxonomiesGetTerms$ github.com/gohugoio/hugo/hugolib

goos: linux
goarch: amd64
pkg: github.com/gohugoio/hugo/hugolib
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
BenchmarkTaxonomiesGetTerms/pages_100-16         	     100	  10308688 ns/op	 6421780 B/op	   73897 allocs/op
BenchmarkTaxonomiesGetTerms/pages_1000-16        	       9	 132214460 ns/op	49648174 B/op	  556238 allocs/op
BenchmarkTaxonomiesGetTerms/pages_10000-16       	       1	7714456586 ns/op	476423784 B/op	 5419983 allocs/op
BenchmarkTaxonomiesGetTerms/pages_20000-16       	       1	41908415387 ns/op	951093296 B/op	10836903 allocs/op
PASS
ok  	github.com/gohugoio/hugo/hugolib	55.180s
```

Please close it if I'm understand it wrongly.

