### PR TITLE
Use the page path and not the backing filename as the last resort in the default sort

### DIFF
--- a/common/paths/pathparser_test.go
+++ b/common/paths/pathparser_test.go
@@ -165,6 +165,7 @@ func TestParse(t *testing.T) {
 				c.Assert(p.Identifiers(), qt.DeepEquals, []string{"txt", "no"})
 				c.Assert(p.Base(), qt.Equals, "/a/b.a.b.txt")
 				c.Assert(p.BaseNoLeadingSlash(), qt.Equals, "a/b.a.b.txt")
+				c.Assert(p.Path(), qt.Equals, "/a/b.a.b.no.txt")
 				c.Assert(p.PathNoLang(), qt.Equals, "/a/b.a.b.txt")
 				c.Assert(p.Ext(), qt.Equals, "txt")
 				c.Assert(p.PathNoIdentifier(), qt.Equals, "/a/b.a.b")
@@ -220,6 +221,7 @@ func TestParse(t *testing.T) {
 				c.Assert(p.NameNoExt(), qt.Equals, "index.no")
 				c.Assert(p.NameNoIdentifier(), qt.Equals, "index")
 				c.Assert(p.NameNoLang(), qt.Equals, "index.md")
+				c.Assert(p.Path(), qt.Equals, "/a/b/index.no.md")
 				c.Assert(p.PathNoLang(), qt.Equals, "/a/b/index.md")
 				c.Assert(p.Section(), qt.Equals, "a")
 			},

--- a/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
+++ b/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
@@ -382,6 +382,28 @@ Single: {{ .Title }}|{{ .Content }}|
 	}
 }
 
+func TestPagesFromGoTmplDefaultPageSort(t *testing.T) {
+	t.Parallel()
+	files := `
+-- hugo.toml --
+defaultContentLanguage = "en"
+-- layouts/index.html --
+{{ range site.RegularPages }}{{ .RelPermalink }}|{{ end}}
+-- content/_content.gotmpl --
+{{ $.AddPage  (dict "kind" "page" "path" "docs/_p22" "title" "A" ) }}
+{{ $.AddPage  (dict "kind" "page" "path" "docs/p12" "title" "A" ) }}
+{{ $.AddPage  (dict "kind" "page" "path" "docs/_p12" "title" "A" ) }}
+-- content/docs/_content.gotmpl --
+{{ $.AddPage  (dict "kind" "page" "path" "_p21" "title" "A" ) }}
+{{ $.AddPage  (dict "kind" "page" "path" "p11" "title" "A" ) }}
+{{ $.AddPage  (dict "kind" "page" "path" "_p11" "title" "A" ) }}
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/index.html", "/docs/_p11/|/docs/_p12/|/docs/_p21/|/docs/_p22/|/docs/p11/|/docs/p12/|")
+}
+
 func TestPagesFromGoTmplEnableAllLanguages(t *testing.T) {
 	t.Parallel()
 

--- a/resources/page/pages_sort.go
+++ b/resources/page/pages_sort.go
@@ -90,14 +90,14 @@ var (
 		if w01 != w02 && w01 != -1 && w02 != -1 {
 			return w01 < w02
 		}
+
 		if p1.Weight() == p2.Weight() {
 			if p1.Date().Unix() == p2.Date().Unix() {
 				c := collatorStringCompare(func(p Page) string { return p.LinkTitle() }, p1, p2)
 				if c == 0 {
-					if p1.File() == nil || p2.File() == nil {
-						return p1.File() == nil
-					}
-					return compare.LessStrings(p1.File().Filename(), p2.File().Filename())
+					// This is the full normalized path, which will contain extension and any language code preserved,
+					// which is what we want for sorting.
+					return compare.LessStrings(p1.PathInfo().Path(), p2.PathInfo().Path())
 				}
 				return c < 0
 			}


### PR DESCRIPTION
This should:

1. Fix some (rare) tiebreaker issues when sorting pages from multiple content adapters.
2. Improve the sorting for pages without a backing file.
