### PR TITLE
tpl: Add bitwise manipulation functions

### DIFF
--- a/docs/content/en/functions/bit/And.md
+++ b/docs/content/en/functions/bit/And.md
@@ -1,0 +1,22 @@
+---
+title: bit.And
+description: Bitwise ANDs two or more numbers together.
+categories: []
+keywords: []
+action:
+  aliases: [band]
+  related:
+    - functions/bit/Clear
+    - functions/bit/Or
+    - functions/bit/Xnor
+    - functions/bit/Xor
+  returnType: int64
+  signatures: [bit.And NUMBER NUMBER...]
+---
+
+{{< new-in 0.135.0 >}}
+
+```go-html-template
+{{ fmt.Printf "%#04b" (bit.And 0b1100 0b0110) }} → 0b0100
+{{ fmt.Printf "%#x" (bit.And 0x1C2 0x7F) }} → 0x42
+```

--- a/docs/content/en/functions/bit/Clear.md
+++ b/docs/content/en/functions/bit/Clear.md
@@ -1,0 +1,23 @@
+---
+title: bit.Clear
+description: Clears bits of the first number if they're set to 1 in any of the other numbers respectively (aka. ANDN).
+categories: []
+keywords: []
+action:
+  aliases: [bandn, bclear]
+  related:
+    - functions/bit/And
+    - functions/bit/Not
+    - functions/bit/Or
+    - functions/bit/Xnor
+    - functions/bit/Xor
+  returnType: int64
+  signatures: [bit.Clear NUMBER NUMBER...]
+---
+
+{{< new-in 0.135.0 >}}
+
+```go-html-template
+{{ fmt.Printf "%#04b" (bit.Clear 0b1100 0b0110) }} → 0b1000
+{{ fmt.Printf "%#x" (bit.Clear 0x1C2 0x7F) }} → 0x180
+```

--- a/docs/content/en/functions/bit/Extract.md
+++ b/docs/content/en/functions/bit/Extract.md
@@ -1,0 +1,22 @@
+---
+title: bit.Extract
+description: Extracts a portion of the bits from a number.
+categories: []
+keywords: []
+action:
+  aliases: []
+  related:
+    - functions/bit/And
+    - functions/bit/ShiftRight
+  returnType: int64
+  signatures: [bit.Extract NUMBER LENGTH SHIFT]
+---
+
+{{< new-in 0.135.0 >}}
+
+Extract returns the last LENGTH bits of (NUMBER >> SHIFT).
+
+```go-html-template
+{{ fmt.Printf "%#x" (bit.Extract 0xABCDEF 4 8) }} → 0xd
+{{ fmt.Printf "%#b" (bit.Extract 0b10011011 3 1) }} → 0b101
+```

--- a/docs/content/en/functions/bit/LeadingZeros.md
+++ b/docs/content/en/functions/bit/LeadingZeros.md
@@ -1,0 +1,21 @@
+---
+title: bit.LeadingZeros
+description: Counts leading 0 bits in a number (when cast to uint64).
+categories: []
+keywords: []
+action:
+  aliases: [clz]
+  related:
+    - functions/bit/OnesCount
+    - functions/bit/TrailingZeros
+  returnType: int64
+  signatures: [bit.LeadingZeros NUMBER]
+---
+
+{{< new-in 0.135.0 >}}
+
+```go-html-template
+{{ bit.LeadingZeros 0 }} → 64
+{{ bit.LeadingZeros -1 }} → 0
+{{ bit.LeadingZeros 0x11223344 }} → 32
+```

--- a/docs/content/en/functions/bit/Not.md
+++ b/docs/content/en/functions/bit/Not.md
@@ -1,0 +1,18 @@
+---
+title: bit.Not
+description: Performs a bitwise NOT on a number.
+categories: []
+keywords: []
+action:
+  aliases: [bnot]
+  related: []
+  returnType: int64
+  signatures: [bit.Not NUMBER]
+---
+
+{{< new-in 0.135.0 >}}
+
+```go-html-template
+{{ fmt.Printf "%#x" (bit.Not 0) }} → -0x1
+{{ fmt.Printf "%#x" (bit.Not 0xAA55AA55) }} → -0xaa55aa56
+```

--- a/docs/content/en/functions/bit/OnesCount.md
+++ b/docs/content/en/functions/bit/OnesCount.md
@@ -1,0 +1,20 @@
+---
+title: bit.OnesCount
+description: Counts the number of 1 bits in a number (aka. population count).
+categories: []
+keywords: []
+action:
+  aliases: [popcnt]
+  related: []
+  returnType: int64
+  signatures: [bit.OnesCount NUMBER]
+---
+
+{{< new-in 0.135.0 >}}
+
+```go-html-template
+{{ bit.OnesCount 0 }} → 0
+{{ bit.OnesCount -1 }} → 64
+{{ bit.OnesCount 0x1111 }} → 4
+{{ bit.OnesCount 0xFF }} → 8
+```

--- a/docs/content/en/functions/bit/Or.md
+++ b/docs/content/en/functions/bit/Or.md
@@ -1,0 +1,22 @@
+---
+title: bit.Or
+description: Bitwise ORs two or more numbers together.
+categories: []
+keywords: []
+action:
+  aliases: [bor]
+  related:
+    - functions/bit/And
+    - functions/bit/Clear
+    - functions/bit/Xnor
+    - functions/bit/Xor
+  returnType: int64
+  signatures: [bit.Or NUMBER NUMBER...]
+---
+
+{{< new-in 0.135.0 >}}
+
+```go-html-template
+{{ fmt.Printf "%#04b" (bit.Or 0b1100 0b0110) }} → 0b1110
+{{ fmt.Printf "%#x" (bit.Or 0x1C2 0x7F) }} → 0x1ff
+```

--- a/docs/content/en/functions/bit/ShiftLeft.md
+++ b/docs/content/en/functions/bit/ShiftLeft.md
@@ -1,0 +1,21 @@
+---
+title: bit.ShiftLeft
+description: Shifts a number to the left by a number of bits.
+categories: []
+keywords: []
+action:
+  aliases: [lsl]
+  related:
+    - functions/bit/ShiftRight
+  returnType: int64
+  signatures: [bit.ShiftLeft NUMBER SHIFT]
+---
+
+{{< new-in 0.135.0 >}}
+
+```go-html-template
+{{ fmt.Printf "%#x" (bit.ShiftLeft 0x10 1) }} → 0x20
+{{ fmt.Printf "%#x" (bit.ShiftLeft 0x101 4) }} → 0x1010
+{{ fmt.Printf "%#x" (bit.ShiftLeft 0x1 63) }} → -0x8000000000000000 
+{{ fmt.Printf "%#x" (bit.ShiftLeft 0x1 64) }} → 0x0
+```

--- a/docs/content/en/functions/bit/ShiftRight.md
+++ b/docs/content/en/functions/bit/ShiftRight.md
@@ -1,0 +1,23 @@
+---
+title: bit.ShiftRight
+description: Shifts a number to the right by a number of bits, extending the sign bit (aka. arithmetic shift).
+categories: []
+keywords: []
+action:
+  aliases: [asr]
+  related:
+    - functions/bit/ShiftLeft
+  returnType: int64
+  signatures: [bit.ShiftRight NUMBER SHIFT]
+---
+
+{{< new-in 0.135.0 >}}
+
+```go-html-template
+{{ fmt.Printf "%#x" (bit.ShiftRight 0x10 1) }} → 0x8
+{{ fmt.Printf "%#x" (bit.ShiftRight 0x101 4) }} → 0x10
+{{/* Sign extension */}}
+{{ fmt.Printf "%#x" (bit.ShiftRight -0x1 1) }} → -0x1
+{{ fmt.Printf "%#x" (bit.ShiftRight -0x1 20) }} → -0x1
+{{ fmt.Printf "%#x" (bit.ShiftRight -0x8 1) }} → -0x4
+```

--- a/docs/content/en/functions/bit/TrailingZeros.md
+++ b/docs/content/en/functions/bit/TrailingZeros.md
@@ -1,0 +1,21 @@
+---
+title: bit.TrailingZeros
+description: Counts trailing 0 bits in a number (when cast to uint64).
+categories: []
+keywords: []
+action:
+  aliases: [ctz]
+  related:
+    - functions/bit/OnesCount
+    - functions/bit/LeadingZeros
+  returnType: int64
+  signatures: [bit.TrailingZeros NUMBER]
+---
+
+{{< new-in 0.135.0 >}}
+
+```go-html-template
+{{ bit.TrailingZeros 0 }} → 64
+{{ bit.TrailingZeros -1 }} → 0
+{{ bit.TrailingZeros 0x10000 }} → 16
+```

--- a/docs/content/en/functions/bit/Xnor.md
+++ b/docs/content/en/functions/bit/Xnor.md
@@ -1,0 +1,23 @@
+---
+title: bit.Xnor
+description: Bitwise XNORs two or more numbers together.
+categories: []
+keywords: []
+action:
+  aliases: [bxnor]
+  related:
+    - functions/bit/And
+    - functions/bit/Clear
+    - functions/bit/Not
+    - functions/bit/Or
+    - functions/bit/Xor
+  returnType: int64
+  signatures: [bit.Xnor NUMBER NUMBER...]
+---
+
+{{< new-in 0.135.0 >}}
+
+```go-html-template
+{{ fmt.Printf "%#04b" (bit.Xnor 0b1100 0b0110) }} → -0b1011
+{{ fmt.Printf "%#x" (bit.Xnor 0x1C2 0x7F) }} → -0x1be
+```

--- a/docs/content/en/functions/bit/Xor.md
+++ b/docs/content/en/functions/bit/Xor.md
@@ -1,0 +1,22 @@
+---
+title: bit.Xor
+description: Bitwise XORs two or more numbers together.
+categories: []
+keywords: []
+action:
+  aliases: [bxor]
+  related:
+    - functions/bit/And
+    - functions/bit/Clear
+    - functions/bit/Or
+    - functions/bit/Xnor
+  returnType: int64
+  signatures: [bit.Xor NUMBER NUMBER...]
+---
+
+{{< new-in 0.135.0 >}}
+
+```go-html-template
+{{ fmt.Printf "%#04b" (bit.Xor 0b1100 0b0110) }} → 0b1010
+{{ fmt.Printf "%#x" (bit.Xor 0x1C2 0x7F) }} → 0x1bd
+```

--- a/docs/content/en/functions/bit/_index.md
+++ b/docs/content/en/functions/bit/_index.md
@@ -1,0 +1,11 @@
+---
+title: Bit functions
+linkTitle: bit
+description: Template functions to perform bitwise operations.
+categories: []
+menu:
+  docs:
+    parent: functions
+---
+
+Use these functions to perform bitwise operations.

--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -2343,6 +2343,119 @@ output:
     - layouts/_internal/_default/rss.xml
 tpl:
   funcs:
+    bit:
+      And:
+        Aliases:
+        - band
+        Args:
+        - inputs
+        Description: And returns the bitwise AND of n1 and n2 or more values.
+        Examples:
+        - - '{{ bit.And 0b0011 0b0110 }}'
+          - "2"
+      Clear:
+        Aliases:
+        - bandn
+        - bclear
+        Args:
+        - inputs
+        Description: Clear returns the bitwise AND of n1 with the NOT of n2 or following values.
+        Examples:
+        - - '{{ bit.Clear 0xFF 0x0F }}'
+          - "240"
+      Extract:
+        Aliases: null
+        Args:
+        - "n"
+        - "l"
+        - "s"
+        Description: Extract returns the last l bits of (n >> s).
+        Examples:
+        - - '{{ bit.Extract 0x170F 4 8 }}'
+          - "7"
+      LeadingZeros:
+        Aliases:
+        - clz
+        Args:
+        - "n"
+        Description: LeadingZeros returns the number of leading 0 bits in n (when cast to uint64).
+        Examples:
+        - - '{{ bit.LeadingZeros 0b11 }}'
+          - "62"
+      Not:
+        Aliases:
+        - bnot
+        Args:
+        - inputs
+        Description: Not returns the bitwise NOT (over 64 bits) of n.
+        Examples:
+        - - '{{ bit.Not 0xFF }}'
+          - "-256"
+      OnesCount:
+        Aliases:
+        - popcnt
+        Args:
+        - "n"
+        Description: OnesCount returns the number of bits set to 1 (known as population count) in n.
+        Examples:
+        - - '{{ bit.OnesCount 0b1101011 }}'
+          - "5"
+      Or:
+        Aliases:
+        - bor
+        Args:
+        - inputs
+        Description: Or returns the bitwise OR of n1 and n2 or more values.
+        Examples:
+        - - '{{ bit.Or 0b0011 0b0110 }}'
+          - "7"
+      ShiftLeft:
+        Aliases:
+        - lsl
+        Args:
+        - "n"
+        - "s"
+        Description: ShiftLeft returns n shifted s bits to the left.
+        Examples:
+        - - '{{ bit.ShiftLeft 0b1001011 2 }}'
+          - "300"
+      ShiftRight:
+        Aliases:
+        - asr
+        Args:
+        - "n"
+        - "s"
+        Description: ShiftRight returns n (arethmetically) shifted s bits to the right.
+        Examples:
+        - - '{{ bit.ShiftRight 0b1001011 2 }}'
+          - "18"
+      TrailingZeros:
+        Aliases:
+        - ctz
+        Args:
+        - "n"
+        Description: TrailingZeros returns the number of trailing 0 bits in n (when cast to uint64).
+        Examples:
+        - - '{{ bit.TrailingZeros 0b100000 }}'
+          - "5"
+      Xnor:
+        Aliases:
+        - bxnor
+        Args:
+        - inputs
+        Description: Xnor returns the bitwise XNOR (Exclusive Not-OR) of n1 and n2 or more values. Equivalent to Not (Xor inputs...).
+        Examples:
+        - - '{{ bit.Xnor 0b0011 0b0110 }}'
+          - "-6"
+      Xor:
+        Aliases:
+        - bxor
+        Args:
+        - inputs
+        Description: Xor returns the bitwise XOR (Exclusive OR) of n1 and n2 or more values.
+        Examples:
+        - - '{{ bit.Xor 0b0011 0b0110 }}'
+          - "5"
     cast:
       ToFloat:
         Aliases:

--- a/tpl/bit/bit.go
+++ b/tpl/bit/bit.go
@@ -1,0 +1,201 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bit provides template functions for bitwise operations.
+package bit
+
+import (
+	"errors"
+	"math/bits"
+
+	"github.com/spf13/cast"
+)
+
+var (
+	errMustTwoNumbersError = errors.New("must provide at least two numbers")
+	errAndNotIntegerError = errors.New("And operator can't be used with non integer value")
+	errClearNotIntegerError = errors.New("Clear operator can't be used with non integer value")
+	errOrNotIntegerError = errors.New("Or operator can't be used with non integer value")
+	errXorNotIntegerError = errors.New("Xor operator can't be used with non integer value")
+	errXnorNotIntegerError = errors.New("Xnor operator can't be used with non integer value")
+)
+
+// New returns a new instance of the bit-namespaced template functions.
+func New() *Namespace {
+	return &Namespace{}
+}
+
+// Namespace provides template functions for the "bit" namespace.
+type Namespace struct{}
+
+// And returns the bitwise AND of n1 and n2 or more values.
+func (ns *Namespace) And(inputs ...any) (int64, error) {
+	if len(inputs) < 2 {
+		return 0, errMustTwoNumbersError
+	}
+	value, err := cast.ToInt64E(inputs[0])
+	if err != nil {
+		return 0, errAndNotIntegerError
+	}
+	for i := 1; i < len(inputs); i++ {
+		andval, anderr := cast.ToInt64E(inputs[i])
+		if anderr != nil {
+			return 0, errAndNotIntegerError
+		}
+		value &= andval
+	}
+	return value, nil
+}
+
+// Clear returns the bitwise AND of n1 with the NOT of n2 or following values.
+func (ns *Namespace) Clear(inputs ...any) (int64, error) {
+	if len(inputs) < 2 {
+		return 0, errMustTwoNumbersError
+	}
+	value, err := cast.ToInt64E(inputs[0])
+	if err != nil {
+		return 0, errAndNotIntegerError
+	}
+	for i := 1; i < len(inputs); i++ {
+		clearval, clearerr := cast.ToInt64E(inputs[i])
+		if clearerr != nil {
+			return 0, errAndNotIntegerError
+		}
+		value &= ^clearval
+	}
+	return value, nil
+}
+
+// Extract returns the last l bits of (n >> s).
+func (ns *Namespace) Extract(n any, l any, s any) (int64, error) {
+	ni, nerr := cast.ToInt64E(n)
+	li, lerr := cast.ToUint8E(l)
+	si, serr := cast.ToUint8E(s)
+	if nerr != nil || serr != nil || lerr != nil {
+		return 0, errors.New("Extract operator can't be used with non integer value")
+	}
+	return (ni >> si) & ((int64(1) << li) - 1), nil
+}
+
+// LeadingZeros returns the number of leading 0 bits in n (when cast to uint64).
+func (ns *Namespace) LeadingZeros(n any) (int64, error) {
+	value, err := cast.ToInt64E(n)
+	if err != nil {
+		return 0, errors.New("LeadingZeros operator can't be used with non integer value")
+	}
+	return int64(bits.LeadingZeros64(uint64(value))), nil
+}
+
+// Not returns the bitwise NOT (over 64 bits) of n.
+func (ns *Namespace) Not(n any) (int64, error) {
+	value, err := cast.ToInt64E(n)
+	if err != nil {
+		return 0, errors.New("Not operator can't be used with non integer value")
+	}
+	return ^value, nil
+}
+
+// OnesCount returns the number of bits set to 1 (known as population count) in n.
+func (ns *Namespace) OnesCount(n any) (int64, error) {
+	value, err := cast.ToInt64E(n)
+	if err != nil {
+		return 0, errors.New("OnesCount operator can't be used with non integer value")
+	}
+	return int64(bits.OnesCount64(uint64(value))), nil
+}
+
+// Or returns the bitwise OR of n1 and n2 or more values.
+func (ns *Namespace) Or(inputs ...any) (int64, error) {
+	if len(inputs) < 2 {
+		return 0, errMustTwoNumbersError
+	}
+	value, err := cast.ToInt64E(inputs[0])
+	if err != nil {
+		return 0, errOrNotIntegerError
+	}
+	for i := 1; i < len(inputs); i++ {
+		orval, orerr := cast.ToInt64E(inputs[i])
+		if orerr != nil {
+			return 0, errOrNotIntegerError
+		}
+		value |= orval
+	}
+	return value, nil
+}
+
+// ShiftLeft returns n shifted s bits to the left.
+func (ns *Namespace) ShiftLeft(n any, s any) (int64, error) {
+	ni, nerr := cast.ToInt64E(n)
+	si, serr := cast.ToUint8E(s)
+	if nerr != nil || serr != nil {
+		return 0, errors.New("ShiftLeft operator can't be used with non integer value")
+	}
+	return ni << si, nil
+}
+
+// ShiftRight returns n (arethmetically) shifted s bits to the right.
+func (ns *Namespace) ShiftRight(n any, s any) (int64, error) {
+	ni, nerr := cast.ToInt64E(n)
+	si, serr := cast.ToUint8E(s)
+	if nerr != nil || serr != nil {
+		return 0, errors.New("ShiftRight operator can't be used with non integer value")
+	}
+	return ni >> si, nil
+}
+
+// TrailingZeros returns the number of trailing 0 bits in n (when cast to uint64).
+func (ns *Namespace) TrailingZeros(n any) (int64, error) {
+	value, err := cast.ToInt64E(n)
+	if err != nil {
+		return 0, errors.New("TrailingZeros operator can't be used with non integer value")
+	}
+	return int64(bits.TrailingZeros64(uint64(value))), nil
+}
+
+// Xnor returns the bitwise XNOR (Exclusive Not-OR) of n1 and n2 or more values. Equivalent to Not (Xor inputs...).
+func (ns *Namespace) Xnor(inputs ...any) (int64, error) {
+	if len(inputs) < 2 {
+		return 0, errMustTwoNumbersError
+	}
+	value, err := cast.ToInt64E(inputs[0])
+	if err != nil {
+		return 0, errXnorNotIntegerError
+	}
+	for i := 1; i < len(inputs); i++ {
+		xorval, xorerr := cast.ToInt64E(inputs[i])
+		if xorerr != nil {
+			return 0, errXnorNotIntegerError
+		}
+		value ^= xorval
+	}
+	return ^value, nil
+}
+
+// Xor returns the bitwise XOR (Exclusive OR) of n1 and n2 or more values.
+func (ns *Namespace) Xor(inputs ...any) (int64, error) {
+	if len(inputs) < 2 {
+		return 0, errMustTwoNumbersError
+	}
+	value, err := cast.ToInt64E(inputs[0])
+	if err != nil {
+		return 0, errXorNotIntegerError
+	}
+	for i := 1; i < len(inputs); i++ {
+		xorval, xorerr := cast.ToInt64E(inputs[i])
+		if xorerr != nil {
+			return 0, errXorNotIntegerError
+		}
+		value ^= xorval
+	}
+	return value, nil
+}

--- a/tpl/bit/bit_test.go
+++ b/tpl/bit/bit_test.go
@@ -1,0 +1,427 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bit
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestAnd(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		x      any
+		y      any
+		expect any
+	}{
+		{0, 0, int64(0)},
+		{2000, 0, int64(0)},
+		{-500, 0, int64(0)},
+		{0b100, 0b10, int64(0)},
+		{0b100, 0b100, int64(0b100)},
+		{0b1010, 0b1100, int64(0b1000)},
+		{"abc", 7, false},
+		{7, "def", false},
+		{"abc", "def", false},
+	} {
+		result, err := ns.And(test.x, test.y)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+
+	// Expect at least 2 numbers
+	_, err := ns.And(0)
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	_, err = ns.And()
+	c.Assert(err, qt.Not(qt.IsNil))
+}
+
+func TestClear(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		x      any
+		y      any
+		expect any
+	}{
+		{0, 0, int64(0)},
+		{2000, 0, int64(2000)},
+		{-500, 0, int64(-500)},
+		{0b100, 0b10, int64(0b100)},
+		{0b100, 0b100, int64(0)},
+		{0b1010, 0b1100, int64(0b10)},
+		{"abc", 7, false},
+		{7, "def", false},
+		{"abc", "def", false},
+	} {
+		result, err := ns.Clear(test.x, test.y)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+	
+	// Expect at least 2 numbers
+	_, err := ns.Clear(0)
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	_, err = ns.Clear()
+	c.Assert(err, qt.Not(qt.IsNil))
+}
+
+func TestExtract(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		n      any
+		l      any
+		s      any
+		expect any
+	}{
+		{0, 0, 0, int64(0)},
+		{0xFFFF, 0, 4, int64(0)},
+		{-1, 0, 4, int64(0)},
+		{0, 1, 0, int64(0)},
+		{0xFFFF, 1, 4, int64(1)},
+		{-1, 1, 4, int64(1)},
+		{0b110100, 3, 2, int64(0b101)},
+		{"abc", 3, 2, false},
+		{52, "abc", 2, false},
+		{52, 3, "abc", false},
+	} {
+		result, err := ns.Extract(test.n, test.l, test.s)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}
+
+func TestLeadingZeros(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		n      any
+		expect any
+	}{
+		{0, int64(64)},
+		{1, int64(63)},
+		{2, int64(62)},
+		{-1, int64(0)},
+		{-0x7FFFFFFFFFFFFFFF, int64(0)},
+		{"abc", false},
+	} {
+		result, err := ns.LeadingZeros(test.n)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}
+
+func TestNot(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		n      any
+		expect any
+	}{
+		{0, int64(-1)},
+		{255, int64(-256)},
+		{-1, int64(0)},
+		{-256, int64(255)},
+		{"abc", false},
+	} {
+		result, err := ns.Not(test.n)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}
+
+func TestOnesCount(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		n      any
+		expect any
+	}{
+		{0, int64(0)},
+		{0b1, int64(1)},
+		{0b11, int64(2)},
+		{0b100100, int64(2)},
+		{-1, int64(64)},
+		{"abc", false},
+	} {
+		result, err := ns.OnesCount(test.n)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}
+
+func TestOr(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		x      any
+		y      any
+		expect any
+	}{
+		{0, 0, int64(0)},
+		{2000, 0, int64(2000)},
+		{-500, 0, int64(-500)},
+		{0b100, 0b10, int64(0b110)},
+		{0b100, 0b100, int64(0b100)},
+		{0b1010, 0b1100, int64(0b1110)},
+		{"abc", 7, false},
+		{7, "def", false},
+		{"abc", "def", false},
+	} {
+		result, err := ns.Or(test.x, test.y)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+
+	// Expect at least 2 numbers
+	_, err := ns.Or(0)
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	_, err = ns.Or()
+	c.Assert(err, qt.Not(qt.IsNil))
+}
+
+func TestShiftLeft(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		x      any
+		y      any
+		expect any
+	}{
+		{0, 0, int64(0)},
+		{2000, 0, int64(2000)},
+		{-500, 0, int64(-500)},
+		{0, 1, int64(0)},
+		{2000, 1, int64(4000)},
+		{-1000, 1, int64(-2000)},
+		{0xF, 16, int64(0xF0000)},
+		{"abc", 7, false},
+		{7, "def", false},
+		{"abc", "def", false},
+	} {
+		result, err := ns.ShiftLeft(test.x, test.y)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}
+
+func TestShiftRight(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		x      any
+		y      any
+		expect any
+	}{
+		{0, 0, int64(0)},
+		{2000, 0, int64(2000)},
+		{-500, 0, int64(-500)},
+		{0, 1, int64(0)},
+		{2000, 1, int64(1000)},
+		{-1000, 1, int64(-500)},
+		{0xF, 1, int64(0x7)},
+		{"abc", 7, false},
+		{7, "def", false},
+		{"abc", "def", false},
+	} {
+		result, err := ns.ShiftRight(test.x, test.y)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}
+
+func TestTrailingZeros(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		n      any
+		expect any
+	}{
+		{0, int64(64)},
+		{1, int64(0)},
+		{2, int64(1)},
+		{0b100000, int64(5)},
+		{-2, int64(1)},
+		{-4, int64(2)},
+		{"abc", false},
+	} {
+		result, err := ns.TrailingZeros(test.n)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}
+
+func TestXnor(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		x      any
+		y      any
+		expect any
+	}{
+		{0, 0, int64(-1)},
+		{2000, 0, int64(-2001)},
+		{-500, 0, int64(499)},
+		{0b100, 0b10, int64(-0b111)},
+		{0b100, 0b100, int64(-0b1)},
+		{0b1010, 0b1100, int64(-0b111)},
+		{"abc", 7, false},
+		{7, "def", false},
+		{"abc", "def", false},
+	} {
+		result, err := ns.Xnor(test.x, test.y)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+
+	// Expect at least 2 numbers
+	_, err := ns.Xnor(0)
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	_, err = ns.Xnor()
+	c.Assert(err, qt.Not(qt.IsNil))
+}
+
+func TestXor(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ns := New()
+
+	for _, test := range []struct {
+		x      any
+		y      any
+		expect any
+	}{
+		{0, 0, int64(0)},
+		{2000, 0, int64(2000)},
+		{-500, 0, int64(-500)},
+		{0b100, 0b10, int64(0b110)},
+		{0b100, 0b100, int64(0)},
+		{0b1010, 0b1100, int64(0b110)},
+		{"abc", 7, false},
+		{7, "def", false},
+		{"abc", "def", false},
+	} {
+		result, err := ns.Xor(test.x, test.y)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+
+	// Expect at least 2 numbers
+	_, err := ns.Xor(0)
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	_, err = ns.Xor()
+	c.Assert(err, qt.Not(qt.IsNil))
+}

--- a/tpl/bit/init.go
+++ b/tpl/bit/init.go
@@ -1,0 +1,122 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bit
+
+import (
+	"context"
+
+	"github.com/gohugoio/hugo/deps"
+	"github.com/gohugoio/hugo/tpl/internal"
+)
+
+const name = "bit"
+
+func init() {
+	f := func(d *deps.Deps) *internal.TemplateFuncsNamespace {
+		ctx := New()
+
+		ns := &internal.TemplateFuncsNamespace{
+			Name:    name,
+			Context: func(cctx context.Context, args ...any) (any, error) { return ctx, nil },
+		}
+
+		ns.AddMethodMapping(ctx.And,
+			[]string{"band"},
+			[][2]string{
+				{"{{ bit.And 0b0011 0b0110 }}", "2"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.Clear,
+			[]string{"bandn", "bclear"},
+			[][2]string{
+				{"{{ bit.Clear 0xFF 0x0F }}", "240"},
+			},
+		)
+		
+		ns.AddMethodMapping(ctx.Extract,
+			nil,
+			[][2]string{
+				{"{{ bit.Extract 0x170F 4 8 }}", "7"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.LeadingZeros,
+			[]string{"clz"},
+			[][2]string{
+				{"{{ bit.LeadingZeros 0b11 }}", "62"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.Not,
+			[]string{"bnot"},
+			[][2]string{
+				{"{{ bit.Not 0xFF }}", "-256"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.OnesCount,
+			[]string{"popcnt"},
+			[][2]string{
+				{"{{ bit.OnesCount 0b1101011 }}", "5"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.Or,
+			[]string{"bor"},
+			[][2]string{
+				{"{{ bit.Or 0b0011 0b0110 }}", "7"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.ShiftLeft,
+			[]string{"lsl"},
+			[][2]string{
+				{"{{ bit.ShiftLeft 0b1001011 2 }}", "300"},
+			},
+		)
+		
+		ns.AddMethodMapping(ctx.ShiftRight,
+			[]string{"asr"},
+			[][2]string{
+				{"{{ bit.ShiftRight 0b1001011 2 }}", "18"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.TrailingZeros,
+			[]string{"ctz"},
+			[][2]string{
+				{"{{ bit.TrailingZeros 0b100000 }}", "5"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.Xnor,
+			[]string{"bxnor"},
+			[][2]string{
+				{"{{ bit.Xnor 0b0011 0b0110 }}", "-6"},
+			},
+		)
+
+		ns.AddMethodMapping(ctx.Xor,
+			[]string{"bxor"},
+			[][2]string{
+				{"{{ bit.Xor 0b0011 0b0110 }}", "5"},
+			},
+		)
+
+		return ns
+	}
+
+	internal.AddTemplateFuncsNamespace(f)
+}

--- a/tpl/tplimpl/template_funcs.go
+++ b/tpl/tplimpl/template_funcs.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gohugoio/hugo/tpl/internal"
 
 	// Init the namespaces
+	_ "github.com/gohugoio/hugo/tpl/bit"
 	_ "github.com/gohugoio/hugo/tpl/cast"
 	_ "github.com/gohugoio/hugo/tpl/collections"
 	_ "github.com/gohugoio/hugo/tpl/compare"


### PR DESCRIPTION
In evaluating to what system we could migrate the [3dbrew.org wiki](https://3dbrew.org), we are considering using Hugo. Unfortunately it lacks bitwise operators, making template-based formatting of certain fields (like IPC command headers) more difficult than needs be. This PR implements said bitwise operators.

Note I'm not sure what version to use for `{{< new-in >}}`, I assume the next release (0.135.0) is correct. Please correct me if this is wrong. 

---

Adds a `bit` package, available to be used from templates to perform bitwise arithmetic.

The exposed functions/operations are:
- And
- Clear (ANDN)
- Extract (last `l` bits of `n >> s`)
- LeadingZeros
- Not
- OnesCount (popcount)
- Or
- ShiftLeft
- ShiftRight
- TrailingZeros
- Xnor
- Xor

Most of them have short aliases, prefixed with `b` if they would clash with existing functions (like boolean logic functions).