### PR TITLE
common/maps: Simplify TestScratchSetInMap/DeleteInMap

### DIFF
--- a/common/maps/scratch_test.go
+++ b/common/maps/scratch_test.go
@@ -185,7 +185,7 @@ func TestScratchSetInMap(t *testing.T) {
 	scratch.SetInMap("key", "zyx", "Zyx")
 	scratch.SetInMap("key", "abc", "Abc (updated)")
 	scratch.SetInMap("key", "def", "Def")
-	c.Assert(scratch.GetSortedMapValues("key"), qt.DeepEquals, []any{0: "Abc (updated)", 1: "Def", 2: "Lux", 3: "Zyx"})
+	c.Assert(scratch.GetSortedMapValues("key"), qt.DeepEquals, any([]any{"Abc (updated)", "Def", "Lux", "Zyx"}))
 }
 
 func TestScratchDeleteInMap(t *testing.T) {
@@ -199,7 +199,7 @@ func TestScratchDeleteInMap(t *testing.T) {
 	scratch.DeleteInMap("key", "abc")
 	scratch.SetInMap("key", "def", "Def")
 	scratch.DeleteInMap("key", "lmn") // Do nothing
-	c.Assert(scratch.GetSortedMapValues("key"), qt.DeepEquals, []any{0: "Def", 1: "Lux", 2: "Zyx"})
+	c.Assert(scratch.GetSortedMapValues("key"), qt.DeepEquals, any([]any{"Def", "Lux", "Zyx"}))
 }
 
 func TestScratchGetSortedMapValues(t *testing.T) {


### PR DESCRIPTION
This PR refactors `TestScratchSetInMap` and `TestScratchDeleteInMap`:

- `scratch.GetSortedMapValues` returns `any`, so the type of the value to compare was changed to `any`.
- Removed unnecessary indexes `0:`, `1:`, `2:` in the slice initializer as they don't add much to readability.