### PR TITLE
build docker images with deploy capability

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -46,4 +46,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: HUGO_BUILD_TAGS=withdeploy
+          build-args: HUGO_BUILD_TAGS=extended,withdeploy

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -46,3 +46,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: HUGO_BUILD_TAGS=withdeploy


### PR DESCRIPTION
This PRs adds one variant of the functionality proposed in #13435: 

The Image is built using the "withdeploy" build tag, enabling deploy capability in all containers.