### PR TITLE
tpl/tplimpl: Remove leading whitespaces produced by Youtube shortcode

### DIFF
--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
@@ -102,7 +102,7 @@ Renders an embedded YouTube video.
     {{- $allow := "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" }}
     {{- $referrerpolicy := "strict-origin-when-cross-origin" }}
 
-    {{- /* Render. */}}
+    {{- /* Render. */ -}}
     <div
       {{- with $class }} class="{{ . }}" {{- end }}
       {{- with $divStyle }} style="{{ . | safeCSS }}" {{- end -}}

--- a/tpl/tplimpl/shortcodes_integration_test.go
+++ b/tpl/tplimpl/shortcodes_integration_test.go
@@ -675,12 +675,12 @@ title: p2
 
 	b := hugolib.Test(t, files)
 
-	b.AssertFileContent("public/p1/index.html", "515600e76b272f51")
-	b.AssertFileContent("public/p2/index.html", "b5ceeace7dfa797a")
+	b.AssertFileContent("public/p1/index.html", "a0a6f5ade9cc3a9f")
+	b.AssertFileContent("public/p2/index.html", "289c655e727e596c")
 
 	files = strings.ReplaceAll(files, "privacy.youtube.privacyEnhanced = false", "privacy.youtube.privacyEnhanced = true")
 
 	b = hugolib.Test(t, files)
-	b.AssertFileContent("public/p1/index.html", "e92c7f4b768d7e23")
-	b.AssertFileContent("public/p2/index.html", "c384e83e035b71d9")
+	b.AssertFileContent("public/p1/index.html", "b76d790c20d2bd04")
+	b.AssertFileContent("public/p2/index.html", "a6db910a9cf54bc1")
 }


### PR DESCRIPTION
Hi! Coming from issue opened in my theme, there is an issue rendering `youtube` shortcode if it is nested in another shortcode in `{{% %}}` mode. `youtube` shortcode outputs a leading whitespace, which is then rendered as a blockquote.

Thanks