### PR TITLE
Fix: swap GITHUB_TOKEN for GH_PAT

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -102,7 +102,8 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # NOTE: You can't use default GITHUB_TOKEN if you want to push container, use Personal Access Token instead. 
+          password: ${{ secrets.GH_PAT }}
 
       - name: Create manifest list and push
         if: ${{ startsWith(github.ref, 'refs/tags') }}


### PR DESCRIPTION
You can't use default `GITHUB_TOKEN` if you want to push container to ghcr, you need to use [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) instead.

Don't forget to add a new secret, and configure scopes for your personal token. 
