### PR TITLE
math: Add cube root function

### DIFF
--- a/docs/content/en/functions/math/Cbrt.md
+++ b/docs/content/en/functions/math/Cbrt.md
@@ -1,0 +1,19 @@
+---
+title: math.Cbrt
+description: Returns the cube root of the given number.
+categories: []
+keywords: []
+action:
+  aliases: []
+  related:
+    - functions/math/Sqrt
+    - functions/math/Pow
+  returnType: float64
+  signatures: [math.Cbrt VALUE]
+---
+
+{{< new-in 0.131.0 >}}
+
+```go-html-template
+{{ math.Cbrt 27 }} → 3
+```

--- a/docs/content/en/functions/math/Pow.md
+++ b/docs/content/en/functions/math/Pow.md
@@ -7,6 +7,7 @@ action:
   aliases: [pow]
   related:
     - functions/math/Sqrt
+    - functions/math/Cbrt
   returnType: float64
   signatures: [math.Pow VALUE1 VALUE2]
 ---

--- a/docs/content/en/functions/math/Sqrt.md
+++ b/docs/content/en/functions/math/Sqrt.md
@@ -6,6 +6,7 @@ keywords: []
 action:
   aliases: []
   related:
+    - functions/math/Cbrt
     - functions/math/Pow
   returnType: float64
   signatures: [math.Sqrt VALUE]

--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -3445,6 +3445,14 @@ tpl:
         Examples:
         - - '{{ math.Atan2 1 2 }}'
           - "0.4636476090008061"
+      Cbrt:
+        Aliases: null
+        Args:
+        - "n"
+        Description: Cbrt returns the cube root of the number n.
+        Examples:
+        - - '{{ math.Cbrt 27 }}'
+          - "3"
       Ceil:
         Aliases: null
         Args:

--- a/tpl/math/init.go
+++ b/tpl/math/init.go
@@ -73,6 +73,13 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.Cbrt,
+			nil,
+			[][2]string{
+				{"{{ math.Cbrt 27 }}", "3"},
+			},
+		)
+
 		ns.AddMethodMapping(ctx.Ceil,
 			nil,
 			[][2]string{

--- a/tpl/math/math.go
+++ b/tpl/math/math.go
@@ -94,6 +94,16 @@ func (ns *Namespace) Atan2(n, m any) (float64, error) {
 	return math.Atan2(afx, afy), nil
 }
 
+// Cbrt returns the cube root of the number n.
+func (ns *Namespace) Cbrt(n any) (float64, error) {
+	af, err := cast.ToFloat64E(n)
+	if err != nil {
+		return 0, errors.New("requires a numeric argument")
+	}
+
+	return math.Cbrt(af), nil
+}
+
 // Ceil returns the least integer value greater than or equal to n.
 func (ns *Namespace) Ceil(n any) (float64, error) {
 	xf, err := cast.ToFloat64E(n)

--- a/tpl/math/math.go
+++ b/tpl/math/math.go
@@ -43,7 +43,7 @@ type Namespace struct{}
 func (ns *Namespace) Abs(n any) (float64, error) {
 	af, err := cast.ToFloat64E(n)
 	if err != nil {
-		return 0, errors.New("the math.Abs function requires a numeric argument")
+		return 0, errors.New("requires a numeric argument")
 	}
 
 	return math.Abs(af), nil
@@ -108,7 +108,7 @@ func (ns *Namespace) Cbrt(n any) (float64, error) {
 func (ns *Namespace) Ceil(n any) (float64, error) {
 	xf, err := cast.ToFloat64E(n)
 	if err != nil {
-		return 0, errors.New("Ceil operator can't be used with non-float value")
+		return 0, errors.New("requires a numeric argument")
 	}
 
 	return math.Ceil(xf), nil
@@ -132,7 +132,7 @@ func (ns *Namespace) Div(inputs ...any) (any, error) {
 func (ns *Namespace) Floor(n any) (float64, error) {
 	xf, err := cast.ToFloat64E(n)
 	if err != nil {
-		return 0, errors.New("Floor operator can't be used with non-float value")
+		return 0, errors.New("requires a numeric argument")
 	}
 
 	return math.Floor(xf), nil
@@ -242,7 +242,7 @@ func (ns *Namespace) Sin(n any) (float64, error) {
 func (ns *Namespace) Sqrt(n any) (float64, error) {
 	af, err := cast.ToFloat64E(n)
 	if err != nil {
-		return 0, errors.New("Sqrt operator can't be used with non integer or float value")
+		return 0, errors.New("requires a numeric argument")
 	}
 
 	return math.Sqrt(af), nil

--- a/tpl/math/math_test.go
+++ b/tpl/math/math_test.go
@@ -221,9 +221,7 @@ func TestSqrt(t *testing.T) {
 
 		// we compare only 4 digits behind point if its a real float
 		// otherwise we usually get different float values on the last positions
-		if result != math.Inf(-1) {
-			result = float64(int(result*10000)) / 10000
-		}
+		result = float64(int(result*10000)) / 10000
 
 		c.Assert(err, qt.IsNil)
 		c.Assert(result, qt.Equals, test.expect)
@@ -233,6 +231,39 @@ func TestSqrt(t *testing.T) {
 	result, err := ns.Sqrt(-1)
 	c.Assert(err, qt.IsNil)
 	c.Assert(result, qt.Satisfies, math.IsNaN)
+}
+
+func TestCbrt(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	for _, test := range []struct {
+		a      any
+		expect any
+	}{
+		{27, 3.0},
+		{0.125, 0.5},
+		{0, 0.0},
+		{-8, -2.0},
+		{"abc", false},
+	} {
+
+		result, err := ns.Cbrt(test.a)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		// we compare only 4 digits behind point if its a real float
+		// otherwise we usually get different float values on the last positions
+		result = float64(int(result*10000)) / 10000
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
 }
 
 func TestMod(t *testing.T) {


### PR DESCRIPTION
The final PR of this series adds the cube root function. While it could be computed via fractional powers, providing a dedicated function has benefits. F.e. it is faster and avoids corner cases. Equally important, it is much clearer to write and read. (Which is especially important as go templates can quickly become convoluted.)