### PR TITLE
config: Use the non-global logger for deprecations when possible

### DIFF
--- a/common/hugo/hugo.go
+++ b/common/hugo/hugo.go
@@ -411,17 +411,28 @@ func IsDartSassGeV2() bool {
 // 2. Their theme to work for at least the last few Hugo versions.
 func Deprecate(item, alternative string, version string) {
 	level := deprecationLogLevelFromVersion(version)
-	DeprecateLevel(item, alternative, version, level)
+	deprecateLevel(item, alternative, version, level)
+}
+
+// See Deprecate for details.
+func DeprecateWithLogger(item, alternative string, version string, log logg.Logger) {
+	level := deprecationLogLevelFromVersion(version)
+	deprecateLevelWithLogger(item, alternative, version, level, log)
 }
 
 // DeprecateLevelMin informs about a deprecation starting at the given version, but with a minimum log level.
 func DeprecateLevelMin(item, alternative string, version string, minLevel logg.Level) {
 	level := max(deprecationLogLevelFromVersion(version), minLevel)
-	DeprecateLevel(item, alternative, version, level)
+	deprecateLevel(item, alternative, version, level)
+}
+
+// deprecateLevel informs about a deprecation logging at the given level.
+func deprecateLevel(item, alternative, version string, level logg.Level) {
+	deprecateLevelWithLogger(item, alternative, version, level, loggers.Log().Logger())
 }
 
 // DeprecateLevel informs about a deprecation logging at the given level.
-func DeprecateLevel(item, alternative, version string, level logg.Level) {
+func deprecateLevelWithLogger(item, alternative, version string, level logg.Level, log logg.Logger) {
 	var msg string
 	if level == logg.LevelError {
 		msg = fmt.Sprintf("%s was deprecated in Hugo %s and subsequently removed. %s", item, version, alternative)
@@ -429,7 +440,7 @@ func DeprecateLevel(item, alternative, version string, level logg.Level) {
 		msg = fmt.Sprintf("%s was deprecated in Hugo %s and will be removed in a future release. %s", item, version, alternative)
 	}
 
-	loggers.Log().Logger().WithLevel(level).WithField(loggers.FieldNameCmd, "deprecated").Logf("%s", msg)
+	log.WithLevel(level).WithField(loggers.FieldNameCmd, "deprecated").Logf("%s", msg)
 }
 
 // We usually do about one minor version a month.

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -396,44 +396,44 @@ func (c *Config) CompileConfig(logger loggers.Logger) error {
 
 	// Legacy paginate values.
 	if c.Paginate != 0 {
-		hugo.Deprecate("site config key paginate", "Use pagination.pagerSize instead.", "v0.128.0")
+		hugo.DeprecateWithLogger("site config key paginate", "Use pagination.pagerSize instead.", "v0.128.0", logger.Logger())
 		c.Pagination.PagerSize = c.Paginate
 	}
 
 	if c.PaginatePath != "" {
-		hugo.Deprecate("site config key paginatePath", "Use pagination.path instead.", "v0.128.0")
+		hugo.DeprecateWithLogger("site config key paginatePath", "Use pagination.path instead.", "v0.128.0", logger.Logger())
 		c.Pagination.Path = c.PaginatePath
 	}
 
 	// Legacy privacy values.
 	if c.Privacy.Twitter.Disable {
-		hugo.Deprecate("site config key privacy.twitter.disable", "Use privacy.x.disable instead.", "v0.141.0")
+		hugo.DeprecateWithLogger("site config key privacy.twitter.disable", "Use privacy.x.disable instead.", "v0.141.0", logger.Logger())
 		c.Privacy.X.Disable = c.Privacy.Twitter.Disable
 	}
 
 	if c.Privacy.Twitter.EnableDNT {
-		hugo.Deprecate("site config key privacy.twitter.enableDNT", "Use privacy.x.enableDNT instead.", "v0.141.0")
+		hugo.DeprecateWithLogger("site config key privacy.twitter.enableDNT", "Use privacy.x.enableDNT instead.", "v0.141.0", logger.Logger())
 		c.Privacy.X.EnableDNT = c.Privacy.Twitter.EnableDNT
 	}
 
 	if c.Privacy.Twitter.Simple {
-		hugo.Deprecate("site config key privacy.twitter.simple", "Use privacy.x.simple instead.", "v0.141.0")
+		hugo.DeprecateWithLogger("site config key privacy.twitter.simple", "Use privacy.x.simple instead.", "v0.141.0", logger.Logger())
 		c.Privacy.X.Simple = c.Privacy.Twitter.Simple
 	}
 
 	// Legacy services values.
 	if c.Services.Twitter.DisableInlineCSS {
-		hugo.Deprecate("site config key services.twitter.disableInlineCSS", "Use services.x.disableInlineCSS instead.", "v0.141.0")
+		hugo.DeprecateWithLogger("site config key services.twitter.disableInlineCSS", "Use services.x.disableInlineCSS instead.", "v0.141.0", logger.Logger())
 		c.Services.X.DisableInlineCSS = c.Services.Twitter.DisableInlineCSS
 	}
 
 	// Legacy permalink tokens
 	vs := fmt.Sprintf("%v", c.Permalinks)
 	if strings.Contains(vs, ":filename") {
-		hugo.Deprecate("the \":filename\" permalink token", "Use \":contentbasename\" instead.", "0.144.0")
+		hugo.DeprecateWithLogger("the \":filename\" permalink token", "Use \":contentbasename\" instead.", "0.144.0", logger.Logger())
 	}
 	if strings.Contains(vs, ":slugorfilename") {
-		hugo.Deprecate("the \":slugorfilename\" permalink token", "Use \":slugorcontentbasename\" instead.", "0.144.0")
+		hugo.DeprecateWithLogger("the \":slugorfilename\" permalink token", "Use \":slugorcontentbasename\" instead.", "0.144.0", logger.Logger())
 	}
 
 	c.C = &ConfigCompiled{


### PR DESCRIPTION
To prevent warnings leaking into parallel tests.
