### PR TITLE
Update gocloud and docs for S3-Compatible Endpoints

### DIFF
--- a/docs/content/en/hosting-and-deployment/hugo-deploy.md
+++ b/docs/content/en/hosting-and-deployment/hugo-deploy.md
@@ -55,8 +55,10 @@ URL = "<FILL ME IN>"
 #URL = "gs://<Bucket Name>"
 
 # Amazon Web Services S3; see https://gocloud.dev/howto/blob/#s3
-# For S3-compatible endpoints, see https://gocloud.dev/howto/blob/#s3-compatible
 #URL = "s3://<Bucket Name>?region=<AWS region>"
+
+# For S3-compatible endpoints, see https://gocloud.dev/howto/blob/#s3-compatible
+#URL = "s3://<Bucket Name>?endpoint=https://my.minio.instance&awssdk=v2&use_path_style=true&disable_https=false
 
 # Microsoft Azure Blob Storage; see https://gocloud.dev/howto/blob/#azure
 #URL = "azblob://$web"

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/yuin/goldmark v1.7.8
 	github.com/yuin/goldmark-emoji v1.0.4
 	go.uber.org/automaxprocs v1.5.3
-	gocloud.dev v0.39.0
+	gocloud.dev v0.40.0
 	golang.org/x/exp v0.0.0-20221031165847-c99f073a8326
 	golang.org/x/image v0.22.0
 	golang.org/x/mod v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ go.opentelemetry.io/otel/trace v1.29.0 h1:J/8ZNK4XgR7a21DZUAsbF8pZ5Jcw1VhACmnYt3
 go.opentelemetry.io/otel/trace v1.29.0/go.mod h1:eHl3w0sp3paPkYstJOmAimxhiFXPg+MMTlEh3nsQgWQ=
 go.uber.org/automaxprocs v1.5.3 h1:kWazyxZUrS3Gs4qUpbwo5kEIMGe/DAvi5Z4tl2NW4j8=
 go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
-gocloud.dev v0.39.0 h1:EYABYGhAalPUaMrbSKOr5lejxoxvXj99nE8XFtsDgds=
-gocloud.dev v0.39.0/go.mod h1:drz+VyYNBvrMTW0KZiBAYEdl8lbNZx+OQ7oQvdrFmSQ=
+gocloud.dev v0.40.0 h1:f8LgP+4WDqOG/RXoUcyLpeIAGOcAbZrZbDQCUee10ng=
+gocloud.dev v0.40.0/go.mod h1:drz+VyYNBvrMTW0KZiBAYEdl8lbNZx+OQ7oQvdrFmSQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
While trying to follow the docs, [Configuring your first
deployment](https://gohugo.io/hosting-and-deployment/hugo-deploy/#configuring-your-first-deployment) gives an
example of using an S3-Compatible endpoint. I could not get this to work with the current codebase.

[gocloud 0.40.0](https://github.com/google/go-cloud/releases/tag/v0.40.0) released on 2024-10-10 includes a
bugfix https://github.com/google/go-cloud/pull/3473 which allows specifying a custom endpoint in an s3 url to
publish to an s3-compatible service, such as MinIO as was linked in that PR
https://github.com/minio/docs/issues/406#issuecomment-1246316964.

I updated the docs to include an s3 URL that works with the updated gocloud library (tested against my MinIO
instance) with example parameters.


Resolves https://github.com/gohugoio/hugo/issues/13159