### PR TITLE
tests: Address deprecation warnings and errors

### DIFF
--- a/config/allconfig/allconfig_integration_test.go
+++ b/config/allconfig/allconfig_integration_test.go
@@ -103,31 +103,7 @@ suffixes = ["html", "xhtml"]
 	b.Assert(contentTypes.Markdown.Suffixes(), qt.DeepEquals, []string{"md", "mdown", "markdown"})
 }
 
-func TestPaginationConfigOld(t *testing.T) {
-	files := `
--- hugo.toml --
- [languages.en]
- weight = 1
- paginatePath = "page-en"
- 
- [languages.de]
- weight = 2
- paginatePath = "page-de"
- paginate = 20
-`
-
-	b := hugolib.Test(t, files)
-
-	confEn := b.H.Sites[0].Conf.Pagination()
-	confDe := b.H.Sites[1].Conf.Pagination()
-
-	b.Assert(confEn.Path, qt.Equals, "page-en")
-	b.Assert(confEn.PagerSize, qt.Equals, 10)
-	b.Assert(confDe.Path, qt.Equals, "page-de")
-	b.Assert(confDe.PagerSize, qt.Equals, 20)
-}
-
-func TestPaginationConfigNew(t *testing.T) {
+func TestPaginationConfig(t *testing.T) {
 	files := `
 -- hugo.toml --
  [languages.en]

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -276,11 +276,13 @@ func TestLoadMultiConfig(t *testing.T) {
 	// Add a random config variable for testing.
 	// side = page in Norwegian.
 	configContentBase := `
-	Paginate = 32
-	PaginatePath = "side"
+	[pagination]
+	pagerSize = 32
+	path = "side"
 	`
 	configContentSub := `
-	PaginatePath = "top"
+	[pagination]
+	path = "top"
 	`
 	mm := afero.NewMemMapFs()
 
@@ -292,8 +294,8 @@ func TestLoadMultiConfig(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	cfg := all.Base
 
-	c.Assert(cfg.PaginatePath, qt.Equals, "top")
-	c.Assert(cfg.Paginate, qt.Equals, 32)
+	c.Assert(cfg.Pagination.Path, qt.Equals, "top")
+	c.Assert(cfg.Pagination.PagerSize, qt.Equals, 32)
 }
 
 func TestLoadConfigFromThemes(t *testing.T) {
@@ -698,10 +700,6 @@ func TestHugoConfig(t *testing.T) {
 	filesTemplate := `
 -- hugo.toml --
 theme = "mytheme"
-[social]
-twitter = "bepsays"
-[author]
-name = "bep"
 [params]
 rootparam = "rootvalue"
 -- config/_default/hugo.toml --
@@ -718,9 +716,6 @@ rootparam: {{ site.Params.rootparam }}
 rootconfigparam: {{ site.Params.rootconfigparam }}
 themeparam: {{ site.Params.themeparam }}
 themeconfigdirparam: {{ site.Params.themeconfigdirparam }}
-social: {{ site.Social }}
-author: {{ site.Author }}
-
 
 `
 
@@ -744,8 +739,6 @@ author: {{ site.Author }}
 				"rootconfigparam: rootconfigvalue",
 				"themeparam: themevalue",
 				"themeconfigdirparam: themeconfigdirvalue",
-				"social: map[twitter:bepsays]",
-				"author: map[name:bep]",
 			)
 		})
 	}
@@ -918,10 +911,8 @@ title: "My Swedish Section"
 -- layouts/index.html --
 LanguageCode: {{ eq site.LanguageCode site.Language.LanguageCode }}|{{ site.Language.LanguageCode }}|
 {{ range $i, $e := (slice site .Site) }}
-{{ $i }}|AllPages: {{ len .AllPages }}|Sections: {{ if .Sections }}true{{ end }}| Author: {{ .Authors }}|BuildDrafts: {{ .BuildDrafts }}|IsMultilingual: {{ .IsMultiLingual }}|Param: {{ .Language.Params.myparam }}|Language string: {{ .Language }}|Languages: {{ .Languages }}
+{{ $i }}|AllPages: {{ len .AllPages }}|Sections: {{ if .Sections }}true{{ end }}|BuildDrafts: {{ .BuildDrafts }}|Param: {{ .Language.Params.myparam }}|Language string: {{ .Language }}|Languages: {{ .Languages }}
 {{ end }}
-
-
 
 `
 	b := NewIntegrationTestBuilder(
@@ -940,7 +931,6 @@ AllPages: 4|
 Sections: true|
 Param: enParamValue
 Param: enParamValue
-IsMultilingual: true
 LanguageCode: true|en-US|
 `)
 

--- a/hugolib/embedded_templates_test.go
+++ b/hugolib/embedded_templates_test.go
@@ -100,7 +100,7 @@ func TestEmbeddedPaginationTemplate(t *testing.T) {
 
 	test := func(variant string, expectedOutput string) {
 		b := newTestSitesBuilder(t)
-		b.WithConfigFile("toml", `paginate = 1`)
+		b.WithConfigFile("toml", `pagination.pagerSize = 1`)
 		b.WithContent(
 			"s1/p01.md", "---\ntitle: p01\n---",
 			"s1/p02.md", "---\ntitle: p02\n---",

--- a/hugolib/hugo_sites_multihost_test.go
+++ b/hugolib/hugo_sites_multihost_test.go
@@ -11,11 +11,13 @@ func TestMultihost(t *testing.T) {
 
 	files := `
 -- hugo.toml --
-paginate = 1
 defaultContentLanguage = "fr"
 defaultContentLanguageInSubdir = false
 staticDir = ["s1", "s2"]
 enableRobotsTXT = true
+
+[pagination]
+pagerSize = 1
 
 [permalinks]
 other = "/somewhere/else/:filename"

--- a/hugolib/hugo_smoke_test.go
+++ b/hugolib/hugo_smoke_test.go
@@ -107,10 +107,13 @@ func TestSmoke(t *testing.T) {
 baseURL = "https://example.com"
 title = "Smoke Site"
 rssLimit = 3
-paginate = 1
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = true
 enableRobotsTXT = true
+
+[pagination]
+pagerSize = 1
+
 [taxonomies]
 category = 'categories'
 tag = 'tags'
@@ -434,10 +437,10 @@ func TestDataRace(t *testing.T) {
 ---
 title: "The Page"
 outputs: ["HTML", "JSON"]
----	
+---
 
 The content.
-	
+
 
 	`
 
@@ -450,10 +453,10 @@ The content.
 ---
 title: "The Home"
 outputs: ["HTML", "JSON", "CSV", "RSS"]
----	
+---
 
 The content.
-	
+
 
 `)
 

--- a/hugolib/paginator_test.go
+++ b/hugolib/paginator_test.go
@@ -24,8 +24,10 @@ import (
 func TestPaginator(t *testing.T) {
 	configFile := `
 baseURL = "https://example.com/foo/"
-paginate = 3
-paginatepath = "thepage"
+
+[pagination]
+pagerSize = 3
+path = "thepage"
 
 [languages.en]
 weight = 1
@@ -161,10 +163,11 @@ Len Pag: {{ len $pag.Pages }}
 func TestPaginatorNodePagesOnly(t *testing.T) {
 	files := `
 -- hugo.toml --
-paginate = 1
+[pagination]
+pagerSize = 1
 -- content/p1.md --
 -- layouts/_default/single.html --
-Paginator: {{ .Paginator }}	
+Paginator: {{ .Paginator }}
 `
 	b, err := TestE(t, files)
 	b.Assert(err, qt.IsNotNil)

--- a/hugolib/rebuild_test.go
+++ b/hugolib/rebuild_test.go
@@ -559,7 +559,8 @@ baseURL = "https://example.com"
 disableKinds = ["term", "taxonomy"]
 disableLiveReload = true
 defaultContentLanguage = "nn"
-paginate = 20
+[pagination]
+pagerSize = 20
 [security]
 enableInlineShortcodes = true
 [languages]
@@ -1431,7 +1432,7 @@ title: "My Sect"
 ---
 title: "P%d"
 ---
-P%d Content.	
+P%d Content.
 `
 
 	for i := 0; i < count; i++ {

--- a/hugolib/securitypolicies_test.go
+++ b/hugolib/securitypolicies_test.go
@@ -123,7 +123,7 @@ func TestSecurityPolicies(t *testing.T) {
 			c.Skip()
 		}
 		cb := func(b *sitesBuilder) {
-			b.WithTemplatesAdded("index.html", `{{ $scss := "body { color: #333; }" | resources.FromString "foo.scss"  | resources.ToCSS (dict "transpiler" "dartsass") }}`)
+			b.WithTemplatesAdded("index.html", `{{ $scss := "body { color: #333; }" | resources.FromString "foo.scss"  | css.Sass (dict "transpiler" "dartsass") }}`)
 		}
 		testVariant(c, cb, "")
 	})
@@ -137,10 +137,10 @@ func TestSecurityPolicies(t *testing.T) {
 			b.WithConfigFile("toml", `
 [security]
 [security.exec]
-allow="none"	
-		
+allow="none"
+
 			`)
-			b.WithTemplatesAdded("index.html", `{{ $scss := "body { color: #333; }" | resources.FromString "foo.scss"  | resources.ToCSS (dict "transpiler" "dartsass") }}`)
+			b.WithTemplatesAdded("index.html", `{{ $scss := "body { color: #333; }" | resources.FromString "foo.scss"  | css.Sass (dict "transpiler" "dartsass") }}`)
 		}
 		testVariant(c, cb, `(?s).*sass(-embedded)?" is not whitelisted in policy "security\.exec\.allow".*`)
 	})
@@ -160,7 +160,7 @@ allow="none"
 		httpTestVariant(c, `{{ $json := resources.GetRemote "%[1]s/fruits.json" }}{{ $json.Content }}`, `(?s).*is not whitelisted in policy "security\.http\.urls".*`,
 			func(b *sitesBuilder) {
 				b.WithConfigFile("toml", `
-[security]		
+[security]
 [security.http]
 urls="none"
 `)
@@ -181,7 +181,7 @@ urls="none"
 		httpTestVariant(c, `{{ $json := resources.GetRemote "%[1]s/fakejson.json" }}{{ $json.Content }}`, ``,
 			func(b *sitesBuilder) {
 				b.WithConfigFile("toml", `
-[security]		
+[security]
 [security.http]
 mediaTypes=["application/json"]
 

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -126,9 +126,10 @@ func TestShortcodeMultipleOutputFormats(t *testing.T) {
 	siteConfig := `
 baseURL = "http://example.com/blog"
 
-paginate = 1
-
 disableKinds = ["section", "term", "taxonomy", "RSS", "sitemap", "robotsTXT", "404"]
+
+[pagination]
+pagerSize = 1
 
 [outputs]
 home = [ "HTML", "AMP", "Calendar" ]

--- a/hugolib/site_output_test.go
+++ b/hugolib/site_output_test.go
@@ -15,7 +15,6 @@ package hugolib
 
 import (
 	"fmt"
-	"html/template"
 	"strings"
 	"testing"
 
@@ -45,10 +44,12 @@ func doTestSiteWithPageOutputs(t *testing.T, outputs []string) {
 	siteConfig := `
 baseURL = "http://example.com/blog"
 
-paginate = 1
 defaultContentLanguage = "en"
 
 disableKinds = ["section", "term", "taxonomy", "RSS", "sitemap", "robotsTXT", "404"]
+
+[pagination]
+pagerSize = 1
 
 [Taxonomies]
 tag = "tags"
@@ -221,10 +222,12 @@ func TestRedefineRSSOutputFormat(t *testing.T) {
 	siteConfig := `
 baseURL = "http://example.com/blog"
 
-paginate = 1
 defaultContentLanguage = "en"
 
 disableKinds = ["page", "section", "term", "taxonomy", "sitemap", "robotsTXT", "404"]
+
+[pagination]
+pagerSize = 1
 
 [outputFormats]
 [outputFormats.RSS]
@@ -249,7 +252,7 @@ baseName = "feed"
 	s := h.Sites[0]
 
 	// Issue #3450
-	c.Assert(s.RSSLink(), qt.Equals, template.URL("http://example.com/blog/feed.xml"))
+	c.Assert(s.Home().OutputFormats().Get("rss").Permalink(), qt.Equals, "http://example.com/blog/feed.xml")
 }
 
 // Issue #3614
@@ -257,10 +260,12 @@ func TestDotLessOutputFormat(t *testing.T) {
 	siteConfig := `
 baseURL = "http://example.com/blog"
 
-paginate = 1
 defaultContentLanguage = "en"
 
 disableKinds = ["page", "section", "term", "taxonomy", "sitemap", "robotsTXT", "404"]
+
+[pagination]
+pagerSize = 1
 
 [mediaTypes]
 [mediaTypes."text/nodot"]

--- a/hugolib/site_sections_test.go
+++ b/hugolib/site_sections_test.go
@@ -115,7 +115,7 @@ PAG|{{ .Title }}|{{ $sect.InSection . }}
 {{ $sections := (.Site.GetPage "section" .Section).Sections.ByWeight }}
 </html>`)
 
-	cfg.Set("paginate", 2)
+	cfg.Set("pagination.pagerSize", 2)
 
 	th, configs := newTestHelperFromProvider(cfg, fs, t)
 

--- a/hugolib/site_stats_test.go
+++ b/hugolib/site_stats_test.go
@@ -32,8 +32,10 @@ func TestSiteStats(t *testing.T) {
 	siteConfig := `
 baseURL = "http://example.com/blog"
 
-paginate = 1
 defaultContentLanguage = "nn"
+
+[pagination]
+pagerSize = 1
 
 [languages]
 [languages.nn]

--- a/hugolib/site_url_test.go
+++ b/hugolib/site_url_test.go
@@ -91,7 +91,7 @@ Do not go gentle into that good night.
 `
 
 	cfg, fs := newTestCfg()
-	cfg.Set("paginate", 1)
+	cfg.Set("pagination.pagerSize", 1)
 	th, configs := newTestHelperFromProvider(cfg, fs, t)
 
 	writeSource(t, fs, filepath.Join("content", "sect1", "_index.md"), fmt.Sprintf(st, "/ss1/"))

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -80,8 +80,9 @@ func doTestTaxonomiesWithAndWithoutContentFile(t *testing.T, uglyURLs bool) {
 baseURL = "http://example.com/blog"
 titleCaseStyle = "firstupper"
 uglyURLs = %t
-paginate = 1
 defaultContentLanguage = "en"
+[pagination]
+pagerSize = 1
 [Taxonomies]
 tag = "tags"
 category = "categories"

--- a/hugolib/template_test.go
+++ b/hugolib/template_test.go
@@ -377,7 +377,7 @@ func TestTemplateFuncs(t *testing.T) {
 	b := newTestSitesBuilder(t).WithDefaultMultiSiteConfig()
 
 	homeTpl := `Site: {{ site.Language.Lang }} / {{ .Site.Language.Lang }} / {{ site.BaseURL }}
-Sites: {{ site.Sites.First.Home.Language.Lang }}
+Sites: {{ site.Sites.Default.Home.Language.Lang }}
 Hugo: {{ hugo.Generator }}
 `
 
@@ -460,7 +460,7 @@ complex: 80: 80
 func TestPartialWithZeroedArgs(t *testing.T) {
 	b := newTestSitesBuilder(t)
 	b.WithTemplatesAdded("index.html",
-		` 
+		`
 X{{ partial "retval" dict }}X
 X{{ partial "retval" slice }}X
 X{{ partial "retval" "" }}X
@@ -696,7 +696,7 @@ func TestApplyWithNamespace(t *testing.T) {
 
 	b.WithTemplates(
 		"index.html", `
-{{ $b := slice " a " "     b "   "       c" }}		
+{{ $b := slice " a " "     b "   "       c" }}
 {{ $a := apply $b "strings.Trim" "." " " }}
 a: {{ $a }}
 `,

--- a/hugolib/testhelpers_test.go
+++ b/hugolib/testhelpers_test.go
@@ -292,10 +292,12 @@ func (s *sitesBuilder) WithDefaultMultiSiteConfig() *sitesBuilder {
 	defaultMultiSiteConfig := `
 baseURL = "http://example.com/blog"
 
-paginate = 1
 disablePathToLower = true
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = true
+
+[pagination]
+pagerSize = 1
 
 [permalinks]
 other = "/somewhere/else/:filename"
@@ -324,7 +326,8 @@ plaque = "plaques"
 weight = 30
 title = "På nynorsk"
 languageName = "Nynorsk"
-paginatePath = "side"
+[Languages.nn.pagination]
+path = "side"
 [Languages.nn.Taxonomies]
 lag = "lag"
 [[Languages.nn.menu.main]]
@@ -336,7 +339,8 @@ weight = 1
 weight = 40
 title = "På bokmål"
 languageName = "Bokmål"
-paginatePath = "side"
+[Languages.nb.pagination]
+path = "side"
 [Languages.nb.Taxonomies]
 lag = "lag"
 ` + commonConfigSections

--- a/resources/resource_transformers/tocss/scss/scss_integration_test.go
+++ b/resources/resource_transformers/tocss/scss/scss_integration_test.go
@@ -396,7 +396,7 @@ h3 {
 
 
 {{ range $stylesheets }}
-  {{ with . | resources.ToCSS | fingerprint }}
+  {{ with . | css.Sass | fingerprint }}
     <link as="style"  href="{{ .RelPermalink }}" rel="preload stylesheet">
   {{ end }}
 {{ end }}

--- a/tpl/page/page_integration_test.go
+++ b/tpl/page/page_integration_test.go
@@ -29,8 +29,9 @@ func TestThatPageIsAvailableEverywhere(t *testing.T) {
 baseURL = 'http://example.com/'
 disableKinds = ["taxonomy", "term"]
 enableInlineShortcodes = true
-paginate = 1
 enableRobotsTXT = true
+[pagination]
+pagerSize = 1
 LANG_CONFIG
 -- content/_index.md --
 ---
@@ -191,7 +192,7 @@ title: "P1"
 
 # Heading 1
 -- layouts/shortcodes/toc.html --
-{{ page.TableOfContents }} 
+{{ page.TableOfContents }}
 -- layouts/_default/single.html --
 {{ .Content }}
 `


### PR DESCRIPTION
Prior to this PR our tests were throwing these errors and warnings:

```text
ERROR deprecated: .Site.Author was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.137.0. Use taxonomies instead.
ERROR deprecated: .Site.Authors was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.137.0. Use taxonomies instead.
ERROR deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.137.0. Use hugo.IsMultilingual instead.
ERROR deprecated: .Site.RSSLink was deprecated in Hugo v0.114.0 and will be removed in Hugo 0.137.0. Use the Output Format's Permalink method instead, e.g. .OutputFormats.Get "RSS".Permalink
ERROR deprecated: .Site.Social was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.137.0. Use .Site.Params instead.
WARN  deprecated: .Sites.First was deprecated in Hugo v0.127.0 and will be removed in a future release. Use .Sites.Default instead.
WARN  deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in a future release. Use css.Sass instead.
WARN  deprecated: site config key paginatePath was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.path instead.
WARN  deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.pagerSize instead.
```