### PR TITLE
tpl/tplimpl: Add details shortcode

### DIFF
--- a/docs/content/en/content-management/shortcodes.md
+++ b/docs/content/en/content-management/shortcodes.md
@@ -94,6 +94,33 @@ Example usage:
 
 Although you can call this shortcode using the `{{</* */>}}` notation, computationally it is more efficient to call it using the `{{%/* */%}}` notation as shown above.
 
+### details
+
+{{% note %}}
+To override Hugo's embedded `details` shortcode, copy the [source code] to a file with the same name in the layouts/shortcodes directory.
+
+[source code]: {{% eturl details %}}
+{{% /note %}}
+
+The `details` shortcode allows you to generate a collapsible details HTML element. Example usage:
+
+```text
+    {{</* details summary="Custom Summary Text" */>}}
+    Showing custom `summary` text.
+    {{</* /details */>}}
+```
+
+Additional examples can be found in source code. The `details` shortcode can use the following named arguments:
+
+summary
+: (`string`) Optional. Specifies the content of the child summary element. Default is "Details"
+
+open
+: (`bool`) Optional. Whether to initially display the contents of the details element. Default is `false`.
+
+[...params]
+: (`object`) Optional. Additional HTML attributes passed directly to the details element. For instance, can specify `name`, `class`, and other global HTML attributes. 
+
 ### figure
 
 {{% note %}}

--- a/tpl/tplimpl/embedded/templates/shortcodes/details.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/details.html
@@ -1,0 +1,72 @@
+{{- /*
+Renders an HTML details element.
+
+@param {string} [summary] The content of the child summary element.
+@param {bool} [open=false] Whether to initially display the contents of the details element.
+@param {object} [...params] Additional HTML attributes passed directly to the details element.
+
+@reference https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
+
+@examples
+
+    {{< details >}}
+    A basic collapsible section.
+    {{< /details >}}
+
+    {{< details summary="Custom Summary Text" >}}
+    Showing custom `summary` text.
+    {{< /details >}}
+
+    {{< details summary="Open Details" open=true >}}
+    Contents displayed initially by using `open`.
+    {{< /details >}}
+
+    {{< details summary="Styled Content" class="my-custom-class" >}}
+    Content can be styled with CSS by specifying a `class`.
+
+    Target details element:
+
+    ```css
+    details.my-custom-class { }
+    ```
+
+    Target summary element:
+
+    ```css
+    details.my-custom-class > summary > * { }
+    ```
+
+    Target inner content:
+
+    ```css
+    details.my-custom-class > :not(summary) { }
+    ```
+    {{< /details >}}
+
+    {{< details summary="Grouped Details" name="my-details" >}}
+    Specifying a `name` allows elements to be connected, with only one able to be open at a time.
+    {{< /details >}}
+
+*/}}
+
+{{- /* Get arguments. */}}
+{{- $summary := or (.Get "summary") (T "details") "Details" }}
+{{- $open := false }}
+{{- if in (slice "false" false 0) (.Get "open") }}
+    {{- $open = false }}
+{{- else if in (slice "true" true 1) (.Get "open")}}
+    {{- $open = true }}
+{{- end }}
+
+{{- /* Render. */}}
+<details
+    {{- if $open }} open{{ end }}
+    {{- range $k, $v := .Params }}
+        {{- if not (or (in (slice "open" "summary") $k) (strings.HasPrefix $k "on")) }}
+        {{- printf " %s=%q" $k $v | safeHTMLAttr }}
+        {{- end }}
+    {{- end -}}
+>
+    <summary>{{ $summary | .Page.RenderString }}</summary>
+    {{ .Inner | .Page.RenderString (dict "display" "block") -}}
+</details>


### PR DESCRIPTION
- Add new shortcode to render details HTML element.
- Implement integration tests to check: default state, custom summary, open state, safeHTML sanitization, allowed attributes, and localization of default summary text.
- Update docs to include details shortcode.

Closes # 13090