### PR TITLE
Add Page.Markup with scope support

### DIFF
--- a/common/hugo/hugo.go
+++ b/common/hugo/hugo.go
@@ -14,6 +14,7 @@
 package hugo
 
 import (
+	"context"
 	"fmt"
 	"html/template"
 	"os"
@@ -29,6 +30,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 
 	"github.com/bep/godartsass/v2"
+	"github.com/gohugoio/hugo/common/hcontext"
 	"github.com/gohugoio/hugo/common/hexec"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/hugofs/files"
@@ -69,6 +71,9 @@ type HugoInfo struct {
 
 	conf ConfigProvider
 	deps []*Dependency
+
+	// Context gives access to some of the context scoped variables.
+	Context Context
 }
 
 // Version returns the current version as a comparable version string.
@@ -125,6 +130,26 @@ func (i HugoInfo) IsMultihost() bool {
 // IsMultilingual reports whether there are two or more configured languages.
 func (i HugoInfo) IsMultilingual() bool {
 	return i.conf.IsMultilingual()
+}
+
+type contextKey string
+
+var markupScope = hcontext.NewContextDispatcher[string](contextKey("markupScope"))
+
+type Context struct{}
+
+func (c Context) MarkupScope(ctx context.Context) string {
+	return GetMarkupScope(ctx)
+}
+
+// SetMarkupScope sets the markup scope in the context.
+func SetMarkupScope(ctx context.Context, s string) context.Context {
+	return markupScope.Set(ctx, s)
+}
+
+// GetMarkupScope gets the markup scope from the context.
+func GetMarkupScope(ctx context.Context) string {
+	return markupScope.Get(ctx)
 }
 
 // ConfigProvider represents the config options that are relevant for HugoInfo.

--- a/common/hugo/hugo_test.go
+++ b/common/hugo/hugo_test.go
@@ -14,6 +14,7 @@
 package hugo
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -62,6 +63,19 @@ func TestDeprecationLogLevelFromVersion(t *testing.T) {
 	c.Assert(deprecationLogLevelFromVersion(ver.String()), qt.Equals, logg.LevelWarn)
 	ver.Minor -= 6
 	c.Assert(deprecationLogLevelFromVersion(ver.String()), qt.Equals, logg.LevelError)
+}
+
+func TestMarkupScope(t *testing.T) {
+	c := qt.New(t)
+
+	conf := testConfig{environment: "production", workingDir: "/mywork", running: false}
+	info := NewInfo(conf, nil)
+
+	ctx := context.Background()
+
+	ctx = SetMarkupScope(ctx, "foo")
+
+	c.Assert(info.Context.MarkupScope(ctx), qt.Equals, "foo")
 }
 
 type testConfig struct {

--- a/common/paths/pathparser.go
+++ b/common/paths/pathparser.go
@@ -153,7 +153,7 @@ func (pp *PathParser) doParse(component, s string, p *Path) (*Path, error) {
 				} else {
 					high = len(p.s)
 				}
-				id := types.LowHigh{Low: i + 1, High: high}
+				id := types.LowHigh[string]{Low: i + 1, High: high}
 				if len(p.identifiers) == 0 {
 					p.identifiers = append(p.identifiers, id)
 				} else if len(p.identifiers) == 1 {
@@ -260,7 +260,7 @@ type Path struct {
 	component  string
 	bundleType PathType
 
-	identifiers []types.LowHigh
+	identifiers []types.LowHigh[string]
 
 	posIdentifierLanguage int
 	disabled              bool

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -107,10 +107,18 @@ func Unwrapv(v any) any {
 	return v
 }
 
-// LowHigh is typically used to represent a slice boundary.
-type LowHigh struct {
+// LowHigh represents a byte or slice boundary.
+type LowHigh[S ~[]byte | string] struct {
 	Low  int
 	High int
+}
+
+func (l LowHigh[S]) IsZero() bool {
+	return l.Low < 0 || (l.Low == 0 && l.High == 0)
+}
+
+func (l LowHigh[S]) Value(source S) S {
+	return source[l.Low:l.High]
 }
 
 // This is only used for debugging purposes.

--- a/common/types/types_test.go
+++ b/common/types/types_test.go
@@ -27,3 +27,25 @@ func TestKeyValues(t *testing.T) {
 	c.Assert(kv.KeyString(), qt.Equals, "key")
 	c.Assert(kv.Values, qt.DeepEquals, []any{"a1", "a2"})
 }
+
+func TestLowHigh(t *testing.T) {
+	c := qt.New(t)
+
+	lh := LowHigh[string]{
+		Low:  2,
+		High: 10,
+	}
+
+	s := "abcdefghijklmnopqrstuvwxyz"
+	c.Assert(lh.IsZero(), qt.IsFalse)
+	c.Assert(lh.Value(s), qt.Equals, "cdefghij")
+
+	lhb := LowHigh[[]byte]{
+		Low:  2,
+		High: 10,
+	}
+
+	sb := []byte(s)
+	c.Assert(lhb.IsZero(), qt.IsFalse)
+	c.Assert(lhb.Value(sb), qt.DeepEquals, []byte("cdefghij"))
+}

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/helpers"
 )
 
@@ -64,84 +63,6 @@ func BenchmarkTrimShortHTML(b *testing.B) {
 func TestBytesToHTML(t *testing.T) {
 	c := qt.New(t)
 	c.Assert(helpers.BytesToHTML([]byte("dobedobedo")), qt.Equals, template.HTML("dobedobedo"))
-}
-
-var benchmarkTruncateString = strings.Repeat("This is a sentence about nothing.", 20)
-
-func BenchmarkTestTruncateWordsToWholeSentence(b *testing.B) {
-	c := newTestContentSpec(nil)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		c.TruncateWordsToWholeSentence(benchmarkTruncateString)
-	}
-}
-
-func TestTruncateWordsToWholeSentence(t *testing.T) {
-	type test struct {
-		input, expected string
-		max             int
-		truncated       bool
-	}
-	data := []test{
-		{"a b c", "a b c", 12, false},
-		{"a b c", "a b c", 3, false},
-		{"a", "a", 1, false},
-		{"This is a sentence.", "This is a sentence.", 5, false},
-		{"This is also a sentence!", "This is also a sentence!", 1, false},
-		{"To be. Or not to be. That's the question.", "To be.", 1, true},
-		{" \nThis is not a sentence\nAnd this is another", "This is not a sentence", 4, true},
-		{"", "", 10, false},
-		{"This... is a more difficult test?", "This... is a more difficult test?", 1, false},
-	}
-	for i, d := range data {
-		cfg := config.New()
-		cfg.Set("summaryLength", d.max)
-		c := newTestContentSpec(cfg)
-		output, truncated := c.TruncateWordsToWholeSentence(d.input)
-		if d.expected != output {
-			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
-		}
-
-		if d.truncated != truncated {
-			t.Errorf("Test %d failed. Expected truncated=%t got %t", i, d.truncated, truncated)
-		}
-	}
-}
-
-func TestTruncateWordsByRune(t *testing.T) {
-	type test struct {
-		input, expected string
-		max             int
-		truncated       bool
-	}
-	data := []test{
-		{"", "", 1, false},
-		{"a b c", "a b c", 12, false},
-		{"a b c", "a b c", 3, false},
-		{"a", "a", 1, false},
-		{"Hello 中国", "", 0, true},
-		{"这是中文，全中文。", "这是中文，", 5, true},
-		{"Hello 中国", "Hello 中", 2, true},
-		{"Hello 中国", "Hello 中国", 3, false},
-		{"Hello中国 Good 好的", "Hello中国 Good 好", 9, true},
-		{"This is a sentence.", "This is", 2, true},
-		{"This is also a sentence!", "This", 1, true},
-		{"To be. Or not to be. That's the question.", "To be. Or not", 4, true},
-		{" \nThis is    not a sentence\n ", "This is not", 3, true},
-	}
-	for i, d := range data {
-		cfg := config.New()
-		cfg.Set("summaryLength", d.max)
-		c := newTestContentSpec(cfg)
-		output, truncated := c.TruncateWordsByRune(strings.Fields(d.input))
-		if d.expected != output {
-			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
-		}
-
-		if d.truncated != truncated {
-			t.Errorf("Test %d failed. Expected truncated=%t got %t", i, d.truncated, truncated)
-		}
-	}
 }
 
 func TestExtractTOCNormalContent(t *testing.T) {

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -61,6 +61,7 @@ var (
 	pageTypesProvider = resource.NewResourceTypesProvider(media.Builtin.OctetType, pageResourceType)
 	nopPageOutput     = &pageOutput{
 		pagePerOutputProviders: nopPagePerOutput,
+		MarkupProvider:         page.NopPage,
 		ContentProvider:        page.NopPage,
 	}
 )
@@ -213,11 +214,8 @@ func (p *pageHeadingsFiltered) page() page.Page {
 
 // For internal use by the related content feature.
 func (p *pageState) ApplyFilterToHeadings(ctx context.Context, fn func(*tableofcontents.Heading) bool) related.Document {
-	r, err := p.m.content.contentToC(ctx, p.pageOutput.pco)
-	if err != nil {
-		panic(err)
-	}
-	headings := r.tableOfContents.Headings.FilterBy(fn)
+	fragments := p.pageOutput.pco.c().Fragments(ctx)
+	headings := fragments.Headings.FilterBy(fn)
 	return &pageHeadingsFiltered{
 		pageState: p,
 		headings:  headings,
@@ -719,6 +717,7 @@ func (p *pageState) shiftToOutputFormat(isRenderingSite bool, idx int) error {
 			})
 			p.pageOutput.contentRenderer = lcp
 			p.pageOutput.ContentProvider = lcp
+			p.pageOutput.MarkupProvider = lcp
 			p.pageOutput.PageRenderProvider = lcp
 			p.pageOutput.TableOfContentsProvider = lcp
 		}

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -821,7 +821,7 @@ func (p *pageMeta) newContentConverter(ps *pageState, markup string) (converter.
 			// This prevents infinite recursion in some cases.
 			return doc
 		}
-		if v, ok := ps.pageOutput.pco.otherOutputs[id]; ok {
+		if v, ok := ps.pageOutput.pco.otherOutputs.Get(id); ok {
 			return v.po.p
 		}
 		return nil

--- a/hugolib/page__output.go
+++ b/hugolib/page__output.go
@@ -65,6 +65,7 @@ func newPageOutput(
 		p:                       ps,
 		f:                       f,
 		pagePerOutputProviders:  providers,
+		MarkupProvider:          page.NopPage,
 		ContentProvider:         page.NopPage,
 		PageRenderProvider:      page.NopPage,
 		TableOfContentsProvider: page.NopPage,
@@ -95,6 +96,7 @@ type pageOutput struct {
 	// output format.
 	contentRenderer page.ContentRenderer
 	pagePerOutputProviders
+	page.MarkupProvider
 	page.ContentProvider
 	page.PageRenderProvider
 	page.TableOfContentsProvider
@@ -119,7 +121,7 @@ func (po *pageOutput) isRendered() bool {
 	if po.renderState > 0 {
 		return true
 	}
-	if po.pco != nil && po.pco.contentRendered {
+	if po.pco != nil && po.pco.contentRendered.Load() {
 		return true
 	}
 	return false
@@ -139,6 +141,7 @@ func (p *pageOutput) setContentProvider(cp *pageContentOutput) {
 	}
 	p.contentRenderer = cp
 	p.ContentProvider = cp
+	p.MarkupProvider = cp
 	p.PageRenderProvider = cp
 	p.TableOfContentsProvider = cp
 	p.RenderShortcodesProvider = cp

--- a/hugolib/shortcode_page.go
+++ b/hugolib/shortcode_page.go
@@ -65,6 +65,7 @@ var zeroShortcode = prerenderedShortcode{}
 type pageForShortcode struct {
 	page.PageWithoutContent
 	page.TableOfContentsProvider
+	page.MarkupProvider
 	page.ContentProvider
 
 	// We need to replace it after we have rendered it, so provide a
@@ -80,6 +81,7 @@ func newPageForShortcode(p *pageState) page.Page {
 	return &pageForShortcode{
 		PageWithoutContent:      p,
 		TableOfContentsProvider: p,
+		MarkupProvider:          page.NopPage,
 		ContentProvider:         page.NopPage,
 		toc:                     template.HTML(tocShortcodePlaceholder),
 		p:                       p,
@@ -105,6 +107,7 @@ var _ types.Unwrapper = (*pageForRenderHooks)(nil)
 type pageForRenderHooks struct {
 	page.PageWithoutContent
 	page.TableOfContentsProvider
+	page.MarkupProvider
 	page.ContentProvider
 	p *pageState
 }
@@ -112,6 +115,7 @@ type pageForRenderHooks struct {
 func newPageForRenderHook(p *pageState) page.Page {
 	return &pageForRenderHooks{
 		PageWithoutContent:      p,
+		MarkupProvider:          page.NopPage,
 		ContentProvider:         page.NopPage,
 		TableOfContentsProvider: p,
 		p:                       p,

--- a/resources/page/page.go
+++ b/resources/page/page.go
@@ -74,9 +74,16 @@ type ChildCareProvider interface {
 	Resources() resource.Resources
 }
 
+type MarkupProvider interface {
+	Markup(opts ...any) Markup
+}
+
 // ContentProvider provides the content related values for a Page.
 type ContentProvider interface {
 	Content(context.Context) (any, error)
+
+	// ContentWithoutSummary returns the Page Content stripped of the summary.
+	ContentWithoutSummary(ctx context.Context) (template.HTML, error)
 
 	// Plain returns the Page Content stripped of HTML markup.
 	Plain(context.Context) string
@@ -169,6 +176,7 @@ type PageProvider interface {
 
 // Page is the core interface in Hugo and what you get as the top level data context in your templates.
 type Page interface {
+	MarkupProvider
 	ContentProvider
 	TableOfContentsProvider
 	PageWithoutContent
@@ -260,7 +268,7 @@ type PageMetaInternalProvider interface {
 type PageRenderProvider interface {
 	// Render renders the given layout with this Page as context.
 	Render(ctx context.Context, layout ...string) (template.HTML, error)
-	// RenderString renders the first value in args with tPaginatorhe content renderer defined
+	// RenderString renders the first value in args with the content renderer defined
 	// for this Page.
 	// It takes an optional map as a second argument:
 	//

--- a/resources/page/page_lazy_contentprovider.go
+++ b/resources/page/page_lazy_contentprovider.go
@@ -35,6 +35,7 @@ type OutputFormatContentProvider interface {
 
 // OutputFormatPageContentProvider holds the exported methods from Page that are "outputFormat aware".
 type OutputFormatPageContentProvider interface {
+	MarkupProvider
 	ContentProvider
 	TableOfContentsProvider
 	PageRenderProvider
@@ -74,6 +75,11 @@ func (lcp *LazyContentProvider) Reset() {
 	lcp.init.Reset()
 }
 
+func (lcp *LazyContentProvider) Markup(opts ...any) Markup {
+	lcp.init.Do(context.Background())
+	return lcp.cp.Markup(opts...)
+}
+
 func (lcp *LazyContentProvider) TableOfContents(ctx context.Context) template.HTML {
 	lcp.init.Do(ctx)
 	return lcp.cp.TableOfContents(ctx)
@@ -87,6 +93,11 @@ func (lcp *LazyContentProvider) Fragments(ctx context.Context) *tableofcontents.
 func (lcp *LazyContentProvider) Content(ctx context.Context) (any, error) {
 	lcp.init.Do(ctx)
 	return lcp.cp.Content(ctx)
+}
+
+func (lcp *LazyContentProvider) ContentWithoutSummary(ctx context.Context) (template.HTML, error) {
+	lcp.init.Do(ctx)
+	return lcp.cp.ContentWithoutSummary(ctx)
 }
 
 func (lcp *LazyContentProvider) Plain(ctx context.Context) string {

--- a/resources/page/page_markup.go
+++ b/resources/page/page_markup.go
@@ -1,0 +1,344 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package page
+
+import (
+	"context"
+	"html/template"
+	"regexp"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/gohugoio/hugo/common/types"
+	"github.com/gohugoio/hugo/markup/tableofcontents"
+	"github.com/gohugoio/hugo/media"
+	"github.com/gohugoio/hugo/tpl"
+)
+
+type Content interface {
+	Content(context.Context) (template.HTML, error)
+	ContentWithoutSummary(context.Context) (template.HTML, error)
+	Summary(context.Context) (Summary, error)
+	Plain(context.Context) string
+	PlainWords(context.Context) []string
+	WordCount(context.Context) int
+	FuzzyWordCount(context.Context) int
+	ReadingTime(context.Context) int
+	Len(context.Context) int
+}
+
+type Markup interface {
+	Render(context.Context) (Content, error)
+	RenderString(ctx context.Context, args ...any) (template.HTML, error)
+	RenderShortcodes(context.Context) (template.HTML, error)
+	Fragments(context.Context) *tableofcontents.Fragments
+}
+
+var _ types.PrintableValueProvider = Summary{}
+
+const (
+	SummaryTypeAuto        = "auto"
+	SummaryTypeManual      = "manual"
+	SummaryTypeFrontMatter = "frontmatter"
+)
+
+type Summary struct {
+	Text      template.HTML
+	Type      string // "auto", "manual" or "frontmatter"
+	Truncated bool
+}
+
+func (s Summary) IsZero() bool {
+	return s.Text == ""
+}
+
+func (s Summary) PrintableValue() any {
+	return s.Text
+}
+
+var _ types.PrintableValueProvider = (*Summary)(nil)
+
+type HtmlSummary struct {
+	source         string
+	SummaryLowHigh types.LowHigh[string]
+	SummaryEndTag  types.LowHigh[string]
+	WrapperStart   types.LowHigh[string]
+	WrapperEnd     types.LowHigh[string]
+	Divider        types.LowHigh[string]
+}
+
+func (s HtmlSummary) wrap(ss string) string {
+	if s.WrapperStart.IsZero() {
+		return ss
+	}
+	return s.source[s.WrapperStart.Low:s.WrapperStart.High] + ss + s.source[s.WrapperEnd.Low:s.WrapperEnd.High]
+}
+
+func (s HtmlSummary) wrapLeft(ss string) string {
+	if s.WrapperStart.IsZero() {
+		return ss
+	}
+
+	return s.source[s.WrapperStart.Low:s.WrapperStart.High] + ss
+}
+
+func (s HtmlSummary) Value(l types.LowHigh[string]) string {
+	return s.source[l.Low:l.High]
+}
+
+func (s HtmlSummary) trimSpace(ss string) string {
+	return strings.TrimSpace(ss)
+}
+
+func (s HtmlSummary) Content() string {
+	if s.Divider.IsZero() {
+		return s.source
+	}
+	ss := s.source[:s.Divider.Low]
+	ss += s.source[s.Divider.High:]
+	return s.trimSpace(ss)
+}
+
+func (s HtmlSummary) Summary() string {
+	if s.Divider.IsZero() {
+		return s.trimSpace(s.wrap(s.Value(s.SummaryLowHigh)))
+	}
+	ss := s.source[s.SummaryLowHigh.Low:s.Divider.Low]
+	if s.SummaryLowHigh.High > s.Divider.High {
+		ss += s.source[s.Divider.High:s.SummaryLowHigh.High]
+	}
+	if !s.SummaryEndTag.IsZero() {
+		ss += s.Value(s.SummaryEndTag)
+	}
+	return s.trimSpace(s.wrap(ss))
+}
+
+func (s HtmlSummary) ContentWithoutSummary() string {
+	if s.Divider.IsZero() {
+		if s.SummaryLowHigh.Low == s.WrapperStart.High && s.SummaryLowHigh.High == s.WrapperEnd.Low {
+			return ""
+		}
+		return s.trimSpace(s.wrapLeft(s.source[s.SummaryLowHigh.High:]))
+	}
+	if s.SummaryEndTag.IsZero() {
+		return s.trimSpace(s.wrapLeft(s.source[s.Divider.High:]))
+	}
+	return s.trimSpace(s.wrapLeft(s.source[s.SummaryEndTag.High:]))
+}
+
+func (s HtmlSummary) Truncated() bool {
+	return s.SummaryLowHigh.High < len(s.source)
+}
+
+func (s *HtmlSummary) resolveParagraphTagAndSetWrapper(mt media.Type) tagReStartEnd {
+	ptag := startEndP
+
+	switch mt.SubType {
+	case media.DefaultContentTypes.AsciiDoc.SubType:
+		ptag = startEndDiv
+	case media.DefaultContentTypes.ReStructuredText.SubType:
+		const markerStart = "<div class=\"document\">"
+		const markerEnd = "</div>"
+		i1 := strings.Index(s.source, markerStart)
+		i2 := strings.LastIndex(s.source, markerEnd)
+		if i1 > -1 && i2 > -1 {
+			s.WrapperStart = types.LowHigh[string]{Low: 0, High: i1 + len(markerStart)}
+			s.WrapperEnd = types.LowHigh[string]{Low: i2, High: len(s.source)}
+		}
+	}
+	return ptag
+}
+
+// ExtractSummaryFromHTML extracts a summary from the given HTML content.
+func ExtractSummaryFromHTML(mt media.Type, input string, numWords int, isCJK bool) (result HtmlSummary) {
+	result.source = input
+	ptag := result.resolveParagraphTagAndSetWrapper(mt)
+
+	if numWords <= 0 {
+		return result
+	}
+
+	var count int
+
+	countWord := func(word string) int {
+		if isCJK {
+			word = tpl.StripHTML(word)
+			runeCount := utf8.RuneCountInString(word)
+			if len(word) == runeCount {
+				return 1
+			} else {
+				return runeCount
+			}
+		}
+
+		return 1
+	}
+
+	high := len(input)
+	if result.WrapperEnd.Low > 0 {
+		high = result.WrapperEnd.Low
+	}
+
+	for j := result.WrapperStart.High; j < high; {
+		s := input[j:]
+		closingIndex := strings.Index(s, "</"+ptag.tagName)
+
+		if closingIndex == -1 {
+			break
+		}
+
+		s = s[:closingIndex]
+
+		// Count the words in the current paragraph.
+		var wi int
+
+		for i, r := range s {
+			if unicode.IsSpace(r) || (i+utf8.RuneLen(r) == len(s)) {
+				word := s[wi:i]
+				count += countWord(word)
+				wi = i
+				if count >= numWords {
+					break
+				}
+			}
+		}
+
+		if count >= numWords {
+			result.SummaryLowHigh = types.LowHigh[string]{
+				Low:  result.WrapperStart.High,
+				High: j + closingIndex + len(ptag.tagName) + 3,
+			}
+			return
+		}
+
+		j += closingIndex + len(ptag.tagName) + 2
+
+	}
+
+	result.SummaryLowHigh = types.LowHigh[string]{
+		Low:  result.WrapperStart.High,
+		High: high,
+	}
+
+	return
+}
+
+// ExtractSummaryFromHTMLWithDivider extracts a summary from the given HTML content with
+// a manual summary divider.
+func ExtractSummaryFromHTMLWithDivider(mt media.Type, input, divider string) (result HtmlSummary) {
+	result.source = input
+	result.Divider.Low = strings.Index(input, divider)
+	result.Divider.High = result.Divider.Low + len(divider)
+
+	if result.Divider.Low == -1 {
+		// No summary.
+		return
+	}
+
+	ptag := result.resolveParagraphTagAndSetWrapper(mt)
+
+	if !mt.IsHTML() {
+		result.Divider, result.SummaryEndTag = expandSummaryDivider(result.source, ptag, result.Divider)
+	}
+
+	result.SummaryLowHigh = types.LowHigh[string]{
+		Low:  result.WrapperStart.High,
+		High: result.Divider.Low,
+	}
+
+	return
+}
+
+var (
+	pOrDiv = regexp.MustCompile(`<p[^>]?>|<div[^>]?>$`)
+
+	startEndDiv = tagReStartEnd{
+		startEndOfString: regexp.MustCompile(`<div[^>]*?>$`),
+		endEndOfString:   regexp.MustCompile(`</div>$`),
+		tagName:          "div",
+	}
+
+	startEndP = tagReStartEnd{
+		startEndOfString: regexp.MustCompile(`<p[^>]*?>$`),
+		endEndOfString:   regexp.MustCompile(`</p>$`),
+		tagName:          "p",
+	}
+)
+
+type tagReStartEnd struct {
+	startEndOfString *regexp.Regexp
+	endEndOfString   *regexp.Regexp
+	tagName          string
+}
+
+func expandSummaryDivider(s string, re tagReStartEnd, divider types.LowHigh[string]) (types.LowHigh[string], types.LowHigh[string]) {
+	var endMarkup types.LowHigh[string]
+
+	if divider.IsZero() {
+		return divider, endMarkup
+	}
+
+	lo, hi := divider.Low, divider.High
+
+	var preserveEndMarkup bool
+
+	// Find the start of the paragraph.
+
+	for i := lo - 1; i >= 0; i-- {
+		if s[i] == '>' {
+			if match := re.startEndOfString.FindString(s[:i+1]); match != "" {
+				lo = i - len(match) + 1
+				break
+			}
+			if match := pOrDiv.FindString(s[:i+1]); match != "" {
+				i -= len(match) - 1
+				continue
+			}
+		}
+
+		r, _ := utf8.DecodeRuneInString(s[i:])
+		if !unicode.IsSpace(r) {
+			preserveEndMarkup = true
+			break
+		}
+	}
+
+	divider.Low = lo
+
+	// Now walk forward to the end of the paragraph.
+	for ; hi < len(s); hi++ {
+		if s[hi] != '>' {
+			continue
+		}
+		if match := re.endEndOfString.FindString(s[:hi+1]); match != "" {
+			hi++
+			break
+		}
+	}
+
+	if preserveEndMarkup {
+		endMarkup.Low = divider.High
+		endMarkup.High = hi
+	} else {
+		divider.High = hi
+	}
+
+	// Consume trailing newline if any.
+	if divider.High < len(s) && s[divider.High] == '\n' {
+		divider.High++
+	}
+
+	return divider, endMarkup
+}

--- a/resources/page/page_markup_integration_test.go
+++ b/resources/page/page_markup_integration_test.go
@@ -1,0 +1,337 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package page_test
+
+import (
+	"testing"
+
+	"github.com/gohugoio/hugo/hugolib"
+	"github.com/gohugoio/hugo/markup/asciidocext"
+	"github.com/gohugoio/hugo/markup/rst"
+)
+
+func TestPageMarkupMethods(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+summaryLength=2
+-- content/p1.md --
+---
+title: "Post 1"
+date: "2020-01-01"
+---
+{{% foo %}}
+-- layouts/shortcodes/foo.html --
+Two *words*.
+{{/* Test that markup scope is set in all relevant constructs. */}}
+{{ if eq hugo.Context.MarkupScope "foo" }}
+
+## Heading 1
+Sint ad mollit qui Lorem ut occaecat culpa officia. Et consectetur aute voluptate non sit ullamco adipisicing occaecat. Sunt deserunt amet sit ad. Deserunt enim voluptate proident ipsum dolore dolor ut sit velit esse est mollit irure esse. Mollit incididunt veniam laboris magna et excepteur sit duis. Magna adipisicing reprehenderit tempor irure.
+### Heading 2
+Exercitation quis est consectetur occaecat nostrud. Ullamco aute mollit aliqua est amet. Exercitation ullamco consectetur dolor labore et non irure eu cillum Lorem.
+{{ end }}
+-- layouts/index.html --
+Home.
+{{ .Content }}
+-- layouts/_default/single.html --
+Single.
+Page.ContentWithoutSummmary: {{ .ContentWithoutSummary }}|
+{{ template "render-scope" (dict "page" . "scope" "main") }}
+{{ template "render-scope" (dict "page" . "scope" "foo") }}
+{{ define "render-scope" }}
+{{ $c := .page.Markup .scope }}
+{{ with $c.Render }}
+{{ $.scope }}: Content: {{ .Content }}|
+ {{ $.scope }}: ContentWithoutSummary: {{ .ContentWithoutSummary }}|
+{{ $.scope }}: Plain: {{ .Plain }}|
+{{ $.scope }}: PlainWords: {{ .PlainWords }}|
+{{ $.scope }}: WordCount: {{ .WordCount }}|
+{{ $.scope }}: FuzzyWordCount: {{ .FuzzyWordCount }}|
+{{ $.scope }}: ReadingTime: {{ .ReadingTime }}|
+{{ $.scope }}: Len: {{ .Len }}|
+{{ $.scope }}: Summary: {{ with .Summary }}{{ . }}{{ else }}nil{{ end }}|
+{{ end }}
+{{ $.scope }}: Fragments: {{ $c.Fragments.Identifiers }}|
+{{ end }}
+
+
+
+`
+
+	b := hugolib.Test(t, files)
+
+	// Main scope.
+	b.AssertFileContent("public/p1/index.html",
+		"Page.ContentWithoutSummmary: |",
+		"main: Content: <p>Two <em>words</em>.</p>\n|",
+		"main: ContentWithoutSummary: |",
+		"main: Plain: Two words.\n|",
+		"PlainWords: [Two words.]|\nmain: WordCount: 2|\nmain: FuzzyWordCount: 100|\nmain: ReadingTime: 1|",
+		"main: Summary: <p>Two <em>words</em>.</p>|\n\nmain: Fragments: []|",
+		"main: Len: 27|",
+	)
+
+	// Foo scope (has more content).
+	b.AssertFileContent("public/p1/index.html",
+		"foo: Content: <p>Two <em>words</em>.</p>\n<h2",
+		"foo: ContentWithoutSummary: <h2",
+		"Plain: Two words.\nHeading 1",
+		"PlainWords: [Two words. Heading 1",
+		"foo: WordCount: 81|\nfoo: FuzzyWordCount: 100|\nfoo: ReadingTime: 1|\nfoo: Len: 622|",
+		"foo: Summary: <p>Two <em>words</em>.</p>|",
+		"foo: Fragments: [heading-1 heading-2]|",
+	)
+}
+
+func TestPageMarkupScope(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ["taxonomy", "term", "rss", "section"]
+-- content/p1.md --
+---
+title: "Post 1"
+date: "2020-01-01"
+---
+
+# P1
+
+{{< foo >}}
+
+Begin:{{% includerendershortcodes "p2" %}}:End
+Begin:{{< includecontent "p3" >}}:End
+
+-- content/p2.md --
+---
+title: "Post 2"
+date: "2020-01-02"
+---
+
+# P2
+-- content/p3.md --
+---
+title: "Post 3"
+date: "2020-01-03"
+---
+
+# P3
+
+{{< foo >}}
+
+-- layouts/index.html --
+Home.
+{{ with site.GetPage "p1" }}
+	{{ with .Markup "home" }}
+	 	{{ .Render.Content }}
+	{{ end }}
+{{ end }}
+-- layouts/_default/single.html --
+Single.
+{{ with .Markup  }}
+	{{ with .Render }}
+	 	{{ .Content }}
+	{{ end }}
+{{ end }}
+-- layouts/_default/_markup/render-heading.html --
+Render heading: title: {{ .Text}} scope: {{ hugo.Context.MarkupScope }}|
+-- layouts/shortcodes/foo.html --
+Foo scope: {{ hugo.Context.MarkupScope }}|
+-- layouts/shortcodes/includerendershortcodes.html --
+{{ $p := site.GetPage (.Get 0) }}
+includerendershortcodes: {{ hugo.Context.MarkupScope }}|{{ $p.Markup.RenderShortcodes }}|
+-- layouts/shortcodes/includecontent.html --
+{{ $p := site.GetPage (.Get 0) }}
+includecontent: {{ hugo.Context.MarkupScope }}|{{ $p.Markup.Render.Content }}|
+
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/p1/index.html", "Render heading: title: P1 scope: |", "Foo scope: |")
+
+	b.AssertFileContent("public/index.html",
+		"Render heading: title: P1 scope: home|",
+		"Foo scope: home|",
+		"Begin:\nincluderendershortcodes: home|</p>\nRender heading: title: P2 scope: home|<p>|:End",
+		"Begin:\nincludecontent: home|Render heading: title: P3 scope: home|Foo scope: home|\n|\n:End",
+	)
+}
+
+func TestPageMarkupWithoutSummary(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+summaryLength=5
+-- content/p1.md --
+---
+title: "Post 1"
+date: "2020-01-01"
+---
+This is summary.
+<!--more-->
+This is content.
+-- content/p2.md --
+---
+title: "Post 2"
+date: "2020-01-01"
+---
+This is some content about a summary and more.
+
+Another paragraph.
+
+Third paragraph.
+-- layouts/_default/single.html --
+Single.
+Page.Summary: {{ .Summary }}|
+{{ with .Markup.Render }}
+Content: {{ .Content }}|
+ContentWithoutSummary: {{ .ContentWithoutSummary }}|
+WordCount: {{ .WordCount }}|
+FuzzyWordCount: {{ .FuzzyWordCount }}|
+{{ with .Summary }}
+Summary: {{ . }}|
+Summary Type: {{ .Type }}|
+Summary Truncated: {{ .Truncated }}|
+{{ end }}
+{{ end }}
+
+`
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContentExact("public/p1/index.html",
+		"Content: <p>This is summary.</p>\n<p>This is content.</p>",
+		"ContentWithoutSummary: <p>This is content.</p>|",
+		"WordCount: 6|",
+		"FuzzyWordCount: 100|",
+		"Summary: <p>This is summary.</p>|",
+		"Summary Type: manual|",
+		"Summary Truncated: true|",
+	)
+	b.AssertFileContent("public/p2/index.html",
+		"Summary: <p>This is some content about a summary and more.</p>|",
+		"WordCount: 13|",
+		"FuzzyWordCount: 100|",
+		"Summary Type: auto",
+		"Summary Truncated: true",
+	)
+}
+
+func TestPageMarkupWithoutSummaryRST(t *testing.T) {
+	t.Parallel()
+	if !rst.Supports() {
+		t.Skip("Skip RST test as not supported")
+	}
+
+	files := `
+-- hugo.toml --
+summaryLength=5
+[security.exec]
+allow = ["rst", "python"]
+
+-- content/p1.rst --
+This is a story about a summary and more.
+
+Another paragraph.
+-- content/p2.rst --
+This is summary.
+<!--more-->
+This is content.
+-- layouts/_default/single.html --
+Single.
+Page.Summary: {{ .Summary }}|
+{{ with .Markup.Render }}
+Content: {{ .Content }}|
+ContentWithoutSummary: {{ .ContentWithoutSummary }}|
+{{ with .Summary }}
+Summary: {{ . }}|
+Summary Type: {{ .Type }}|
+Summary Truncated: {{ .Truncated }}|
+{{ end }}
+{{ end }}
+
+`
+
+	b := hugolib.Test(t, files)
+
+	// Auto summary.
+	b.AssertFileContentExact("public/p1/index.html",
+		"Content: <div class=\"document\">\n\n\n<p>This is a story about a summary and more.</p>\n<p>Another paragraph.</p>\n</div>|",
+		"Summary: <div class=\"document\">\n\n\n<p>This is a story about a summary and more.</p></div>|\nSummary Type: auto|\nSummary Truncated: true|",
+		"ContentWithoutSummary: <div class=\"document\">\n<p>Another paragraph.</p>\n</div>|",
+	)
+
+	// Manual summary.
+	b.AssertFileContentExact("public/p2/index.html",
+		"Content: <div class=\"document\">\n\n\n<p>This is summary.</p>\n<p>This is content.</p>\n</div>|",
+		"ContentWithoutSummary: <div class=\"document\"><p>This is content.</p>\n</div>|",
+		"Summary: <div class=\"document\">\n\n\n<p>This is summary.</p>\n</div>|\nSummary Type: manual|\nSummary Truncated: true|",
+	)
+}
+
+func TestPageMarkupWithoutSummaryAsciidoc(t *testing.T) {
+	t.Parallel()
+	if !asciidocext.Supports() {
+		t.Skip("Skip asiidoc test as not supported")
+	}
+
+	files := `
+-- hugo.toml --
+summaryLength=5
+[security.exec]
+allow = ["asciidoc", "python"]
+
+-- content/p1.ad --
+This is a story about a summary and more.
+
+Another paragraph.
+-- content/p2.ad --
+This is summary.
+<!--more-->
+This is content.
+-- layouts/_default/single.html --
+Single.
+Page.Summary: {{ .Summary }}|
+{{ with .Markup.Render }}
+Content: {{ .Content }}|
+ContentWithoutSummary: {{ .ContentWithoutSummary }}|
+{{ with .Summary }}
+Summary: {{ . }}|
+Summary Type: {{ .Type }}|
+Summary Truncated: {{ .Truncated }}|
+{{ end }}
+{{ end }}
+
+`
+
+	b := hugolib.Test(t, files)
+
+	// Auto summary.
+	b.AssertFileContentExact("public/p1/index.html",
+		"Content: <div class=\"paragraph\">\n<p>This is a story about a summary and more.</p>\n</div>\n<div class=\"paragraph\">\n<p>Another paragraph.</p>\n</div>\n|",
+		"Summary: <div class=\"paragraph\">\n<p>This is a story about a summary and more.</p>\n</div>|",
+		"Summary Type: auto|\nSummary Truncated: true|",
+		"ContentWithoutSummary: <div class=\"paragraph\">\n<p>Another paragraph.</p>\n</div>|",
+	)
+
+	// Manual summary.
+	b.AssertFileContentExact("public/p2/index.html",
+		"Content: <div class=\"paragraph\">\n<p>This is summary.</p>\n</div>\n<div class=\"paragraph\">\n<p>This is content.</p>\n</div>|",
+		"ContentWithoutSummary: <div class=\"paragraph\">\n<p>This is content.</p>\n</div>|",
+		"Summary: <div class=\"paragraph\">\n<p>This is summary.</p>\n</div>|\nSummary Type: manual|\nSummary Truncated: true|",
+	)
+}

--- a/resources/page/page_markup_test.go
+++ b/resources/page/page_markup_test.go
@@ -1,0 +1,151 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package page
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/gohugoio/hugo/common/types"
+	"github.com/gohugoio/hugo/media"
+)
+
+func TestExtractSummaryFromHTML(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		mt                          media.Type
+		input                       string
+		isCJK                       bool
+		numWords                    int
+		expectSummary               string
+		expectContentWithoutSummary string
+	}{
+		{media.Builtin.ReStructuredTextType, "<div class=\"document\">\n\n\n<p>Simple Page</p>\n</div>", false, 70, "<div class=\"document\">\n\n\n<p>Simple Page</p>\n</div>", ""},
+		{media.Builtin.ReStructuredTextType, "<div class=\"document\"><p>First paragraph</p><p>Second paragraph</p></div>", false, 2, `<div class="document"><p>First paragraph</p></div>`, "<div class=\"document\"><p>Second paragraph</p></div>"},
+		{media.Builtin.MarkdownType, "<p>First paragraph</p>", false, 10, "<p>First paragraph</p>", ""},
+		{media.Builtin.MarkdownType, "<p>First paragraph</p><p>Second paragraph</p>", false, 2, "<p>First paragraph</p>", "<p>Second paragraph</p>"},
+		{media.Builtin.MarkdownType, "<p>First paragraph</p><p>Second paragraph</p><p>Third paragraph</p>", false, 3, "<p>First paragraph</p><p>Second paragraph</p>", "<p>Third paragraph</p>"},
+		{media.Builtin.AsciiDocType, "<div><p>First paragraph</p></div><div><p>Second paragraph</p></div>", false, 2, "<div><p>First paragraph</p></div>", "<div><p>Second paragraph</p></div>"},
+		{media.Builtin.MarkdownType, "<p>这是中文，全中文</p><p>a这是中文，全中文</p>", true, 5, "<p>这是中文，全中文</p>", "<p>a这是中文，全中文</p>"},
+	}
+
+	for i, test := range tests {
+		summary := ExtractSummaryFromHTML(test.mt, test.input, test.numWords, test.isCJK)
+		c.Assert(summary.Summary(), qt.Equals, test.expectSummary, qt.Commentf("Summary %d", i))
+		c.Assert(summary.ContentWithoutSummary(), qt.Equals, test.expectContentWithoutSummary, qt.Commentf("ContentWithoutSummary %d", i))
+	}
+}
+
+func TestExtractSummaryFromHTMLWithDivider(t *testing.T) {
+	c := qt.New(t)
+
+	const divider = "FOOO"
+
+	tests := []struct {
+		mt                          media.Type
+		input                       string
+		expectSummary               string
+		expectContentWithoutSummary string
+		expectContent               string
+	}{
+		{media.Builtin.MarkdownType, "<p>First paragraph</p><p>FOOO</p><p>Second paragraph</p>", "<p>First paragraph</p>", "<p>Second paragraph</p>", "<p>First paragraph</p><p>Second paragraph</p>"},
+		{media.Builtin.MarkdownType, "<p>First paragraph</p>\n<p>FOOO</p>\n<p>Second paragraph</p>", "<p>First paragraph</p>", "<p>Second paragraph</p>", "<p>First paragraph</p>\n<p>Second paragraph</p>"},
+		{media.Builtin.MarkdownType, "<p>FOOO</p>\n<p>First paragraph</p>", "", "<p>First paragraph</p>", "<p>First paragraph</p>"},
+		{media.Builtin.MarkdownType, "<p>First paragraph</p><p>Second paragraphFOOO</p><p>Third paragraph</p>", "<p>First paragraph</p><p>Second paragraph</p>", "<p>Third paragraph</p>", "<p>First paragraph</p><p>Second paragraph</p><p>Third paragraph</p>"},
+		{media.Builtin.MarkdownType, "<p>这是中文，全中文FOOO</p><p>a这是中文，全中文</p>", "<p>这是中文，全中文</p>", "<p>a这是中文，全中文</p>", "<p>这是中文，全中文</p><p>a这是中文，全中文</p>"},
+		{media.Builtin.MarkdownType, `<p>a <strong>b</strong>` + "\v" + ` c</p>` + "\n<p>FOOO</p>", "<p>a <strong>b</strong>\v c</p>", "", "<p>a <strong>b</strong>\v c</p>"},
+
+		{media.Builtin.HTMLType, "<p>First paragraph</p>FOOO<p>Second paragraph</p>", "<p>First paragraph</p>", "<p>Second paragraph</p>", "<p>First paragraph</p><p>Second paragraph</p>"},
+
+		{media.Builtin.ReStructuredTextType, "<div class=\"document\">\n\n\n<p>This is summary.</p>\n<p>FOOO</p>\n<p>This is content.</p>\n</div>", "<div class=\"document\">\n\n\n<p>This is summary.</p>\n</div>", "<div class=\"document\"><p>This is content.</p>\n</div>", "<div class=\"document\">\n\n\n<p>This is summary.</p>\n<p>This is content.</p>\n</div>"},
+		{media.Builtin.ReStructuredTextType, "<div class=\"document\"><p>First paragraphFOOO</p><p>Second paragraph</p></div>", "<div class=\"document\"><p>First paragraph</p></div>", "<div class=\"document\"><p>Second paragraph</p></div>", `<div class="document"><p>First paragraph</p><p>Second paragraph</p></div>`},
+
+		{media.Builtin.AsciiDocType, "<div class=\"paragraph\"><p>Summary Next Line</p></div><div class=\"paragraph\"><p>FOOO</p></div><div class=\"paragraph\"><p>Some more text</p></div>", "<div class=\"paragraph\"><p>Summary Next Line</p></div>", "<div class=\"paragraph\"><p>Some more text</p></div>", "<div class=\"paragraph\"><p>Summary Next Line</p></div><div class=\"paragraph\"><p>Some more text</p></div>"},
+		{media.Builtin.AsciiDocType, "<div class=\"paragraph\">\n<p>Summary Next Line</p>\n</div>\n<div class=\"paragraph\">\n<p>FOOO</p>\n</div>\n<div class=\"paragraph\">\n<p>Some more text</p>\n</div>\n", "<div class=\"paragraph\">\n<p>Summary Next Line</p>\n</div>", "<div class=\"paragraph\">\n<p>Some more text</p>\n</div>", "<div class=\"paragraph\">\n<p>Summary Next Line</p>\n</div>\n<div class=\"paragraph\">\n<p>Some more text</p>\n</div>"},
+		{media.Builtin.AsciiDocType, "<div><p>FOOO</p></div><div><p>First paragraph</p></div>", "", "<div><p>First paragraph</p></div>", "<div><p>First paragraph</p></div>"},
+		{media.Builtin.AsciiDocType, "<div><p>First paragraphFOOO</p></div><div><p>Second paragraph</p></div>", "<div><p>First paragraph</p></div>", "<div><p>Second paragraph</p></div>", "<div><p>First paragraph</p></div><div><p>Second paragraph</p></div>"},
+	}
+
+	for i, test := range tests {
+		summary := ExtractSummaryFromHTMLWithDivider(test.mt, test.input, divider)
+		c.Assert(summary.Summary(), qt.Equals, test.expectSummary, qt.Commentf("Summary %d", i))
+		c.Assert(summary.ContentWithoutSummary(), qt.Equals, test.expectContentWithoutSummary, qt.Commentf("ContentWithoutSummary %d", i))
+		c.Assert(summary.Content(), qt.Equals, test.expectContent, qt.Commentf("Content %d", i))
+	}
+}
+
+func TestExpandDivider(t *testing.T) {
+	c := qt.New(t)
+
+	for i, test := range []struct {
+		input           string
+		divider         string
+		ptag            tagReStartEnd
+		expect          string
+		expectEndMarkup string
+	}{
+		{"<p>First paragraph</p>\n<p>FOOO</p>\n<p>Second paragraph</p>", "FOOO", startEndP, "<p>FOOO</p>\n", ""},
+		{"<div class=\"paragraph\">\n<p>FOOO</p>\n</div>", "FOOO", startEndDiv, "<div class=\"paragraph\">\n<p>FOOO</p>\n</div>", ""},
+		{"<div><p>FOOO</p></div><div><p>Second paragraph</p></div>", "FOOO", startEndDiv, "<div><p>FOOO</p></div>", ""},
+		{"<div><p>First paragraphFOOO</p></div><div><p>Second paragraph</p></div>", "FOOO", startEndDiv, "FOOO", "</p></div>"},
+		{"   <p> abc FOOO  </p>  ", "FOOO", startEndP, "FOOO", "  </p>"},
+		{"   <p>  FOOO  </p>  ", "FOOO", startEndP, "<p>  FOOO  </p>", ""},
+		{"   <p>\n  \nFOOO  </p>  ", "FOOO", startEndP, "<p>\n  \nFOOO  </p>", ""},
+		{"   <div>  FOOO  </div>  ", "FOOO", startEndDiv, "<div>  FOOO  </div>", ""},
+	} {
+
+		l := types.LowHigh[string]{Low: strings.Index(test.input, test.divider), High: strings.Index(test.input, test.divider) + len(test.divider)}
+		e, t := expandSummaryDivider(test.input, test.ptag, l)
+		c.Assert(test.input[e.Low:e.High], qt.Equals, test.expect, qt.Commentf("[%d] Test.expect %q", i, test.input))
+		c.Assert(test.input[t.Low:t.High], qt.Equals, test.expectEndMarkup, qt.Commentf("[%d] Test.expectEndMarkup %q", i, test.input))
+	}
+}
+
+func BenchmarkSummaryFromHTML(b *testing.B) {
+	b.StopTimer()
+	input := "<p>First paragraph</p><p>Second paragraph</p>"
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		summary := ExtractSummaryFromHTML(media.Builtin.MarkdownType, input, 2, false)
+		if s := summary.Content(); s != input {
+			b.Fatalf("unexpected content: %q", s)
+		}
+		if s := summary.ContentWithoutSummary(); s != "<p>Second paragraph</p>" {
+			b.Fatalf("unexpected content without summary: %q", s)
+		}
+		if s := summary.Summary(); s != "<p>First paragraph</p>" {
+			b.Fatalf("unexpected summary: %q", s)
+		}
+	}
+}
+
+func BenchmarkSummaryFromHTMLWithDivider(b *testing.B) {
+	b.StopTimer()
+	input := "<p>First paragraph</p><p>FOOO</p><p>Second paragraph</p>"
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		summary := ExtractSummaryFromHTMLWithDivider(media.Builtin.MarkdownType, input, "FOOO")
+		if s := summary.Content(); s != "<p>First paragraph</p><p>Second paragraph</p>" {
+			b.Fatalf("unexpected content: %q", s)
+		}
+		if s := summary.ContentWithoutSummary(); s != "<p>Second paragraph</p>" {
+			b.Fatalf("unexpected content without summary: %q", s)
+		}
+		if s := summary.Summary(); s != "<p>First paragraph</p>" {
+			b.Fatalf("unexpected summary: %q", s)
+		}
+	}
+}

--- a/resources/page/page_nop.go
+++ b/resources/page/page_nop.go
@@ -44,6 +44,8 @@ import (
 var (
 	NopPage                 Page            = new(nopPage)
 	NopContentRenderer      ContentRenderer = new(nopContentRenderer)
+	NopMarkup               Markup          = new(nopMarkup)
+	NopContent              Content         = new(nopContent)
 	NopCPageContentRenderer                 = struct {
 		OutputFormatPageContentProvider
 		ContentRenderer
@@ -109,7 +111,15 @@ func (p *nopPage) BundleType() string {
 	return ""
 }
 
+func (p *nopPage) Markup(...any) Markup {
+	return NopMarkup
+}
+
 func (p *nopPage) Content(context.Context) (any, error) {
+	return "", nil
+}
+
+func (p *nopPage) ContentWithoutSummary(ctx context.Context) (template.HTML, error) {
 	return "", nil
 }
 
@@ -546,4 +556,70 @@ func (r *nopContentRenderer) ParseContent(ctx context.Context, content []byte) (
 
 func (r *nopContentRenderer) RenderContent(ctx context.Context, content []byte, doc any) (converter.ResultRender, bool, error) {
 	return nil, false, nil
+}
+
+type (
+	nopMarkup  int
+	nopContent int
+)
+
+var (
+	_ Markup  = (*nopMarkup)(nil)
+	_ Content = (*nopContent)(nil)
+)
+
+func (c *nopMarkup) Render(context.Context) (Content, error) {
+	return NopContent, nil
+}
+
+func (c *nopMarkup) RenderString(ctx context.Context, args ...any) (template.HTML, error) {
+	return "", nil
+}
+
+func (c *nopMarkup) RenderShortcodes(context.Context) (template.HTML, error) {
+	return "", nil
+}
+
+func (c *nopContent) Plain(context.Context) string {
+	return ""
+}
+
+func (c *nopContent) PlainWords(context.Context) []string {
+	return nil
+}
+
+func (c *nopContent) WordCount(context.Context) int {
+	return 0
+}
+
+func (c *nopContent) FuzzyWordCount(context.Context) int {
+	return 0
+}
+
+func (c *nopContent) ReadingTime(context.Context) int {
+	return 0
+}
+
+func (c *nopContent) Len(context.Context) int {
+	return 0
+}
+
+func (c *nopContent) Content(context.Context) (template.HTML, error) {
+	return "", nil
+}
+
+func (c *nopContent) ContentWithoutSummary(context.Context) (template.HTML, error) {
+	return "", nil
+}
+
+func (c *nopMarkup) Fragments(context.Context) *tableofcontents.Fragments {
+	return nil
+}
+
+func (c *nopMarkup) FragmentsHTML(context.Context) template.HTML {
+	return ""
+}
+
+func (c *nopContent) Summary(context.Context) (Summary, error) {
+	return Summary{}, nil
 }

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -149,6 +149,10 @@ func (p *testPage) Content(context.Context) (any, error) {
 	panic("testpage: not implemented")
 }
 
+func (p *testPage) Markup(...any) Markup {
+	panic("testpage: not implemented")
+}
+
 func (p *testPage) ContentBaseName() string {
 	panic("testpage: not implemented")
 }
@@ -175,6 +179,10 @@ func (p *testPage) Date() time.Time {
 
 func (p *testPage) Description() string {
 	return ""
+}
+
+func (p *testPage) ContentWithoutSummary(ctx context.Context) (template.HTML, error) {
+	return "", nil
 }
 
 func (p *testPage) Dir() string {


### PR DESCRIPTION
Edit in 2024-08-16. I have revised my take on this after talking to @jmooring and thinking a little. The (original) primary motivation behind this PR (for me, anyway) was to make it possible to render different versions of a given page's content on, say, the home page. But we also want to make room for further improvements in this area without blowing the scope of this PR out of proportions. I have always wanted to create a map of the rendered content, but that would only be practical for Goldmark (and hard even there, I guess). I think that and similar extensions should be fairly simple to fit in the below.

* I have added `ContentWithoutSummary`, which I know many have asked for
* I have reduced the amount of name changes; `FuzzyWordCount` has been around for a decade and has become a brand by now.
* The _content Summary_ type will have a `Type` discriminator that is either "auto" or "manual" or "frontmatter" 
* For now, I suggest we keep all old content methods as aliases on `Page`, e.g. `.Content`, `.WordCount` etc.

----

With this you can do:

```handlebars
{{ with .Markup }}
  {{ with .Render }}
    {{ .Content }} 
    {{ .WordCount }} // ... etc.
  {{ end }}
{{ end }}
```

You can also give it its own scope:

```handlebars
{{ range site.RegularPages | first 20 }}
  {{ with .Markup "home" }}
    {{ .Render.Content }}
  {{ end }}
{{ end }}
```

```go
type Markup interface {
	Render(context.Context) (Content, error)
	RenderString(ctx context.Context, args ...any) (template.HTML, error)
	RenderShortcodes(context.Context) (template.HTML, error)
	Fragments(context.Context) *tableofcontents.Fragments
}

type Content interface {
        Content(context.Context) template.HTML
	ContentWithoutSummary(context.Context) template.HTML
	Summary(context.Context) Summary
	Plain(context.Context) string
	PlainWords(context.Context) []string
	WordCount(context.Context) int
	FuzzyWordCount(context.Context) int
	ReadingTime(context.Context) int
	Len(context.Context) int
}


type Summary struct {
	Text      template.HTML
	Type      string // "auto" or "manual".
	Truncated bool
}
```

Fixes #8680
