### PR TITLE
commands: Make sure the browser gets refreshed on changes when --disableFastRender is set

### DIFF
--- a/commands/hugobuilder.go
+++ b/commands/hugobuilder.go
@@ -972,6 +972,9 @@ func (c *hugoBuilder) handleEvents(watcher *watcher.Batcher,
 					lrl.Logf("force refresh")
 					livereload.ForceRefresh()
 				}
+			} else {
+				lrl.Logf("force refresh")
+				livereload.ForceRefresh()
 			}
 
 			if len(cssChanges) > 0 {


### PR DESCRIPTION
Fixes #13727
