### PR TITLE
tests: Get rid of redundant os.Exit in TestMain

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -56,19 +56,17 @@ func TestUnfinished(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(
-		testscript.RunMain(m, map[string]func() int{
-			// The main program.
-			"hugo": func() int {
-				err := commands.Execute(os.Args[1:])
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					return 1
-				}
-				return 0
-			},
-		}),
-	)
+	testscript.RunMain(m, map[string]func() int{
+		// The main program.
+		"hugo": func() int {
+			err := commands.Execute(os.Args[1:])
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				return 1
+			}
+			return 0
+		},
+	})
 }
 
 var commonTestScriptsParam = testscript.Params{


### PR DESCRIPTION
This PR simplifies tests by removing redundant `os.Exit` calls in `TestMain` functions. 

As of Go 1.15, we do not need to call `os.Exit(m.Run())` explicitly, as value returned by `m.Run()` is stored into unexported field of `m` and go test executable is smart enough to automatically call `os.Exit(retValue)` when `TestMain` returns. See golang/go#34129.
