### PR TITLE
common/hreflect: Replace the map/RWMutex method cache with sync.Map

### DIFF
--- a/common/hreflect/helpers_test.go
+++ b/common/hreflect/helpers_test.go
@@ -134,3 +134,17 @@ func BenchmarkGetMethodByName(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkGetMethodByNamePara(b *testing.B) {
+	v := reflect.ValueOf(&testStruct{})
+	methods := []string{"Method1", "Method2", "Method3", "Method4", "Method5"}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for _, method := range methods {
+				_ = GetMethodByName(v, method)
+			}
+		}
+	})
+}


### PR DESCRIPTION
It's much faster when running in parallel:

```
GetMethodByName-10        125.1n ± 6%   181.7n ± 7%  +45.30% (p=0.002 n=6)
GetMethodByNamePara-10   770.10n ± 1%   24.77n ± 9%  -96.78% (p=0.002 n=6)
```
