### PR TITLE
deps: Upgrade github.com/spf13/cast v1.8.0 => v1.9.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1
 	github.com/sanity-io/litter v1.5.8
 	github.com/spf13/afero v1.14.0
-	github.com/spf13/cast v1.8.0
+	github.com/spf13/cast v1.9.2
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/fsync v0.10.1
 	github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -434,8 +434,8 @@ github.com/shogo82148/go-shuffle v0.0.0-20180218125048-27e6095f230d/go.mod h1:2h
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/afero v1.14.0 h1:9tH6MapGnn/j0eb0yIXiLjERO8RB6xIVZRDCX7PtqWA=
 github.com/spf13/afero v1.14.0/go.mod h1:acJQ8t0ohCGuMN3O+Pv0V0hgMxNYDlvdk+VTfyZmbYo=
-github.com/spf13/cast v1.8.0 h1:gEN9K4b8Xws4EX0+a0reLmhq8moKn7ntRlQYgjPeCDk=
-github.com/spf13/cast v1.8.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/spf13/cast v1.9.2 h1:SsGfm7M8QOFtEzumm7UZrZdLLquNdzFYfIbEXntcFbE=
+github.com/spf13/cast v1.9.2/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/fsync v0.10.1 h1:JRnB7G72b+gIBaBcpn5ibJSd7ww1iEahXSX2B8G6dSE=

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -1406,7 +1406,7 @@ home = ["html"]
 			"home":     {"html"},
 			"page":     {"html"},
 			"rss":      {"rss"},
-			"section":  nil,
+			"section":  {},
 			"taxonomy": {"html", "rss"},
 			"term":     {"html", "rss"},
 		})

--- a/tpl/math/math_test.go
+++ b/tpl/math/math_test.go
@@ -258,7 +258,7 @@ func TestMod(t *testing.T) {
 		{int32(3), int32(2), int64(1)},
 		{int64(3), int64(2), int64(1)},
 		{"3", "2", int64(1)},
-		{"3.1", "2", false},
+		{"3.1", "2", int64(1)},
 		{"aaa", "0", false},
 		{"3", "aaa", false},
 	} {
@@ -304,7 +304,7 @@ func TestModBool(t *testing.T) {
 		{int64(3), int64(2), false},
 		{"3", "3", true},
 		{"3", "2", false},
-		{"3.1", "2", nil},
+		{"3.1", "2", false},
 		{"aaa", "0", nil},
 		{"3", "aaa", nil},
 	} {


### PR DESCRIPTION
Notes about test changes:

- The `math.Mod` and `math.ModBool` template functions now handle floats represented as strings. See [spf13/cast/pull/261](https://github.com/spf13/cast/pull/261). 

- Although I didn't spend a lot time digging through our code, I was unable to determine which `spf13/cast` change was responsible for the required change to our `TestLoadConfigYamlEnvVar` test, where we now get an empty slice instead of `nil`. I verified that this change does not affect which files are published.  Or to put it another way, this still works great:

  ```text
  HUGO_OUTPUTS="section: []" hugo
  ```
