### PR TITLE
markup/highlight: Add wrapperClass option

### DIFF
--- a/markup/highlight/config.go
+++ b/markup/highlight/config.go
@@ -45,12 +45,17 @@ var DefaultConfig = Config{
 	NoClasses:          true,
 	LineNumbersInTable: true,
 	TabWidth:           4,
+	WrapperClass:       "highlight",
 }
 
 type Config struct {
 	Style string
 
+	// Enable syntax highlighting of fenced code blocks.
 	CodeFences bool
+
+	// The class or classes to use for the outermost element of the highlighted code.
+	WrapperClass string
 
 	// Use inline CSS styles.
 	NoClasses bool

--- a/markup/highlight/highlight.go
+++ b/markup/highlight/highlight.go
@@ -202,7 +202,7 @@ func highlight(fw hugio.FlexiWriter, code, lang string, attributes []attributes.
 	}
 
 	if !cfg.Hl_inline {
-		writeDivStart(w, attributes)
+		writeDivStart(w, attributes, cfg.WrapperClass)
 	}
 
 	options := cfg.toHTMLOptions()
@@ -303,8 +303,9 @@ func (s startEnd) End(code bool) string {
 	return s.end(code)
 }
 
-func writeDivStart(w hugio.FlexiWriter, attrs []attributes.Attribute) {
-	w.WriteString(`<div class="highlight`)
+func writeDivStart(w hugio.FlexiWriter, attrs []attributes.Attribute, wrapperClass string) {
+	w.WriteString(`<div class="`)
+	w.WriteString(wrapperClass)
 	if attrs != nil {
 		for _, attr := range attrs {
 			if attr.Name == "class" {

--- a/markup/highlight/highlight_integration_test.go
+++ b/markup/highlight/highlight_integration_test.go
@@ -103,3 +103,29 @@ xəx := 0
 		<span class="nx">xəx</span>
 	`)
 }
+
+func TestHighlightClass(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- config.toml --
+[markup.highlight]
+noClasses = false
+wrapperClass = "highlight no-prose"
+-- content/_index.md --
+---
+title: home
+---
+§§§go
+xəx := 0
+§§§
+-- layouts/index.html --
+{{ .Content }}
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/index.html", `
+		 <div class="highlight no-prose"><pre
+	`)
+}


### PR DESCRIPTION
The need comes from Tailwind's typography plugin. There's currently no way to turn that off outside of the markup, see https://github.com/tailwindlabs/tailwindcss-typography/pull/363
