### PR TITLE
tpl/tplimpl: trim descriptions rather than just chomp

### DIFF
--- a/tpl/tplimpl/embedded/templates/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/opengraph.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="{{ . }}">
 {{- end }}
 
-{{- with or .Description .Summary site.Params.description | plainify | htmlUnescape | chomp }}
-  <meta property="og:description" content="{{ . }}">
+{{- with or .Description .Summary site.Params.description | plainify | htmlUnescape }}
+  <meta property="og:description" content="{{ trim . "\n\r\t " }}">
 {{- end }}
 
 {{- with or .Params.locale site.Language.LanguageCode }}

--- a/tpl/tplimpl/embedded/templates/schema.html
+++ b/tpl/tplimpl/embedded/templates/schema.html
@@ -2,8 +2,8 @@
   <meta itemprop="name" content="{{ . }}">
 {{- end }}
 
-{{- with or .Description .Summary site.Params.description | plainify | htmlUnescape | chomp }}
-  <meta itemprop="description" content="{{ . }}">
+{{- with or .Description .Summary site.Params.description | plainify | htmlUnescape }}
+  <meta itemprop="description" content="{{ trim . "\n\r\t " }}">
 {{- end }}
 
 {{- $ISO8601 := "2006-01-02T15:04:05-07:00" }}

--- a/tpl/tplimpl/embedded/templates/twitter_cards.html
+++ b/tpl/tplimpl/embedded/templates/twitter_cards.html
@@ -10,8 +10,8 @@
   <meta name="twitter:title" content="{{ . }}">
 {{- end }}
 
-{{- with or .Description .Summary site.Params.description | plainify | htmlUnescape | chomp }}
-  <meta name="twitter:description" content="{{ . }}">
+{{- with or .Description .Summary site.Params.description | plainify | htmlUnescape }}
+  <meta name="twitter:description" content="{{ trim . "\n\r\t " }}">
 {{- end }}
 
 {{- $twitterSite := "" }}


### PR DESCRIPTION
This PR proposes that we trim whitespace from both ends of descriptions rather than just chomp.

A bit of context for this change: since upgrading to Hugo 0.135.0, opentelemetry.io many page descriptions have been padded with (IMHO unnecessary) whitespace. If the Hugo templates are `chomp`ing the description text, it might as well just `trim` both ends of any whitespace, right? :) 

/cc @svrnm @theletterf