### PR TITLE
tpl: Fix language handling in partials

### DIFF
--- a/common/paths/pathparser.go
+++ b/common/paths/pathparser.go
@@ -724,7 +724,7 @@ func (p *Path) IsContentData() bool {
 	return p.pathType == TypeContentData
 }
 
-func (p Path) ForBundleType(t Type) *Path {
+func (p Path) ForType(t Type) *Path {
 	p.pathType = t
 	return &p
 }

--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -180,7 +180,7 @@ func (t *pageTrees) collectAndMarkStaleIdentities(p *paths.Path) []identity.Iden
 
 	if p.Component() == files.ComponentFolderContent {
 		// It may also be a bundled content resource.
-		key := p.ForBundleType(paths.TypeContentResource).Base()
+		key := p.ForType(paths.TypeContentResource).Base()
 		tree = t.treeResources
 		nCount = 0
 		tree.ForEeachInDimension(key, doctree.DimensionLanguage.Index(),


### PR DESCRIPTION
We now use the same code path for all templates re this.

Fixes #13612
