### PR TITLE
Add support for backslash escaping in url and permalinks

### DIFF
--- a/resources/page/permalinks_test.go
+++ b/resources/page/permalinks_test.go
@@ -92,6 +92,10 @@ func TestPermalinkExpansion(t *testing.T) {
 			expanded, err := expander.Expand("posts", page)
 			c.Assert(err, qt.IsNil)
 			c.Assert(expanded, qt.Equals, item.expandsTo)
+
+			expanded, err = expander.ExpandPattern(item.spec, page)
+			c.Assert(err, qt.IsNil)
+			c.Assert(expanded, qt.Equals, item.expandsTo)
 		})
 
 	}

--- a/resources/page/permalinks_test.go
+++ b/resources/page/permalinks_test.go
@@ -44,6 +44,8 @@ var testdataPermalinks = []struct {
 	{"/:sections/", true, "/a/b/c/"},                                // Sections
 	{"/:sections[last]/", true, "/c/"},                              // Sections
 	{"/:sections[0]/:sections[last]/", true, "/a/c/"},               // Sections
+	{"/\\:filename", true, "/:filename"},                            // Escape sequence
+	{"/special\\::slug/", true, "/special:the-slug/"},               // Escape sequence
 
 	// Failures
 	{"/blog/:fred", false, ""},
@@ -117,6 +119,7 @@ func TestPermalinkExpansionMultiSection(t *testing.T) {
 			"posts":   "/:slug",
 			"blog":    "/:section/:year",
 			"recipes": "/:slugorfilename",
+			"special": "/special\\::slug",
 		},
 	}
 	expander, err := NewPermalinkExpander(urlize, permalinksConfig)
@@ -137,6 +140,10 @@ func TestPermalinkExpansionMultiSection(t *testing.T) {
 	expanded, err = expander.Expand("recipes", page_slug_fallback)
 	c.Assert(err, qt.IsNil)
 	c.Assert(expanded, qt.Equals, "/page-filename")
+
+	expanded, err = expander.Expand("special", page)
+	c.Assert(err, qt.IsNil)
+	c.Assert(expanded, qt.Equals, "/special:the-slug")
 }
 
 func TestPermalinkExpansionConcurrent(t *testing.T) {


### PR DESCRIPTION
Fixes #12918. I didn't improve the error handling because the go date formatting tokens are supported. If you have something like `:example1` it would be a valid format since 1 is the number of the month. I think leaving the invalid token error as is is better.