### PR TITLE
cache: apply httpcache defaults for polling config

### DIFF
--- a/cache/httpcache/httpcache.go
+++ b/cache/httpcache/httpcache.go
@@ -188,7 +188,7 @@ func (gm *GlobMatcher) CompilePredicate() (func(string) bool, error) {
 	return p, nil
 }
 
-func DecodeConfig(bcfg config.BaseConfig, m map[string]any) (Config, error) {
+func DecodeConfig(_ config.BaseConfig, m map[string]any) (Config, error) {
 	if len(m) == 0 {
 		return DefaultConfig, nil
 	}
@@ -212,6 +212,17 @@ func DecodeConfig(bcfg config.BaseConfig, m map[string]any) (Config, error) {
 
 	if c.Cache.For.IsZero() {
 		c.Cache.For = DefaultConfig.Cache.For
+	}
+
+	for pci := range c.Polls {
+		if c.Polls[pci].For.IsZero() {
+			c.Polls[pci].For = DefaultConfig.Cache.For
+			c.Polls[pci].Disable = true
+		}
+	}
+
+	if len(c.Polls) == 0 {
+		c.Polls = DefaultConfig.Polls
 	}
 
 	return c, nil

--- a/cache/httpcache/httpcache_test.go
+++ b/cache/httpcache/httpcache_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/gohugoio/hugo/config"
 )
 
 func TestGlobMatcher(t *testing.T) {
@@ -39,4 +40,34 @@ func TestGlobMatcher(t *testing.T) {
 	c.Assert(p("foo.css"), qt.IsFalse)
 	c.Assert(p("foo/bar/foo.css"), qt.IsFalse)
 	c.Assert(p("foo/bar/foo.xml"), qt.IsTrue)
+}
+
+func TestDefaultConfig(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := DefaultConfig.Compile()
+	c.Assert(err, qt.IsNil)
+}
+
+func TestDecodeConfigInjectsDefaultAndCompiles(t *testing.T) {
+	c := qt.New(t)
+
+	cfg, err := DecodeConfig(config.BaseConfig{}, map[string]interface{}{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg, qt.DeepEquals, DefaultConfig)
+
+	_, err = cfg.Compile()
+	c.Assert(err, qt.IsNil)
+
+	cfg, err = DecodeConfig(config.BaseConfig{}, map[string]any{
+		"cache": map[string]any{
+			"polls": []map[string]any{
+				{"disable": true},
+			},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	_, err = cfg.Compile()
+	c.Assert(err, qt.IsNil)
 }


### PR DESCRIPTION
Previously, compiling the config with partial or missing poll configs
would introduce a panic. This ensures that the default poll configs
are applied in such scenarios.

Fixes #13471
