### PR TITLE
Do not warn on potentially unsafe HTML comments when unsafe=false

### DIFF
--- a/markup/goldmark/goldmark_integration_test.go
+++ b/markup/goldmark/goldmark_integration_test.go
@@ -885,9 +885,26 @@ title: "p1"
 <img border="0" src="pic_trulli.jpg" alt="Trulli">
 -->
 
-XSS 
+## XSS 
 
 <!-- --><script>alert("I just escaped the HTML comment")</script><!-- -->
+
+
+## More
+
+This is a <!--hidden--> word.
+
+This is a <!-- hidden--> word.
+
+This is a <!-- hidden --> word.
+
+This is a <!-- 
+hidden --> word.
+
+This is a <!-- 
+hidden
+--> word.
+
 
 -- layouts/_default/single.html --
 {{ .Content }}

--- a/markup/goldmark/goldmark_integration_test.go
+++ b/markup/goldmark/goldmark_integration_test.go
@@ -912,10 +912,19 @@ hidden
 
 	b := hugolib.Test(t, files, hugolib.TestOptWarn())
 
-	b.AssertFileContent("public/p1/index.html", "! <!-- raw HTML omitted -->")
+	b.AssertFileContent("public/p1/index.html",
+		"! <!-- raw HTML omitted -->",
+		"! <!-- hidden -->",
+		"! <!-- This is a comment -->",
+		"! script",
+	)
 	b.AssertLogContains("! Raw HTML omitted")
 
 	b = hugolib.Test(t, strings.ReplaceAll(files, "markup.goldmark.renderer.unsafe = false", "markup.goldmark.renderer.unsafe = true"), hugolib.TestOptWarn())
-	b.AssertFileContent("public/p1/index.html", "<!-- This is a comment -->")
+	b.AssertFileContent("public/p1/index.html",
+		"! <!-- raw HTML omitted -->",
+		"<!-- hidden -->",
+		"<!-- This is a comment -->",
+	)
 	b.AssertLogContains("! WARN")
 }

--- a/markup/goldmark/goldmark_integration_test.go
+++ b/markup/goldmark/goldmark_integration_test.go
@@ -918,7 +918,7 @@ hidden
 		"! <!-- This is a comment -->",
 		"! script",
 	)
-	b.AssertLogContains("! Raw HTML omitted")
+	b.AssertLogContains("! WARN")
 
 	b = hugolib.Test(t, strings.ReplaceAll(files, "markup.goldmark.renderer.unsafe = false", "markup.goldmark.renderer.unsafe = true"), hugolib.TestOptWarn())
 	b.AssertFileContent("public/p1/index.html",


### PR DESCRIPTION
We will still not render these comments, so from a safety perspective this is the same, but HTML comments are very common also inside Markdown and too useful to throw away.

Updates #13278
