### PR TITLE
collections: Add function to partition page slices

### DIFF
--- a/common/collections/collections.go
+++ b/common/collections/collections.go
@@ -19,3 +19,9 @@ package collections
 type Grouper interface {
 	Group(key any, items any) (any, error)
 }
+
+// Partitioner defines a very generic way to partition sets of items into
+// chunks of given maximal length.
+type Partitioner interface {
+	Partition(n any, items any) (any, error)
+}

--- a/docs/content/en/functions/collections/Partition.md
+++ b/docs/content/en/functions/collections/Partition.md
@@ -1,0 +1,22 @@
+---
+title: collections.Partition
+description: Partitions a slice of pages into a slice of slices of pages with fixed (maximal) length.
+categories: []
+keywords: []
+action:
+  related: []
+  returnType: [][]page.Pages
+  signatures: [collections.Partition N PAGES]
+---
+
+{{< new-in 0.131.0 >}}
+
+A set of 5 pages can be partitioned as show in this example:
+
+```go-html-template
+{{ .Site.RegularPages | collections.Partition 5 }} → [Pages(5)]
+{{ .Site.RegularPages | collections.Partition 4 }} → [Pages(4) Pages(1)]
+{{ .Site.RegularPages | collections.Partition 3 }} → [Pages(3) Pages(2)]
+{{ .Site.RegularPages | collections.Partition 2 }} → [Pages(2) Pages(2) Pages(1)]
+{{ .Site.RegularPages | collections.Partition 1 }} → [Pages(1) Pages(1) Pages(1) Pages(1) Pages(1)]
+```

--- a/docs/content/en/methods/pages/PartitionWith.md
+++ b/docs/content/en/methods/pages/PartitionWith.md
@@ -1,0 +1,42 @@
+---
+title: PartitionWith
+description: Partitions a slice of pages into a slice of slices of pages with fixed (maximal) length.
+categories: []
+keywords: []
+action:
+  related: []
+  returnType: [][]page.Pages
+  signatures: [PAGES.PartitionWith N]
+---
+
+{{< new-in 0.131.0 >}}
+
+This template shows how to partition a set of 5 pages into chunks of some size:
+
+```go-html-template
+{{ $allPages := .Site.RegularPages }}
+
+<p>Number pages: {{ len $allPages }}</p>
+
+<ul>
+  <li>Chunk size: 5 => Partitions: {{ $allPages.PartitionWith 5 }}</li>
+  <li>Chunk size: 4 => Partitions: {{ $allPages.PartitionWith 4 }}</li>
+  <li>Chunk size: 3 => Partitions: {{ $allPages.PartitionWith 3 }}</li>
+  <li>Chunk size: 2 => Partitions: {{ $allPages.PartitionWith 2 }}</li>
+  <li>Chunk size: 1 => Partitions: {{ $allPages.PartitionWith 1 }}</li>
+</ul>
+```
+
+Which generates the following output:
+
+```html
+<p>Number pages: 5</p>
+
+<ul>
+  <li>Chunk size: 5 => Partitions: [Pages(5)]</li>
+  <li>Chunk size: 4 => Partitions: [Pages(4) Pages(1)]</li>
+  <li>Chunk size: 3 => Partitions: [Pages(3) Pages(2)]</li>
+  <li>Chunk size: 2 => Partitions: [Pages(2) Pages(2) Pages(1)]</li>
+  <li>Chunk size: 1 => Partitions: [Pages(1) Pages(1) Pages(1) Pages(1) Pages(1)]</li>
+</ul>
+```

--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -2560,6 +2560,16 @@ tpl:
         - - '{{ $scratch := newScratch }}{{ $scratch.Add "b" 2 }}{{ $scratch.Add "b"
             2 }}{{ $scratch.Get "b" }}'
           - "4"
+      Partition:
+        Aliases:
+        - partition
+        Args:
+        - "n"
+        - items
+        Description: |-
+          Partition splits a set of items into chunks of given maximal length.
+          This is currently only supported for Pages.
+        Examples: []
       Querify:
         Aliases:
         - querify

--- a/resources/page/pagepartition.go
+++ b/resources/page/pagepartition.go
@@ -1,0 +1,64 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package page
+
+import "github.com/spf13/cast"
+
+// PagesPartition is a slice of Pages objects.
+type PagesPartition []Pages
+
+func (p Pages) PartitionWith(n int) (PagesPartition, error) {
+	if len(p) < 1 {
+		return nil, nil
+	}
+	nv, err := cast.ToIntE(n)
+	if err != nil {
+		return nil, err
+	}
+	return p.partition(nv)
+}
+
+func (p Pages) partition(n int) (PagesPartition, error) {
+	if n < 1 {
+		return nil, nil
+	}
+
+	all := len(p)
+	wholes := all / n
+	remainder := all % n
+
+	parts := wholes
+	if remainder > 0 {
+		parts = parts + 1
+	}
+
+	partition := make([]Pages, parts)
+
+	for i := 0; i < wholes; i++ {
+		partition[i] = make([]Page, n)
+		for j := 0; j < n; j++ {
+			partition[i][j] = p[i*n+j]
+		}
+	}
+
+	if remainder > 0 {
+		partition[wholes] = make([]Page, remainder)
+		for j := 0; j < remainder; j++ {
+			partition[wholes][j] = p[wholes*n+j]
+		}
+
+	}
+
+	return partition, nil
+}

--- a/resources/page/pages.go
+++ b/resources/page/pages.go
@@ -20,6 +20,8 @@ import (
 	"github.com/gohugoio/hugo/compare"
 
 	"github.com/gohugoio/hugo/resources/resource"
+
+	"github.com/spf13/cast"
 )
 
 // Pages is a slice of Page objects. This is the most common list type in Hugo.
@@ -100,6 +102,20 @@ func (p Pages) Group(key any, in any) (any, error) {
 // Len returns the number of pages in the list.
 func (p Pages) Len() int {
 	return len(p)
+}
+
+// Partition splits a set of items into sets of given length.
+// This implements collections.Partitioner.
+func (p Pages) Partition(n any, in any) (any, error) {
+	nv, err := cast.ToIntE(n)
+	if err != nil {
+		return nil, err
+	}
+	pages, err := ToPages(in)
+	if err != nil {
+		return Pages{}, err
+	}
+	return pages.partition(nv)
 }
 
 // ProbablyEq wraps compare.ProbablyEqer

--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -432,6 +432,27 @@ func (ns *Namespace) Last(limit any, l any) (any, error) {
 	return seqv.Slice(seqv.Len()-limitv, seqv.Len()).Interface(), nil
 }
 
+// Partition splits a set of items into chunks of given maximal length.
+// This is currently only supported for Pages.
+func (ns *Namespace) Partition(n any, items any) (any, error) {
+	nv, err := cast.ToIntE(n)
+	if err != nil {
+		return nil, err
+	}
+
+	if p, ok := items.(collections.Partitioner); ok {
+		return p.Partition(nv, items)
+	}
+
+	in := newSliceElement(items)
+
+	if p, ok := in.(collections.Partitioner); ok {
+		return p.Partition(nv, items)
+	}
+
+	return nil, fmt.Errorf("partitioning not supported for type %T %T", items, in)
+}
+
 // Querify encodes the given params in URL-encoded form ("bar=baz&foo=quux") sorted by key.
 func (ns *Namespace) Querify(params ...any) (string, error) {
 	qs := url.Values{}

--- a/tpl/collections/init.go
+++ b/tpl/collections/init.go
@@ -170,6 +170,11 @@ func init() {
 			[][2]string{},
 		)
 
+		ns.AddMethodMapping(ctx.Partition,
+			[]string{"partition"},
+			[][2]string{},
+		)
+
 		ns.AddMethodMapping(ctx.Seq,
 			[]string{"seq"},
 			[][2]string{


### PR DESCRIPTION
Another thing I think is missing from the standard palette of template functions: partition a slice (of pages) into a set of equal chunks (plus a possible remainder).

This implements the proposal from issue [#11553](https://github.com/gohugoio/hugo/issues/11553).

Help wanted to discuss the implementation details. I'll also add docs and tests.

