### PR TITLE
Typo fixes

### DIFF
--- a/config/configProvider.go
+++ b/config/configProvider.go
@@ -76,7 +76,7 @@ type AllProvider interface {
 }
 
 // We cannot import the media package as that would create a circular dependency.
-// This interface defineds a sub set of what media.ContentTypes provides.
+// This interface defines a subset of what media.ContentTypes provides.
 type ContentTypesProvider interface {
 	IsContentSuffix(suffix string) bool
 	IsContentFile(filename string) bool

--- a/hugolib/content_map_test.go
+++ b/hugolib/content_map_test.go
@@ -517,7 +517,7 @@ func TestHTMLNotContent(t *testing.T) {
 -- hugo.toml.temp --
 [contentTypes]
 [contentTypes."text/markdown"]
-# Emopty for now.
+# Empty for now.
 -- hugo.yaml.temp --
 contentTypes:
   text/markdown: {}

--- a/hugolib/filesystems/basefs.go
+++ b/hugolib/filesystems/basefs.go
@@ -397,7 +397,7 @@ func (d *SourceFilesystem) mounts() []hugofs.FileMetaInfo {
 	})
 
 	// Filter out any mounts not belonging to this filesystem.
-	// TODO(bep) I think this is superflous.
+	// TODO(bep) I think this is superfluous.
 	n := 0
 	for _, mm := range m {
 		if mm.Meta().Component == d.Name {

--- a/hugolib/integrationtest_builder.go
+++ b/hugolib/integrationtest_builder.go
@@ -918,7 +918,7 @@ type IntegrationTestConfig struct {
 
 	// The files to use on txtar format, see
 	// https://pkg.go.dev/golang.org/x/exp/cmd/txtar
-	// There are some conentions used in this test setup.
+	// There are some contentions used in this test setup.
 	// - §§§ can be used to wrap code fences.
 	// - §§ can be used to wrap multiline strings.
 	// - filenames prefixed with sourcefilename: will be read from the file system relative to the current dir.

--- a/tpl/tplimpl/embedded/templates/_shortcodes/instagram.html
+++ b/tpl/tplimpl/embedded/templates/_shortcodes/instagram.html
@@ -3,7 +3,7 @@
   {{- with .Get 0 -}}
     {{- template "render-instagram" (dict "id" . "pc" $pc) -}}
   {{- else -}}
-    {{- errorf "The %q shortocde requires a single positional parameter, the ID of the Instagram post. See %s" .Name .Position -}}
+    {{- errorf "The %q shortcode requires a single positional parameter, the ID of the Instagram post. See %s" .Name .Position -}}
   {{- end -}}
 {{- end -}}
 

--- a/tpl/tplimpl/embedded/templates/_shortcodes/vimeo_simple.html
+++ b/tpl/tplimpl/embedded/templates/_shortcodes/vimeo_simple.html
@@ -6,14 +6,14 @@
       {{- $ctx = merge $ctx (dict "id" . "class" ($.Get "class")) -}}
       {{- template "render-vimeo" $ctx -}}
     {{- else -}}
-      {{- errorf "The %q shortocde requires a single named parameter, the ID of the Vimeo video. See %s" .Name .Position -}}
+      {{- errorf "The %q shortcode requires a single named parameter, the ID of the Vimeo video. See %s" .Name .Position -}}
     {{- end -}}
   {{- else -}}
     {{- with .Get 0 -}}
       {{- $ctx = merge $ctx (dict "id" . "class" ($.Get 1)) -}}
       {{- template "render-vimeo" $ctx -}}
     {{- else -}}
-      {{- errorf "The %q shortocde requires a single positional parameter, the ID of the Vimeo video. See %s" .Name .Position -}}
+      {{- errorf "The %q shortcode requires a single positional parameter, the ID of the Vimeo video. See %s" .Name .Position -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
To help find typos I used this from root:

`npx cspell \"**/*.*\" --no-progress --quiet`

with config:

```json
{
  "version": "0.2",
  "allowCompoundWords": true,
  "flagWords": [
    "alot",
    "hte",
    "teh"
  ],
  "ignorePaths": [
    "**/*.ics"
  ],
  "ignoreRegExpList": [
    "# cspell: ignore everything after a right arrow",
    "\\s+→\\s+.+"
  ],
  "language": "de,en,en-US,es,fr,it,lorem",
  "words": [
    "# ----------------------------------------------------------------------",
    "# cspell: ignore foreign language words",
    "# cspell: ignore miscellaneous",
    "# cspell: ignore operating systems and software packages",
    "# cspell: ignore proper nouns",
    "abcdefghi",
    "abcdefghijk",
    "abcdefghis",
    "abcdefgs",
    "abcdefs",
    "ABNF",
    "absurlified",
    "absurlify",
    "acfg",
    "Afero",
    "alloc",
    "Anchorize",
    "Andrey",
    "antialiasing",
    "argsv",
    "asciidoctor",
    "attrtp",
    "bcfg",
    "benchcmp",
    "bepsays",
    "bezpieczeństwo",
    "bgcolor",
    "Bjørn",
    "blogm",
    "bofi",
    "boolor",
    "brotli",
    "bydate",
    "bylength",
    "byparam",
    "bypubdate",
    "bytype",
    "canonify",
    "cascadeparam",
    "ccolor",
    "cerr",
    "chaseadamsio",
    "choco",
    "CLOUDFRONTDISTRIBUTIONID",
    "Cmds",
    "codeowners",
    "Commentf",
    "composability",
    "concatr",
    "configurators",
    "confmu",
    "contentmemw",
    "Contentr",
    "contentrc",
    "corejs",
    "CPATH",
    "curr",
    "dcfg",
    "Debugf",
    "debugl",
    "defang",
    "defaultv",
    "deindent",
    "deletefd",
    "didn",
    "disqus",
    "Dmitry",
    "dname",
    "doas",
    "dokumentation",
    "dostounix",
    "downscale",
    "downscaled",
    "downscaling",
    "dring",
    "dynacache",
    "Eliott",
    "Emojify",
    "émotion",
    "envtags",
    "eopkg",
    "Eqer",
    "errch",
    "errorf",
    "Erroridf",
    "errorl",
    "Errorln",
    "errorsw",
    "esbuild",
    "exif",
    "extj",
    "ferr",
    "ferrors",
    "ferrs",
    "filefs",
    "filterby",
    "fims",
    "Flexi",
    "fmcfg",
    "fname",
    "Français",
    "fromt",
    "fromv",
    "fromvs",
    "fset",
    "fsnotify",
    "fsnotity",
    "gcaws",
    "geolocalized",
    "getenv",
    "gfilters",
    "giph",
    "giphy",
    "gitee",
    "givenv",
    "goarch",
    "gobench",
    "GOCACHE",
    "godartsassv",
    "GOEXE",
    "gofmt",
    "gohtml",
    "gohugo",
    "gohugoio",
    "goimports",
    "goldmark",
    "golibsass",
    "golint",
    "gomod",
    "gomods",
    "gotmpl",
    "graphb",
    "grayscale",
    "Gregor",
    "greppable",
    "Groot",
    "Gruber",
    "gtag",
    "gzipped",
    "hcontext",
    "hexec",
    "hglob",
    "hreflect",
    "hset",
    "htesting",
    "htext",
    "htime",
    "hugio",
    "hugofs",
    "icfg",
    "Idents",
    "idprefix",
    "idseparator",
    "iface",
    "imgconfig",
    "imgs",
    "indirected",
    "Infof",
    "infol",
    "Infoln",
    "infow",
    "inor",
    "instgrm",
    "intelli",
    "iofs",
    "isatty",
    "ishex",
    "istemp",
    "Jaco",
    "jdoe",
    "jmespath",
    "jmooring",
    "JSHTML",
    "Jsonify",
    "jsons",
    "KaTeX",
    "Keyer",
    "keyt",
    "kubuntu",
    "ldquo",
    "libros",
    "lidx",
    "Linkify",
    "lofi",
    "logg",
    "logln",
    "lrport",
    "lubuntu",
    "Lundmark",
    "Markdownify",
    "marshal",
    "marshaling",
    "MathJax",
    "mathrm",
    "mconf",
    "mdash",
    "memfs",
    "metaw",
    "miesiąc",
    "miesięcy",
    "milli",
    "minifier",
    "minifiers",
    "misérables",
    "Mkcert",
    "monokai",
    "moolor",
    "multihost",
    "myblog",
    "mybucket",
    "mybundle",
    "myclass",
    "myconfigdir",
    "mydata",
    "mydeployment",
    "mydir",
    "myenv",
    "myexistingsite",
    "myhugosite",
    "myjekyllsite",
    "myjsoncontent",
    "mymodule",
    "myparam",
    "myposts",
    "mysection",
    "mysite",
    "mysource",
    "mystatic",
    "mytag",
    "mytemplate",
    "mytheme",
    "mytomlcontent",
    "myworkingdir",
    "myyamlcontent",
    "Netravali",
    "Neue",
    "newfd",
    "newp",
    "nfilename",
    "nlocker",
    "Nobase",
    "noclasses",
    "nofilefilename",
    "nofileslug",
    "nofileslugs",
    "nofiletitle",
    "Noll",
    "noopener",
    "noshift",
    "nosql",
    "nread",
    "NUMWORKERMULTIPLIER",
    "Octopress",
    "oklch",
    "onclick",
    "optionsm",
    "optsm",
    "optsv",
    "osfs",
    "pandoc",
    "Pastorius",
    "pathc",
    "Pathify",
    "pcfg",
    "pconf",
    "pdate",
    "performantly",
    "pkcs",
    "pkeys",
    "pkgin",
    "Plainify",
    "preconfigured",
    "prerendering",
    "printm",
    "projekt",
    "proto",
    "publicw",
    "publishw",
    "Querify",
    "Randomising",
    "rbylength",
    "rbypubdate",
    "rbysection",
    "RCDATA",
    "rclone",
    "rcsources",
    "rdquo",
    "Rebuilder",
    "receiverv",
    "redir",
    "redirection",
    "redirections",
    "regexs",
    "régime",
    "Resizer",
    "resolvedm",
    "resultch",
    "resultv",
    "Resumé",
    "resv",
    "rgba",
    "Roboto",
    "rootv",
    "rsmith",
    "Samsa",
    "Satoshi",
    "sectnocontent",
    "sectnofrontmatter",
    "Sedykh",
    "Segoe",
    "seqv",
    "Serveur",
    "setm",
    "shortcode",
    "shortcodes",
    "shouldn",
    "smap",
    "SMSI",
    "spath",
    "stringifier",
    "struct",
    "stuttery",
    "stype",
    "subexpression",
    "subexpressions",
    "suppressable",
    "Syncer",
    "tableofcontents",
    "Tarantsov",
    "tbody",
    "tctx",
    "tdewolff",
    "Templ",
    "templating",
    "tfoot",
    "THEAD",
    "themeconfigdirparam",
    "tinygo",
    "tjones",
    "tmpbucketdir",
    "tmpfsdir",
    "tmpl",
    "toclevels",
    "Tocs",
    "tocss",
    "tomlcontent",
    "tplimpl",
    "tracel",
    "transpile",
    "transpilerv",
    "transpiles",
    "tsti",
    "Ufour",
    "unaddressable",
    "uncloned",
    "uncomparable",
    "undelimited",
    "Unmarshable",
    "unmarshal",
    "unmarshaled",
    "unmarshaling",
    "unmarshall",
    "unmarshals",
    "unnormalized",
    "unnudged",
    "unorderable",
    "Unported",
    "unpublishdate",
    "unrendered",
    "Unsharp",
    "Unwrapv",
    "updatefd",
    "upgrader",
    "urlize",
    "Uthree",
    "vals",
    "varn",
    "vfunc",
    "Warnf",
    "Warnidf",
    "warnl",
    "Warnln",
    "WEBM",
    "Webp",
    "WHATWG",
    "withc",
    "xfeff",
    "xubuntu",
    "yamlcontent",
    "Yukihiro",
    "Zeroer",
    "zgotmplz",
    "zoolor",
    "zoop"
  ]
}
```