### PR TITLE
Add roles and versions as new dimensions (in addition to language)

### DIFF
--- a/cache/dynacache/dynacache.go
+++ b/cache/dynacache/dynacache.go
@@ -340,7 +340,7 @@ func GetOrCreatePartition[K comparable, V any](c *Cache, name string, opts Optio
 		panic("invalid Weight, must be between 1 and 100")
 	}
 
-	if partitionNameRe.FindString(name) != name {
+	if !partitionNameRe.MatchString(name) {
 		panic(fmt.Sprintf("invalid partition name %q", name))
 	}
 

--- a/common/hstrings/strings.go
+++ b/common/hstrings/strings.go
@@ -127,8 +127,3 @@ func ToString(v any) (string, bool) {
 	}
 	return "", false
 }
-
-type (
-	Strings2 [2]string
-	Strings3 [3]string
-)

--- a/common/paths/pathparser.go
+++ b/common/paths/pathparser.go
@@ -14,6 +14,7 @@
 package paths
 
 import (
+	"fmt"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -779,4 +780,13 @@ func HasExt(p string) bool {
 		}
 	}
 	return false
+}
+
+// ValidateIdentifier returns true if the given string is a valid identifier according
+// to Hugo's basic path normalization rules.
+func ValidateIdentifier(s string) error {
+	if s == NormalizePathStringBasic(s) {
+		return nil
+	}
+	return fmt.Errorf("must be all lower case and no spaces")
 }

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -143,3 +143,10 @@ func NewBool(b bool) *bool {
 type PrintableValueProvider interface {
 	PrintableValue() any
 }
+
+type (
+	Strings2 [2]string
+	Strings3 [3]string
+	Ints2    [2]int
+	Ints3    [3]int
+)

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -559,11 +559,17 @@ type RootConfig struct {
 	// Set this to true to put all languages below their language ID.
 	DefaultContentLanguageInSubdir bool
 
+	// The default content role to use for the site.
+	DefaultContentRole string
+
 	// Set this to true to put the default role in a subdirectory.
-	DefaultRoleInSubdir bool
+	DefaultContentRoleInSubdir bool
+
+	// The default content version to use for the site.
+	DefaultContentVersion string
 
 	// Set to true to render the default version in a subdirectory.
-	DefaultVersionInSubdir bool
+	DefaultContentVersionInSubdir bool
 
 	// The default output format to use for the site.
 	// If not set, we will use the first output format.

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/hugolib/roles"
 	"github.com/gohugoio/hugo/hugolib/segments"
+	"github.com/gohugoio/hugo/hugolib/versions"
 	"github.com/gohugoio/hugo/langs"
 	"github.com/gohugoio/hugo/markup/markup_config"
 	"github.com/gohugoio/hugo/media"
@@ -143,6 +144,9 @@ type Config struct {
 
 	// The roles configuration section contains the top level roles configuration options.
 	Roles *config.ConfigNamespace[map[string]roles.RoleConfig, roles.Roles] `mapstructure:"-"`
+
+	// The versions configuration section contains the top level versions configuration options.
+	Versions *config.ConfigNamespace[map[string]versions.VersionConfig, versions.Versions] `mapstructure:"-"`
 
 	// The outputs configuration section maps a Page Kind (a string) to a slice of output formats.
 	// This can be overridden in the front matter.
@@ -554,6 +558,12 @@ type RootConfig struct {
 	// By default, we put the default content language in the root and the others below their language ID, e.g. /no/.
 	// Set this to true to put all languages below their language ID.
 	DefaultContentLanguageInSubdir bool
+
+	// Set this to true to put the default role in a subdirectory.
+	DefaultRoleInSubdir bool
+
+	// Set to true to render the default version in a subdirectory.
+	DefaultVersionInSubdir bool
 
 	// The default output format to use for the site.
 	// If not set, we will use the first output format.

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gohugoio/hugo/config/services"
 	"github.com/gohugoio/hugo/deploy/deployconfig"
 	"github.com/gohugoio/hugo/helpers"
+	"github.com/gohugoio/hugo/hugolib/roles"
 	"github.com/gohugoio/hugo/hugolib/segments"
 	"github.com/gohugoio/hugo/langs"
 	"github.com/gohugoio/hugo/markup/markup_config"
@@ -139,6 +140,9 @@ type Config struct {
 
 	// The outputformats configuration sections maps a format name (a string) to a configuration object for that format.
 	OutputFormats *config.ConfigNamespace[map[string]output.OutputFormatConfig, output.Formats] `mapstructure:"-"`
+
+	// The roles configuration section contains the top level roles configuration options.
+	Roles *config.ConfigNamespace[map[string]roles.RoleConfig, roles.Roles] `mapstructure:"-"`
 
 	// The outputs configuration section maps a Page Kind (a string) to a slice of output formats.
 	// This can be overridden in the front matter.

--- a/config/allconfig/alldecoders.go
+++ b/config/allconfig/alldecoders.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gohugoio/hugo/config/security"
 	"github.com/gohugoio/hugo/config/services"
 	"github.com/gohugoio/hugo/deploy/deployconfig"
+	"github.com/gohugoio/hugo/hugolib/roles"
 	"github.com/gohugoio/hugo/hugolib/segments"
 	"github.com/gohugoio/hugo/langs"
 	"github.com/gohugoio/hugo/markup/markup_config"
@@ -207,6 +208,15 @@ var allDecoderSetups = map[string]decodeWeight{
 		decode: func(d decodeWeight, p decodeConfig) error {
 			var err error
 			p.c.OutputFormats, err = output.DecodeConfig(p.c.MediaTypes.Config, p.p.Get(d.key))
+			return err
+		},
+	},
+	"roles": {
+		key: "roles",
+		decode: func(d decodeWeight, p decodeConfig) error {
+			var err error
+			m := maps.CleanConfigStringMap(p.p.GetStringMap(d.key))
+			p.c.Roles, err = roles.DecodeConfig(m)
 			return err
 		},
 	},

--- a/config/allconfig/alldecoders.go
+++ b/config/allconfig/alldecoders.go
@@ -71,8 +71,10 @@ var allDecoderSetups = map[string]decodeWeight{
 				return err
 			}
 
-			// This need to match with Lang which is always lower case.
+			// This need to match with the map keys, always lower case.
 			p.c.RootConfig.DefaultContentLanguage = strings.ToLower(p.c.RootConfig.DefaultContentLanguage)
+			p.c.RootConfig.DefaultContentRole = strings.ToLower(p.c.RootConfig.DefaultContentRole)
+			p.c.RootConfig.DefaultContentVersion = strings.ToLower(p.c.RootConfig.DefaultContentVersion)
 
 			return nil
 		},
@@ -217,7 +219,7 @@ var allDecoderSetups = map[string]decodeWeight{
 		decode: func(d decodeWeight, p decodeConfig) error {
 			var err error
 			m := maps.CleanConfigStringMap(p.p.GetStringMap(d.key))
-			p.c.Roles, err = roles.DecodeConfig(m)
+			p.c.Roles, err = roles.DecodeConfig(p.c.RootConfig.DefaultContentRole, m)
 			return err
 		},
 	},
@@ -226,7 +228,7 @@ var allDecoderSetups = map[string]decodeWeight{
 		decode: func(d decodeWeight, p decodeConfig) error {
 			var err error
 			m := maps.CleanConfigStringMap(p.p.GetStringMap(d.key))
-			p.c.Versions, err = versions.DecodeConfig(m)
+			p.c.Versions, err = versions.DecodeConfig(p.c.RootConfig.DefaultContentVersion, m)
 			return err
 		},
 	},

--- a/config/allconfig/alldecoders.go
+++ b/config/allconfig/alldecoders.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gohugoio/hugo/deploy/deployconfig"
 	"github.com/gohugoio/hugo/hugolib/roles"
 	"github.com/gohugoio/hugo/hugolib/segments"
+	"github.com/gohugoio/hugo/hugolib/versions"
 	"github.com/gohugoio/hugo/langs"
 	"github.com/gohugoio/hugo/markup/markup_config"
 	"github.com/gohugoio/hugo/media"
@@ -217,6 +218,15 @@ var allDecoderSetups = map[string]decodeWeight{
 			var err error
 			m := maps.CleanConfigStringMap(p.p.GetStringMap(d.key))
 			p.c.Roles, err = roles.DecodeConfig(m)
+			return err
+		},
+	},
+	"versions": {
+		key: "versions",
+		decode: func(d decodeWeight, p decodeConfig) error {
+			var err error
+			m := maps.CleanConfigStringMap(p.p.GetStringMap(d.key))
+			p.c.Versions, err = versions.DecodeConfig(m)
 			return err
 		},
 	},

--- a/config/allconfig/configlanguage.go
+++ b/config/allconfig/configlanguage.go
@@ -165,6 +165,8 @@ func (c ConfigLanguage) GetConfigSection(s string) any {
 		return c.config.MediaTypes.Config
 	case "outputFormats":
 		return c.config.OutputFormats.Config
+	case "roles":
+		return c.config.Roles.Config
 	case "permalinks":
 		return c.config.Permalinks
 	case "minify":

--- a/config/allconfig/configlanguage.go
+++ b/config/allconfig/configlanguage.go
@@ -167,6 +167,8 @@ func (c ConfigLanguage) GetConfigSection(s string) any {
 		return c.config.OutputFormats.Config
 	case "roles":
 		return c.config.Roles.Config
+	case "versions":
+		return c.config.Versions.Config
 	case "permalinks":
 		return c.config.Permalinks
 	case "minify":
@@ -212,6 +214,14 @@ func (c ConfigLanguage) DefaultContentLanguage() string {
 
 func (c ConfigLanguage) DefaultContentLanguageInSubdir() bool {
 	return c.config.DefaultContentLanguageInSubdir
+}
+
+func (c ConfigLanguage) DefaultRoleInSubdir() bool {
+	return c.config.DefaultRoleInSubdir
+}
+
+func (c ConfigLanguage) DefaultVersionInSubdir() bool {
+	return c.config.DefaultVersionInSubdir
 }
 
 func (c ConfigLanguage) SummaryLength() int {

--- a/config/allconfig/configlanguage.go
+++ b/config/allconfig/configlanguage.go
@@ -216,12 +216,12 @@ func (c ConfigLanguage) DefaultContentLanguageInSubdir() bool {
 	return c.config.DefaultContentLanguageInSubdir
 }
 
-func (c ConfigLanguage) DefaultRoleInSubdir() bool {
-	return c.config.DefaultRoleInSubdir
+func (c ConfigLanguage) DefaultContentRoleInSubdir() bool {
+	return c.config.DefaultContentRoleInSubdir
 }
 
-func (c ConfigLanguage) DefaultVersionInSubdir() bool {
-	return c.config.DefaultVersionInSubdir
+func (c ConfigLanguage) DefaultContentVersionInSubdir() bool {
+	return c.config.DefaultContentVersionInSubdir
 }
 
 func (c ConfigLanguage) SummaryLength() int {

--- a/config/configProvider.go
+++ b/config/configProvider.go
@@ -50,8 +50,8 @@ type AllProvider interface {
 	IsUglyURLs(section string) bool
 	DefaultContentLanguage() string
 	DefaultContentLanguageInSubdir() bool
-	DefaultRoleInSubdir() bool
-	DefaultVersionInSubdir() bool
+	DefaultContentRoleInSubdir() bool
+	DefaultContentVersionInSubdir() bool
 	IsLangDisabled(string) bool
 	SummaryLength() int
 	Pagination() Pagination

--- a/config/configProvider.go
+++ b/config/configProvider.go
@@ -50,6 +50,8 @@ type AllProvider interface {
 	IsUglyURLs(section string) bool
 	DefaultContentLanguage() string
 	DefaultContentLanguageInSubdir() bool
+	DefaultRoleInSubdir() bool
+	DefaultVersionInSubdir() bool
 	IsLangDisabled(string) bool
 	SummaryLength() int
 	Pagination() Pagination

--- a/hugolib/content_map.go
+++ b/hugolib/content_map.go
@@ -218,6 +218,10 @@ func (m *pageMap) AddFi(fi hugofs.FileMetaInfo, buildConfig *BuildCfg) (pageCoun
 		return
 	}
 
+	if m == nil {
+		panic("nil pageMap")
+	}
+
 	insertResource := func(fim hugofs.FileMetaInfo) error {
 		resourceCount++
 		pi := fi.Meta().PathInfo
@@ -356,7 +360,7 @@ func (m *pageMap) addPagesFromGoTmplFi(fi hugofs.FileMetaInfo, buildConfig *Buil
 				Watching:          s.Conf.Watching(),
 				HandlePage: func(pt *pagesfromdata.PagesFromTemplate, pc *pagemeta.PageConfig) error {
 					s := pt.Site.(*Site)
-					if err := pc.Compile(pt.GoTmplFi.Meta().PathInfo.Base(), true, "", s.Log, s.conf.MediaTypes.Config); err != nil {
+					if err := pc.Compile(pt.GoTmplFi.Meta().PathInfo.Base(), true, "", s.Log, s.Conf); err != nil {
 						return err
 					}
 

--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -911,20 +911,22 @@ func (s *contentNodeShifter) Insert(old, new contentNodeI) (contentNodeI, conten
 	}
 }
 
-func newPageMap(i int, s *Site, mcache *dynacache.Cache, pageTrees *pageTrees) *pageMap {
+func newPageMap(sitei, rolei int, s *Site, mcache *dynacache.Cache, pageTrees *pageTrees) *pageMap {
 	var m *pageMap
+
+	siteRoleKey := fmt.Sprintf("s%d/%d", sitei, rolei)
 
 	var taxonomiesConfig taxonomiesConfig = s.conf.Taxonomies
 
 	m = &pageMap{
-		pageTrees:              pageTrees.Shape(0, i),
-		cachePages1:            dynacache.GetOrCreatePartition[string, page.Pages](mcache, fmt.Sprintf("/pag1/%d", i), dynacache.OptionsPartition{Weight: 10, ClearWhen: dynacache.ClearOnRebuild}),
-		cachePages2:            dynacache.GetOrCreatePartition[string, page.Pages](mcache, fmt.Sprintf("/pag2/%d", i), dynacache.OptionsPartition{Weight: 10, ClearWhen: dynacache.ClearOnRebuild}),
-		cacheGetTerms:          dynacache.GetOrCreatePartition[string, map[string]page.Pages](mcache, fmt.Sprintf("/gett/%d", i), dynacache.OptionsPartition{Weight: 5, ClearWhen: dynacache.ClearOnRebuild}),
-		cacheResources:         dynacache.GetOrCreatePartition[string, resource.Resources](mcache, fmt.Sprintf("/ress/%d", i), dynacache.OptionsPartition{Weight: 60, ClearWhen: dynacache.ClearOnRebuild}),
-		cacheContentRendered:   dynacache.GetOrCreatePartition[string, *resources.StaleValue[contentSummary]](mcache, fmt.Sprintf("/cont/ren/%d", i), dynacache.OptionsPartition{Weight: 70, ClearWhen: dynacache.ClearOnChange}),
-		cacheContentPlain:      dynacache.GetOrCreatePartition[string, *resources.StaleValue[contentPlainPlainWords]](mcache, fmt.Sprintf("/cont/pla/%d", i), dynacache.OptionsPartition{Weight: 70, ClearWhen: dynacache.ClearOnChange}),
-		contentTableOfContents: dynacache.GetOrCreatePartition[string, *resources.StaleValue[contentTableOfContents]](mcache, fmt.Sprintf("/cont/toc/%d", i), dynacache.OptionsPartition{Weight: 70, ClearWhen: dynacache.ClearOnChange}),
+		pageTrees:              pageTrees.Shape(doctree.DimensionLanguage.Index(), sitei).Shape(doctree.DimensionRole.Index(), rolei),
+		cachePages1:            dynacache.GetOrCreatePartition[string, page.Pages](mcache, fmt.Sprintf("/pag1/%s", siteRoleKey), dynacache.OptionsPartition{Weight: 10, ClearWhen: dynacache.ClearOnRebuild}),
+		cachePages2:            dynacache.GetOrCreatePartition[string, page.Pages](mcache, fmt.Sprintf("/pag2/%s", siteRoleKey), dynacache.OptionsPartition{Weight: 10, ClearWhen: dynacache.ClearOnRebuild}),
+		cacheGetTerms:          dynacache.GetOrCreatePartition[string, map[string]page.Pages](mcache, fmt.Sprintf("/gett/%s", siteRoleKey), dynacache.OptionsPartition{Weight: 5, ClearWhen: dynacache.ClearOnRebuild}),
+		cacheResources:         dynacache.GetOrCreatePartition[string, resource.Resources](mcache, fmt.Sprintf("/ress/%s", siteRoleKey), dynacache.OptionsPartition{Weight: 60, ClearWhen: dynacache.ClearOnRebuild}),
+		cacheContentRendered:   dynacache.GetOrCreatePartition[string, *resources.StaleValue[contentSummary]](mcache, fmt.Sprintf("/cont/ren/%s", siteRoleKey), dynacache.OptionsPartition{Weight: 70, ClearWhen: dynacache.ClearOnChange}),
+		cacheContentPlain:      dynacache.GetOrCreatePartition[string, *resources.StaleValue[contentPlainPlainWords]](mcache, fmt.Sprintf("/cont/pla/%s", siteRoleKey), dynacache.OptionsPartition{Weight: 70, ClearWhen: dynacache.ClearOnChange}),
+		contentTableOfContents: dynacache.GetOrCreatePartition[string, *resources.StaleValue[contentTableOfContents]](mcache, fmt.Sprintf("/cont/toc/%s", siteRoleKey), dynacache.OptionsPartition{Weight: 70, ClearWhen: dynacache.ClearOnChange}),
 
 		contentDataFileSeenItems: maps.NewCache[string, map[uint64]bool](),
 
@@ -935,7 +937,7 @@ func newPageMap(i int, s *Site, mcache *dynacache.Cache, pageTrees *pageTrees) *
 			taxonomyTermDisabled: !s.conf.IsKindEnabled(kinds.KindTerm),
 			pageDisabled:         !s.conf.IsKindEnabled(kinds.KindPage),
 		},
-		i: i,
+		i: sitei,
 		s: s,
 	}
 

--- a/hugolib/doctree/dimensions.go
+++ b/hugolib/doctree/dimensions.go
@@ -14,12 +14,13 @@
 package doctree
 
 const (
-	// Language is currently the only dimension in the Hugo build matrix.
+	// Dimensions in the Hugo build matrix.
 	DimensionLanguage DimensionFlag = 1 << iota
+	DimensionRole
 )
 
-// Dimension is a row in the Hugo build matrix which currently has one value: language.
-type Dimension [1]int
+// Dimension is a row in the Hugo build matrix which currently has two values: language and role.
+type Dimension [2]int
 
 // DimensionFlag is a flag in the Hugo build matrix.
 type DimensionFlag byte

--- a/hugolib/doctree/dimensions.go
+++ b/hugolib/doctree/dimensions.go
@@ -15,15 +15,16 @@ package doctree
 
 const (
 	// Dimensions in the Hugo build matrix.
-	DimensionLanguage DimensionFlag = 1 << iota
+	DimensionLanguage DimensionFlag = iota + 1
+	DimensionVersion
 	DimensionRole
 )
 
-// Dimension is a row in the Hugo build matrix which currently has two values: language and role.
-type Dimension [2]int
+// Dimension is a row in the Hugo build matrix which currently has two values: language, version and role, in that order.
+type Dimension [3]int
 
 // DimensionFlag is a flag in the Hugo build matrix.
-type DimensionFlag byte
+type DimensionFlag int8
 
 // Has returns whether the given flag is set.
 func (d DimensionFlag) Has(o DimensionFlag) bool {

--- a/hugolib/doctree/dimensions_test.go
+++ b/hugolib/doctree/dimensions_test.go
@@ -35,3 +35,10 @@ func TestDimensionFlag(t *testing.T) {
 	c.Assert(DimensionLanguage.Index(), qt.Equals, 0)
 	c.Assert(p.Index(), qt.Equals, 11)
 }
+
+func TestDimensionsIndex(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(DimensionLanguage.Index(), qt.Equals, 0)
+	c.Assert(DimensionVersion.Index(), qt.Equals, 1)
+	c.Assert(DimensionRole.Index(), qt.Equals, 2)
+}

--- a/hugolib/doctree/nodeshifttree.go
+++ b/hugolib/doctree/nodeshifttree.go
@@ -64,7 +64,7 @@ type (
 type NodeShiftTree[T any] struct {
 	tree *radix.Tree
 
-	// E.g. [language, role].
+	// [language, version, role].
 	dims    Dimension
 	shifter Shifter[T]
 
@@ -173,6 +173,7 @@ func (r *NodeShiftTree[T]) InsertIntoValuesDimension(s string, v T) (T, T, bool)
 	if vv, ok := r.tree.Get(s); ok {
 		v, existing, updated = r.shifter.Insert(vv.(T), v)
 	}
+
 	r.tree.Insert(s, v)
 	return v, existing, updated
 }
@@ -418,6 +419,8 @@ func (t NodeShiftTree[T]) clone() *NodeShiftTree[T] {
 }
 
 func (r *NodeShiftTree[T]) shift(t T, exact bool) (T, bool, DimensionFlag) {
+	// TODO1 exact.
+	exact = true
 	return r.shifter.Shift(t, r.dims, exact)
 }
 

--- a/hugolib/doctree/treeshifttree.go
+++ b/hugolib/doctree/treeshifttree.go
@@ -13,7 +13,10 @@
 
 package doctree
 
-import "iter"
+import (
+	"fmt"
+	"iter"
+)
 
 var _ TreeThreadSafe[string] = (*TreeShiftTree[string])(nil)
 
@@ -46,7 +49,7 @@ func NewTreeShiftTree[T comparable](dimensionsLengths []int) *TreeShiftTree[T] {
 
 func (t TreeShiftTree[T]) Shape(d, v int) *TreeShiftTree[T] {
 	if v < 0 || v >= len(t.dimensions[d]) {
-		panic("dimension value out of range")
+		panic(fmt.Sprintf("invalid dimension %d, value %d", d, v))
 	}
 	t.v = v
 	t.d = d

--- a/hugolib/doctree/treeshifttree_test.go
+++ b/hugolib/doctree/treeshifttree_test.go
@@ -23,6 +23,6 @@ import (
 func TestTreeShiftTree(t *testing.T) {
 	c := qt.New(t)
 
-	tree := doctree.NewTreeShiftTree[string](0, 10)
+	tree := doctree.NewTreeShiftTree[string]([]int{10})
 	c.Assert(tree, qt.IsNotNil)
 }

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -51,7 +51,14 @@ import (
 
 // HugoSites represents the sites to build. Each site represents a language.
 type HugoSites struct {
+	// The current site slice.
+	// When rendering, this slice will be shifted out.
+	// TODO1 check that access of this isn't cached.
 	Sites []*Site
+
+	// All sites for all roles.
+	// TODO1 consider adding versions to this, too.
+	rolesSites [][]*Site
 
 	Configs *allconfig.Configs
 

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -462,6 +462,9 @@ func (p *pageState) Translations() page.Pages {
 
 func (ps *pageState) initCommonProviders(pp pagePaths) error {
 	if ps.IsPage() {
+		if ps.s == nil {
+			panic("no site")
+		}
 		ps.posNextPrev = &nextPrev{init: ps.s.init.prevNext}
 		ps.posNextPrevSection = &nextPrev{init: ps.s.init.prevNextInSection}
 		ps.InSectionPositioner = newPagePositionInSection(ps.posNextPrevSection)
@@ -676,6 +679,7 @@ func (p *pageState) posOffset(offset int) text.Position {
 // shiftToOutputFormat is serialized. The output format idx refers to the
 // full set of output formats for all sites.
 // This is serialized.
+// TODO1 with the added dimensions, we need to compress the pageOutputs slice.
 func (p *pageState) shiftToOutputFormat(isRenderingSite bool, idx int) error {
 	if err := p.initPage(); err != nil {
 		return err

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -515,6 +515,9 @@ params:
 		case "keywords":
 			pcfg.Keywords = cast.ToStringSlice(v)
 			params[loki] = pcfg.Keywords
+		case "roles":
+			pcfg.Roles = cast.ToStringSlice(v)
+			params[loki] = pcfg.Roles
 		case "headless":
 			// Legacy setting for leaf bundles.
 			// This is since Hugo 0.63 handled in a more general way for all
@@ -672,7 +675,7 @@ params:
 		return err
 	}
 
-	if err := pcfg.Compile("", false, ext, p.s.Log, p.s.conf.MediaTypes.Config); err != nil {
+	if err := pcfg.Compile("", false, ext, p.s.Log, p.s.Conf); err != nil {
 		return err
 	}
 

--- a/hugolib/page__new.go
+++ b/hugolib/page__new.go
@@ -134,11 +134,15 @@ func (h *HugoSites) doNewPage(m *pageMeta) (*pageState, *paths.Path, error) {
 				lang = m.pathInfo.Lang()
 			}
 
-			m.s = h.resolveSite(lang)
+			// TODO1
+			m.s = h.resolveSite(lang, pcfg.VersionsCompiledMap, pcfg.RolesCompiledMap)
 
 			if m.s == nil {
-				return nil, fmt.Errorf("no site found for language %q", lang)
+				return nil, fmt.Errorf("no site found for language %q, versions %v and roles %v", lang, pcfg.VersionsCompiledMap, pcfg.RolesCompiledMap)
 			}
+
+			fmt.Println("new page", m.pathInfo.Path(), "for site", m.s.dim, "b", lang, pcfg.VersionsCompiledMap, pcfg.RolesCompiledMap)
+
 		}
 
 		var tc viewName

--- a/hugolib/page__paths.go
+++ b/hugolib/page__paths.go
@@ -155,10 +155,12 @@ func createTargetPathDescriptor(p *pageState) (page.TargetPathDescriptor, error)
 		}
 	}
 
-	versionPrefix := s.getPrefixVersion()
-	addPrefix(versionPrefix, versionPrefix)
+	// Add path prefixes.
+	// Add any role first, as that is a natural candidate for external ACL checks.
 	rolePrefix := s.getPrefixRole()
 	addPrefix(rolePrefix, rolePrefix)
+	versionPrefix := s.getPrefixVersion()
+	addPrefix(versionPrefix, versionPrefix)
 	addPrefix(s.getLanguageTargetPathLang(alwaysInSubDir), s.getLanguagePermalinkLang(alwaysInSubDir))
 
 	if desc.URL != "" && strings.IndexByte(desc.URL, ':') >= 0 {

--- a/hugolib/page__paths.go
+++ b/hugolib/page__paths.go
@@ -139,8 +139,27 @@ func createTargetPathDescriptor(p *pageState) (page.TargetPathDescriptor, error)
 		desc.BaseName = pageInfoPage.BaseNameNoIdentifier()
 	}
 
-	desc.PrefixFilePath = s.getLanguageTargetPathLang(alwaysInSubDir)
-	desc.PrefixLink = s.getLanguagePermalinkLang(alwaysInSubDir)
+	addPrefix := func(filePath, link string) {
+		if filePath != "" {
+			if desc.PrefixFilePath != "" {
+				desc.PrefixFilePath += "/"
+			}
+			desc.PrefixFilePath += filePath
+		}
+
+		if link != "" {
+			if desc.PrefixLink != "" {
+				desc.PrefixLink += "/"
+			}
+			desc.PrefixLink += link
+		}
+	}
+
+	versionPrefix := s.getPrefixVersion()
+	addPrefix(versionPrefix, versionPrefix)
+	rolePrefix := s.getPrefixRole()
+	addPrefix(rolePrefix, rolePrefix)
+	addPrefix(s.getLanguageTargetPathLang(alwaysInSubDir), s.getLanguagePermalinkLang(alwaysInSubDir))
 
 	if desc.URL != "" && strings.IndexByte(desc.URL, ':') >= 0 {
 		// Attempt to parse and expand an url

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -468,7 +468,7 @@ type targetPather interface {
 }
 
 type targetPathsHolder struct {
-	// relURL is usually the same as OutputFormat.RelPermalink, but can be different
+	// relURL is usually the saTargetPaths{me as OutputFormat.RelPermalink, but can be different
 	// for non-permalinkable output formats. These shares RelPermalink with the main (first) output format.
 	relURL string
 	paths  page.TargetPaths

--- a/hugolib/pagecollections.go
+++ b/hugolib/pagecollections.go
@@ -30,14 +30,14 @@ import (
 
 // pageFinder provides ways to find a Page in a Site.
 type pageFinder struct {
-	pageMap *pageMap
+	pm *pageMap
 }
 
 func newPageFinder(m *pageMap) *pageFinder {
 	if m == nil {
 		panic("must provide a pageMap")
 	}
-	c := &pageFinder{pageMap: m}
+	c := &pageFinder{pm: m}
 	return c
 }
 
@@ -149,7 +149,7 @@ func (c *pageFinder) getContentNode(context page.Page, isReflink bool, ref strin
 }
 
 func (c *pageFinder) getContentNodeForRef(context page.Page, isReflink, hadExtension bool, inRef, ref string) (contentNodeI, error) {
-	s := c.pageMap.s
+	s := c.pm.s
 	contentPathParser := s.Conf.PathParser()
 
 	if context != nil && !strings.HasPrefix(ref, "/") {
@@ -213,7 +213,7 @@ func (c *pageFinder) getContentNodeForRef(context page.Page, isReflink, hadExten
 		return nil, nil
 	}
 
-	n = c.pageMap.pageReverseIndex.Get(nameNoIdentifier)
+	n = c.pm.pageReverseIndex.Get(nameNoIdentifier)
 	if n == ambiguousContentNode {
 		return nil, fmt.Errorf("page reference %q is ambiguous", inRef)
 	}
@@ -222,7 +222,7 @@ func (c *pageFinder) getContentNodeForRef(context page.Page, isReflink, hadExten
 }
 
 func (c *pageFinder) getContentNodeFromRefReverseLookup(ref string, fi hugofs.FileMetaInfo) (contentNodeI, error) {
-	s := c.pageMap.s
+	s := c.pm.s
 	meta := fi.Meta()
 	dir := meta.Filename
 	if !fi.IsDir() {
@@ -239,7 +239,7 @@ func (c *pageFinder) getContentNodeFromRefReverseLookup(ref string, fi hugofs.Fi
 	// There may be multiple matches, but we will only use the first one.
 	for _, pc := range pcs {
 		pi := s.Conf.PathParser().Parse(pc.Component, pc.Path)
-		if n := c.pageMap.treePages.Get(pi.Base()); n != nil {
+		if n := c.pm.treePages.Get(pi.Base()); n != nil {
 			return n, nil
 		}
 	}
@@ -247,7 +247,7 @@ func (c *pageFinder) getContentNodeFromRefReverseLookup(ref string, fi hugofs.Fi
 }
 
 func (c *pageFinder) getContentNodeFromPath(s string, ref string) (contentNodeI, error) {
-	n := c.pageMap.treePages.Get(s)
+	n := c.pm.treePages.Get(s)
 	if n != nil {
 		return n, nil
 	}

--- a/hugolib/pages_capture.go
+++ b/hugolib/pages_capture.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	"github.com/bep/logg"
-	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/common/rungroup"
+	"github.com/gohugoio/hugo/common/types"
 	"github.com/spf13/afero"
 
 	"github.com/gohugoio/hugo/source"
@@ -118,7 +118,7 @@ func (c *pagesCollector) Collect() (collectErr error) {
 		logFilesProcessed(true)
 	}()
 
-	c.g = rungroup.Run[hugofs.FileMetaInfo](c.ctx, rungroup.Config[hugofs.FileMetaInfo]{
+	c.g = rungroup.Run(c.ctx, rungroup.Config[hugofs.FileMetaInfo]{
 		NumWorkers: numWorkers,
 		Handle: func(ctx context.Context, fi hugofs.FileMetaInfo) error {
 			numPages, numResources, err := c.m.AddFi(fi, c.buildConfig)
@@ -314,7 +314,7 @@ func (c *pagesCollector) collectDirDir(path string, root hugofs.FileMetaInfo, in
 			return nil, filepath.SkipDir
 		}
 
-		seen := map[hstrings.Strings2]hugofs.FileMetaInfo{}
+		seen := map[types.Strings2]hugofs.FileMetaInfo{}
 		for _, fi := range readdir {
 			if fi.IsDir() {
 				continue
@@ -327,7 +327,7 @@ func (c *pagesCollector) collectDirDir(path string, root hugofs.FileMetaInfo, in
 			// These would eventually have been filtered out as duplicates when
 			// inserting them into the document store,
 			// but doing it here will preserve a consistent ordering.
-			baseLang := hstrings.Strings2{pi.Base(), meta.Lang}
+			baseLang := types.Strings2{pi.Base(), meta.Lang}
 			if fi2, ok := seen[baseLang]; ok {
 				if c.h.Configs.Base.PrintPathWarnings && !c.h.isRebuild() {
 					c.logger.Warnf("Duplicate content path: %q file: %q file: %q", pi.Base(), fi2.Meta().Filename, meta.Filename)
@@ -377,7 +377,7 @@ func (c *pagesCollector) collectDirDir(path string, root hugofs.FileMetaInfo, in
 
 func (c *pagesCollector) handleBundleLeaf(dir, bundle hugofs.FileMetaInfo, inPath string, readdir []hugofs.FileMetaInfo) error {
 	bundlePi := bundle.Meta().PathInfo
-	seen := map[hstrings.Strings2]bool{}
+	seen := map[types.Strings2]bool{}
 
 	walk := func(path string, info hugofs.FileMetaInfo) error {
 		if info.IsDir() {
@@ -399,7 +399,7 @@ func (c *pagesCollector) handleBundleLeaf(dir, bundle hugofs.FileMetaInfo, inPat
 		// These would eventually have been filtered out as duplicates when
 		// inserting them into the document store,
 		// but doing it here will preserve a consistent ordering.
-		baseLang := hstrings.Strings2{pi.Base(), info.Meta().Lang}
+		baseLang := types.Strings2{pi.Base(), info.Meta().Lang}
 		if seen[baseLang] {
 			return nil
 		}

--- a/hugolib/roles/roles.go
+++ b/hugolib/roles/roles.go
@@ -1,0 +1,146 @@
+// Copyright 2024 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package roles
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/gohugoio/hugo/common/paths"
+	"github.com/gohugoio/hugo/config"
+	"github.com/gohugoio/hugo/hugofs/glob"
+	"github.com/mitchellh/mapstructure"
+)
+
+type RoleConfig struct {
+	// Whether this role is the default role.
+	// This will be rendered in the root.
+	// There can only be one default role.
+	Default bool
+
+	// The weight of the role.
+	// Used to determine the order of the roles.
+	// If zero, we use the role name.
+	Weight int
+}
+
+type Role struct {
+	Name string
+	RoleConfig
+}
+
+type Roles struct {
+	roleConfigs map[string]RoleConfig
+	Sorted      []Role
+}
+
+func (r Roles) IndexDefault() int {
+	for i, role := range r.Sorted {
+		if role.Default {
+			return i
+		}
+	}
+	panic("no default role found")
+}
+
+// IndexMatch returns the index of the first role that matches the given Glob pattern.
+func (r Roles) IndexMatch(pattern string) (int, error) {
+	g, err := glob.GetGlob(pattern)
+	if err != nil {
+		return 0, err
+	}
+	for i, role := range r.Sorted {
+		if g.Match(role.Name) {
+			return i, nil
+		}
+	}
+	return -1, nil
+}
+
+func (r *Roles) init() error {
+	if len(r.roleConfigs) == 0 {
+		// Add a default role.
+		r.roleConfigs["guest"] = RoleConfig{Default: true}
+	}
+
+	var defaultSeen int
+	for k, v := range r.roleConfigs {
+		if k == "" {
+			return errors.New("role name cannot be empty")
+		}
+
+		if err := paths.ValidateIdentifier(k); err != nil {
+			// TODO1 config keys gets auto lowercased, so this will (almost) never happen.
+			// TODO1: Page.cloneForRole(role)
+			// TODO1: Tree store: linked list for dimension nodes.
+			return fmt.Errorf("role name %q is invalid: %s", k, err)
+		}
+
+		if v.Default {
+			defaultSeen++
+		}
+
+		if defaultSeen > 1 {
+			return errors.New("only one role can be the default role")
+		}
+
+		r.Sorted = append(r.Sorted, Role{Name: k, RoleConfig: v})
+	}
+
+	// Sort by weight if set, then by name.
+	sort.SliceStable(r.Sorted, func(i, j int) bool {
+		ri, rj := r.Sorted[i], r.Sorted[j]
+		if ri.Weight == rj.Weight {
+			return ri.Name < rj.Name
+		}
+		if rj.Weight == 0 {
+			return true
+		}
+		if ri.Weight == 0 {
+			return false
+		}
+		return ri.Weight < rj.Weight
+	})
+
+	if defaultSeen == 0 {
+		// If no default role is set, we set the first one.
+		first := r.Sorted[0]
+		first.Default = true
+		r.roleConfigs[first.Name] = first.RoleConfig
+		r.Sorted[0] = first
+	}
+
+	return nil
+}
+
+func (r Roles) Has(role string) bool {
+	_, found := r.roleConfigs[role]
+	return found
+}
+
+func DecodeConfig(m map[string]any) (*config.ConfigNamespace[map[string]RoleConfig, Roles], error) {
+	return config.DecodeNamespace[map[string]RoleConfig](m, func(in any) (Roles, any, error) {
+		var roles Roles
+		var conf map[string]RoleConfig
+		if err := mapstructure.Decode(m, &conf); err != nil {
+			return roles, nil, err
+		}
+		roles.roleConfigs = conf
+		if err := roles.init(); err != nil {
+			return roles, nil, err
+		}
+		return roles, nil, nil
+	})
+}

--- a/hugolib/roles/roles.go
+++ b/hugolib/roles/roles.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Hugo Authors. All rights reserved.
+// Copyright 2025 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ func (r Roles) IndexMatch(pattern string) (int, error) {
 func (r *Roles) init() error {
 	if len(r.roleConfigs) == 0 {
 		// Add a default role.
-		r.roleConfigs["guest"] = RoleConfig{Default: true}
+		r.roleConfigs[""] = RoleConfig{Default: true}
 	}
 
 	var defaultSeen int

--- a/hugolib/roles/roles_integration_test.go
+++ b/hugolib/roles/roles_integration_test.go
@@ -20,18 +20,28 @@ import (
 )
 
 // TODO1 role hierarchy.
-func TestRoles(t *testing.T) {
+func TestRolesAndVersions(t *testing.T) {
+	// TODO1 for resources, don't apply a default lang,role, etc. Insert with -1 as a null value.
 	t.Parallel()
 	files := `
 -- hugo.toml --
 baseURL = "https://example.org/"
+defaultVersionInSubdir = true
+defaultRoleInSubdir = true
+defaultContentLanguageInSubdir = true
 disableKinds = ["taxonomy", "term", "rss", "sitemap"]
 [roles]
-  [roles.guest]
-  	default = true
-	weight = 100
-  [roles.member]
-	weight = 200
+[roles.guest]
+default = true
+weight = 100
+[roles.member]
+weight = 200
+[versions]
+[versions."v2.0.0"]
+default = true
+weight = 100
+[versions."v1.2.3"]
+weight = 300
 -- content/memberonly.md --
 ---
 title: "Member Only"
@@ -41,6 +51,7 @@ Member content.
 -- content/public.md --
 ---
 title: "Public"
+versions: ["v1.2.3"]
 ---
 Users with no (blank) role will see this.
 -- layouts/_default/single.html --

--- a/hugolib/roles/roles_integration_test.go
+++ b/hugolib/roles/roles_integration_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package roles_test
+
+import (
+	"testing"
+
+	"github.com/gohugoio/hugo/hugolib"
+)
+
+// TODO1 role hierarchy.
+func TestRoles(t *testing.T) {
+	t.Parallel()
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+disableKinds = ["taxonomy", "term", "rss", "sitemap"]
+[roles]
+  [roles.guest]
+  	default = true
+	weight = 100
+  [roles.member]
+	weight = 200
+-- content/memberonly.md --
+---
+title: "Member Only"
+roles: ["member"]
+---
+Member content.
+-- content/public.md --
+---
+title: "Public"
+---
+Users with no (blank) role will see this.
+-- layouts/_default/single.html --
+{{ .Title }}|{{ .Content }}|
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertPublishDir("memberonly")
+}

--- a/hugolib/roles/roles_integration_test.go
+++ b/hugolib/roles/roles_integration_test.go
@@ -26,29 +26,29 @@ func TestRolesAndVersions(t *testing.T) {
 	files := `
 -- hugo.toml --
 baseURL = "https://example.org/"
-defaultVersionInSubdir = true
-defaultRoleInSubdir = true
+defaultContentVersion = "v2.0.0"
+defaultContentVersionInSubdir = true
+defaultContentRoleInSubdir = true
+defaultContentRole = "guest"
 defaultContentLanguageInSubdir = true
 disableKinds = ["taxonomy", "term", "rss", "sitemap"]
 [roles]
 [roles.guest]
-default = true
 weight = 100
 [roles.member]
 weight = 200
 [versions]
 [versions."v2.0.0"]
-default = true
 weight = 100
 [versions."v1.2.3"]
 weight = 300
--- content/memberonly.md --
+-- content/memberonlypost.md --
 ---
 title: "Member Only"
 roles: ["member"]
 ---
 Member content.
--- content/public.md --
+-- content/publicpost.md --
 ---
 title: "Public"
 versions: ["v1.2.3"]

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1456,7 +1456,7 @@ func (s *Site) getLanguagePermalinkLang(alwaysInSubDir bool) string {
 func (s *Site) getPrefixRole() string {
 	role := s.role
 	if role.Default {
-		if s.conf.DefaultRoleInSubdir {
+		if s.conf.DefaultContentRoleInSubdir {
 			return role.Name
 		}
 		return ""
@@ -1467,7 +1467,7 @@ func (s *Site) getPrefixRole() string {
 func (s *Site) getPrefixVersion() string {
 	version := s.version
 	if version.Default {
-		if s.conf.DefaultVersionInSubdir {
+		if s.conf.DefaultContentVersionInSubdir {
 			return version.Name
 		}
 		return ""

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -167,7 +167,7 @@ func pageRenderer(
 		targetPath := p.targetPaths().TargetFilename
 
 		// TODO1 remove.
-		fmt.Println("targetPath", p.s.rolei, targetPath, p.m.pageConfig.Roles, p.m.pageConfig.RolesCompiledMap)
+		fmt.Println("targetPath", s.dim, targetPath, "versions:", p.m.pageConfig.VersionsCompiledMap, "roles:", p.m.pageConfig.RolesCompiledMap)
 
 		s.Log.Trace(
 			func() string {

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -166,6 +166,9 @@ func pageRenderer(
 
 		targetPath := p.targetPaths().TargetFilename
 
+		// TODO1 remove.
+		fmt.Println("targetPath", p.s.rolei, targetPath, p.m.pageConfig.Roles, p.m.pageConfig.RolesCompiledMap)
+
 		s.Log.Trace(
 			func() string {
 				return fmt.Sprintf("rendering outputFormat %q kind %q using layout %q to %q", p.pageOutput.f.Name, p.Kind(), templ.Name(), targetPath)

--- a/hugolib/versions/versions.go
+++ b/hugolib/versions/versions.go
@@ -1,0 +1,144 @@
+// Copyright 2025 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versions
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/gohugoio/hugo/common/hugo"
+	"github.com/gohugoio/hugo/common/paths"
+	"github.com/gohugoio/hugo/config"
+	"github.com/gohugoio/hugo/hugofs/glob"
+	"github.com/mitchellh/mapstructure"
+)
+
+type VersionConfig struct {
+	// Whether this version is the default version.
+	// This will be by default rendered in the root.
+	// There can only be one default version.
+	Default bool
+
+	// The weight of the version.
+	// Used to determine the order of the versions.
+	// If zero, we use the version name to sort.
+	// TODO1 sort by semantic version.
+	Weight int
+}
+
+type Version struct {
+	Name string
+	VersionConfig
+}
+
+type Versions struct {
+	versionConfigs map[string]VersionConfig
+	Sorted         []Version
+}
+
+func (r Versions) IndexDefault() int {
+	for i, version := range r.Sorted {
+		if version.Default {
+			return i
+		}
+	}
+	panic("no default version found")
+}
+
+// IndexMatch returns the index of the first version that matches the given Glob pattern.
+func (r Versions) IndexMatch(pattern string) (int, error) {
+	g, err := glob.GetGlob(pattern)
+	if err != nil {
+		return 0, err
+	}
+	for i, version := range r.Sorted {
+		if g.Match(version.Name) {
+			return i, nil
+		}
+	}
+	return -1, nil
+}
+
+func (r *Versions) init() error {
+	if len(r.versionConfigs) == 0 {
+		// Add a default version.
+		r.versionConfigs[""] = VersionConfig{Default: true}
+	}
+
+	var defaultSeen int
+	for k, v := range r.versionConfigs {
+		if k == "" {
+			return errors.New("version name cannot be empty")
+		}
+		if err := paths.ValidateIdentifier(k); err != nil {
+			return fmt.Errorf("version name %q is invalid: %s", k, err)
+		}
+
+		if v.Default {
+			defaultSeen++
+		}
+
+		if defaultSeen > 1 {
+			return errors.New("only one version can be the default version")
+		}
+		r.Sorted = append(r.Sorted, Version{Name: k, VersionConfig: v})
+	}
+
+	// Sort by weight if set, then by name.
+	sort.SliceStable(r.Sorted, func(i, j int) bool {
+		ri, rj := r.Sorted[i], r.Sorted[j]
+		if ri.Weight == rj.Weight {
+			v1, v2 := hugo.VersionString(ri.Name), hugo.VersionString(rj.Name)
+			return v1.Compare(v2) < 0
+		}
+		if rj.Weight == 0 {
+			return true
+		}
+		if ri.Weight == 0 {
+			return false
+		}
+		return ri.Weight < rj.Weight
+	})
+
+	if defaultSeen == 0 {
+		// If no default version is set, we set the first one.
+		first := r.Sorted[0]
+		first.Default = true
+		r.versionConfigs[first.Name] = first.VersionConfig
+		r.Sorted[0] = first
+	}
+
+	return nil
+}
+
+func (r Versions) Has(version string) bool {
+	_, found := r.versionConfigs[version]
+	return found
+}
+
+func DecodeConfig(m map[string]any) (*config.ConfigNamespace[map[string]VersionConfig, Versions], error) {
+	return config.DecodeNamespace[map[string]VersionConfig](m, func(in any) (Versions, any, error) {
+		var versions Versions
+		var conf map[string]VersionConfig
+		if err := mapstructure.Decode(m, &conf); err != nil {
+			return versions, nil, err
+		}
+		versions.versionConfigs = conf
+		if err := versions.init(); err != nil {
+			return versions, nil, err
+		}
+		return versions, nil, nil
+	})
+}

--- a/resources/page/pagemeta/page_frontmatter.go
+++ b/resources/page/pagemeta/page_frontmatter.go
@@ -191,8 +191,8 @@ func (p *PageConfig) CompileEearly(conf config.AllProvider) error {
 	defaultIdx = configuredVersions.IndexDefault()
 
 	if p.Versions == nil {
-		p.RolesCompiled = []int{defaultIdx}
-		p.RolesCompiledMap[defaultIdx] = true
+		p.VersionsCompiled = []int{defaultIdx}
+		p.VersionsCompiledMap[defaultIdx] = true
 	} else {
 		for _, pattern := range p.Versions {
 			i, err := configuredVersions.IndexMatch(pattern)


### PR DESCRIPTION
The implementation here is still early and non-working. So, the `role` part of this has been thought about a lot (at least by me, e.g. in #519). The `versions` part of this is a little vaguer, but I think it helps with the end result to add them both in one go.

So,

```markdown
---
title: Hugo Rocks!
roles: [public]
versions: [v1.2.3, `v2.*`]
```

Note that the Glob pattern support in `v2.*` is also new – but I suspect we will need something like that for this.

As for `languages`, it will be possible to configure a role/version as the default (e.g. the "current version"). I guess it also makes sense to control whether the default should be rendered to a sub folder or not.

As to the order of the prefixes, `role` needs to come first, I guess.

* I guess we will also add `versions` and `roles` to the file mount config.
* I'm thinking we could also add some kind of "counter identifier" in content filenames, e.g. `content/mybundle/index.§1.md` and `content/mybundle/index.§2.md` to allow having multiple variants of the same content path.

/cc @jmooring 



## New API

* `Server.Version`; a struct with ` Name`, `Site` ...
* `Server.Versions`; a slice of `Version`.
* `Server.Role`; a struct with ` Name`, `Site` ...
* `Server.Roles`; a slice of `Role`.

Note that we currently have `Site.Sites`, which is, with the above setup coming, a little confusing, so we should possibly also consider to add `Site` to `Language`, to make the API uniform.

## New Config

I've thought about this, and decided to not make up any new clever syntax, but just mimic how we do it for languages.

```toml
defaultContentRole = "guest"
defaultContentRoleInSubdir = true
defaultContentVersion = "v2.0.0"
defaultContentVersionInSubdir = true

[roles]
[languages."guest"]
disabled = false
weight = 43
[versions]
[versions."v2.0.0"]
disabled = false
weight = 42
```

 
