### PR TITLE
Replace .Text with .PlainText

### DIFF
--- a/tpl/tplimpl/embedded/templates/_default/_markup/render-image.html
+++ b/tpl/tplimpl/embedded/templates/_default/_markup/render-image.html
@@ -12,7 +12,7 @@
     {{- end -}}
   {{- end -}}
 {{- end -}}
-<img src="{{ $src }}" alt="{{ .Text }}"
+<img src="{{ $src }}" alt="{{ .PlainText }}"
   {{- with .Title }} title="{{ . }}" {{- end -}}
   {{- range $k, $v := .Attributes -}}
     {{- if $v -}}


### PR DESCRIPTION
Replace .Text with .PlainText in alt to conform with the CommonMark specification: “Only the plain string content is rendered, without formatting.”