### PR TITLE
tpl: Warn and skip non-hook templates inside /layouts/_markup

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -396,6 +396,7 @@ func newHugoSites(cfg deps.DepsCfg, d *deps.Deps, pageTrees *pageTrees, sites []
 			templateStore, err := tplimpl.NewStore(
 				tplimpl.StoreOptions{
 					Fs:                     s.BaseFs.Layouts.Fs,
+					Log:                    s.Log,
 					DefaultContentLanguage: s.Conf.DefaultContentLanguage(),
 					Watching:               s.Conf.Watching(),
 					PathParser:             s.Conf.PathParser(),

--- a/tpl/tplimpl/templatestore_integration_test.go
+++ b/tpl/tplimpl/templatestore_integration_test.go
@@ -844,6 +844,21 @@ All.
 	b.AssertLogContains("Duplicate content path")
 }
 
+// Issue #13577.
+func TestPrintPathWarningOnInvalidMarkupFilename(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+-- layouts/all.html --
+All.
+-- layouts/_markup/sitemap.xml --
+`
+	b := hugolib.Test(t, files, hugolib.TestOptWarn())
+
+	b.AssertLogContains("unrecognized render hook")
+}
+
 func BenchmarkExecuteWithContext(b *testing.B) {
 	files := `
 -- hugo.toml --


### PR DESCRIPTION
Fixes #13577
