### PR TITLE
deps: Upgrade github.com/gohugoio/hashstructure from 0.1.0 to 0.3.0

### DIFF
--- a/common/hashing/hashing_test.go
+++ b/common/hashing/hashing_test.go
@@ -142,3 +142,16 @@ func BenchmarkHashString(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkHashMap(b *testing.B) {
+	m := map[string]interface{}{}
+	for i := 0; i < 1000; i++ {
+		m[fmt.Sprintf("key%d", i)] = i
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		HashString(m)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/gobuffalo/flect v1.0.3
 	github.com/gobwas/glob v0.2.3
 	github.com/gohugoio/go-i18n/v2 v2.1.3-0.20230805085216-e63c13218d0e
-	github.com/gohugoio/hashstructure v0.1.0
+	github.com/gohugoio/hashstructure v0.3.0
 	github.com/gohugoio/httpcache v0.7.0
 	github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0
 	github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/gohugoio/go-i18n/v2 v2.1.3-0.20230805085216-e63c13218d0e h1:QArsSubW7
 github.com/gohugoio/go-i18n/v2 v2.1.3-0.20230805085216-e63c13218d0e/go.mod h1:3Ltoo9Banwq0gOtcOwxuHG6omk+AwsQPADyw2vQYOJQ=
 github.com/gohugoio/hashstructure v0.1.0 h1:kBSTMLMyTXbrJVAxaKI+wv30MMJJxn9Q8kfQtJaZ400=
 github.com/gohugoio/hashstructure v0.1.0/go.mod h1:8ohPTAfQLTs2WdzB6k9etmQYclDUeNsIHGPAFejbsEA=
+github.com/gohugoio/hashstructure v0.3.0 h1:orHavfqnBv0ffQmobOp41Y9HKEMcjrR/8EFAzpngmGs=
+github.com/gohugoio/hashstructure v0.3.0/go.mod h1:8ohPTAfQLTs2WdzB6k9etmQYclDUeNsIHGPAFejbsEA=
 github.com/gohugoio/httpcache v0.7.0 h1:ukPnn04Rgvx48JIinZvZetBfHaWE7I01JR2Q2RrQ3Vs=
 github.com/gohugoio/httpcache v0.7.0/go.mod h1:fMlPrdY/vVJhAriLZnrF5QpN3BNAcoBClgAyQd+lGFI=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0 h1:MNdY6hYCTQEekY0oAfsxWZU1CDt6iH+tMLgyMJQh/sg=


### PR DESCRIPTION
Faster hashing of maps:

```
           │ stash.bench  │      deps-hashstructv030.bench      │
           │    sec/op    │    sec/op     vs base               │
HashMap-10   198.9µ ± ∞ ¹   142.6µ ± ∞ ¹  -28.31% (p=0.029 n=4)
¹ need >= 6 samples for confidence interval at level 0.95

           │  stash.bench  │      deps-hashstructv030.bench       │
           │     B/op      │     B/op       vs base               │
HashMap-10   92.38Ki ± ∞ ¹   37.14Ki ± ∞ ¹  -59.80% (p=0.029 n=4)
¹ need >= 6 samples for confidence interval at level 0.95

           │ stash.bench  │      deps-hashstructv030.bench      │
           │  allocs/op   │  allocs/op    vs base               │
HashMap-10   6.747k ± ∞ ¹   4.748k ± ∞ ¹  -29.63% (p=0.029 n=4)
```
