### PR TITLE
Fix build with Go 1.24

### DIFF
--- a/common/hugio/hasBytesWriter_test.go
+++ b/common/hugio/hasBytesWriter_test.go
@@ -48,16 +48,16 @@ func TestHasBytesWriter(t *testing.T) {
 
 	for i := 0; i < 22; i++ {
 		h, w := neww()
-		fmt.Fprintf(w, rndStr()+"abc __foobar"+rndStr())
+		fmt.Fprint(w, rndStr()+"abc __foobar"+rndStr())
 		c.Assert(h.Patterns[0].Match, qt.Equals, true)
 
 		h, w = neww()
-		fmt.Fprintf(w, rndStr()+"abc __f")
-		fmt.Fprintf(w, "oo bar"+rndStr())
+		fmt.Fprint(w, rndStr()+"abc __f")
+		fmt.Fprint(w, "oo bar"+rndStr())
 		c.Assert(h.Patterns[0].Match, qt.Equals, true)
 
 		h, w = neww()
-		fmt.Fprintf(w, rndStr()+"abc __moo bar")
+		fmt.Fprint(w, rndStr()+"abc __moo bar")
 		c.Assert(h.Patterns[0].Match, qt.Equals, false)
 	}
 

--- a/common/hugo/hugo.go
+++ b/common/hugo/hugo.go
@@ -423,7 +423,7 @@ func DeprecateLevel(item, alternative, version string, level logg.Level) {
 		msg = fmt.Sprintf("%s was deprecated in Hugo %s and will be removed in a future release. %s", item, version, alternative)
 	}
 
-	loggers.Log().Logger().WithLevel(level).WithField(loggers.FieldNameCmd, "deprecated").Logf(msg)
+	loggers.Log().Logger().WithLevel(level).WithField(loggers.FieldNameCmd, "deprecated").Logf("%s", msg)
 }
 
 // We usually do about one minor version a month.


### PR DESCRIPTION
Go 1.24 provides stricter checking that forbids passing a variable as a format string to Printf-family functions with no other arguments. Remove instances of this. See also:

https://tip.golang.org/doc/go1.24#vet