### PR TITLE
resources/page: Expand parmalinks tokens in `url`

### DIFF
--- a/hugolib/page__paths.go
+++ b/hugolib/page__paths.go
@@ -141,6 +141,21 @@ func createTargetPathDescriptor(p *pageState) (page.TargetPathDescriptor, error)
 	desc.PrefixFilePath = s.getLanguageTargetPathLang(alwaysInSubDir)
 	desc.PrefixLink = s.getLanguagePermalinkLang(alwaysInSubDir)
 
+	if desc.URL != "" && strings.IndexByte(desc.URL, ':') >= 0 {
+		// Attempt to parse and expand an url. Probably it's a good
+		// idea to cache the parsed url to avoid regexp matching and memory allocations.
+
+		opath, err := d.ResourceSpec.Permalinks.ExpandPattern(desc.URL, p)
+		if err != nil {
+			return desc, err
+		}
+
+		if opath != "" {
+			opath, _ = url.QueryUnescape(opath)
+			desc.URL = opath
+		}
+	}
+
 	opath, err := d.ResourceSpec.Permalinks.Expand(p.Section(), p)
 	if err != nil {
 		return desc, err

--- a/hugolib/page_permalink_test.go
+++ b/hugolib/page_permalink_test.go
@@ -59,6 +59,8 @@ func TestPermalink(t *testing.T) {
 
 		// test URL overrides
 		{"x/y/z/boofar.md", "", "", "/z/y/q/", false, false, "/z/y/q/", "/z/y/q/"},
+		// test URL override with expands
+		{"x/y/z/boofar.md", "", "test", "/z/:slug/", false, false, "/z/test/", "/z/test/"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
This change allows to use permalink tokens in `url` front matter fields. This should be useful to target more specific pages instead of using a global permalink configuration. It's expected to be used with `cascade`.

Fixes #9714.