### PR TITLE
parser/pageparser: Add coverage for all IsX methods of Item

### DIFF
--- a/parser/pageparser/item.go
+++ b/parser/pageparser/item.go
@@ -104,7 +104,7 @@ func (i Item) ValTyped(source []byte) any {
 }
 
 func (i Item) IsText() bool {
-	return i.Type == tText || i.Type == tIndentation
+	return i.Type == tText || i.IsIndentation()
 }
 
 func (i Item) IsIndentation() bool {
@@ -152,7 +152,7 @@ func (i Item) IsFrontMatter() bool {
 }
 
 func (i Item) IsDone() bool {
-	return i.Type == tError || i.Type == tEOF
+	return i.IsError() || i.IsEOF()
 }
 
 func (i Item) IsEOF() bool {
@@ -166,18 +166,19 @@ func (i Item) IsError() bool {
 func (i Item) ToString(source []byte) string {
 	val := i.Val(source)
 	switch {
-	case i.Type == tEOF:
+	case i.IsEOF():
 		return "EOF"
-	case i.Type == tError:
+	case i.IsError():
 		return string(val)
-	case i.Type == tIndentation:
+	case i.IsIndentation():
 		return fmt.Sprintf("%s:[%s]", i.Type, util.VisualizeSpaces(val))
 	case i.Type > tKeywordMarker:
 		return fmt.Sprintf("<%s>", val)
 	case len(val) > 50:
 		return fmt.Sprintf("%v:%.20q...", i.Type, val)
+	default:
+		return fmt.Sprintf("%v:[%s]", i.Type, val)
 	}
-	return fmt.Sprintf("%v:[%s]", i.Type, val)
 }
 
 type ItemType int

--- a/parser/pageparser/item_test.go
+++ b/parser/pageparser/item_test.go
@@ -47,3 +47,217 @@ func TestItemValTyped(t *testing.T) {
 	source = []byte("xtrue")
 	c.Assert(Item{low: 0, high: len(source)}.ValTyped(source), qt.Equals, "xtrue")
 }
+
+func TestItemBoolMethods(t *testing.T) {
+	c := qt.New(t)
+
+	source := []byte("  shortcode ")
+	tests := []struct {
+		name   string
+		item   Item
+		source []byte
+		want   bool
+		call   func(Item, []byte) bool
+	}{
+		{
+			name: "IsText true",
+			item: Item{Type: tText},
+			call: func(i Item, _ []byte) bool { return i.IsText() },
+			want: true,
+		},
+		{
+			name: "IsIndentation false",
+			item: Item{Type: tText},
+			call: func(i Item, _ []byte) bool { return i.IsIndentation() },
+			want: false,
+		},
+		{
+			name: "IsShortcodeName",
+			item: Item{Type: tScName},
+			call: func(i Item, _ []byte) bool { return i.IsShortcodeName() },
+			want: true,
+		},
+		{
+			name: "IsNonWhitespace true",
+			item: Item{
+				Type: tText,
+				low:  2,
+				high: 11,
+			},
+			source: source,
+			call:   func(i Item, src []byte) bool { return i.IsNonWhitespace(src) },
+			want:   true,
+		},
+		{
+			name: "IsShortcodeParam false",
+			item: Item{Type: tScParamVal},
+			call: func(i Item, _ []byte) bool { return i.IsShortcodeParam() },
+			want: false,
+		},
+		{
+			name: "IsInlineShortcodeName",
+			item: Item{Type: tScNameInline},
+			call: func(i Item, _ []byte) bool { return i.IsInlineShortcodeName() },
+			want: true,
+		},
+		{
+			name: "IsLeftShortcodeDelim tLeftDelimScWithMarkup",
+			item: Item{Type: tLeftDelimScWithMarkup},
+			call: func(i Item, _ []byte) bool { return i.IsLeftShortcodeDelim() },
+			want: true,
+		},
+		{
+			name: "IsLeftShortcodeDelim tLeftDelimScNoMarkup",
+			item: Item{Type: tLeftDelimScNoMarkup},
+			call: func(i Item, _ []byte) bool { return i.IsLeftShortcodeDelim() },
+			want: true,
+		},
+		{
+			name: "IsRightShortcodeDelim tRightDelimScWithMarkup",
+			item: Item{Type: tRightDelimScWithMarkup},
+			call: func(i Item, _ []byte) bool { return i.IsRightShortcodeDelim() },
+			want: true,
+		},
+		{
+			name: "IsRightShortcodeDelim tRightDelimScNoMarkup",
+			item: Item{Type: tRightDelimScNoMarkup},
+			call: func(i Item, _ []byte) bool { return i.IsRightShortcodeDelim() },
+			want: true,
+		},
+		{
+			name: "IsShortcodeClose",
+			item: Item{Type: tScClose},
+			call: func(i Item, _ []byte) bool { return i.IsShortcodeClose() },
+			want: true,
+		},
+		{
+			name: "IsShortcodeParamVal",
+			item: Item{Type: tScParamVal},
+			call: func(i Item, _ []byte) bool { return i.IsShortcodeParamVal() },
+			want: true,
+		},
+		{
+			name: "IsShortcodeMarkupDelimiter tLeftDelimScWithMarkup",
+			item: Item{Type: tLeftDelimScWithMarkup},
+			call: func(i Item, _ []byte) bool { return i.IsShortcodeMarkupDelimiter() },
+			want: true,
+		},
+		{
+			name: "IsShortcodeMarkupDelimiter tRightDelimScWithMarkup",
+			item: Item{Type: tRightDelimScWithMarkup},
+			call: func(i Item, _ []byte) bool { return i.IsShortcodeMarkupDelimiter() },
+			want: true,
+		},
+		{
+			name: "IsFrontMatter TypeFrontMatterYAML",
+			item: Item{Type: TypeFrontMatterYAML},
+			call: func(i Item, _ []byte) bool { return i.IsFrontMatter() },
+			want: true,
+		},
+		{
+			name: "IsFrontMatter TypeFrontMatterTOML",
+			item: Item{Type: TypeFrontMatterTOML},
+			call: func(i Item, _ []byte) bool { return i.IsFrontMatter() },
+			want: true,
+		},
+		{
+			name: "IsFrontMatter TypeFrontMatterJSON",
+			item: Item{Type: TypeFrontMatterJSON},
+			call: func(i Item, _ []byte) bool { return i.IsFrontMatter() },
+			want: true,
+		},
+		{
+			name: "IsFrontMatter TypeFrontMatterORG",
+			item: Item{Type: TypeFrontMatterORG},
+			call: func(i Item, _ []byte) bool { return i.IsFrontMatter() },
+			want: true,
+		},
+		{
+			name: "IsDone tError",
+			item: Item{Type: tError},
+			call: func(i Item, _ []byte) bool { return i.IsDone() },
+			want: true,
+		},
+		{
+			name: "IsDone tEOF",
+			item: Item{Type: tEOF},
+			call: func(i Item, _ []byte) bool { return i.IsDone() },
+			want: true,
+		},
+		{
+			name: "IsEOF",
+			item: Item{Type: tEOF},
+			call: func(i Item, _ []byte) bool { return i.IsEOF() },
+			want: true,
+		},
+		{
+			name: "IsError",
+			item: Item{Type: tError},
+			call: func(i Item, _ []byte) bool { return i.IsError() },
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.call(tt.item, tt.source)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestItem_ToString(t *testing.T) {
+	c := qt.New(t)
+
+	source := []byte("src")
+	long := make([]byte, 100)
+	for i := range long {
+		long[i] = byte(i)
+	}
+
+	tests := []struct {
+		name   string
+		item   Item
+		source []byte
+		want   string
+		call   func(Item, []byte) string
+	}{
+		{
+			name: "EOF",
+			item: Item{Type: tEOF},
+			call: func(i Item, _ []byte) string { return i.ToString(source) },
+			want: "EOF",
+		},
+		{
+			name: "Error",
+			item: Item{Type: tError},
+			call: func(i Item, _ []byte) string { return i.ToString(source) },
+			want: "",
+		},
+		{
+			name: "Indentation",
+			item: Item{Type: tIndentation},
+			call: func(i Item, _ []byte) string { return i.ToString(source) },
+			want: "tIndentation:[]",
+		},
+		{
+			name: "Long",
+			item: Item{Type: tKeywordMarker + 1, low: 0, high: 100},
+			call: func(i Item, _ []byte) string { return i.ToString(long) },
+			want: "<" + string(long) + ">",
+		},
+		{
+			name: "Empty",
+			item: Item{Type: tKeywordMarker + 1},
+			call: func(i Item, _ []byte) string { return i.ToString([]byte("")) },
+			want: "<>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.call(tt.item, tt.source)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}


### PR DESCRIPTION

This PR adds unit tests for all `IsX` boolean methods of the `Item` struct in the `parser/pageparser` package.