### PR TITLE
fix server.redirects.fromRe being ignored unless server.redirects.from set

### DIFF
--- a/config/commonConfig.go
+++ b/config/commonConfig.go
@@ -450,7 +450,7 @@ func (c *CacheBuster) CompileConfig(logger loggers.Logger) error {
 }
 
 func (r Redirect) IsZero() bool {
-	return r.From == ""
+	return r.From == "" && r.FromRe == ""
 }
 
 const (


### PR DESCRIPTION
Tiny fix: server.redirects.fromRe was being ignored unless server.redirects.from was also set. 