### PR TITLE
Add support for Obsidian type blockquote alerts

### DIFF
--- a/docs/content/en/render-hooks/blockquotes.md
+++ b/docs/content/en/render-hooks/blockquotes.md
@@ -24,6 +24,20 @@ Blockquote render hook templates receive the following [context]:
 
 (`string`) Applicable when [`Type`](#type) is `alert`, this is the alert type converted to lowercase. See the [alerts](#alerts) section below.
 
+###### AlertTitle
+
+{{< new-in 0.134.0 >}}
+
+(`hstring.HTML`) Applicable when [`Type`](#type) is `alert` when using [Obsidian callouts] syntax, this is the alert title converted to HTML. 
+
+###### AlertSign
+
+{{< new-in 0.134.0 >}}
+
+(`string`) Applicable when [`Type`](#type) is `alert` when using [Obsidian callouts] syntax, this is one of "+", "-" or "" (empty string) to indicate the presence of a foldable sign.
+
+[Obsidian callouts]: https://help.obsidian.md/Editing+and+formatting/Callouts
+
 ###### Attributes
 
 (`map`) The [Markdown attributes], available if you configure your site as follows:
@@ -117,13 +131,13 @@ Also known as _callouts_ or _admonitions_, alerts are blockquotes used to emphas
 
 
 {{% note %}}
-This syntax is compatible with the GitHub Alert Markdown extension.
+This syntax is compatible with both the GitHub Alert Markdown extension and Obsidian's callout syntax. 
+But note that GitHub will not recognize callouts with one of Obsidian's extensions (e.g. callout title or the foldable sign).
 {{% /note %}}
-
 
 The first line of each alert is an alert designator consisting of an exclamation point followed by the alert type, wrapped within brackets.
 
-The blockquote render hook below renders a multilingual alert if an alert desginator is present, otherwise it renders a blockquote according to the CommonMark specification.
+The blockquote render hook below renders a multilingual alert if an alert designator is present, otherwise it renders a blockquote according to the CommonMark specification.
 
 {{< code file=layouts/_default/_markup/render-blockquote.html copy=true >}}
 {{ $emojis := dict

--- a/markup/converter/hooks/hooks.go
+++ b/markup/converter/hooks/hooks.go
@@ -109,6 +109,16 @@ type BlockquoteContext interface {
 	// The GitHub alert type converted to lowercase, e.g. "note".
 	// Only set if Type is "alert".
 	AlertType() string
+
+	// The alert title.
+	// Currently only relevant for Obsidian alerts.
+	// GitHub does not suport alert titles and will not render alerts with titles.
+	AlertTitle() hstring.HTML
+
+	// The alert sign,  "+" or "-" or "" used to indicate folding.
+	// Currently only relevant for Obsidian alerts.
+	// GitHub does not suport alert signs and will not render alerts with signs.
+	AlertSign() string
 }
 
 type PositionerSourceTargetProvider interface {

--- a/markup/goldmark/blockquotes/blockquotes_integration_test.go
+++ b/markup/goldmark/blockquotes/blockquotes_integration_test.go
@@ -109,3 +109,48 @@ Content: {{ .Content }}
 	b := hugolib.Test(t, files)
 	b.AssertFileContent("public/p1/index.html", "Content: <blockquote>\n</blockquote>\n")
 }
+
+func TestBlockquObsidianWithTitleAndSign(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+-- content/_index.md --
+---
+title: "Home"
+---
+
+> [!danger]
+> Do not approach or handle without protective gear.
+
+
+> [!tip] Callouts can have custom titles
+> Like this one.
+
+> [!tip] Title-only callout
+
+> [!faq]- Foldable negated callout
+> Yes! In a foldable callout, the contents are hidden when the callout is collapsed
+
+> [!faq]+ Foldable callout
+> Yes! In a foldable callout, the contents are hidden when the callout is collapsed
+
+-- layouts/index.html --
+{{ .Content }}
+-- layouts/_default/_markup/render-blockquote.html --
+AlertType: {{ .AlertType }}|
+AlertTitle: {{ .AlertTitle }}|
+AlertSign: {{ .AlertSign | safeHTML }}|
+Text: {{ .Text }}|
+	
+	`
+
+	b := hugolib.Test(t, files)
+	b.AssertFileContent("public/index.html",
+		"AlertType: tip|\nAlertTitle: Callouts can have custom titles|\nAlertSign: |",
+		"AlertType: tip|\nAlertTitle: Title-only callout</p>|\nAlertSign: |",
+		"AlertType: faq|\nAlertTitle: Foldable negated callout|\nAlertSign: -|\nText: <p>Yes!",
+		"AlertType: faq|\nAlertTitle: Foldable callout|\nAlertSign: +|",
+		"AlertType: danger|\nAlertTitle: |\nAlertSign: |\nText: <p>Do not approach or handle without protective gear.</p>\n|",
+	)
+}

--- a/markup/goldmark/blockquotes/blockquotes_test.go
+++ b/markup/goldmark/blockquotes/blockquotes_test.go
@@ -19,42 +19,50 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
-func TestResolveGitHubAlert(t *testing.T) {
+func TestResolveBlockQuoteAlert(t *testing.T) {
 	t.Parallel()
 
 	c := qt.New(t)
 
 	tests := []struct {
 		input    string
-		expected string
+		expected blockQuoteAlert
 	}{
 		{
 			input:    "[!NOTE]",
-			expected: "note",
+			expected: blockQuoteAlert{typ: "note"},
 		},
 		{
-			input:    "[!WARNING]",
-			expected: "warning",
+			input:    "[!FaQ]",
+			expected: blockQuoteAlert{typ: "faq"},
 		},
 		{
-			input:    "[!TIP]",
-			expected: "tip",
+			input:    "[!NOTE]+",
+			expected: blockQuoteAlert{typ: "note", sign: "+"},
 		},
 		{
-			input:    "[!IMPORTANT]",
-			expected: "important",
+			input:    "[!NOTE]-",
+			expected: blockQuoteAlert{typ: "note", sign: "-"},
 		},
 		{
-			input:    "[!CAUTION]",
-			expected: "caution",
+			input:    "[!NOTE] This is a note",
+			expected: blockQuoteAlert{typ: "note", title: "This is a note"},
 		},
 		{
-			input:    "[!FOO]",
-			expected: "",
+			input:    "[!NOTE]+ This is a note",
+			expected: blockQuoteAlert{typ: "note", sign: "+", title: "This is a note"},
+		},
+		{
+			input:    "[!NOTE]+ This is a title\nThis is not.",
+			expected: blockQuoteAlert{typ: "note", sign: "+", title: "This is a title"},
+		},
+		{
+			input:    "[!NOTE]\nThis is not.",
+			expected: blockQuoteAlert{typ: "note"},
 		},
 	}
 
-	for _, test := range tests {
-		c.Assert(resolveGitHubAlert("<p>"+test.input), qt.Equals, test.expected)
+	for i, test := range tests {
+		c.Assert(resolveBlockQuoteAlert("<p>"+test.input), qt.Equals, test.expected, qt.Commentf("Test %d", i))
 	}
 }


### PR DESCRIPTION
* Make the alert type parsing more flexible to support more types
* Add `AlertTitle` and `AlertSign` (for folding)

Note that GitHub will not render callouts with alert title/sign.

See https://help.obsidian.md/Editing+and+formatting/Callouts

Closes #12805
Closes #12801
