### PR TITLE
deps: Set toolchain go1.21.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -161,4 +161,6 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.2.0 // indirect
 )
 
+toolchain go1.21.0
+
 go 1.20


### PR DESCRIPTION
To hopefully resolve dependabot issues.
