### PR TITLE
Fix some server/watch rebuild issues

### DIFF
--- a/cache/dynacache/dynacache_test.go
+++ b/cache/dynacache/dynacache_test.go
@@ -147,13 +147,13 @@ func TestClear(t *testing.T) {
 
 	c.Assert(cache.Keys(predicateAll), qt.HasLen, 4)
 
-	cache.ClearOnRebuild()
+	cache.ClearOnRebuild(nil)
 
 	// Stale items are always cleared.
 	c.Assert(cache.Keys(predicateAll), qt.HasLen, 2)
 
 	cache = newTestCache(t)
-	cache.ClearOnRebuild(identity.StringIdentity("changed"))
+	cache.ClearOnRebuild(nil, identity.StringIdentity("changed"))
 
 	c.Assert(cache.Keys(nil), qt.HasLen, 1)
 

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -33,6 +33,9 @@ const (
 
 	// GenghisKhan is an Identity everyone relates to.
 	GenghisKhan = StringIdentity("__genghiskhan")
+
+	StructuralChangeAdd    = StringIdentity("__structural_change_add")
+	StructuralChangeRemove = StringIdentity("__structural_change_remove")
 )
 
 var NopManager = new(nopManager)

--- a/resources/resource_factories/bundler/bundler.go
+++ b/resources/resource_factories/bundler/bundler.go
@@ -95,6 +95,10 @@ func (c *Client) Concat(targetPath string, r resource.Resources) (resource.Resou
 		}
 
 		idm := c.rs.Cfg.NewIdentityManager("concat")
+
+		// Re-create on structural changes.
+		idm.AddIdentity(identity.StructuralChangeAdd, identity.StructuralChangeRemove)
+
 		// Add the concatenated resources as dependencies to the composite resource
 		// so that we can track changes to the individual resources.
 		idm.AddIdentityForEach(identity.ForEeachIdentityProviderFunc(


### PR DESCRIPTION
Two issues:

1. Fixe potential edit-loop in server/watch mode (see below)
2. Drain the cache eviction stack before we start calculating the change set. This should allow more fine grained rebuilds for bigger sites and/or in low memory situations.

The fix in 6c68142cc1338640e2bfe2add661a7b4d7bee6ab wasn't really fixing the complete problem.

In Hugo we have some steps that takes more time than others, one example being CSS building with TailwindCSS.

The symptom here is that sometimes when you:

1. Edit content or templates that does not trigger a CSS rebuild => Snappy rebuild.
2. Edit stylesheet or add a CSS class to template that triggers a CSS rebuild => relatively slow rebuild (expected)
3. Then back to content editing or template edits that should not trigger a CSS rebuild => relatively slow rebuild (not expected)

This commit fixes this by pulling the dynacache GC step up and merge it with the cache buster step.

Fixes #13316
