### PR TITLE
all: Replace _build with build in tests

### DIFF
--- a/hugolib/cascade_test.go
+++ b/hugolib/cascade_test.go
@@ -892,7 +892,7 @@ disableKinds = ['home','rss','sitemap','taxonomy','term']
 ---
 title: s
 cascade:
-  _build:
+  build:
     render: never
 ---
 -- content/s/p1.md --

--- a/hugolib/disableKinds_test.go
+++ b/hugolib/disableKinds_test.go
@@ -44,14 +44,14 @@ tags: ["mytag"]
 `, "sect/no-list.md", `
 ---
 title: No List
-_build:
+build:
   list: false
 ---
 
 `, "sect/no-render.md", `
 ---
 title: No List
-_build:
+build:
   render: false
 ---
 `,
@@ -59,14 +59,14 @@ _build:
 ---
 title: No Render Link
 aliases: ["/link-alias"]
-_build:
+build:
   render: link
 ---
 `,
 			"sect/no-publishresources/index.md", `
 ---
 title: No Publish Resources
-_build:
+build:
   publishResources: false
 ---
 
@@ -81,7 +81,7 @@ headless: true
 ---
 title: Headless Local Lists
 cascade:
-    _build:
+    build:
         render: false
         list: local
         publishResources: false
@@ -365,7 +365,7 @@ Data1: {{ $data1.RelPermalink }}
 `)
 
 	b.WithContent("section/bundle-false/index.md", `---\ntitle: BundleFalse
-_build:
+build:
   publishResources: false
 ---`,
 		"section/bundle-false/data1.json", "Some data1",
@@ -388,7 +388,7 @@ func TestNoRenderAndNoPublishResources(t *testing.T) {
 	noRenderPage := `
 ---
 title: %s
-_build:
+build:
     render: false
     publishResources: false
 ---

--- a/hugolib/params_test.go
+++ b/hugolib/params_test.go
@@ -57,7 +57,7 @@ Summary: {{ .Summary }}|
 	)
 }
 
-func TestFrontMatterParamsKindPath(t *testing.T) {
+func TestFrontMatterParamsPath(t *testing.T) {
 	t.Parallel()
 
 	files := `
@@ -72,10 +72,9 @@ date: 2019-08-07
 path: "/a/b/c"
 slug: "s1"
 ---
--- content/mysection.md --
+-- content/mysection/_index.md --
 ---
 title: "My Section"
-kind: "section"
 date: 2022-08-07
 path: "/a/b"
 ---

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -615,7 +615,7 @@ var weightedPage5 = `+++
 weight = "5"
 title = "Five"
 
-[_build]
+[build]
 render = "never"
 +++
 Front Matter with Ordered Pages 5`

--- a/resources/page/pagemeta/pagemeta_test.go
+++ b/resources/page/pagemeta/pagemeta_test.go
@@ -31,7 +31,7 @@ func TestDecodeBuildConfig(t *testing.T) {
 	c := qt.New(t)
 
 	configTempl := `
-[_build]
+[build]
 render = %s
 list = %s
 publishResources = true`
@@ -82,7 +82,7 @@ publishResources = true`
 	} {
 		cfg, err := config.FromConfigString(fmt.Sprintf(configTempl, test.args...), "toml")
 		c.Assert(err, qt.IsNil)
-		bcfg, err := DecodeBuildConfig(cfg.Get("_build"))
+		bcfg, err := DecodeBuildConfig(cfg.Get("build"))
 		c.Assert(err, qt.IsNil)
 
 		eq := qt.CmpEquals(hqt.DeepAllowUnexported(BuildConfig{}))


### PR DESCRIPTION
_build is deprecated and now shows up as warning.
