### PR TITLE
tpl/tplimpl: Prevent overloading of embedded comment shortcode

### DIFF
--- a/common/paths/path.go
+++ b/common/paths/path.go
@@ -428,3 +428,16 @@ func ToSlashPreserveLeading(s string) string {
 func IsSameFilePath(s1, s2 string) bool {
 	return path.Clean(ToSlashTrim(s1)) == path.Clean(ToSlashTrim(s2))
 }
+
+// ToSlashNoExtensions returns the result of replacing each separator character
+// in path s with a slash ('/') character, then removing all file extensions.
+// For example, "/a/b/c.d/e.f.g" becomes "/a/b/c.d/e".
+func ToSlashNoExtensions(s string) string {
+	s = filepath.ToSlash(s)
+	d, f := path.Split(s)
+	i := strings.Index(f, ".")
+	if i >= 0 {
+		f = f[:i]
+	}
+	return path.Join(d, f)
+}

--- a/common/paths/path_test.go
+++ b/common/paths/path_test.go
@@ -15,6 +15,7 @@ package paths
 
 import (
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -309,5 +310,43 @@ func TestIsSameFilePath(t *testing.T) {
 		{"/a/b/c", "/a/b/c/././././", true},
 	} {
 		c.Assert(IsSameFilePath(filepath.FromSlash(this.a), filepath.FromSlash(this.b)), qt.Equals, this.expected, qt.Commentf("a: %s b: %s", this.a, this.b))
+	}
+}
+
+func TestToSlashNoExtensions(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"a", "a"},
+		{"a/", "a"},
+		{"/a", "/a"},
+		{"/a/", "/a"},
+		{"a.b", "a"},
+		{"a.b/", "a.b"},
+		{"/a.b", "/a"},
+		{"/a.b/", "/a.b"},
+		{"a/b", "a/b"},
+		{"a/b/", "a/b"},
+		{"a/b", "a/b"},
+		{"/a/b/", "/a/b"},
+		{"a/b/c.d", "a/b/c"},
+		{"a/b/c.d", "a/b/c"},
+		{"a/b/c.d.e", "a/b/c"},
+		{"a/b/c.d/e", "a/b/c.d/e"},
+		{"a/b/c.d/e.f", "a/b/c.d/e"},
+		{"a/b/c.d/e.f.g", "a/b/c.d/e"},
+		{"a.", "a"},
+		{".a", ""},
+		{"/", "/"},
+		{".", ""},
+		{"", ""},
+	}
+	for k, tt := range tests {
+		t.Run(strconv.Itoa(k), func(t *testing.T) {
+			if got := ToSlashNoExtensions(tt.path); got != tt.want {
+				t.Errorf("ToSlashNoExtensions() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/tpl/tplimpl/embedded/templates/shortcodes/comment.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/comment.html
@@ -1,1 +1,3 @@
+{{- /* DO NOT REMOVE THIS SHORTCODE FROM THE CODE BASE. */ -}}
+{{- /* DOING SO WOULD EXPOSE HIDDEN INFORMATION. */ -}}
 {{- $noop := .Inner -}}


### PR DESCRIPTION
Creates a mechanism to prevent loading of user space templates that
match a list of reserved paths. The primary intent is to prevent users
from overloading specific embedded templates. For example, with the
string "shortcodes/comment" in the list of reserved paths, we do not
load any of the following from user space:

  - layouts/shortcodes/comment.html
  - layouts/shortcodes/comment.html.html
  - layouts/shortcodes/comment.en.html.html
  - layouts/shortcodes/comment.json"
  - layouts/shortcodes/comment.json.json"
  - layouts/shortcodes/comment.en.json.json"