### PR TITLE
tpl: HTTPS the instagram Shortcode JS

### DIFF
--- a/tpl/tplimpl/embedded/templates/shortcodes/instagram.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/instagram.html
@@ -239,6 +239,6 @@
     </div>
   </blockquote>
   {{- if not .pc.Simple -}}
-    <script async src="//www.instagram.com/embed.js"></script>
+    <script async src="https://www.instagram.com/embed.js"></script>
   {{- end -}}
 {{- end -}}

--- a/tpl/tplimpl/shortcodes_integration_test.go
+++ b/tpl/tplimpl/shortcodes_integration_test.go
@@ -256,7 +256,7 @@ Content: {{ .Content }}
 
 	// Regular mode
 	b := hugolib.Test(t, files)
-	b.AssertFileContent("public/index.html", "a7937c49665872d3")
+	b.AssertFileContent("public/index.html", "6e93404b93277876")
 
 	// Simple mode
 	files = strings.ReplaceAll(files, "privacy.instagram.simple = false", "privacy.instagram.simple = true")


### PR DESCRIPTION
This JavaScript will always load over HTTPS so it's best to specify that. Protocol-less loaded resources are an anti-pattern (REF: https://www.paulirish.com/2010/the-protocol-relative-url/)