### PR TITLE
Misc 0.137.0 fixes

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/gohugoio/hugo/deploy"
-	"github.com/gohugoio/hugo/deploy/deployconfig"
 
 	"github.com/bep/simplecobra"
 	"github.com/spf13/cobra"
@@ -47,17 +46,7 @@ documentation.
 			return deployer.Deploy(ctx)
 		},
 		withc: func(cmd *cobra.Command, r *rootCommand) {
-			cmd.ValidArgsFunction = cobra.NoFileCompletions
-			cmd.Flags().String("target", "", "target deployment from deployments section in config file; defaults to the first one")
-			_ = cmd.RegisterFlagCompletionFunc("target", cobra.NoFileCompletions)
-			cmd.Flags().Bool("confirm", false, "ask for confirmation before making changes to the target")
-			cmd.Flags().Bool("dryRun", false, "dry run")
-			cmd.Flags().Bool("force", false, "force upload of all files")
-			cmd.Flags().Bool("invalidateCDN", deployconfig.DefaultConfig.InvalidateCDN, "invalidate the CDN cache listed in the deployment target")
-			cmd.Flags().Int("maxDeletes", deployconfig.DefaultConfig.MaxDeletes, "maximum # of files to delete, or -1 to disable")
-			_ = cmd.RegisterFlagCompletionFunc("maxDeletes", cobra.NoFileCompletions)
-			cmd.Flags().Int("workers", deployconfig.DefaultConfig.Workers, "number of workers to transfer files. defaults to 10")
-			_ = cmd.RegisterFlagCompletionFunc("workers", cobra.NoFileCompletions)
+			applyDeployFlags(cmd, r)
 		},
 	}
 }

--- a/commands/deploy_flags.go
+++ b/commands/deploy_flags.go
@@ -1,0 +1,33 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"github.com/gohugoio/hugo/deploy/deployconfig"
+	"github.com/spf13/cobra"
+)
+
+func applyDeployFlags(cmd *cobra.Command, r *rootCommand) {
+	cmd.ValidArgsFunction = cobra.NoFileCompletions
+	cmd.Flags().String("target", "", "target deployment from deployments section in config file; defaults to the first one")
+	_ = cmd.RegisterFlagCompletionFunc("target", cobra.NoFileCompletions)
+	cmd.Flags().Bool("confirm", false, "ask for confirmation before making changes to the target")
+	cmd.Flags().Bool("dryRun", false, "dry run")
+	cmd.Flags().Bool("force", false, "force upload of all files")
+	cmd.Flags().Bool("invalidateCDN", deployconfig.DefaultConfig.InvalidateCDN, "invalidate the CDN cache listed in the deployment target")
+	cmd.Flags().Int("maxDeletes", deployconfig.DefaultConfig.MaxDeletes, "maximum # of files to delete, or -1 to disable")
+	_ = cmd.RegisterFlagCompletionFunc("maxDeletes", cobra.NoFileCompletions)
+	cmd.Flags().Int("workers", deployconfig.DefaultConfig.Workers, "number of workers to transfer files. defaults to 10")
+	_ = cmd.RegisterFlagCompletionFunc("workers", cobra.NoFileCompletions)
+}

--- a/commands/deploy_off.go
+++ b/commands/deploy_off.go
@@ -44,6 +44,7 @@ func newDeployCommand() simplecobra.Commander {
 			return errors.New("deploy not supported in this version of Hugo; install a release with 'withdeploy' in the archive filename or build yourself with the 'withdeploy' build tag. Also see https://github.com/gohugoio/hugo/pull/12995")
 		},
 		withc: func(cmd *cobra.Command, r *rootCommand) {
+			applyDeployFlags(cmd, r)
 			cmd.Hidden = true
 		},
 	}

--- a/common/hugo/vars_withdeploy.go
+++ b/common/hugo/vars_withdeploy.go
@@ -1,0 +1,19 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build withdeploy
+// +build withdeploy
+
+package hugo
+
+var IsWithdeploy = true

--- a/common/hugo/vars_withdeploy_off.go
+++ b/common/hugo/vars_withdeploy_off.go
@@ -1,0 +1,19 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !withdeploy
+// +build !withdeploy
+
+package hugo
+
+var IsWithdeploy = false

--- a/common/hugo/version.go
+++ b/common/hugo/version.go
@@ -152,6 +152,9 @@ func BuildVersionString() string {
 	if IsExtended {
 		version += "+extended"
 	}
+	if IsWithdeploy {
+		version += "+withdeploy"
+	}
 
 	osArch := bi.GoOS + "/" + bi.GoArch
 

--- a/hugoreleaser.toml
+++ b/hugoreleaser.toml
@@ -185,6 +185,25 @@ archive_alias_replacements = { "linux-amd64.tar.gz" = "Linux-64bit.tar.gz" }
         [[builds.os.archs]]
             goarch = "amd64"
 
+[[builds]]
+    path = "container1/windows/extended-withdeploy"
+
+    [builds.build_settings]
+        flags = ["-buildmode", "exe", "-tags", "extended,withdeploy"]
+        env = [
+            "CGO_ENABLED=1",
+            "CC=x86_64-w64-mingw32-gcc",
+            "CXX=x86_64-w64-mingw32-g++",
+        ]
+        ldflags = "-s -w -X github.com/gohugoio/hugo/common/hugo.vendorInfo=gohugoio -extldflags '-static'"
+
+    [[builds.os]]
+        goos = "windows"
+        [builds.os.build_settings]
+            binary = "hugo.exe"
+        [[builds.os.archs]]
+            goarch = "amd64"
+
 [[archives]]
     paths = ["builds/container1/unix/regular/**"]
 [[archives]]
@@ -209,6 +228,13 @@ archive_alias_replacements = { "linux-amd64.tar.gz" = "Linux-64bit.tar.gz" }
     paths = ["builds/**/windows/extended/**"]
     [archives.archive_settings]
         name_template = "{{ .Project }}_extended_{{ .Tag | trimPrefix `v` }}_{{ .Goos }}-{{ .Goarch }}"
+        [archives.archive_settings.type]
+            format    = "zip"
+            extension = ".zip"
+[[archives]]
+    paths = ["builds/**/windows/extended-withdeploy/**"]
+    [archives.archive_settings]
+        name_template = "{{ .Project }}_extended_withdeploy_{{ .Tag | trimPrefix `v` }}_{{ .Goos }}-{{ .Goarch }}"
         [archives.archive_settings.type]
             format    = "zip"
             extension = ".zip"

--- a/main_withdeploy_off_test.go
+++ b/main_withdeploy_off_test.go
@@ -1,0 +1,29 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !withdeploy
+// +build !withdeploy
+
+package main
+
+import (
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+)
+
+func TestWithdeploy(t *testing.T) {
+	p := commonTestScriptsParam
+	p.Dir = "testscripts/withdeploy-off"
+	testscript.Run(t, p)
+}

--- a/markup/goldmark/goldmark_integration_test.go
+++ b/markup/goldmark/goldmark_integration_test.go
@@ -804,7 +804,7 @@ H~2~0
 }
 
 // Issue 12997.
-func TestGoldmarkRawHTMLWarning(t *testing.T) {
+func TestGoldmarkRawHTMLWarningBlocks(t *testing.T) {
 	files := `
 -- hugo.toml --
 disableKinds = ['home','rss','section','sitemap','taxonomy','term']
@@ -814,6 +814,30 @@ markup.goldmark.renderer.unsafe = false
 title: "p1"
 ---
 <div>Some raw HTML</div>
+-- layouts/_default/single.html --
+{{ .Content }}
+`
+
+	b := hugolib.Test(t, files, hugolib.TestOptWarn())
+
+	b.AssertFileContent("public/p1/index.html", "<!-- raw HTML omitted -->")
+	b.AssertLogContains("WARN  Raw HTML omitted from \"/content/p1.md\"; see https://gohugo.io/getting-started/configuration-markup/#rendererunsafe\nYou can suppress this warning by adding the following to your site configuration:\nignoreLogs = ['warning-goldmark-raw-html']")
+
+	b = hugolib.Test(t, strings.ReplaceAll(files, "markup.goldmark.renderer.unsafe = false", "markup.goldmark.renderer.unsafe = true"), hugolib.TestOptWarn())
+	b.AssertFileContent("public/p1/index.html", "! <!-- raw HTML omitted -->")
+	b.AssertLogContains("! WARN")
+}
+
+func TestGoldmarkRawHTMLWarningInline(t *testing.T) {
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+markup.goldmark.renderer.unsafe = false
+-- content/p1.md --
+---
+title: "p1"
+---
+<em>raw HTML</em>
 -- layouts/_default/single.html --
 {{ .Content }}
 `

--- a/testscripts/withdeploy-off/deploy_off.txt
+++ b/testscripts/withdeploy-off/deploy_off.txt
@@ -1,0 +1,3 @@
+! hugo deploy --force
+# Issue 13012
+stderr 'deploy not supported in this version of Hugo'


### PR DESCRIPTION
- **commands: Print the "deploy not available" error message even if flags provided**
- **build: Add missing withdeploy archive for Windows**
- **markup: Goldmark log "Raw HTML omitted" warning also for inline HTML**
