### PR TITLE
Remove deprecations <= v0.122.0 (note)

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/htime"
-	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/common/types"
@@ -141,8 +140,6 @@ type rootCommand struct {
 
 	logLevel string
 
-	verbose bool
-	debug   bool
 	quiet   bool
 	devMode bool // Hidden flag.
 
@@ -482,17 +479,6 @@ func (r *rootCommand) createLogger(running bool) (loggers.Logger, error) {
 			default:
 				return nil, fmt.Errorf("invalid log level: %q, must be one of debug, warn, info or error", r.logLevel)
 			}
-		} else {
-			if r.verbose {
-				hugo.Deprecate("--verbose", "use --logLevel info", "v0.114.0")
-				hugo.Deprecate("--verbose", "use --logLevel info", "v0.114.0")
-				level = logg.LevelInfo
-			}
-
-			if r.debug {
-				hugo.Deprecate("--debug", "use --logLevel debug", "v0.114.0")
-				level = logg.LevelDebug
-			}
 		}
 	}
 
@@ -560,8 +546,6 @@ Complete documentation is available at https://gohugo.io/.`
 	cmd.PersistentFlags().BoolVar(&r.quiet, "quiet", false, "build in quiet mode")
 	cmd.PersistentFlags().BoolVarP(&r.renderToMemory, "renderToMemory", "M", false, "render to memory (mostly useful when running the server)")
 
-	cmd.PersistentFlags().BoolVarP(&r.verbose, "verbose", "v", false, "verbose output")
-	cmd.PersistentFlags().BoolVarP(&r.debug, "debug", "", false, "debug output")
 	cmd.PersistentFlags().BoolVarP(&r.devMode, "devMode", "", false, "only used for internal testing, flag hidden.")
 	cmd.PersistentFlags().StringVar(&r.logLevel, "logLevel", "", "log level (debug|info|warn|error)")
 	_ = cmd.RegisterFlagCompletionFunc("logLevel", cobra.FixedCompletions([]string{"debug", "info", "warn", "error"}, cobra.ShellCompDirectiveNoFileComp))

--- a/common/hugo/hugo_test.go
+++ b/common/hugo/hugo_test.go
@@ -63,6 +63,10 @@ func TestDeprecationLogLevelFromVersion(t *testing.T) {
 	c.Assert(deprecationLogLevelFromVersion(ver.String()), qt.Equals, logg.LevelWarn)
 	ver.Minor -= 6
 	c.Assert(deprecationLogLevelFromVersion(ver.String()), qt.Equals, logg.LevelError)
+
+	// Added just to find the threshold for where we can remove deprecated items.
+	// Subtract 5 from the minor version of the first ERRORed version => 0.122.0.
+	c.Assert(deprecationLogLevelFromVersion("0.127.0"), qt.Equals, logg.LevelError)
 }
 
 func TestMarkupScope(t *testing.T) {

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -888,29 +888,16 @@ func fromLoadConfigResult(fs afero.Fs, logger loggers.Logger, res config.LoadCon
 		var differentRootKeys []string
 		switch x := v.(type) {
 		case maps.Params:
-			var params maps.Params
-			pv, found := x["params"]
-			if found {
-				params = pv.(maps.Params)
-			} else {
-				params = maps.Params{
+			_, found := x["params"]
+			if !found {
+				x["params"] = maps.Params{
 					maps.MergeStrategyKey: maps.ParamsMergeStrategyDeep,
 				}
-				x["params"] = params
 			}
 
 			for kk, vv := range x {
 				if kk == "_merge" {
 					continue
-				}
-				if kk != maps.MergeStrategyKey && !configLanguageKeys[kk] {
-					// This should have been placed below params.
-					// We accidentally allowed it in the past, so we need to support it a little longer,
-					// But log a warning.
-					if _, found := params[kk]; !found {
-						hugo.Deprecate(fmt.Sprintf("config: languages.%s.%s: custom params on the language top level", k, kk), fmt.Sprintf("Put the value below [languages.%s.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120", k), "v0.112.0")
-						params[kk] = vv
-					}
 				}
 				if kk == "baseurl" {
 					// baseURL configure don the language level is a multihost setup.

--- a/hugolib/page__common.go
+++ b/hugolib/page__common.go
@@ -57,7 +57,6 @@ type pageCommon struct {
 
 	// All of these represents the common parts of a page.Page
 	navigation.PageMenusProvider
-	page.AuthorProvider
 	page.AlternativeOutputFormatsProvider
 	page.ChildCareProvider
 	page.FileProvider

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/gohugoio/hugo/common/constants"
 	"github.com/gohugoio/hugo/common/hashing"
-	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
@@ -106,23 +105,6 @@ func (m *pageMetaParams) init(preserveOringal bool) {
 
 func (p *pageMeta) Aliases() []string {
 	return p.pageConfig.Aliases
-}
-
-// Deprecated: Use taxonomies instead.
-func (p *pageMeta) Author() page.Author {
-	hugo.Deprecate(".Page.Author", "Use taxonomies instead.", "v0.98.0")
-	authors := p.Authors()
-
-	for _, author := range authors {
-		return author
-	}
-	return page.Author{}
-}
-
-// Deprecated: Use taxonomies instead.
-func (p *pageMeta) Authors() page.AuthorList {
-	hugo.Deprecate(".Page.Authors", "Use taxonomies instead.", "v0.112.0")
-	return nil
 }
 
 func (p *pageMeta) BundleType() string {

--- a/hugolib/page__new.go
+++ b/hugolib/page__new.go
@@ -183,7 +183,6 @@ func (h *HugoSites) doNewPage(m *pageMeta) (*pageState, *paths.Path, error) {
 			dependencyManager:                 m.s.Conf.NewIdentityManager(m.Path()),
 			pageCommon: &pageCommon{
 				FileProvider:              m,
-				AuthorProvider:            m,
 				store:                     maps.NewScratch(),
 				Positioner:                page.NopPage,
 				InSectionPositioner:       page.NopPage,

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"html/template"
 	"io"
 	"mime"
 	"net/url"
@@ -412,12 +411,6 @@ func newHugoSites(cfg deps.DepsCfg, d *deps.Deps, pageTrees *pageTrees, sites []
 	return h, nil
 }
 
-// Deprecated: Use hugo.IsServer instead.
-func (s *Site) IsServer() bool {
-	hugo.Deprecate(".Site.IsServer", "Use hugo.IsServer instead.", "v0.120.0")
-	return s.conf.Internal.Running
-}
-
 // Returns the server port.
 func (s *Site) ServerPort() int {
 	return s.conf.C.BaseURL.Port()
@@ -430,13 +423,6 @@ func (s *Site) Title() string {
 
 func (s *Site) Copyright() string {
 	return s.conf.Copyright
-}
-
-// Deprecated: Use .Site.Home.OutputFormats.Get "rss" instead.
-func (s *Site) RSSLink() template.URL {
-	hugo.Deprecate(".Site.RSSLink", "Use the Output Format's Permalink method instead, e.g. .OutputFormats.Get \"RSS\".Permalink", "v0.114.0")
-	rssOutputFormat := s.home.OutputFormats().Get("rss")
-	return template.URL(rssOutputFormat.Permalink())
 }
 
 func (s *Site) Config() page.SiteConfig {
@@ -518,18 +504,6 @@ func (s *Site) Authors() page.AuthorList {
 func (s *Site) Social() map[string]string {
 	hugo.Deprecate(".Site.Social", "Implement taxonomy 'social' or use .Site.Params.Social instead.", "v0.124.0")
 	return s.conf.Social
-}
-
-// Deprecated: Use .Site.Config.Services.Disqus.Shortname instead.
-func (s *Site) DisqusShortname() string {
-	hugo.Deprecate(".Site.DisqusShortname", "Use .Site.Config.Services.Disqus.Shortname instead.", "v0.120.0")
-	return s.Config().Services.Disqus.Shortname
-}
-
-// Deprecated: Use .Site.Config.Services.GoogleAnalytics.ID instead.
-func (s *Site) GoogleAnalytics() string {
-	hugo.Deprecate(".Site.GoogleAnalytics", "Use .Site.Config.Services.GoogleAnalytics.ID instead.", "v0.120.0")
-	return s.Config().Services.GoogleAnalytics.ID
 }
 
 func (s *Site) Param(key any) (any, error) {

--- a/resources/page/page.go
+++ b/resources/page/page.go
@@ -51,14 +51,6 @@ type AlternativeOutputFormatsProvider interface {
 	AlternativeOutputFormats() OutputFormats
 }
 
-// AuthorProvider provides author information.
-type AuthorProvider interface {
-	// Deprecated: Use taxonomies instead.
-	Author() Author
-	// Deprecated: Use taxonomies instead.
-	Authors() AuthorList
-}
-
 // ChildCareProvider provides accessors to child resources.
 type ChildCareProvider interface {
 	// Pages returns a list of pages of all kinds.
@@ -308,9 +300,6 @@ type PageWithoutContent interface {
 	PaginatorProvider
 	Positioner
 	navigation.PageMenusProvider
-
-	// TODO(bep)
-	AuthorProvider
 
 	// Page lookups/refs
 	GetPageProvider

--- a/resources/page/page_nop.go
+++ b/resources/page/page_nop.go
@@ -77,20 +77,6 @@ func (p *nopPage) Layout() string {
 	return ""
 }
 
-func (p *nopPage) RSSLink() template.URL {
-	return ""
-}
-
-// Deprecated: Use taxonomies instead.
-func (p *nopPage) Author() Author {
-	return Author{}
-}
-
-// Deprecated: Use taxonomies instead.
-func (p *nopPage) Authors() AuthorList {
-	return nil
-}
-
 func (p *nopPage) AllTranslations() Pages {
 	return nil
 }
@@ -165,14 +151,6 @@ func (p *nopPage) Eq(other any) bool {
 
 func (p *nopPage) ExpiryDate() (t time.Time) {
 	return
-}
-
-func (p *nopPage) Ext() string {
-	return ""
-}
-
-func (p *nopPage) Extension() string {
-	return ""
 }
 
 func (p *nopPage) File() *source.File {

--- a/resources/page/site.go
+++ b/resources/page/site.go
@@ -14,7 +14,6 @@
 package page
 
 import (
-	"html/template"
 	"time"
 
 	"github.com/gohugoio/hugo/common/maps"
@@ -53,9 +52,6 @@ type Site interface {
 
 	// A shortcut to the home
 	Home() Page
-
-	// Deprecated: Use hugo.IsServer instead.
-	IsServer() bool
 
 	// Returns the server port.
 	ServerPort() int
@@ -117,12 +113,6 @@ type Site interface {
 	// Deprecated: Use .Site.Params instead.
 	Social() map[string]string
 
-	// Deprecated: Use Config().Services.GoogleAnalytics instead.
-	GoogleAnalytics() string
-
-	// Deprecated: Use Config().Privacy.Disqus instead.
-	DisqusShortname() string
-
 	// BuildDrafts is deprecated and will be removed in a future release.
 	BuildDrafts() bool
 
@@ -131,9 +121,6 @@ type Site interface {
 
 	// LanguagePrefix returns the language prefix for this site.
 	LanguagePrefix() string
-
-	// Deprecated: Use .Site.Home.OutputFormats.Get "rss" instead.
-	RSSLink() template.URL
 
 	maps.StoreProvider
 
@@ -195,11 +182,6 @@ func (s *siteWrapper) Authors() AuthorList {
 	return s.s.Authors()
 }
 
-// Deprecated: Use .Site.Config.Services.GoogleAnalytics.ID instead.
-func (s *siteWrapper) GoogleAnalytics() string {
-	return s.s.GoogleAnalytics()
-}
-
 func (s *siteWrapper) GetPage(ref ...string) (Page, error) {
 	return s.s.GetPage(ref...)
 }
@@ -230,11 +212,6 @@ func (s *siteWrapper) Sections() Pages {
 
 func (s *siteWrapper) Home() Page {
 	return s.s.Home()
-}
-
-// Deprecated: Use hugo.IsServer instead.
-func (s *siteWrapper) IsServer() bool {
-	return s.s.IsServer()
 }
 
 func (s *siteWrapper) ServerPort() int {
@@ -315,18 +292,8 @@ func (s *siteWrapper) IsMultiLingual() bool {
 	return s.s.IsMultiLingual()
 }
 
-// Deprecated: Use .Site.Config.Services.Disqus.Shortname instead.
-func (s *siteWrapper) DisqusShortname() string {
-	return s.s.DisqusShortname()
-}
-
 func (s *siteWrapper) LanguagePrefix() string {
 	return s.s.LanguagePrefix()
-}
-
-// Deprecated: Use .Site.Home.OutputFormats.Get "rss" instead.
-func (s *siteWrapper) RSSLink() template.URL {
-	return s.s.RSSLink()
 }
 
 func (s *siteWrapper) Store() *maps.Scratch {
@@ -416,18 +383,8 @@ func (t testSite) Languages() langs.Languages {
 	return nil
 }
 
-// Deprecated: Use .Site.Config.Services.GoogleAnalytics.ID instead.
-func (t testSite) GoogleAnalytics() string {
-	return ""
-}
-
 func (t testSite) MainSections() []string {
 	return nil
-}
-
-// Deprecated: Use hugo.IsServer instead.
-func (t testSite) IsServer() bool {
-	return false
 }
 
 func (t testSite) Language() *langs.Language {
@@ -474,11 +431,6 @@ func (s testSite) Config() SiteConfig {
 	return SiteConfig{}
 }
 
-// Deprecated: Use .Site.Config.Services.Disqus.Shortname instead.
-func (testSite) DisqusShortname() string {
-	return ""
-}
-
 func (s testSite) BuildDrafts() bool {
 	return false
 }
@@ -490,11 +442,6 @@ func (s testSite) IsMultiLingual() bool {
 
 func (s testSite) Param(key any) (any, error) {
 	return nil, nil
-}
-
-// Deprecated: Use .Site.Home.OutputFormats.Get "rss" instead.
-func (s testSite) RSSLink() template.URL {
-	return ""
 }
 
 func (s testSite) Store() *maps.Scratch {

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -127,16 +127,6 @@ func (p *testPage) AlternativeOutputFormats() OutputFormats {
 	panic("testpage: not implemented")
 }
 
-// Deprecated: Use taxonomies instead.
-func (p *testPage) Author() Author {
-	return Author{}
-}
-
-// Deprecated: Use taxonomies instead.
-func (p *testPage) Authors() AuthorList {
-	return nil
-}
-
 func (p *testPage) BaseFileName() string {
 	panic("testpage: not implemented")
 }
@@ -199,14 +189,6 @@ func (p *testPage) Eq(other any) bool {
 
 func (p *testPage) ExpiryDate() time.Time {
 	return p.expiryDate
-}
-
-func (p *testPage) Ext() string {
-	panic("testpage: not implemented")
-}
-
-func (p *testPage) Extension() string {
-	panic("testpage: not implemented")
 }
 
 func (p *testPage) File() *source.File {
@@ -457,10 +439,6 @@ func (p *testPage) PrevPage() Page {
 
 func (p *testPage) PublishDate() time.Time {
 	return p.pubDate
-}
-
-func (p *testPage) RSSLink() template.URL {
-	return ""
 }
 
 func (p *testPage) RawContent() string {

--- a/source/fileInfo.go
+++ b/source/fileInfo.go
@@ -56,13 +56,6 @@ func (fi *File) Dir() string {
 	return fi.pathToDir(fi.p().Dir())
 }
 
-// Extension is an alias to Ext().
-// Deprecated: Use Ext() instead.
-func (fi *File) Extension() string {
-	hugo.Deprecate(".File.Extension", "Use .File.Ext instead.", "v0.96.0")
-	return fi.Ext()
-}
-
 // Ext returns a file's extension without the leading period (e.g. "md").
 func (fi *File) Ext() string { return fi.p().Ext() }
 

--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/gohugoio/hugo/common/collections"
-	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/deps"
@@ -187,54 +186,6 @@ func (ns *Namespace) Dictionary(values ...any) (map[string]any, error) {
 	}
 
 	return root, nil
-}
-
-// EchoParam returns the value in the collection c with key k if is set; otherwise, it returns an
-// empty string.
-// Deprecated: Use the index function instead.
-func (ns *Namespace) EchoParam(c, k any) any {
-	hugo.Deprecate("collections.EchoParam", "Use the index function instead.", "v0.120.0")
-	av, isNil := indirect(reflect.ValueOf(c))
-	if isNil {
-		return ""
-	}
-
-	var avv reflect.Value
-	switch av.Kind() {
-	case reflect.Array, reflect.Slice:
-		index, ok := k.(int)
-		if ok && av.Len() > index {
-			avv = av.Index(index)
-		}
-	case reflect.Map:
-		kv := reflect.ValueOf(k)
-		if kv.Type().AssignableTo(av.Type().Key()) {
-			avv = av.MapIndex(kv)
-		}
-	}
-
-	avv, isNil = indirect(avv)
-
-	if isNil {
-		return ""
-	}
-
-	if avv.IsValid() {
-		switch avv.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			return avv.Int()
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			return avv.Uint()
-		case reflect.Float32, reflect.Float64:
-			return avv.Float()
-		case reflect.String:
-			return avv.String()
-		case reflect.Bool:
-			return avv.Bool()
-		}
-	}
-
-	return ""
 }
 
 // First returns the first limit items in list l.

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -232,39 +232,6 @@ func TestReverse(t *testing.T) {
 	c.Assert(err, qt.Not(qt.IsNil))
 }
 
-func TestEchoParam(t *testing.T) {
-	t.Skip("deprecated, will be removed in Hugo 0.133.0")
-	t.Parallel()
-	c := qt.New(t)
-
-	ns := newNs()
-
-	for i, test := range []struct {
-		a      any
-		key    any
-		expect any
-	}{
-		{[]int{1, 2, 3}, 1, int64(2)},
-		{[]uint{1, 2, 3}, 1, uint64(2)},
-		{[]float64{1.1, 2.2, 3.3}, 1, float64(2.2)},
-		{[]string{"foo", "bar", "baz"}, 1, "bar"},
-		{[]TstX{{A: "a", B: "b"}, {A: "c", B: "d"}, {A: "e", B: "f"}}, 1, ""},
-		{map[string]int{"foo": 1, "bar": 2, "baz": 3}, "bar", int64(2)},
-		{map[string]uint{"foo": 1, "bar": 2, "baz": 3}, "bar", uint64(2)},
-		{map[string]float64{"foo": 1.1, "bar": 2.2, "baz": 3.3}, "bar", float64(2.2)},
-		{map[string]string{"foo": "FOO", "bar": "BAR", "baz": "BAZ"}, "bar", "BAR"},
-		{map[string]TstX{"foo": {A: "a", B: "b"}, "bar": {A: "c", B: "d"}, "baz": {A: "e", B: "f"}}, "bar", ""},
-		{map[string]any{"foo": nil}, "foo", ""},
-		{(*[]string)(nil), "bar", ""},
-	} {
-		errMsg := qt.Commentf("[%d] %v", i, test)
-
-		result := ns.EchoParam(test.a, test.key)
-
-		c.Assert(result, qt.Equals, test.expect, errMsg)
-	}
-}
-
 func TestFirst(t *testing.T) {
 	t.Parallel()
 	c := qt.New(t)

--- a/tpl/collections/init.go
+++ b/tpl/collections/init.go
@@ -67,11 +67,6 @@ func init() {
 			[][2]string{},
 		)
 
-		ns.AddMethodMapping(ctx.EchoParam,
-			[]string{"echoParam"},
-			[][2]string{},
-		)
-
 		ns.AddMethodMapping(ctx.First,
 			[]string{"first"},
 			[][2]string{},

--- a/tpl/lang/lang.go
+++ b/tpl/lang/lang.go
@@ -26,7 +26,6 @@ import (
 	translators "github.com/gohugoio/localescompressed"
 
 	"github.com/gohugoio/hugo/common/hreflect"
-	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/deps"
 	"github.com/spf13/cast"
 )
@@ -238,12 +237,6 @@ func (ns *Namespace) FormatNumberCustom(precision, number any, options ...any) (
 	}
 
 	return string(b), nil
-}
-
-// Deprecated: Use lang.FormatNumberCustom instead.
-func (ns *Namespace) NumFmt(precision, number any, options ...any) (string, error) {
-	hugo.Deprecate("lang.NumFmt", "Use lang.FormatNumberCustom instead.", "v0.120.0")
-	return ns.FormatNumberCustom(precision, number, options...)
 }
 
 type pagesLanguageMerger interface {


### PR DESCRIPTION
These have, once we release this, been logging ERROR for 6 minor versions.
