### PR TITLE
common/paths: support `.gotmpl` outer filetype extension

### DIFF
--- a/common/paths/pathparser_test.go
+++ b/common/paths/pathparser_test.go
@@ -184,6 +184,23 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			"Identifiers (with gotmpl outer filetype ext)",
+			"/a/b.a.b.no.gotmpl.txt",
+			func(c *qt.C, p *Path) {
+				c.Assert(p.Name(), qt.Equals, "b.a.b.no.txt")
+				c.Assert(p.NameNoIdentifier(), qt.Equals, "b")
+				c.Assert(p.NameNoExt(), qt.Equals, "b.a.b.no")
+				c.Assert(p.NameNoLang(), qt.Equals, "b.a.b.txt")
+				c.Assert(p.Identifiers(), qt.DeepEquals, []string{"txt", "gotmpl", "no", "b", "a", "b"})
+				c.Assert(p.IdentifiersUnknown(), qt.DeepEquals, []string{"b", "a", "b"})
+				c.Assert(p.Base(), qt.Equals, "/a/b.txt")
+				c.Assert(p.Path(), qt.Equals, "/a/b.a.b.no.txt")
+				c.Assert(p.PathNoLang(), qt.Equals, "/a/b.txt")
+				c.Assert(p.Ext(), qt.Equals, "txt")
+				c.Assert(p.PathNoIdentifier(), qt.Equals, "/a/b")
+			},
+		},
+		{
 			"Home branch cundle",
 			"/_index.md",
 			func(c *qt.C, p *Path) {
@@ -427,6 +444,13 @@ func TestParseLayouts(t *testing.T) {
 				c.Assert(p.Lang(), qt.Equals, "")
 				c.Assert(p.Kind(), qt.Equals, "term")
 				c.Assert(p.OutputFormat(), qt.Equals, "html")
+			},
+		},
+		{
+			"Term (with gotmpl outer filetype ext)",
+			"/term.gotmpl.html",
+			func(c *qt.C, p *Path) {
+				c.Assert(p.PathBeforeLangAndOutputFormatAndExt(), qt.Equals, "/term")
 			},
 		},
 		{

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -142,7 +142,9 @@ title: "%s"
 # Doc
 
 {{< myShort >}}
+{{< myShortGotmpl >}}
 {{< noExt >}}
+{{< noExtGotmpl >}}
 {{%% onlyHTML %%}}
 
 {{< myInner >}}{{< myShort >}}{{< /myInner >}}
@@ -156,6 +158,7 @@ outputs: ["CSV"]
 # Doc
 
 CSV: {{< myShort >}}
+CSV: {{< myShortGotmpl >}}
 `
 
 	b := newTestSitesBuilder(t).WithConfigFile("toml", siteConfig)
@@ -167,11 +170,17 @@ CSV: {{< myShort >}}
 		"layouts/index.amp.html", `Home AMP: {{ .Title }}|{{ .Content }}`,
 		"layouts/index.ics", `Home Calendar: {{ .Title }}|{{ .Content }}`,
 		"layouts/shortcodes/myShort.html", `ShortHTML`,
+		"layouts/shortcodes/myShortGotmpl.gotmpl.html", `ShortHTMLGotmpl`,
 		"layouts/shortcodes/myShort.amp.html", `ShortAMP`,
+		"layouts/shortcodes/myShortGotmpl.amp.gotmpl.html", `ShortAMPGotmpl`,
 		"layouts/shortcodes/myShort.csv", `ShortCSV`,
+		"layouts/shortcodes/myShortGotmpl.gotmpl.csv", `ShortCSVGotmpl`,
 		"layouts/shortcodes/myShort.ics", `ShortCalendar`,
+		"layouts/shortcodes/myShortGotmpl.gotmpl.ics", `ShortCalendarGotmpl`,
 		"layouts/shortcodes/myShort.json", `ShortJSON`,
+		"layouts/shortcodes/myShortGotmpl.gotmpl.json", `ShortJSONGotmpl`,
 		"layouts/shortcodes/noExt", `ShortNoExt`,
+		"layouts/shortcodes/noExtGotmpl.gotmpl", `ShortNoExtGotmpl`,
 		"layouts/shortcodes/onlyHTML.html", `ShortOnlyHTML`,
 		"layouts/shortcodes/myInner.html", `myInner:--{{- .Inner -}}--`,
 	)
@@ -193,7 +202,9 @@ CSV: {{< myShort >}}
 	b.AssertFileContent("public/index.html",
 		"Home HTML",
 		"ShortHTML",
+		"ShortHTMLGotmpl",
 		"ShortNoExt",
+		"ShortNoExtGotmpl",
 		"ShortOnlyHTML",
 		"myInner:--ShortHTML--",
 	)
@@ -201,7 +212,9 @@ CSV: {{< myShort >}}
 	b.AssertFileContent("public/amp/index.html",
 		"Home AMP",
 		"ShortAMP",
+		"ShortAMPGotmpl",
 		"ShortNoExt",
+		"ShortNoExtGotmpl",
 		"ShortOnlyHTML",
 		"myInner:--ShortAMP--",
 	)
@@ -209,7 +222,9 @@ CSV: {{< myShort >}}
 	b.AssertFileContent("public/index.ics",
 		"Home Calendar",
 		"ShortCalendar",
+		"ShortCalendarGotmpl",
 		"ShortNoExt",
+		"ShortNoExtGotmpl",
 		"ShortOnlyHTML",
 		"myInner:--ShortCalendar--",
 	)
@@ -217,7 +232,9 @@ CSV: {{< myShort >}}
 	b.AssertFileContent("public/sect/mypage/index.html",
 		"Single HTML",
 		"ShortHTML",
+		"ShortHTMLGotmpl",
 		"ShortNoExt",
+		"ShortNoExtGotmpl",
 		"ShortOnlyHTML",
 		"myInner:--ShortHTML--",
 	)
@@ -225,7 +242,9 @@ CSV: {{< myShort >}}
 	b.AssertFileContent("public/sect/mypage/index.json",
 		"Single JSON",
 		"ShortJSON",
+		"ShortJSONGotmpl",
 		"ShortNoExt",
+		"ShortNoExtGotmpl",
 		"ShortOnlyHTML",
 		"myInner:--ShortJSON--",
 	)
@@ -234,7 +253,9 @@ CSV: {{< myShort >}}
 		// No special AMP template
 		"Single HTML",
 		"ShortAMP",
+		"ShortAMPGotmpl",
 		"ShortNoExt",
+		"ShortNoExtGotmpl",
 		"ShortOnlyHTML",
 		"myInner:--ShortAMP--",
 	)
@@ -242,6 +263,7 @@ CSV: {{< myShort >}}
 	b.AssertFileContent("public/sect/mycsvpage/index.csv",
 		"Single CSV",
 		"ShortCSV",
+		"ShortCSVGotmpl",
 	)
 }
 

--- a/tpl/partials/partials_integration_test.go
+++ b/tpl/partials/partials_integration_test.go
@@ -35,14 +35,18 @@ func TestInclude(t *testing.T) {
 baseURL = 'http://example.com/'
 -- layouts/index.html --
 partial: {{ partials.Include "foo.html" . }}
+partial: {{ partials.Include "bar.html" . }}
 -- layouts/partials/foo.html --
 foo
+-- layouts/partials/bar.gotmpl.html --
+bar
   `
 
 	b := hugolib.Test(t, files)
 
 	b.AssertFileContent("public/index.html", `
 partial: foo
+partial: bar
 `)
 }
 


### PR DESCRIPTION
This allows for text editors to (more easily) detect both the outer (e.g. `gotmpl`) and inner (.e.g `html`) syntax used in templates.

A `.gotmpl` extension is considered an outer filetype and ignored in template resolution when:
* It is not recognized as a Kind, Language, or OutputFormat
* It is not the last extension (as this signifies a content adapter)

For example:
* `layouts/home.gotmpl.html` -> same as `layouts/home.html`
* `layouts/_shortcodes/foo.gotmpl.html` -> `{{< foo >}}`
* `layouts/_partials/foo.gotmpl.html` -> `{{ partial "foo.html" }}

Note that if both an e.g. `layouts/home.html` and `layouts/home.gotmpl.html` exist, the latter takes precedence. Same with shortcode templates.

When using the embedded webserver, later writes to e.g. `layouts/home.html` *will* reflect in the stored template.

Closes #10449

---

If this is a worthwhile change, any feedback is appreciated 🙂

I thought on whether to have `Path()` remove the outer filetype extension or instead add a separate method `PathNoOuterftypeExt()` and update references to `Path()` where needed. Let me know if a separate method is preferrable.