### PR TITLE
math: Add exp and log2 / log10 functions

### DIFF
--- a/docs/content/en/functions/math/E.md
+++ b/docs/content/en/functions/math/E.md
@@ -1,0 +1,19 @@
+---
+title: math.E
+description: Returns the mathematical constant e.
+categories: []
+keywords: []
+action:
+  aliases: []
+  related:
+    - functions/math/Exp
+    - functions/math/Log
+  returnType: float64
+  signatures: [math.E]
+---
+
+{{< new-in 0.131.0 >}}
+
+```go-html-template
+{{ math.E }} → 2.718281828459045
+```

--- a/docs/content/en/functions/math/Exp.md
+++ b/docs/content/en/functions/math/Exp.md
@@ -8,6 +8,8 @@ action:
   related:
     - functions/math/E
     - functions/math/Log
+    - functions/math/Log2
+    - functions/math/Log10
   returnType: float64
   signatures: [math.Exp VALUE]
 ---

--- a/docs/content/en/functions/math/Exp.md
+++ b/docs/content/en/functions/math/Exp.md
@@ -1,0 +1,19 @@
+---
+title: math.Exp
+description: Returns the base-e exponential of the given number.
+categories: []
+keywords: []
+action:
+  aliases: []
+  related:
+    - functions/math/E
+    - functions/math/Log
+  returnType: float64
+  signatures: [math.Exp VALUE]
+---
+
+{{< new-in 0.131.0 >}}
+
+```go-html-template
+{{ math.Exp 1 }} → 2.718281828459045
+```

--- a/docs/content/en/functions/math/Log.md
+++ b/docs/content/en/functions/math/Log.md
@@ -5,11 +5,15 @@ categories: []
 keywords: []
 action:
   aliases: []
-  related: []
+  related:
+    - functions/math/Log2
+    - functions/math/Log10
+    - functions/math/E
+    - functions/math/Exp
   returnType: float64
   signatures: [math.Log VALUE]
 ---
 
 ```go-html-template
-{{ math.Log 42 }} → 3.737
+{{ math.Log 2.718281828459045 }} → 1
 ```

--- a/docs/content/en/functions/math/Log10.md
+++ b/docs/content/en/functions/math/Log10.md
@@ -1,21 +1,21 @@
 ---
-title: math.E
-description: Returns the mathematical constant e.
+title: math.Log10
+description: Returns the decimal logarithm of the given number.
 categories: []
 keywords: []
 action:
   aliases: []
   related:
-    - functions/math/Exp
     - functions/math/Log
     - functions/math/Log2
-    - functions/math/Log10
+    - functions/math/E
+    - functions/math/Exp
   returnType: float64
-  signatures: [math.E]
+  signatures: [math.Log10 VALUE]
 ---
 
 {{< new-in 0.131.0 >}}
 
 ```go-html-template
-{{ math.E }} → 2.718281828459045
+{{ math.Log10 100 }} → 2
 ```

--- a/docs/content/en/functions/math/Log2.md
+++ b/docs/content/en/functions/math/Log2.md
@@ -1,21 +1,21 @@
 ---
-title: math.E
-description: Returns the mathematical constant e.
+title: math.Log2
+description: Returns the binary logarithm of the given number.
 categories: []
 keywords: []
 action:
   aliases: []
   related:
-    - functions/math/Exp
     - functions/math/Log
-    - functions/math/Log2
     - functions/math/Log10
+    - functions/math/E
+    - functions/math/Exp
   returnType: float64
-  signatures: [math.E]
+  signatures: [math.Log2 VALUE]
 ---
 
 {{< new-in 0.131.0 >}}
 
 ```go-html-template
-{{ math.E }} → 2.718281828459045
+{{ math.Log2 8 }} → 3
 ```

--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -3506,8 +3506,24 @@ tpl:
         - "n"
         Description: Log returns the natural logarithm of the number n.
         Examples:
-        - - '{{ math.Log 1 }}'
-          - "0"
+        - - '{{ math.Log 2.718281828459045 }}'
+          - "1"
+      Log2:
+        Aliases: null
+        Args:
+        - "n"
+        Description: Log2 returns the binary logarithm of the number n.
+        Examples:
+        - - '{{ math.Log2 8 }}'
+          - "3"
+      Log10:
+        Aliases: null
+        Args:
+        - "n"
+        Description: Log10 returns the decimal logarithm of the number n.
+        Examples:
+        - - '{{ math.Log10 100 }}'
+          - "2"
       Max:
         Aliases: null
         Args:

--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -3476,6 +3476,21 @@ tpl:
         Examples:
         - - '{{ div 6 3 }}'
           - "2"
+      E:
+        Aliases: null
+        Args: null
+        Description: Returns the mathematical constant e.
+        Examples:
+        - - '{{ math.E }}'
+          - "2.718281828459045"
+      Exp:
+        Aliases: null
+        Args:
+        - "n"
+        Description: Exp returns the base-e exponential of n.
+        Examples:
+        - - '{{ math.Exp 1 }}'
+          - "2.718281828459045"
       Floor:
         Aliases: null
         Args:

--- a/tpl/math/init.go
+++ b/tpl/math/init.go
@@ -94,6 +94,20 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.E,
+			nil,
+			[][2]string{
+				{"{{ math.E }}", "2.718281828459045"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.Exp,
+			nil,
+			[][2]string{
+				{"{{ math.Exp 1 }}", "2.718281828459045"},
+			},
+		)
+
 		ns.AddMethodMapping(ctx.Floor,
 			nil,
 			[][2]string{

--- a/tpl/math/init.go
+++ b/tpl/math/init.go
@@ -118,7 +118,21 @@ func init() {
 		ns.AddMethodMapping(ctx.Log,
 			nil,
 			[][2]string{
-				{"{{ math.Log 1 }}", "0"},
+				{"{{ math.Log 2.718281828459045 }}", "1"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.Log2,
+			nil,
+			[][2]string{
+				{"{{ math.Log2 8 }}", "3"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.Log10,
+			nil,
+			[][2]string{
+				{"{{ math.Log10 100 }}", "2"},
 			},
 		)
 

--- a/tpl/math/math.go
+++ b/tpl/math/math.go
@@ -138,6 +138,20 @@ func (ns *Namespace) Log(n any) (float64, error) {
 	return math.Log(af), nil
 }
 
+// Returns the mathematical constant e.
+func (ns *Namespace) E() float64 {
+	return math.E
+}
+
+// Exp returns the base-e exponential of n.
+func (ns *Namespace) Exp(n any) (float64, error) {
+	af, err := cast.ToFloat64E(n)
+	if err != nil {
+		return 0, errors.New("requires a numeric argument")
+	}
+	return math.Exp(af), nil
+}
+
 // Max returns the greater of all numbers in inputs. Any slices in inputs are flattened.
 func (ns *Namespace) Max(inputs ...any) (maximum float64, err error) {
 	return ns.applyOpToScalarsOrSlices("Max", math.Max, inputs...)

--- a/tpl/math/math.go
+++ b/tpl/math/math.go
@@ -132,10 +132,30 @@ func (ns *Namespace) Floor(n any) (float64, error) {
 func (ns *Namespace) Log(n any) (float64, error) {
 	af, err := cast.ToFloat64E(n)
 	if err != nil {
-		return 0, errors.New("Log operator can't be used with non integer or float value")
+		return 0, errors.New("requires a numeric argument")
 	}
 
 	return math.Log(af), nil
+}
+
+// Log2 returns the binary logarithm of the number n.
+func (ns *Namespace) Log2(n any) (float64, error) {
+	af, err := cast.ToFloat64E(n)
+	if err != nil {
+		return 0, errors.New("requires a numeric argument")
+	}
+
+	return math.Log2(af), nil
+}
+
+// Log10 returns the decimal logarithm of the number n.
+func (ns *Namespace) Log10(n any) (float64, error) {
+	af, err := cast.ToFloat64E(n)
+	if err != nil {
+		return 0, errors.New("requires a numeric argument")
+	}
+
+	return math.Log10(af), nil
 }
 
 // Returns the mathematical constant e.

--- a/tpl/math/math_test.go
+++ b/tpl/math/math_test.go
@@ -548,6 +548,59 @@ func TestProduct(t *testing.T) {
 	c.Assert(err, qt.Not(qt.IsNil))
 }
 
+// Test exponential functions
+
+func TestE(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	expect := 2.7182
+	result := ns.E()
+
+	// we compare only 4 digits behind point if its a real float
+	// otherwise we usually get different float values on the last positions
+	result = float64(int(result*10000)) / 10000
+
+	c.Assert(result, qt.Equals, expect)
+}
+
+func TestExp(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	for _, test := range []struct {
+		a      any
+		expect any
+	}{
+		{0, 1.0},
+		{1, 2.7182},
+		{2, 7.3890},
+		{-1.0, 0.3678},
+		{"abc", false},
+	} {
+
+		result, err := ns.Exp(test.a)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		// we compare only 4 digits behind point if its a real float
+		// otherwise we usually get different float values on the last positions
+		if result != math.Inf(-1) {
+			result = float64(int(result*10000)) / 10000
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}
+
 // Test trigonometric functions
 
 func TestPi(t *testing.T) {

--- a/tpl/math/math_test.go
+++ b/tpl/math/math_test.go
@@ -155,47 +155,6 @@ func TestFloor(t *testing.T) {
 	}
 }
 
-func TestLog(t *testing.T) {
-	t.Parallel()
-	c := qt.New(t)
-
-	ns := New()
-
-	for _, test := range []struct {
-		a      any
-		expect any
-	}{
-		{1, 0.0},
-		{3, 1.0986},
-		{0, math.Inf(-1)},
-		{1.0, 0.0},
-		{3.1, 1.1314},
-		{"abc", false},
-	} {
-
-		result, err := ns.Log(test.a)
-
-		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
-			continue
-		}
-
-		// we compare only 4 digits behind point if its a real float
-		// otherwise we usually get different float values on the last positions
-		if result != math.Inf(-1) {
-			result = float64(int(result*10000)) / 10000
-		}
-
-		c.Assert(err, qt.IsNil)
-		c.Assert(result, qt.Equals, test.expect)
-	}
-
-	// Separate test for Log(-1) -- returns NaN
-	result, err := ns.Log(-1)
-	c.Assert(err, qt.IsNil)
-	c.Assert(result, qt.Satisfies, math.IsNaN)
-}
-
 func TestSqrt(t *testing.T) {
 	t.Parallel()
 	c := qt.New(t)
@@ -599,6 +558,129 @@ func TestExp(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 		c.Assert(result, qt.Equals, test.expect)
 	}
+}
+
+// Test logarithmic functions
+
+func TestLog(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	for _, test := range []struct {
+		a      any
+		expect any
+	}{
+		{1, 0.0},
+		{3, 1.0986},
+		{0, math.Inf(-1)},
+		{1.0, 0.0},
+		{3.1, 1.1314},
+		{"abc", false},
+	} {
+
+		result, err := ns.Log(test.a)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		// we compare only 4 digits behind point if its a real float
+		// otherwise we usually get different float values on the last positions
+		if result != math.Inf(-1) {
+			result = float64(int(result*10000)) / 10000
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+
+	// Separate test for Log(-1) -- returns NaN
+	result, err := ns.Log(-1)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, qt.Satisfies, math.IsNaN)
+}
+
+func TestLog2(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	for _, test := range []struct {
+		a      any
+		expect any
+	}{
+		{1, 0.0},
+		{2, 1.0},
+		{0, math.Inf(-1)},
+		{8.0, 3.0},
+		{"abc", false},
+	} {
+
+		result, err := ns.Log2(test.a)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		// we compare only 4 digits behind point if its a real float
+		// otherwise we usually get different float values on the last positions
+		if result != math.Inf(-1) {
+			result = float64(int(result*10000)) / 10000
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+
+	// Separate test for Log2(-1) -- returns NaN
+	result, err := ns.Log2(-1)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, qt.Satisfies, math.IsNaN)
+}
+
+func TestLog10(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	for _, test := range []struct {
+		a      any
+		expect any
+	}{
+		{1, 0.0},
+		{10, 1.0},
+		{0, math.Inf(-1)},
+		{100.0, 2.0},
+		{"abc", false},
+	} {
+
+		result, err := ns.Log10(test.a)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		// we compare only 4 digits behind point if its a real float
+		// otherwise we usually get different float values on the last positions
+		if result != math.Inf(-1) {
+			result = float64(int(result*10000)) / 10000
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+
+	// Separate test for Log10(-1) -- returns NaN
+	result, err := ns.Log10(-1)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, qt.Satisfies, math.IsNaN)
 }
 
 // Test trigonometric functions


### PR DESCRIPTION
Hugo already has the natural `log` function. So it seems like a gap missing out on its inverse, the `exp` function.

We also add a `log2` (binary logarithm) and `log10` (decimal logarithm) function which both can be very useful at times. By including explicit functions, template authors do not have to implement change of base themselves. (We do not do change of base but rather use functions provided by the golang math lib.)