### PR TITLE
tpl/tplimpl: Use plain text for image render hook alt attribute

### DIFF
--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -246,9 +246,10 @@ iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAA
 func TestRenderHooksDefaultEscape(t *testing.T) {
 	files := `
 -- hugo.toml --
-[markup.goldmark.renderHooks]
+[markup.goldmark.extensions.typographer]
+disable = true
 [markup.goldmark.renderHooks.image]
-  enableDefault = ENABLE
+enableDefault = ENABLE
 [markup.goldmark.renderHooks.link]
 enableDefault = ENABLE
 [markup.goldmark.parser]
@@ -256,6 +257,7 @@ wrapStandAloneImageWithinParagraph = false
 [markup.goldmark.parser.attribute]
 block = true
 title = true
+
 -- content/_index.md --
 ---
 title: "Home"
@@ -279,7 +281,7 @@ Image: ![alt-"<>&](/destination-"<> 'title-"<>&')
 			if enabled {
 				b.AssertFileContent("public/index.html",
 					"Link: <a href=\"/destination-%22%3C%3E\" title=\"title-&#34;&lt;&gt;&amp;\">text-&quot;&lt;&gt;&amp;</a>",
-					"img src=\"/destination-%22%3C%3E\" alt=\"alt-&quot;&lt;&gt;&amp;\" title=\"title-&#34;&lt;&gt;&amp;\">",
+					"img src=\"/destination-%22%3C%3E\" alt=\"alt-&#34;&lt;&gt;&amp;\" title=\"title-&#34;&lt;&gt;&amp;\">",
 					"&gt;&lt;script&gt;",
 				)
 			} else {

--- a/tpl/tplimpl/embedded/templates/_default/_markup/render-image.html
+++ b/tpl/tplimpl/embedded/templates/_default/_markup/render-image.html
@@ -12,7 +12,7 @@
     {{- end -}}
   {{- end -}}
 {{- end -}}
-<img src="{{ $src }}" alt="{{ .Text }}"
+<img src="{{ $src }}" alt="{{ .PlainText }}"
   {{- with .Title }} title="{{ . }}" {{- end -}}
   {{- range $k, $v := .Attributes -}}
     {{- if $v -}}

--- a/tpl/tplimpl/render_hook_integration_test.go
+++ b/tpl/tplimpl/render_hook_integration_test.go
@@ -146,6 +146,8 @@ func TestEmbeddedImageRenderHook(t *testing.T) {
 -- config.toml --
 baseURL = 'https://example.org/dir/'
 disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+[markup.goldmark.extensions.typographer]
+disable = true
 [markup.goldmark.parser]
 wrapStandAloneImageWithinParagraph = false
 [markup.goldmark.parser.attribute]
@@ -174,7 +176,7 @@ iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAA
 	b.AssertFileContent("public/p1/index.html",
 		`<img src="" alt="">`,
 		`<img src="/dir/p1/pixel.png" alt="alt1">`,
-		`<img src="/dir/p1/pixel.png" alt="alt2-&amp;&lt;&gt;&rsquo;" title="&amp;&lt;&gt;&#39;">`,
+		`<img src="/dir/p1/pixel.png" alt="alt2-&amp;&lt;&gt;&#39;" title="&amp;&lt;&gt;&#39;">`,
 		`<img src="/dir/p1/pixel.png?a=b&amp;c=d#fragment" alt="alt3">`,
 		`<img src="/dir/p1/pixel.png" alt="alt4">`,
 	)
@@ -185,7 +187,7 @@ iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAA
 	b.AssertFileContent("public/p1/index.html",
 		`<img src="" alt="">`,
 		`<img src="/dir/p1/pixel.png" alt="alt1">`,
-		`<img src="/dir/p1/pixel.png" alt="alt2-&amp;&lt;&gt;&rsquo;" title="&amp;&lt;&gt;&#39;">`,
+		`<img src="/dir/p1/pixel.png" alt="alt2-&amp;&lt;&gt;&#39;" title="&amp;&lt;&gt;&#39;">`,
 		`<img src="/dir/p1/pixel.png?a=b&amp;c=d#fragment" alt="alt3" class="foo" id="bar">`,
 		`<img src="/dir/p1/pixel.png" alt="alt4" id="&#34;&gt;&lt;script&gt;alert()&lt;/script&gt;">`,
 	)


### PR DESCRIPTION
I disabled the Goldmark typographer extension in the affected tests to make the results easier to reason about.

