### PR TITLE
server: Fix fixUrl handling of empty URLs

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -819,7 +819,7 @@ func (c *serverCommand) fixURL(baseURLFromConfig, baseURLFromFlag string, port i
 	if useLocalhost {
 		if certsSet {
 			u.Scheme = "https"
-		} else if u.Scheme == "https" {
+		} else {
 			u.Scheme = "http"
 		}
 		u.Host = "localhost"


### PR DESCRIPTION
Before this patch "hugo server -O" in a project with no baseUrl defined would result in

    Web Server is available at //localhost:60387/ (bind address 127.0.0.1)
    Press Ctrl+C to stop
    The file //localhost:60387 does not exist.
    WARN  Failed to open browser: exit status 1

After the patch:

    Web Server is available at http://localhost:60473/ (bind address 127.0.0.1)
    Press Ctrl+C to stop

and the browser opens as expected.