### PR TITLE
parser/pageparser: Don't allow parameters after closing tag in shortcodes

### DIFF
--- a/parser/pageparser/pagelexer_shortcode.go
+++ b/parser/pageparser/pagelexer_shortcode.go
@@ -322,6 +322,7 @@ func lexInsideShortcode(l *pageLexer) stateFunc {
 		}
 		l.closingState++
 		l.isInline = false
+		l.elementStepNum = 0
 		l.emit(tScClose)
 	case r == '\\':
 		l.ignore()

--- a/parser/pageparser/pageparser_shortcode_test.go
+++ b/parser/pageparser/pageparser_shortcode_test.go
@@ -126,6 +126,9 @@ var shortCodeLexerTests = []lexerTest{
 	{"self-closing with param", `{{< sc1 param1 />}}`, []typeText{
 		tstLeftNoMD, tstSC1, tstParam1, tstSCClose, tstRightNoMD, tstEOF,
 	}, nil},
+	{"self-closing with extra keyword", `{{< sc1 / keyword>}}`, []typeText{
+		tstLeftNoMD, tstSC1, tstSCClose, nti(tError, "closing tag for shortcode 'keyword' does not match start tag"),
+	}, nil},
 	{"multiple self-closing with param", `{{< sc1 param1 />}}{{< sc1 param1 />}}`, []typeText{
 		tstLeftNoMD, tstSC1, tstParam1, tstSCClose, tstRightNoMD,
 		tstLeftNoMD, tstSC1, tstParam1, tstSCClose, tstRightNoMD, tstEOF,


### PR DESCRIPTION
## Problem:
Previously, the following self-closing shortcode syntax was incorrectly allowed:
{{% sc / param %}}

## Solution:
Only allow parameters before the self-closing tag

---------------------------------------------------
After some iterations, I believe I found the "intended" solution to this problem (I hope 😅).
Let me know if more tests/changes are needed. Thank you for your work on this project!