### PR TITLE
Refactor: filepath.Walk to filepath.WalkDir

### DIFF
--- a/codegen/methods.go
+++ b/codegen/methods.go
@@ -21,7 +21,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os"
+	"io/fs"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -180,9 +180,9 @@ func (c *Inspector) parseSource() {
 		fileExcludes := regexp.MustCompile("autogen")
 		var filenames []string
 
-		filepath.Walk(c.ProjectRootDir, func(path string, info os.FileInfo, err error) error {
-			if info.IsDir() {
-				if dirExcludes.MatchString(info.Name()) {
+		filepath.WalkDir(c.ProjectRootDir, func(path string, d fs.DirEntry, err error) error {
+			if d.IsDir() {
+				if dirExcludes.MatchString(d.Name()) {
 					return filepath.SkipDir
 				}
 			}

--- a/commands/mod.go
+++ b/commands/mod.go
@@ -16,6 +16,7 @@ package commands
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -265,11 +266,11 @@ Run "go help get" for more information. All flags available for "go get" is also
 							return errors.New("must not be run from the file system root")
 						}
 
-						filepath.Walk(dirname, func(path string, info os.FileInfo, err error) error {
-							if info.IsDir() {
+						filepath.WalkDir(dirname, func(path string, d fs.DirEntry, err error) error {
+							if d.IsDir() {
 								return nil
 							}
-							if info.Name() == "go.mod" {
+							if d.Name() == "go.mod" {
 								// Found a module.
 								dir := filepath.Dir(path)
 

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -550,7 +550,7 @@ func (h *HugoSites) handleDataFile(r *source.File) error {
 		return nil
 	}
 
-	// filepath.Walk walks the files in lexical order, '/' comes before '.'
+	// filepath.WalkDir walks the files in lexical order, '/' comes before '.'
 	higherPrecedentData := current[r.BaseFileName()]
 
 	switch data.(type) {


### PR DESCRIPTION
filepath.Walk calls os.Lstat for every file or directory to retrieve os.FileInfo, which can be slower.

filepath.WalkDir avoids unnecessary system calls since it provides a fs.DirEntry, which includes file type information without requiring a stat call.