### PR TITLE
Remove github.com/cli/safeexec

### DIFF
--- a/common/hexec/exec.go
+++ b/common/hexec/exec.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 
 	"github.com/bep/logg"
-	"github.com/cli/safeexec"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/config"
@@ -115,9 +114,8 @@ func IsNotFound(err error) bool {
 
 // SafeCommand is a wrapper around os/exec Command which uses a LookPath
 // implementation that does not search in current directory before looking in PATH.
-// See https://github.com/cli/safeexec and the linked issues.
 func SafeCommand(name string, arg ...string) (*exec.Cmd, error) {
-	bin, err := safeexec.LookPath(name)
+	bin, err := exec.LookPath(name)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +195,7 @@ func (e *Exec) Npx(name string, arg ...any) (Runner, error) {
 		tryFuncs := map[binaryLocation]tryFunc{
 			binaryLocationNodeModules: func() func(...any) (Runner, error) {
 				nodeBinFilename := filepath.Join(e.workingDir, nodeModulesBinPath, name)
-				_, err := safeexec.LookPath(nodeBinFilename)
+				_, err := exec.LookPath(nodeBinFilename)
 				if err != nil {
 					return nil
 				}
@@ -215,7 +213,7 @@ func (e *Exec) Npx(name string, arg ...any) (Runner, error) {
 				}
 			},
 			binaryLocationPath: func() func(...any) (Runner, error) {
-				if _, err := safeexec.LookPath(name); err != nil {
+				if _, err := exec.LookPath(name); err != nil {
 					return nil
 				}
 				return func(arg2 ...any) (Runner, error) {
@@ -346,7 +344,7 @@ func (c *commandeer) command(arg ...any) (*cmdWrapper, error) {
 		bin = c.fullyQualifiedName
 	} else {
 		var err error
-		bin, err = safeexec.LookPath(c.name)
+		bin, err = exec.LookPath(c.name)
 		if err != nil {
 			return nil, &NotFoundError{
 				name:   c.name,
@@ -384,7 +382,7 @@ func InPath(binaryName string) bool {
 	if strings.Contains(binaryName, "/") {
 		panic("binary name should not contain any slash")
 	}
-	_, err := safeexec.LookPath(binaryName)
+	_, err := exec.LookPath(binaryName)
 	return err == nil
 }
 
@@ -394,7 +392,7 @@ func LookPath(binaryName string) string {
 	if strings.Contains(binaryName, "/") {
 		panic("binary name should not contain any slash")
 	}
-	s, err := safeexec.LookPath(binaryName)
+	s, err := exec.LookPath(binaryName)
 	if err != nil {
 		return ""
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/bep/tmc v0.5.1
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/clbanning/mxj/v2 v2.7.0
-	github.com/cli/safeexec v1.0.1
 	github.com/disintegration/gift v1.2.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/evanw/esbuild v0.24.2
@@ -120,6 +119,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.3 // indirect
 	github.com/aws/smithy-go v1.22.2 // indirect
+	github.com/cli/safeexec v1.0.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect


### PR DESCRIPTION
This PR removes the dependency on `github.com/cli/safeexec` as mentioned in issue #13516.

Note: The package still appears as an indirect dependency in go.mod because `github.com/bep/godartsass/v2` requires it. Even after updating godartsass to the latest version, this dependency remains.