### PR TITLE
Update Go Version to 1.22.6 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Twitter:      https://twitter.com/gohugoio
 # Website:      https://gohugo.io/
 
-FROM golang:1.21-alpine AS build
+FROM golang:1.22.6-alpine AS build
 
 # Optionally set HUGO_BUILD_TAGS to "extended" or "nodeploy" when building like so:
 #   docker build --build-arg HUGO_BUILD_TAGS=extended .


### PR DESCRIPTION
updates the Go version in the Dockerfile from 1.21.13 to 1.22.6 to resolve compatibility issues with the go.mod requirements.