### PR TITLE
chore: Remove deprecated build tags

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build withdeploy
-// +build withdeploy
 
 package commands
 

--- a/commands/deploy_off.go
+++ b/commands/deploy_off.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !withdeploy
-// +build !withdeploy
 
 // Copyright 2024 The Hugo Authors. All rights reserved.
 //

--- a/common/hugo/vars_extended.go
+++ b/common/hugo/vars_extended.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build extended
-// +build extended
 
 package hugo
 

--- a/common/hugo/vars_regular.go
+++ b/common/hugo/vars_regular.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !extended
-// +build !extended
 
 package hugo
 

--- a/common/hugo/vars_withdeploy.go
+++ b/common/hugo/vars_withdeploy.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build withdeploy
-// +build withdeploy
 
 package hugo
 

--- a/common/hugo/vars_withdeploy_off.go
+++ b/common/hugo/vars_withdeploy_off.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !withdeploy
-// +build !withdeploy
 
 package hugo
 

--- a/deploy/cloudfront.go
+++ b/deploy/cloudfront.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build withdeploy
-// +build withdeploy
 
 package deploy
 

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build withdeploy
-// +build withdeploy
 
 package deploy
 

--- a/deploy/deploy_azure.go
+++ b/deploy/deploy_azure.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !solaris && withdeploy
-// +build !solaris,withdeploy
 
 package deploy
 

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build withdeploy
-// +build withdeploy
 
 package deploy
 

--- a/deploy/deployconfig/deployConfig_test.go
+++ b/deploy/deployconfig/deployConfig_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build withdeploy
-// +build withdeploy
 
 package deployconfig
 

--- a/deploy/google.go
+++ b/deploy/google.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build withdeploy
-// +build withdeploy
 
 package deploy
 

--- a/main_withdeploy_off_test.go
+++ b/main_withdeploy_off_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !withdeploy
-// +build !withdeploy
 
 package main
 

--- a/main_withdeploy_test.go
+++ b/main_withdeploy_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build withdeploy
-// +build withdeploy
 
 package main
 

--- a/resources/image_extended_test.go
+++ b/resources/image_extended_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build extended
-// +build extended
 
 package resources_test
 

--- a/resources/images/webp/webp.go
+++ b/resources/images/webp/webp.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build extended
-// +build extended
 
 package webp
 

--- a/resources/images/webp/webp_notavailable.go
+++ b/resources/images/webp/webp_notavailable.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !extended
-// +build !extended
 
 package webp
 

--- a/resources/resource_transformers/tocss/scss/client_extended.go
+++ b/resources/resource_transformers/tocss/scss/client_extended.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build extended
-// +build extended
 
 package scss
 

--- a/resources/resource_transformers/tocss/scss/client_notavailable.go
+++ b/resources/resource_transformers/tocss/scss/client_notavailable.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !extended
-// +build !extended
 
 package scss
 

--- a/resources/resource_transformers/tocss/scss/tocss.go
+++ b/resources/resource_transformers/tocss/scss/tocss.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build extended
-// +build extended
 
 package scss
 


### PR DESCRIPTION
This PR removes outdated in Go 1.22 `// +build` comments by running the command:
```
go fix -fix buildtag ./...
```

Changes to `tpl/internal/go_templates` were not made.

From https://pkg.go.dev/cmd/go#hdr-Build_constraints:

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.