### PR TITLE
parser: handle org-mode filetags as slice

### DIFF
--- a/parser/metadecoders/decoder.go
+++ b/parser/metadecoders/decoder.go
@@ -251,6 +251,10 @@ func (d Decoder) unmarshalORG(data []byte, v any) error {
 			frontMatter[k[:len(k)-2]] = strings.Fields(v)
 		} else if strings.Contains(v, "\n") {
 			frontMatter[k] = strings.Split(v, "\n")
+		} else if k == "filetags" {
+			trimmed := strings.TrimPrefix(v, ":")
+			trimmed = strings.TrimSuffix(trimmed, ":")
+			frontMatter[k] = strings.Split(trimmed, ":")
 		} else if k == "date" || k == "lastmod" || k == "publishdate" || k == "expirydate" {
 			frontMatter[k] = parseORGDate(v)
 		} else {

--- a/parser/metadecoders/decoder_test.go
+++ b/parser/metadecoders/decoder_test.go
@@ -131,6 +131,8 @@ func TestUnmarshalToInterface(t *testing.T) {
 		{[]byte("#+a: foo bar\n#+a: baz"), ORG, map[string]any{"a": []string{string("foo bar"), string("baz")}}},
 		{[]byte(`#+DATE: <2020-06-26 Fri>`), ORG, map[string]any{"date": "2020-06-26"}},
 		{[]byte(`#+LASTMOD: <2020-06-26 Fri>`), ORG, map[string]any{"lastmod": "2020-06-26"}},
+		{[]byte(`#+FILETAGS: :work:`), ORG, map[string]any{"filetags": []string{"work"}}},
+		{[]byte(`#+FILETAGS: :work:fun:`), ORG, map[string]any{"filetags": []string{"work", "fun"}}},
 		{[]byte(`#+PUBLISHDATE: <2020-06-26 Fri>`), ORG, map[string]any{"publishdate": "2020-06-26"}},
 		{[]byte(`#+EXPIRYDATE: <2020-06-26 Fri>`), ORG, map[string]any{"expirydate": "2020-06-26"}},
 		{[]byte(`a = "b"`), TOML, expect},


### PR DESCRIPTION
This adds support for filetags by slicing them according to [the org mode tag specification](https://orgmode.org/guide/Tags.html).

Can be used to create taxonomies based on org-mode tags