### PR TITLE
config/allconfig: Throw error when output format is not defined

### DIFF
--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -734,7 +734,7 @@ func (c *Configs) Validate(logger loggers.Logger) error {
 
 // transientErr returns the last transient error found during config compilation.
 func (c *Configs) transientErr() error {
-	for _, l := range c.LanguageConfigSlice {
+	for _, l := range c.LanguageConfigMap {
 		if l.C.transientErr != nil {
 			return l.C.transientErr
 		}

--- a/config/allconfig/allconfig_integration_test.go
+++ b/config/allconfig/allconfig_integration_test.go
@@ -175,3 +175,21 @@ func TestMapUglyURLs(t *testing.T) {
 	b.Assert(c.C.IsUglyURLSection("posts"), qt.IsTrue)
 	b.Assert(c.C.IsUglyURLSection("blog"), qt.IsFalse)
 }
+
+// Issue 13199
+func TestInvalidOutputFormat(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+[outputs]
+home = ['html','foo']
+-- layouts/index.html --
+x
+`
+
+	b, err := hugolib.TestE(t, files)
+	b.Assert(err, qt.IsNotNil)
+	b.Assert(err.Error(), qt.Contains, `failed to create config: unknown output format "foo" for kind "home"`)
+}


### PR DESCRIPTION
Fixes #13199