### PR TITLE
Add some more server options/improvements

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -84,6 +84,10 @@ const (
 	configChangeGoWork = "go work file"
 )
 
+const (
+	hugoHeaderRedirect = "X-Hugo-Redirect"
+)
+
 func newHugoBuilder(r *rootCommand, s *serverCommand, onConfigLoaded ...func(reloaded bool) error) *hugoBuilder {
 	var visitedURLs *types.EvictingQueue[string]
 	if s != nil && !s.disableFastRender {
@@ -307,67 +311,65 @@ func (f *fileServer) createEndpoint(i int) (*http.ServeMux, net.Listener, string
 				w.Header().Set(header.Key, header.Value)
 			}
 
-			if redirect := serverConfig.MatchRedirect(requestURI); !redirect.IsZero() {
-				// fullName := filepath.Join(dir, filepath.FromSlash(path.Clean("/"+name)))
-				doRedirect := true
-				// This matches Netlify's behavior and is needed for SPA behavior.
-				// See https://docs.netlify.com/routing/redirects/rewrites-proxies/
-				if !redirect.Force {
-					path := filepath.Clean(strings.TrimPrefix(requestURI, baseURL.Path()))
-					if root != "" {
-						path = filepath.Join(root, path)
-					}
-					var fs afero.Fs
-					f.c.withConf(func(conf *commonConfig) {
-						fs = conf.fs.PublishDirServer
-					})
-
-					fi, err := fs.Stat(path)
-
-					if err == nil {
-						if fi.IsDir() {
-							// There will be overlapping directories, so we
-							// need to check for a file.
-							_, err = fs.Stat(filepath.Join(path, "index.html"))
-							doRedirect = err != nil
-						} else {
-							doRedirect = false
+			if canRedirect(requestURI, r) {
+				if redirect := serverConfig.MatchRedirect(requestURI, r.Header); !redirect.IsZero() {
+					doRedirect := true
+					// This matches Netlify's behavior and is needed for SPA behavior.
+					// See https://docs.netlify.com/routing/redirects/rewrites-proxies/
+					if !redirect.Force {
+						path := filepath.Clean(strings.TrimPrefix(requestURI, baseURL.Path()))
+						if root != "" {
+							path = filepath.Join(root, path)
 						}
-					}
-				}
+						var fs afero.Fs
+						f.c.withConf(func(conf *commonConfig) {
+							fs = conf.fs.PublishDirServer
+						})
 
-				if doRedirect {
-					switch redirect.Status {
-					case 404:
-						w.WriteHeader(404)
-						file, err := fs.Open(strings.TrimPrefix(redirect.To, baseURL.Path()))
+						fi, err := fs.Stat(path)
+
 						if err == nil {
-							defer file.Close()
-							io.Copy(w, file)
-						} else {
-							fmt.Fprintln(w, "<h1>Page Not Found</h1>")
+							if fi.IsDir() {
+								// There will be overlapping directories, so we
+								// need to check for a file.
+								_, err = fs.Stat(filepath.Join(path, "index.html"))
+								doRedirect = err != nil
+							} else {
+								doRedirect = false
+							}
 						}
-						return
-					case 200:
-						if r2 := f.rewriteRequest(r, strings.TrimPrefix(redirect.To, baseURL.Path())); r2 != nil {
-							requestURI = redirect.To
-							r = r2
-						}
-					default:
-						w.Header().Set("Content-Type", "")
-						http.Redirect(w, r, redirect.To, redirect.Status)
-						return
+					}
 
+					if doRedirect {
+						w.Header().Set(hugoHeaderRedirect, "true")
+						switch redirect.Status {
+						case 404:
+							w.WriteHeader(404)
+							file, err := fs.Open(strings.TrimPrefix(redirect.To, baseURL.Path()))
+							if err == nil {
+								defer file.Close()
+								io.Copy(w, file)
+							} else {
+								fmt.Fprintln(w, "<h1>Page Not Found</h1>")
+							}
+							return
+						case 200:
+							if r2 := f.rewriteRequest(r, strings.TrimPrefix(redirect.To, baseURL.Path())); r2 != nil {
+								requestURI = redirect.To
+								r = r2
+							}
+						default:
+							w.Header().Set("Content-Type", "")
+							http.Redirect(w, r, redirect.To, redirect.Status)
+							return
+
+						}
 					}
 				}
-
 			}
 
 			if f.c.fastRenderMode && f.c.errState.buildErr() == nil {
-				// Sec-Fetch-Mode should be sent by all recent browser versions, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode#navigate
-				// Fall back to the file extension if not set.
-				// The main take here is that we don't want to have CSS/JS files etc. partake in this logic.
-				if r.Header.Get("Sec-Fetch-Mode") == "navigate" || strings.HasSuffix(requestURI, "/") || strings.HasSuffix(requestURI, "html") || strings.HasSuffix(requestURI, "htm") {
+				if isNavigation(requestURI, r) {
 					if !f.c.visitedURLs.Contains(requestURI) {
 						// If not already on stack, re-render that single page.
 						if err := f.c.partialReRender(requestURI); err != nil {
@@ -1232,4 +1234,25 @@ func formatByteCount(b uint64) string {
 	}
 	return fmt.Sprintf("%.1f %cB",
 		float64(b)/float64(div), "kMGTPE"[exp])
+}
+
+func canRedirect(requestURIWithoutQuery string, r *http.Request) bool {
+	if r.Header.Get(hugoHeaderRedirect) != "" {
+		return false
+	}
+	return isNavigation(requestURIWithoutQuery, r)
+}
+
+// Sec-Fetch-Mode should be sent by all recent browser versions, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode#navigate
+// Fall back to the file extension if not set.
+// The main take here is that we don't want to have CSS/JS files etc. partake in this logic.
+func isNavigation(requestURIWithoutQuery string, r *http.Request) bool {
+	return r.Header.Get("Sec-Fetch-Mode") == "navigate" || isPropablyHTMLRequest(requestURIWithoutQuery)
+}
+
+func isPropablyHTMLRequest(requestURIWithoutQuery string) bool {
+	if strings.HasSuffix(requestURIWithoutQuery, "/") || strings.HasSuffix(requestURIWithoutQuery, "html") || strings.HasSuffix(requestURIWithoutQuery, "htm") {
+		return true
+	}
+	return !strings.Contains(requestURIWithoutQuery, ".")
 }

--- a/config/commonConfig_test.go
+++ b/config/commonConfig_test.go
@@ -71,17 +71,33 @@ X-Content-Type-Options = "nosniff"
 
 [[server.redirects]]
 from = "/foo/**"
-to = "/foo/index.html"
+to = "/baz/index.html"
+status = 200
+
+[[server.redirects]]
+from = "/loop/**"
+to = "/loop/foo/"
+status = 200
+
+[[server.redirects]]
+from = "/b/**"
+fromRe = "/b/(.*)/"
+to = "/baz/$1/"
+status = 200
+
+[[server.redirects]]
+fromRe = "/c/(.*)/"
+to = "/boo/$1/"
+status = 200
+
+[[server.redirects]]
+fromRe = "/d/(.*)/"
+to = "/boo/$1/"
 status = 200
 
 [[server.redirects]]
 from = "/google/**"
 to = "https://google.com/"
-status = 301
-
-[[server.redirects]]
-from = "/**"
-to = "/default/index.html"
 status = 301
 
 
@@ -100,45 +116,35 @@ status = 301
 		{Key: "X-XSS-Protection", Value: "1; mode=block"},
 	})
 
-	c.Assert(s.MatchRedirect("/foo/bar/baz"), qt.DeepEquals, Redirect{
+	c.Assert(s.MatchRedirect("/foo/bar/baz", nil), qt.DeepEquals, Redirect{
 		From:   "/foo/**",
-		To:     "/foo/",
+		To:     "/baz/",
 		Status: 200,
 	})
 
-	c.Assert(s.MatchRedirect("/someother"), qt.DeepEquals, Redirect{
-		From:   "/**",
-		To:     "/default/",
-		Status: 301,
+	c.Assert(s.MatchRedirect("/foo/bar/", nil), qt.DeepEquals, Redirect{
+		From:   "/foo/**",
+		To:     "/baz/",
+		Status: 200,
 	})
 
-	c.Assert(s.MatchRedirect("/google/foo"), qt.DeepEquals, Redirect{
+	c.Assert(s.MatchRedirect("/b/c/", nil), qt.DeepEquals, Redirect{
+		From:   "/b/**",
+		FromRe: "/b/(.*)/",
+		To:     "/baz/c/",
+		Status: 200,
+	})
+
+	c.Assert(s.MatchRedirect("/c/d/", nil).To, qt.Equals, "/boo/d/")
+	c.Assert(s.MatchRedirect("/c/d/e/", nil).To, qt.Equals, "/boo/d/e/")
+
+	c.Assert(s.MatchRedirect("/someother", nil), qt.DeepEquals, Redirect{})
+
+	c.Assert(s.MatchRedirect("/google/foo", nil), qt.DeepEquals, Redirect{
 		From:   "/google/**",
 		To:     "https://google.com/",
 		Status: 301,
 	})
-
-	// No redirect loop, please.
-	c.Assert(s.MatchRedirect("/default/index.html"), qt.DeepEquals, Redirect{})
-	c.Assert(s.MatchRedirect("/default/"), qt.DeepEquals, Redirect{})
-
-	for _, errorCase := range []string{
-		`[[server.redirects]]
-from = "/**"
-to = "/file"
-status = 301`,
-		`[[server.redirects]]
-from = "/**"
-to = "/foo/file.html"
-status = 301`,
-	} {
-
-		cfg, err := FromConfigString(errorCase, "toml")
-		c.Assert(err, qt.IsNil)
-		_, err = DecodeServer(cfg)
-		c.Assert(err, qt.Not(qt.IsNil))
-
-	}
 }
 
 func TestBuildConfigCacheBusters(t *testing.T) {


### PR DESCRIPTION
New options:

* `FromHeaders`: Server header matching for redirects
* `FromRe`: Regexp with group support, i.e. it replaces $1, $2 in To with the group matches.

Note that if both `From` and `FromRe` is set, both must match.

Also

* Allow redirects to non HTML URLs as long as the Sec-Fetch-Mode is set to navigate on the request.
* Detect and stop redirect loops.

This was all done while testing out InertiaJS with Hugo. So, after this commit, this setup will support the main parts of the protocol that Inertia uses:

```toml
[server]
    [[server.headers]]
        for = '/**/inertia.json'
        [server.headers.values]
            Content-Type = 'text/html'
            X-Inertia    = 'true'
            Vary         = 'Accept'

    [[server.redirects]]
        force       = true
        from        = '/**/'
        fromRe      = "^/(.*)/$"
        fromHeaders = { "X-Inertia" = "true" }
        status      = 301
        to          = '/$1/inertia.json'
```

Unfortunately, a provider like Netlify does not support redirects matching by request headers. It should be possible with some edge function, but then again, I'm not sure that InertiaJS is a very good fit with the common Hugo use cases.

But this commit should be generally useful.