### PR TITLE
Add asciidoctor to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,8 @@ RUN apk add --no-cache \
     git \
     runuser \
     nodejs \
-    npm
+    npm \
+    asciidoctor
 
 RUN mkdir -p /var/hugo/bin /cache && \
     addgroup -Sg 1000 hugo && \


### PR DESCRIPTION
It would be helpful to have `asciidoctor` in the official container image to support the Hugo asciidoc feature. 