### PR TITLE
docker: fix permission issues in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ ENV HUGO_CACHEDIR=/cache
 ENV PATH="/var/hugo/bin:$PATH"
 
 COPY scripts/docker/entrypoint.sh /entrypoint.sh
-COPY --link --from=dart-sass /out/dart-sass /var/hugo/bin/dart-sass
+COPY --from=dart-sass /out/dart-sass /var/hugo/bin/dart-sass
 
 # Update PATH to reflect the new dependencies.
 # For more complex setups, we should probably find a way to

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,9 +76,9 @@ RUN mkdir -p /var/hugo/bin /cache && \
     # See https://github.com/gohugoio/hugo/issues/9810
     runuser -u hugo -- git config --global core.quotepath false
 
+USER hugo:hugo
 VOLUME /project
 WORKDIR /project
-USER hugo:hugo
 ENV HUGO_CACHEDIR=/cache
 ENV PATH="/var/hugo/bin:$PATH"
 


### PR DESCRIPTION
I think the `--link` option might've caused a permission issue for the non-root `hugo` user.

Related issues:

- #12970
- #12971

Also noticed that the `/project` workdir was created before we assumed the `hugo:hugo` user, which resulted in that directory being owned by `root`. I reordered the instructions to make sure `/project` is owned by the correct user.