### PR TITLE
Throw error if resources.PostProcess is used in a deferred template

### DIFF
--- a/tpl/templates/defer_integration_test.go
+++ b/tpl/templates/defer_integration_test.go
@@ -200,3 +200,23 @@ func TestDeferFromContentAdapterShouldFail(t *testing.T) {
 	b.Assert(err, qt.Not(qt.IsNil))
 	b.Assert(err.Error(), qt.Contains, "error calling Defer: this method cannot be called before the site is fully initialized")
 }
+
+func TestDeferPostProcessShouldThrowAnError(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+-- assets/mytext.txt --
+ABCD.
+-- layouts/index.html --
+Home
+{{ with (templates.Defer (dict "key" "foo")) }}
+{{ $mytext := resources.Get "mytext.txt" | minify | resources.PostProcess }}
+{{ end }}
+
+`
+	b, err := hugolib.TestE(t, files)
+
+	b.Assert(err, qt.Not(qt.IsNil))
+	b.Assert(err.Error(), qt.Contains, "resources.PostProcess cannot be used in a deferred template")
+}

--- a/tpl/tplimpl/template_ast_transformers.go
+++ b/tpl/tplimpl/template_ast_transformers.go
@@ -16,6 +16,7 @@ package tplimpl
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/gohugoio/hugo/helpers"
 	htmltemplate "github.com/gohugoio/hugo/tpl/internal/go_templates/htmltemplate"
@@ -248,7 +249,12 @@ func (c *templateContext) handleDefer(withNode *parse.WithNode) {
 	n := l.Nodes[0].(*parse.ActionNode)
 
 	inner := withNode.List.CopyList()
-	innerHash := helpers.MD5String(inner.String())
+	s := inner.String()
+	if strings.Contains(s, "resources.PostProcess") {
+		c.err = errors.New("resources.PostProcess cannot be used in a deferred template")
+		return
+	}
+	innerHash := helpers.MD5String(s)
 	deferredID := tpl.HugoDeferredTemplatePrefix + innerHash
 
 	c.deferNodes[deferredID] = inner


### PR DESCRIPTION
That just doesn't work.

See #12655
