### PR TITLE
images.Text: Add option for vertical alignment

### DIFF
--- a/docs/content/en/functions/images/Text.md
+++ b/docs/content/en/functions/images/Text.md
@@ -21,6 +21,9 @@ alignx
  {{< new-in 0.141.0 />}}
 : (`string`) The horizontal alignment of the text relative to the horizontal offset, one of `left`, `center`, or `right`. Default is `left`.
 
+aligny
+: (`string`) The vertical alignment of the text relative to the vertical offset, one of `top`, `center`, or `bottom`. Default is `top`.
+
 color
 : (`string`) The font color, either a 3-digit or 6-digit hexadecimal color code. Default is `#ffffff` (white).
 

--- a/resources/images/filters.go
+++ b/resources/images/filters.go
@@ -79,6 +79,7 @@ func (*Filters) Text(text string, options ...any) gift.Filter {
 		x:           10,
 		y:           10,
 		alignx:      "left",
+		aligny:      "top",
 		linespacing: 2,
 	}
 
@@ -101,6 +102,11 @@ func (*Filters) Text(text string, options ...any) gift.Filter {
 				tf.alignx = cast.ToString(v)
 				if tf.alignx != "left" && tf.alignx != "center" && tf.alignx != "right" {
 					panic("alignx must be one of left, center, right")
+				}
+			case "aligny":
+				tf.aligny = cast.ToString(v)
+				if tf.aligny != "top" && tf.aligny != "center" && tf.aligny != "bottom" {
+					panic("aligny must be one of top, center, bottom")
 				}
 
 			case "linespacing":

--- a/resources/images/text.go
+++ b/resources/images/text.go
@@ -36,6 +36,7 @@ type textFilter struct {
 	color       color.Color
 	x, y        int
 	alignx      string
+	aligny      string
 	size        float64
 	linespacing int
 	fontSource  hugio.ReadSeekCloserProvider
@@ -110,12 +111,19 @@ func (f textFilter) Draw(dst draw.Image, src image.Image, options *gift.Options)
 		}
 		finalLines = append(finalLines, currentLine)
 	}
+	// Total height of the text from the top of the first line to the baseline of the last line
+	totalHeight := len(finalLines)*fontHeight + (len(finalLines)-1)*f.linespacing
 
 	// Correct y position based on font and size
-	f.y = f.y + fontHeight
-
-	// Start position
-	y := f.y
+	y := f.y + fontHeight
+	switch f.aligny {
+	case "top":
+		// Do nothing
+	case "center":
+		y = y - totalHeight/2
+	case "bottom":
+		y = y - totalHeight
+	}
 
 	// Draw text line by line
 	for _, line := range finalLines {


### PR DESCRIPTION
Add option ``aligny`` to specify the vertical alignment of the text with respect to the ``y`` offset from the top of the image. Possible values of ``aligny`` are ``top`` (default), ``center``, and ``bottom``.

The height of the block of text is measured from the top of the first line to the baseline of the last line.

- ``top``: (Current behaviour) The top of the first line of the block of text is at an offset of ``y`` from the top of the image.

- ``center``: The vertical center of the block of text is at an offset of ``y`` from the top of the image.

- ``bottom``: The baseline of the last line of the text is at an offset of ``y`` from the top of the image.

Resolves #13414

Examples:
- Vertically center-aligned text with ``aligny`` set to ``center``
![center-1](https://github.com/user-attachments/assets/96362477-fd90-4be5-8d4b-f9c513330072)
![center-2](https://github.com/user-attachments/assets/faa522d0-49bf-4473-a7f1-be406bdb6c4b)
![center-3](https://github.com/user-attachments/assets/9eab719c-7ea3-49d4-9fa0-707488be8ba2)
- Title is ``bottom``-aligned and subtitle is ``top``-aligned
![bottom-1](https://github.com/user-attachments/assets/8a844ae9-61a6-40fb-8397-91d5ca780c7d)
![bottom-2](https://github.com/user-attachments/assets/1671f17a-5494-4c67-b6b6-c421fad78bed)