### PR TITLE
parser/pageparser: enforce non-alphanumeric parameters must be quoted

### DIFF
--- a/parser/pageparser/pagelexer_shortcode.go
+++ b/parser/pageparser/pagelexer_shortcode.go
@@ -139,7 +139,13 @@ func lexShortcodeParam(l *pageLexer, escapedQuoteStart bool) stateFunc {
 }
 
 func lexShortcodeParamVal(l *pageLexer) stateFunc {
-	l.consumeToSpace()
+	for {
+		r := l.next()
+		if r == eof || isSpace(r) || (!isAlphaNumericOrHyphen(r) && r != '.') {
+			l.backup()
+			break
+		}
+	}
 	l.emit(tScParamVal)
 	return lexInsideShortcode
 }

--- a/parser/pageparser/pageparser_shortcode_test.go
+++ b/parser/pageparser/pageparser_shortcode_test.go
@@ -100,6 +100,9 @@ var shortCodeLexerTests = []lexerTest{
 	{"non-alphanumerics param quoted", `{{< sc1 "-ziL-.%QigdO-4" >}}`, []typeText{
 		tstLeftNoMD, tstSC1, nti(tScParam, "-ziL-.%QigdO-4"), tstRightNoMD, tstEOF,
 	}, nil},
+	{"non-alphanumerics param non quoted", `{{< sc1 param1=% >}}`, []typeText{
+		tstLeftNoMD, tstSC1, tstParam1, nti(tScParamVal, ""), nti(tError, "unrecognized character in shortcode action: U+0025 '%'. Note: Parameters with non-alphanumeric args must be quoted"),
+	}, nil},
 	{"raw string", `{{< sc1` + "`" + "Hello World" + "`" + ` >}}`, []typeText{
 		tstLeftNoMD, tstSC1, nti(tScParam, "Hello World"), tstRightNoMD, tstEOF,
 	}, nil},


### PR DESCRIPTION
## Problem:
Before unquoted named parameters would be parsed until a space was
found, allowing for non-alphanumeric parameters.

## Solution:
Parse until a space, or a non-alphanumeric character is found.
