### PR TITLE
hugolib: Emit ignorable warning when home page is a leaf bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Twitter:      https://twitter.com/gohugoio
 # Website:      https://gohugo.io/
 
-ARG GO_VERSION="1.24.0"
+ARG GO_VERSION="1.24"
 ARG ALPINE_VERSION="3.22"
 ARG DART_SASS_VERSION="1.79.3"
 
@@ -19,7 +19,7 @@ RUN apk add clang lld
 COPY --from=xx / /
 
 ARG TARGETPLATFORM
-RUN xx-apk add musl-dev gcc g++ 
+RUN xx-apk add musl-dev gcc g++
 
 # Optionally set HUGO_BUILD_TAGS to "none" or "withdeploy" when building like so:
 # docker build --build-arg HUGO_BUILD_TAGS=withdeploy .
@@ -72,7 +72,7 @@ RUN mkdir -p /var/hugo/bin /cache && \
     adduser -Sg hugo -u 1000 -h /var/hugo hugo && \
     chown -R hugo: /var/hugo /cache && \
     # For the Hugo's Git integration to work.
-    runuser -u hugo -- git config --global --add safe.directory /project && \ 
+    runuser -u hugo -- git config --global --add safe.directory /project && \
     # See https://github.com/gohugoio/hugo/issues/9810
     runuser -u hugo -- git config --global core.quotepath false
 

--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -24,6 +24,7 @@ const (
 	WarnRenderShortcodesInHTML     = "warning-rendershortcodes-in-html"
 	WarnGoldmarkRawHTML            = "warning-goldmark-raw-html"
 	WarnPartialSuperfluousPrefix   = "warning-partial-superfluous-prefix"
+	WarnHomePageIsLeafBundle       = "warning-home-page-is-leaf-bundle"
 )
 
 // Field/method names with special meaning.

--- a/hugolib/page__new.go
+++ b/hugolib/page__new.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gohugoio/hugo/hugofs/files"
 	"github.com/gohugoio/hugo/resources"
 
+	"github.com/gohugoio/hugo/common/constants"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 
@@ -39,6 +40,14 @@ func (h *HugoSites) newPage(m *pageMeta) (*pageState, *paths.Path, error) {
 		// Make sure that any partially created page part is marked as stale.
 		m.MarkStale()
 	}
+
+	if p != nil && pth != nil && p.IsHome() && pth.IsLeafBundle() {
+		msg := "Using %s in your content's root directory is usually incorrect for your home page. "
+		msg += "You should use %s instead. If you don't rename this file, your home page will be "
+		msg += "treated as a leaf bundle, meaning it won't be able to have any child pages or sections."
+		h.Log.Warnidf(constants.WarnHomePageIsLeafBundle, msg, pth.PathNoLeadingSlash(), strings.ReplaceAll(pth.PathNoLeadingSlash(), "index", "_index"))
+	}
+
 	return p, pth, err
 }
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1968,3 +1968,35 @@ Title: {{ .Title }}
 		"deprecated: path in front matter was deprecated",
 	)
 }
+
+// Issue 13538
+func TestHomePageIsLeafBundle(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+defaultContentLanguage = 'de'
+defaultContentLanguageInSubdir = true
+[languages.de]
+weight = 1
+[languages.en]
+weight = 2
+-- layouts/all.html --
+{{ .Title }}
+-- content/index.de.md --
+---
+title: home de
+---
+-- content/index.en.org --
+---
+title: home en
+---
+`
+
+	b := Test(t, files, TestOptWarn())
+
+	b.AssertFileContent("public/de/index.html", "home de")
+	b.AssertFileContent("public/en/index.html", "home en")
+	b.AssertLogContains("Using index.de.md in your content's root directory is usually incorrect for your home page. You should use _index.de.md instead.")
+	b.AssertLogContains("Using index.en.org in your content's root directory is usually incorrect for your home page. You should use _index.en.org instead.")
+}


### PR DESCRIPTION
Closes #13538

This also fixes a problem with the Docker build in order to make the tests go green.

> golang:1.24.0-alpine3.22: failed to resolve source metadata for docker.io/library/golang:1.24.0-alpine3.22: docker.io/library/golang:1.24.0-alpine3.22: not found


