### PR TITLE
Fix it so publishDate rolls up to section, taxonomy, or term pages

### DIFF
--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -1428,7 +1428,7 @@ func (sa *sitePagesAssembler) applyAggregates() error {
 					}
 
 					if wasZeroDates {
-						pageBundle.m.pageConfig.Dates.UpdateDateAndLastmodIfAfter(sp.m.pageConfig.Dates)
+						pageBundle.m.pageConfig.Dates.UpdateDateAndLastmodAndPublishDateIfAfter(sp.m.pageConfig.Dates)
 					}
 
 					if pageBundle.IsHome() {
@@ -1565,7 +1565,7 @@ func (sa *sitePagesAssembler) applyAggregatesToTaxonomiesAndTerms() error {
 							return
 						}
 
-						p.m.pageConfig.Dates.UpdateDateAndLastmodIfAfter(sp.m.pageConfig.Dates)
+						p.m.pageConfig.Dates.UpdateDateAndLastmodAndPublishDateIfAfter(sp.m.pageConfig.Dates)
 					})
 				}
 

--- a/resources/page/pagemeta/page_frontmatter.go
+++ b/resources/page/pagemeta/page_frontmatter.go
@@ -57,12 +57,16 @@ func (d Dates) IsDateOrLastModAfter(in Dates) bool {
 	return d.Date.After(in.Date) || d.Lastmod.After(in.Lastmod)
 }
 
-func (d *Dates) UpdateDateAndLastmodIfAfter(in Dates) {
+func (d *Dates) UpdateDateAndLastmodAndPublishDateIfAfter(in Dates) {
 	if in.Date.After(d.Date) {
 		d.Date = in.Date
 	}
 	if in.Lastmod.After(d.Lastmod) {
 		d.Lastmod = in.Lastmod
+	}
+
+	if in.PublishDate.After(d.PublishDate) && in.PublishDate.Before(htime.Now()) {
+		d.PublishDate = in.PublishDate
 	}
 }
 


### PR DESCRIPTION
Fixes #12438
