### PR TITLE
math: Add golden ratio constant

### DIFF
--- a/docs/content/en/functions/math/Phi.md
+++ b/docs/content/en/functions/math/Phi.md
@@ -1,0 +1,17 @@
+---
+title: math.Phi
+description: Returns the golden ratio constant phi.
+categories: []
+keywords: []
+action:
+  aliases: []
+  related:
+  returnType: float64
+  signatures: [math.Phi]
+---
+
+{{< new-in 0.130.0 >}}
+
+```go-html-template
+{{ math.Phi }} → 1.618033988749895
+```

--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -3541,6 +3541,13 @@ tpl:
         Examples:
         - - '{{ mul 2 3 }}'
           - "6"
+      Phi:
+        Aliases: null
+        Args: null
+        Description: Returns the golden ratio constant phi.
+        Examples:
+        - - '{{ math.Phi }}'
+          - "1.618033988749895"
       Pi:
         Aliases: null
         Args: null

--- a/tpl/math/init.go
+++ b/tpl/math/init.go
@@ -143,6 +143,13 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.Phi,
+			nil,
+			[][2]string{
+				{"{{ math.Phi }}", "1.618033988749895"},
+			},
+		)
+
 		ns.AddMethodMapping(ctx.Pi,
 			nil,
 			[][2]string{

--- a/tpl/math/math.go
+++ b/tpl/math/math.go
@@ -179,6 +179,11 @@ func (ns *Namespace) Mul(inputs ...any) (any, error) {
 	return ns.doArithmetic(inputs, '*')
 }
 
+// Returns the golden ratio constant phi.
+func (ns *Namespace) Phi() float64 {
+	return math.Phi
+}
+
 // Pi returns the mathematical constant pi.
 func (ns *Namespace) Pi() float64 {
 	return math.Pi

--- a/tpl/math/math_test.go
+++ b/tpl/math/math_test.go
@@ -879,3 +879,19 @@ func TestToRadians(t *testing.T) {
 		c.Assert(result, qt.Equals, test.expect)
 	}
 }
+
+func TestPhi(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	expect := 1.6180
+	result := ns.Phi()
+
+	// we compare only 4 digits behind point if its a real float
+	// otherwise we usually get different float values on the last positions
+	result = float64(int(result*10000)) / 10000
+
+	c.Assert(result, qt.Equals, expect)
+}


### PR DESCRIPTION
This PR add the golden ratio constant. This constant is often used in graphical contexts to get pleasing aesthetics. In will be useful for subdividing layouts, partition page space or fitting images and possibly more.