### PR TITLE
tpl/tplimpl: Copy embedded HTML table render hook to each output format

### DIFF
--- a/tpl/tplimpl/templatestore_integration_test.go
+++ b/tpl/tplimpl/templatestore_integration_test.go
@@ -1508,3 +1508,43 @@ mytexts|safeHTML: {{ partial "mytext.txt" . | safeHTML }}
 		"mytexts|safeHTML: <div>mytext</div>",
 	)
 }
+
+func TestIssue13351(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+[outputs]
+home = ['html','json']
+[outputFormats.html]
+weight = 1
+[outputFormats.json]
+weight = 2
+-- content/_index.md --
+---
+title: home
+---
+a|b
+:--|:--
+1|2
+-- layouts/index.html --
+{{ .Content }}
+-- layouts/index.json --
+{{ .Content }}
+`
+
+	b := hugolib.Test(t, files)
+	b.AssertFileContent("public/index.html", "<table>")
+	b.AssertFileContent("public/index.json", "<table>")
+
+	f := strings.ReplaceAll(files, "weight = 1", "weight = 0")
+	b = hugolib.Test(t, f)
+	b.AssertFileContent("public/index.html", "<table>")
+	b.AssertFileContent("public/index.json", "<table>")
+
+	f = strings.ReplaceAll(files, "weight = 1", "")
+	b = hugolib.Test(t, f)
+	b.AssertFileContent("public/index.html", "<table>")
+	b.AssertFileContent("public/index.json", "<table>")
+}


### PR DESCRIPTION
Closes #13351

With other render hooks we do something like this:

https://github.com/gohugoio/hugo/blob/b6c8dfa9dc4e446bae7d50088fb568939f6ccd4a/markup/goldmark/blockquotes/blockquotes.go#L82-L85

where `renderBlockquoteDefault` is essentially copied from Goldmark's source. The bits that we're copying are short and simple. But the Goldmark source for tables (it's an extension) is neither short nor simple, so we panic instead:

https://github.com/gohugoio/hugo/blob/b6c8dfa9dc4e446bae7d50088fb568939f6ccd4a/markup/goldmark/tables/tables.go#L72-L75

Instead of trying to recreate Goldmark's table extension in a `renderTableDefault` function, this PR simply registers a copy of the embedded table render hook for all output formats.