### PR TITLE
Trim whitespace before details tag for details shortcode

### DIFF
--- a/tpl/tplimpl/embedded/templates/shortcodes/details.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/details.html
@@ -63,7 +63,7 @@ Renders an HTML details element.
   {{- $open = true }}
 {{- end }}
 
-{{- /* Render. */}}
+{{- /* Render. */ -}}
 <details
   {{- with $class }} class="{{ . }}" {{- end }}
   {{- with $name }} name="{{ . }}" {{- end }}


### PR DESCRIPTION
Currently when using the details shortcode, there will always be a new line before the actual `<details>` tag. This might cause rendering an extra `<p>\n</p>` tag before the details tag. This patch fixes this issue by simply trim the whitespace before `<details>` tag start.

Example usage:

```markdown
Paragraph content. Before the usage of the details shortcode, there is a new empty line.

{{< details summary="See the details" >}}
detail content
{{< /details >}}
```

Before the patch, it will render as something like:

```html
<p>Paragraph content. Before the usage of the details shortcode, there is a new empty line.</p>
<p>
</p>
<details>
  <summary>See the details</summary>
  detail content
</details>
```

After the patch:

```html
<p>Paragraph content. Before the usage of the details shortcode, there is a new empty line.</p>
<details>
  <summary>See the details</summary>
  detail content
</details>
```

----

Related to unit test, I have run `mage -v test` on my machine and the related tests are passed. Since I'm quite new to this project, I enabled the "Allow edits by maintainers" option. so if unit test is needed for the issue that this patch is attempt to address, feel free to directly adding commit to this PR to add unit test.