### PR TITLE
markup/goldmark/blockquotes: Fix handling of lower/mixed case GitHub alerts

### DIFF
--- a/markup/goldmark/blockquotes/blockquotes.go
+++ b/markup/goldmark/blockquotes/blockquotes.go
@@ -237,7 +237,8 @@ var _ hooks.PositionerSourceTargetProvider = (*blockquoteContext)(nil)
 // https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
 // Five types:
 // [!NOTE], [!TIP], [!WARNING], [!IMPORTANT], [!CAUTION]
-var gitHubAlertRe = regexp.MustCompile(`^<p>\[!(NOTE|TIP|WARNING|IMPORTANT|CAUTION)\]`)
+// Note that GitHub's implementation is case-insensitive.
+var gitHubAlertRe = regexp.MustCompile(`(?i)^<p>\[!(NOTE|TIP|WARNING|IMPORTANT|CAUTION)\]`)
 
 // resolveGitHubAlert returns one of note, tip, warning, important or caution.
 // An empty string if no match.

--- a/markup/goldmark/blockquotes/blockquotes_integration_test.go
+++ b/markup/goldmark/blockquotes/blockquotes_integration_test.go
@@ -68,6 +68,11 @@ title: "p1"
 > Note triggering showing the position.
 {showpos="true"}
 
+
+> [!nOtE]  
+> Mixed case alert type.
+
+
 `
 
 	b := hugolib.Test(t, files)
@@ -79,6 +84,9 @@ title: "p1"
 		"Blockquote Alert Attributes: |<p>This is a tip with attributes.</p>\n|map[class:foo bar id:baz]|",
 		filepath.FromSlash("/content/p1.md:20:3"),
 		"Blockquote Alert Page: |<p>This is a tip with attributes.</p>\n|p1|p1|",
+
+		// Issue 12767.
+		"Blockquote Alert: |<p>Mixed case alert type.</p>\n|alert",
 	)
 }
 


### PR DESCRIPTION
Fixes #12767
