### PR TITLE
markup/highlight: Remove noHl option

### DIFF
--- a/markup/highlight/config.go
+++ b/markup/highlight/config.go
@@ -33,7 +33,6 @@ const (
 	lineNosKey     = "linenos"
 	hlLinesKey     = "hl_lines"
 	linosStartKey  = "linenostart"
-	noHlKey        = "nohl"
 )
 
 var DefaultConfig = Config{
@@ -59,9 +58,6 @@ type Config struct {
 
 	// Use inline CSS styles.
 	NoClasses bool
-
-	// No highlighting.
-	NoHl bool
 
 	// When set, line numbers will be printed.
 	LineNos            bool
@@ -234,8 +230,6 @@ func normalizeHighlightOptions(m map[string]any) {
 
 	for k, v := range m {
 		switch k {
-		case noHlKey:
-			m[noHlKey] = cast.ToBool(v)
 		case lineNosKey:
 			if v == "table" || v == "inline" {
 				m["lineNumbersInTable"] = v == "table"

--- a/markup/highlight/highlight.go
+++ b/markup/highlight/highlight.go
@@ -168,7 +168,7 @@ func highlight(fw hugio.FlexiWriter, code, lang string, attributes []attributes.
 		lexer = chromalexers.Get(lang)
 	}
 
-	if lexer == nil && (cfg.GuessSyntax && !cfg.NoHl) {
+	if lexer == nil && cfg.GuessSyntax {
 		lexer = lexers.Analyse(code)
 		if lexer == nil {
 			lexer = lexers.Fallback

--- a/markup/internal/attributes/attributes.go
+++ b/markup/internal/attributes/attributes.go
@@ -36,7 +36,6 @@ var chromaHighlightProcessingAttributes = map[string]bool{
 	"lineNoStart":        true,
 	"lineNumbersInTable": true,
 	"noClasses":          true,
-	"nohl":               true,
 	"style":              true,
 	"tabWidth":           true,
 }


### PR DESCRIPTION
Closes #9885

We have excluded this option from the documentation for years because all it does is negate `guessSyntax`. And we should consider removing that too (separate issue) because only a handful of lexers provide an Anaylzer.