### PR TITLE
Print cli usage of `hugo gen chromastyles` alongside css

### DIFF
--- a/commands/gen.go
+++ b/commands/gen.go
@@ -75,7 +75,9 @@ See https://xyproto.github.io/splash/docs/all.html for a preview of the availabl
 					return err
 				}
 				formatter := html.New(html.WithAllClasses(true))
-				formatter.WriteCSS(os.Stdout, style)
+				w := os.Stdout
+				fmt.Fprintf(w, "/* Generated using: hugo %s */\n\n", strings.Join(os.Args[1:], " "))
+				formatter.WriteCSS(w, style)
 				return nil
 			},
 			withc: func(cmd *cobra.Command, r *rootCommand) {


### PR DESCRIPTION
When I was playing around generating chromastyles, I forgot what style I was using during generation. `hugo gen chromastyles [flags] [args]` doesn't print any information about how the styles were generated, which would be beneficial to know.

This pull request prints a comment above the generated css styles showing the cli usage during the chromastyles generation.

Now it ouputs like
```console
$ ./hugo gen chromastyles --style=catppuccin-macchiato
/* Generated using: hugo gen chromastyles --style=catppuccin-macchiato */

/* Background */ .bg { color:#cad3f5;background-color:#24273a; }
/* PreWrapper */ .chroma { color:#cad3f5;background-color:#24273a; }
...
```