### PR TITLE
Fix site.GetPage, never do short lookups for paths with leadig slash

### DIFF
--- a/hugolib/pagecollections.go
+++ b/hugolib/pagecollections.go
@@ -110,11 +110,6 @@ func (c *pageFinder) getPageForRefs(ref ...string) (page.Page, error) {
 		key = refs[1]
 	}
 
-	key = filepath.ToSlash(key)
-	if !strings.HasPrefix(key, "/") {
-		key = "/" + key
-	}
-
 	return c.getPage(nil, key)
 }
 
@@ -211,9 +206,7 @@ func (c *pageFinder) getContentNodeForRef(context page.Page, isReflink, hadExten
 	var doSimpleLookup bool
 	if isReflink || context == nil {
 		slashCount := strings.Count(inRef, "/")
-		if slashCount <= 1 {
-			doSimpleLookup = slashCount == 0 || ref[0] == '/'
-		}
+		doSimpleLookup = slashCount == 0
 	}
 
 	if !doSimpleLookup {

--- a/hugolib/pagecollections_test.go
+++ b/hugolib/pagecollections_test.go
@@ -413,6 +413,35 @@ layout: p2
 	b.AssertFileContent("public/s1/p2/index.html", "p1")
 }
 
+func TestGetPageNewsVsTagsNewsIssue12638(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['rss','section','sitemap']
+[taxonomies]
+  tag = "tags"
+-- content/p1.md --
+---
+title: p1
+tags: [news]
+---
+-- layouts/index.html --
+/tags/news: {{ with .Site.GetPage "/tags/news" }}{{ .Title }}{{ end }}|
+news: {{ with .Site.GetPage "news" }}{{ .Title }}{{ end }}|
+/news: {{ with .Site.GetPage "/news" }}{{ .Title }}{{ end }}|
+
+`
+
+	b := Test(t, files)
+
+	b.AssertFileContent("public/index.html",
+		"/tags/news: News|",
+		"news: News|",
+		"/news: |",
+	)
+}
+
 func TestGetPageBundleToRegular(t *testing.T) {
 	files := `
 -- hugo.toml --


### PR DESCRIPTION
Fixes #12638
