### PR TITLE
Always strip taxonomy name prefix from term name

### DIFF
--- a/hugolib/page__new.go
+++ b/hugolib/page__new.go
@@ -172,7 +172,7 @@ func (h *HugoSites) doNewPage(m *pageMeta) (*pageState, *paths.Path, error) {
 			}
 			m.singular = tc.singular
 			if m.pageConfig.Kind == kinds.KindTerm {
-				m.term = paths.TrimLeading(strings.TrimPrefix(m.pathInfo.Unnormalized().Base(), tc.pluralTreeKey))
+				m.term = paths.TrimLeading(strings.TrimPrefix(m.pathInfo.Unnormalized().Base(), "/"+tc.plural))
 			}
 		}
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1968,3 +1968,25 @@ Title: {{ .Title }}
 		"deprecated: path in front matter was deprecated",
 	)
 }
+
+// See #13422
+func TestPageTermWithSpaceInTaxonomyName(t *testing.T) {
+	t.Parallel()
+	files := `
+-- hugo.toml --
+[taxonomies]
+"book author" = "book authors"
+-- content/p1.md --
+---
+title: "p1"
+kind: "page"
+lang: "en"
+path: "mypath"
+book authors: ["Author One"]
+---
+-- layouts/_default/term.html --
+{{ .Data.Term }}
+`
+	b := Test(t, files, TestOptWarn())
+	b.AssertFileContent("public/book-authors/author-one/index.html", "Author One")
+}


### PR DESCRIPTION
If the taxonomy name differs when normalized versus unnormalized (e.g., because it has a space in it which is converted to a dash when normalized), the plural tree key will not match as a prefix to the term's base path (which is normalized). Use the non-normalized taxonomy name instead to ensure that the prefix always matches and is trimmed.

Fixes: gohugoio/hugo#13422