### PR TITLE
Mark loong64 as FMA-using architecture

### DIFF
--- a/resources/images/imagetesting/testing.go
+++ b/resources/images/imagetesting/testing.go
@@ -231,4 +231,5 @@ var UsesFMA = runtime.GOARCH == "s390x" ||
 	runtime.GOARCH == "ppc64" ||
 	runtime.GOARCH == "ppc64le" ||
 	runtime.GOARCH == "arm64" ||
-	runtime.GOARCH == "riscv64"
+	runtime.GOARCH == "riscv64" ||
+	runtime.GOARCH == "loong64"


### PR DESCRIPTION
See output of `grep FMADD go/test/codegen/floats.go`. This can also be found in the LoongArch Reference Manual: https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#_fmaddmsubnmaddnmsub_sd