### PR TITLE
chore: Update GitHub workflow template upload-pages-artifact to v4

### DIFF
--- a/docs/content/en/hosting-and-deployment/hosting-on-github/index.md
+++ b/docs/content/en/hosting-and-deployment/hosting-on-github/index.md
@@ -129,7 +129,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./public
 


### PR DESCRIPTION
Seems like `upload-pages-artifact v3` [has now been deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) starting January 30th, 2025, this is a quick fix to ensure the template uses v4 instead because I've just ran into this issue.