### PR TITLE
tpl/transform: Make Plainify and ToMath return template.HTML

### DIFF
--- a/docs/content/en/functions/transform/Plainify.md
+++ b/docs/content/en/functions/transform/Plainify.md
@@ -6,7 +6,7 @@ keywords: []
 action:
   aliases: [plainify]
   related: []
-  returnType: string
+  returnType: template.HTML
   signatures: [transform.Plainify INPUT]
 aliases: [/functions/plainify]
 ---

--- a/tpl/transform/transform_integration_test.go
+++ b/tpl/transform/transform_integration_test.go
@@ -141,8 +141,7 @@ func TestToMath(t *testing.T) {
 -- hugo.toml --
 disableKinds = ['page','rss','section','sitemap','taxonomy','term']
 -- layouts/index.html --
-{{ $result := transform.ToMath "c = \\pm\\sqrt{a^2 + b^2}" }}
-{{ printf "%v" $result | safeHTML }}
+{{ transform.ToMath "c = \\pm\\sqrt{a^2 + b^2}" }}
   `
 	b := hugolib.Test(t, files)
 

--- a/tpl/transform/transform_test.go
+++ b/tpl/transform/transform_test.go
@@ -244,6 +244,6 @@ func TestPlainify(t *testing.T) {
 		}
 
 		b.Assert(err, qt.IsNil)
-		b.Assert(result, qt.Equals, test.expect)
+		b.Assert(result, qt.Equals, template.HTML(test.expect.(string)))
 	}
 }


### PR DESCRIPTION
None of these are useful as plain strings in the templates, which forces the users to do `transform.Plainify "foo" | safeHTML`.

If people have trust issues with the output of these functions, they need to just stop using them.

Closes #8732
