### PR TITLE
hugolib: Make .Site.Author deprecation warning clearer

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -511,20 +511,20 @@ func (s *Site) Params() maps.Params {
 // Deprecated: Use taxonomies instead.
 func (s *Site) Author() map[string]any {
 	if len(s.conf.Author) != 0 {
-		hugo.Deprecate(".Site.Author", "Use taxonomies instead.", "v0.124.0")
+		hugo.Deprecate(".Site.Author", "Implement taxonomy 'author' or use .Site.Params.Author instead.", "v0.124.0")
 	}
 	return s.conf.Author
 }
 
 // Deprecated: Use taxonomies instead.
 func (s *Site) Authors() page.AuthorList {
-	hugo.Deprecate(".Site.Authors", "Use taxonomies instead.", "v0.124.0")
+	hugo.Deprecate(".Site.Authors", "Implement taxonomy 'authors' or use .Site.Params.Author instead.", "v0.124.0")
 	return page.AuthorList{}
 }
 
 // Deprecated: Use .Site.Params instead.
 func (s *Site) Social() map[string]string {
-	hugo.Deprecate(".Site.Social", "Use .Site.Params instead.", "v0.124.0")
+	hugo.Deprecate(".Site.Social", "Implement taxonomy 'social' or use .Site.Params.Social instead.", "v0.124.0")
 	return s.conf.Social
 }
 


### PR DESCRIPTION
As suggested in #12269, this updates this deprecation warning:

> WARN  deprecated: .Site.Author was deprecated in Hugo v0.124.0 and will be removed in a future release. **Use taxonomies instead.**

to instead say

> WARN  deprecated: .Site.Author was deprecated in Hugo v0.124.0 and will be removed in a future release. **Implement taxonomy 'author' or use .Site.Params.Author instead.**

I just needed to fix this and found the clarification in that issue very helpful, so thought it would be useful if those were the official guidelines. 

Fixes #12269