### PR TITLE
resources/page: Improve front matter date validation

### DIFF
--- a/resources/page/pagemeta/page_frontmatter.go
+++ b/resources/page/pagemeta/page_frontmatter.go
@@ -728,7 +728,7 @@ func (f *frontmatterFieldHandlers) newDateFieldHandler(key string, setter func(d
 	return func(d *FrontMatterDescriptor) (bool, error) {
 		v, found := d.PageConfig.Params[key]
 
-		if !found {
+		if !found || v == "" {
 			return false, nil
 		}
 
@@ -739,7 +739,7 @@ func (f *frontmatterFieldHandlers) newDateFieldHandler(key string, setter func(d
 			var err error
 			date, err = htime.ToTimeInDefaultLocationE(v, d.Location)
 			if err != nil {
-				return false, fmt.Errorf("invalid front matter: %s: %s: see %s", key, v, d.PathOrTitle)
+				return false, fmt.Errorf("the %q front matter field is not a parsable date: see %s", key, d.PathOrTitle)
 			}
 			d.PageConfig.Params[key] = date
 		}

--- a/resources/page/pagemeta/pagemeta_integration_test.go
+++ b/resources/page/pagemeta/pagemeta_integration_test.go
@@ -14,6 +14,7 @@
 package pagemeta_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gohugoio/hugo/hugolib"
@@ -42,4 +43,56 @@ Date: 2024-03-13 06:00:00 &#43;0000 GMT
 Lastmod: 2024-03-13 06:00:00 &#43;0000 GMT
 Eq: true
 `)
+}
+
+func TestDateValidation(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+-- content/_index.md --
++++
+date = DATE
++++
+-- layouts/index.html --
+{{ .Date.UTC.Format "2006-01-02" }}
+--
+`
+	errorMsg := `ERROR the "date" front matter field is not a parsable date`
+
+	// Valid (TOML)
+	f := strings.ReplaceAll(files, "DATE", "2024-10-01")
+	b := hugolib.Test(t, f)
+	b.AssertFileContent("public/index.html", "2024-10-01")
+
+	// Valid (string)
+	f = strings.ReplaceAll(files, "DATE", `"2024-10-01"`)
+	b = hugolib.Test(t, f)
+	b.AssertFileContent("public/index.html", "2024-10-01")
+
+	// Valid (empty string)
+	f = strings.ReplaceAll(files, "DATE", `""`)
+	b = hugolib.Test(t, f)
+	b.AssertFileContent("public/index.html", "0001-01-01")
+
+	// Valid (int)
+	f = strings.ReplaceAll(files, "DATE", "0")
+	b = hugolib.Test(t, f)
+	b.AssertFileContent("public/index.html", "1970-01-01")
+
+	// Invalid (string)
+	f = strings.ReplaceAll(files, "DATE", `"2024-42-42"`)
+	b, _ = hugolib.TestE(t, f)
+	b.AssertLogContains(errorMsg)
+
+	// Invalid (bool)
+	f = strings.ReplaceAll(files, "DATE", "true")
+	b, _ = hugolib.TestE(t, f)
+	b.AssertLogContains(errorMsg)
+
+	// Invalid (float)
+	f = strings.ReplaceAll(files, "DATE", "6.7")
+	b, _ = hugolib.TestE(t, f)
+	b.AssertLogContains(errorMsg)
 }


### PR DESCRIPTION
Improve the error message and treat empty strings as zero dates.

Closes #12898