### PR TITLE
output: Fix docshelper template lookup order for AMP pages

### DIFF
--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -1865,7 +1865,7 @@ output:
     - layouts/_default/demolayout-baseof.html
     - layouts/_default/single-baseof.html
     - layouts/_default/baseof.html
-  - Example: AMP single page
+  - Example: AMP single page in "posts" section
     Kind: page
     OutputFormat: amp
     Suffix: html
@@ -1874,17 +1874,17 @@ output:
     - layouts/posts/single.html
     - layouts/_default/single.amp.html
     - layouts/_default/single.html
-  - Example: AMP single page, French language
+  - Example: AMP single page in "posts" section, French language
     Kind: page
-    OutputFormat: html
+    OutputFormat: amp
     Suffix: html
     Template Lookup Order:
-    - layouts/posts/single.fr.html.html
-    - layouts/posts/single.html.html
+    - layouts/posts/single.fr.amp.html
+    - layouts/posts/single.amp.html
     - layouts/posts/single.fr.html
     - layouts/posts/single.html
-    - layouts/_default/single.fr.html.html
-    - layouts/_default/single.html.html
+    - layouts/_default/single.fr.amp.html
+    - layouts/_default/single.amp.html
     - layouts/_default/single.fr.html
     - layouts/_default/single.html
   - Example: Home page

--- a/output/docshelper.go
+++ b/output/docshelper.go
@@ -46,8 +46,8 @@ func createLayoutExamples() any {
 		{"Base template for single page in \"posts\" section", layouts.LayoutDescriptor{Baseof: true, Kind: "page", Type: "posts", OutputFormatName: "html", Suffix: "html"}},
 		{"Single page in \"posts\" section with layout set to \"demolayout\"", layouts.LayoutDescriptor{Kind: "page", Type: "posts", Layout: demoLayout, OutputFormatName: "html", Suffix: "html"}},
 		{"Base template for single page in \"posts\" section with layout set to \"demolayout\"", layouts.LayoutDescriptor{Baseof: true, Kind: "page", Type: "posts", Layout: demoLayout, OutputFormatName: "html", Suffix: "html"}},
-		{"AMP single page", layouts.LayoutDescriptor{Kind: "page", Type: "posts", OutputFormatName: "amp", Suffix: "html"}},
-		{"AMP single page, French language", layouts.LayoutDescriptor{Kind: "page", Type: "posts", Lang: "fr", OutputFormatName: "html", Suffix: "html"}},
+		{"AMP single page in \"posts\" section", layouts.LayoutDescriptor{Kind: "page", Type: "posts", OutputFormatName: "amp", Suffix: "html"}},
+		{"AMP single page in \"posts\" section, French language", layouts.LayoutDescriptor{Kind: "page", Type: "posts", Lang: "fr", OutputFormatName: "amp", Suffix: "html"}},
 		// Typeless pages get "page" as type
 		{"Home page", layouts.LayoutDescriptor{Kind: "home", Type: "page", OutputFormatName: "html", Suffix: "html"}},
 		{"Base template for home page", layouts.LayoutDescriptor{Baseof: true, Kind: "home", Type: "page", OutputFormatName: "html", Suffix: "html"}},


### PR DESCRIPTION
Fixes #12797