### PR TITLE
encoding: Add the ZlibCompress function

### DIFF
--- a/tpl/encoding/encoding.go
+++ b/tpl/encoding/encoding.go
@@ -15,6 +15,8 @@
 package encoding
 
 import (
+	"bytes"
+	"compress/zlib"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -113,4 +115,46 @@ type jsonifyOpts struct {
 	Prefix       string
 	Indent       string
 	NoHTMLEscape bool
+}
+
+// ZlibCompress returns the compressed data of the given content and optional level.
+func (ns *Namespace) ZlibCompress(args ...any) (string, error) {
+	var (
+		input string
+		err   error
+	)
+	level := 9
+	switch len(args) {
+	case 0:
+		return "", nil
+	case 1:
+		input, err = cast.ToStringE(args[0])
+	case 2:
+		input, err = cast.ToStringE(args[0])
+		if err != nil {
+			break
+		}
+
+		level, err = cast.ToIntE(args[1])
+	default:
+		err = errors.New("too many arguments to ZlibCompress")
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	var buffer bytes.Buffer
+	writer, err := zlib.NewWriterLevel(&buffer, level)
+	if err != nil {
+		return "", err
+	}
+
+	_, err = writer.Write([]byte(input))
+	writer.Close()
+	if err != nil {
+		return "", err
+	}
+
+	return buffer.String(), nil
 }

--- a/tpl/encoding/encoding_test.go
+++ b/tpl/encoding/encoding_test.go
@@ -14,6 +14,7 @@
 package encoding
 
 import (
+	"encoding/base64"
 	"html/template"
 	"math"
 	"testing"
@@ -117,5 +118,34 @@ func TestJsonify(t *testing.T) {
 
 		c.Assert(err, qt.IsNil)
 		c.Assert(result, qt.Equals, test.expect, qt.Commentf("#%d", i))
+	}
+}
+
+func TestZlibCompress(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New()
+
+	for _, test := range []struct {
+		v      any
+		lvl    any
+		expect any // base64 URL encoding result or false
+	}{
+		{"foobar", 9, "eNpKy89PSiwCBAAA__8IqwJ6"},
+		{"Hello world!", "1", "eAEADADz_0hlbGxvIHdvcmxkIQEAAP__HQkEXg=="},
+		// errors
+		{"", 100, false},
+	} {
+
+		result, err := ns.ZlibCompress(test.v, test.lvl)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(base64.URLEncoding.EncodeToString([]byte(result)), qt.Equals, test.expect)
 	}
 }


### PR DESCRIPTION
The PR adds zlib compression support to the template, which is useful for generating [Kroki](kroki.io) diagrams without requiring remote APIs, reducing build time and avoiding network issues.

Template usage:

```go
{{ $diagram := `blockdiag {
  Kroki -> generates -> "Block diagrams";
  Kroki -> is -> "very easy!";

  Kroki [color = "greenyellow"];
  "Block diagrams" [color = "pink"];
  "very easy!" [color = "orange"];
}`
}}
{{- $encoded := encoding.ZlibCompress $diagram | encoding.Base64Encode }}
{{- $encoded = replace $encoded "+" "-" }}
{{- $encoded = replace $encoded "/" "_" }}
{{- $encoded = replace $encoded "=" "" }}
<img src="https://kroki.io/blockdiag/svg/{{ $encoded }}">
```

If this feature is not going to be accepted, please feel free to close it.