### PR TITLE
commands/server: Display correct multihost language in console

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -627,7 +627,7 @@ func (c *serverCommand) setServerInfoInConfig() error {
 		panic("no server ports set")
 	}
 	return c.withConfE(func(conf *commonConfig) error {
-		for i, language := range conf.configs.Languages {
+		for i, language := range conf.configs.LanguagesDefaultFirst {
 			isMultihost := conf.configs.IsMultihost
 			var serverPort int
 			if isMultihost {


### PR DESCRIPTION
Fixes #12564