### PR TITLE
Capitalize UTF in sitemap.xml and sitemapindex.xml

### DIFF
--- a/tpl/tplimpl/embedded/templates/rss.xml
+++ b/tpl/tplimpl/embedded/templates/rss.xml
@@ -30,7 +30,7 @@
 {{- if ge $limit 1 }}
 {{- $pages = $pages | first $limit }}
 {{- end }}
-{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+{{- printf "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/tpl/tplimpl/embedded/templates/sitemap.xml
+++ b/tpl/tplimpl/embedded/templates/sitemap.xml
@@ -1,4 +1,4 @@
-{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+{{ printf "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range where .Pages "Sitemap.Disable" "ne" true }}

--- a/tpl/tplimpl/embedded/templates/sitemapindex.xml
+++ b/tpl/tplimpl/embedded/templates/sitemapindex.xml
@@ -1,4 +1,4 @@
-{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+{{ printf "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" | safeHTML }}
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {{ range . }}
   <sitemap>


### PR DESCRIPTION
Hey,

I was using the default sitemap.xml and google search console kept giving me a error but not saying what.
After some testing I concluded that the `utf-8` was not uppercase, after changint that google search console concluded whit no errors.

Also cheked other sitemaps and all have it uppercase. Its also shown as `encoding="UTF-8"` on https://www.sitemaps.org/protocol.html

Thanks ✌️