### PR TITLE
Add support for js.Build/esbuild "loader" option

### DIFF
--- a/resources/resource_transformers/js/options.go
+++ b/resources/resource_transformers/js/options.go
@@ -435,7 +435,7 @@ func toBuildOptions(opts Options) (buildOptions api.BuildOptions, err error) {
 	if opts.Loaders != nil {
 		loaders = make(map[string]api.Loader)
 		for k, v := range opts.Loaders {
-			// use the same stings as the esbuild cli.
+			// Use the same strings as the esbuild cli.
 			// See https://github.com/evanw/esbuild/blob/d34e79e2a998c21bb71d57b92b0017ca11756912/internal/config/config.go#L208
 			switch strings.ToLower(v) {
 			case "none":


### PR DESCRIPTION
fix: https://github.com/gohugoio/hugo/issues/9978

related: https://github.com/gohugoio/hugo/issues/7697

related pr: https://github.com/stackkrocket/hugo/commit/bc95ebc0e7b11369d712f65ff82789a54fd54d0d

I actually don't think the related PR is the correct way to go about this, since it only adds support for SVGs and adds it in an opinionated way. esbuild doesn't have a default loader for SVGs, and some libraries might choose to import the SVGs as something other than text, like a File object, base64, etc.

This PR adds support to specify the loader types for multiple extensions, using the same words as the official esbuild cli

https://esbuild.github.io/api/#loader
https://github.com/evanw/esbuild/blob/d34e79e2a998c21bb71d57b92b0017ca11756912/internal/config/config.go#L208

So here, more than just SVG support can be added, such as .ttf files (required by ckeditor, for example).

Usage example:

```html
{{ $js := resources.Get `ts/index.ts` }}
{{ $loaders := dict `.svg` `text`  `.ttf` `text` }}
{{ $opts := dict `target` `es2016`  `minify` true  `sourcemap` `external`  `targetPath` `js/app.min.js`  `loaders` $loaders }}
{{ $js = $js | js.Build $opts | fingerprint }}
<script src="{{ $js.RelPermalink }}"></script>
```

I would be happy to add any needed tests or documentation for this, if it were to be accepted to move forward with.