### PR TITLE
markup/goldmark: Change default cell alignment in table render hook

### DIFF
--- a/markup/goldmark/tables/tables.go
+++ b/markup/goldmark/tables/tables.go
@@ -129,7 +129,7 @@ func (r *htmlRenderer) renderCell(w util.BufWriter, source []byte, node ast.Node
 	case gast.AlignCenter:
 		alignment = "center"
 	default:
-		alignment = "left"
+		alignment = ""
 	}
 
 	cell := hooks.TableCell{Text: hstring.HTML(text), Alignment: alignment}

--- a/markup/goldmark/tables/tables_integration_test.go
+++ b/markup/goldmark/tables/tables_integration_test.go
@@ -32,7 +32,7 @@ title = true
 | Item              | In Stock | Price |
 | :---------------- | :------: | ----: |
 | Python Hat        |   True   | 23.99 |
-| SQL **Hat**           |   True   | 23.99 |
+| SQL **Hat**       |   True   | 23.99 |
 | Codecademy Tee    |  False   | 19.99 |
 | Codecademy Hoodie |  False   | 42.99 |
 {.foo foo="bar"}
@@ -65,8 +65,8 @@ Attributes: {{ .Attributes }}|
 	)
 
 	b.AssertFileContent("public/p1/index.html",
-		"table-1-thead: 0: 0: left: Month| 1: left: Savings|$",
-		"table-1-tbody: 0: 0: left: January| 1: left: $250| 1: 0: left: February| 1: left: $80| 2: 0: left: March| 1: left: $420|$",
+		"table-1-thead: 0: 0: : Month| 1: : Savings|$",
+		"table-1-tbody: 0: 0: : January| 1: : $250| 1: 0: : February| 1: : $80| 2: 0: : March| 1: : $420|$",
 	)
 }
 

--- a/tpl/tplimpl/embedded/templates/_default/_markup/render-table.html
+++ b/tpl/tplimpl/embedded/templates/_default/_markup/render-table.html
@@ -8,7 +8,11 @@
     {{- range .THead }}
       <tr>
         {{- range . }}
-          <th {{ printf "style=%q" (printf "text-align: %s" .Alignment) | safeHTMLAttr }}>
+          <th
+            {{- with .Alignment }}
+              {{- printf " style=%q" (printf "text-align: %s" .) | safeHTMLAttr }}
+            {{- end -}}
+          >
             {{- .Text -}}
           </th>
         {{- end }}
@@ -19,7 +23,11 @@
     {{- range .TBody }}
       <tr>
         {{- range . }}
-          <td {{ printf "style=%q" (printf "text-align: %s" .Alignment) | safeHTMLAttr }}>
+          <td
+            {{- with .Alignment }}
+              {{- printf " style=%q" (printf "text-align: %s" .) | safeHTMLAttr }}
+            {{- end -}}
+          >
             {{- .Text -}}
           </td>
         {{- end }}


### PR DESCRIPTION
Change the default table cell alignment from "left" to an empty string.

Closes #12886