### PR TITLE
markup/goldmark: Fix panic on empty Markdown header

### DIFF
--- a/markup/goldmark/render_hooks.go
+++ b/markup/goldmark/render_hooks.go
@@ -499,10 +499,10 @@ func (r *hookedRenderer) renderHeading(w util.BufWriter, source []byte, node ast
 
 	text := ctx.PopRenderedString()
 
-	// All ast.Heading nodes are guaranteed to have an attribute called "id"
-	// that is an array of bytes that encode a valid string.
-	anchori, _ := n.AttributeString("id")
-	anchor := anchori.([]byte)
+	var anchor []byte
+	if anchori, ok := n.AttributeString("id"); ok {
+		anchor, _ = anchori.([]byte)
+	}
 
 	page, pageInner := render.GetPageAndPageInner(ctx)
 

--- a/markup/goldmark/toc_integration_test.go
+++ b/markup/goldmark/toc_integration_test.go
@@ -258,7 +258,29 @@ title: p7 (emoji)
 `)
 
 	// emoji
+
 	b.AssertFileContent("public/p7/index.html", `
 <li><a href="#a-snake-emoji">A &#x1f40d; emoji</a></li>
 `)
+}
+
+func TestIssue13416(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+-- layouts/index.html --
+Content:{{ .Content }}|
+-- layouts/_default/_markup/render-heading.html --
+-- content/_index.md --
+---
+title: home
+---
+#
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileExists("public/index.html", true)
 }


### PR DESCRIPTION
Fixes #13416
