### PR TITLE
Deploy, walkLocal performance

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -487,7 +487,71 @@ func knownHiddenDirectory(name string) bool {
 // walkLocal walks the source directory and returns a flat list of files,
 // using localFile.SlashPath as the map keys.
 func (d *Deployer) walkLocal(fs afero.Fs, matchers []*deployconfig.Matcher, include, exclude glob.Glob, mediaTypes media.Types, mappath func(string) string) (map[string]*localFile, error) {
-	retval := map[string]*localFile{}
+	retval := sync.Map{}
+
+	// Create a worker pool
+	workerCount := d.cfg.Workers
+	jobs := make(chan string, workerCount)
+	errs := make(chan error, workerCount)
+	var wg sync.WaitGroup
+
+	// Start workers
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for path := range jobs {
+				info, err := fs.Stat(path)
+				if err != nil {
+					errs <- err
+					continue
+				}
+
+				// .DS_Store is an internal MacOS attribute file; skip it.
+				if info.IsDir() || info.Name() == ".DS_Store" {
+					continue
+				}
+
+				// When a file system is HFS+, its filepath is in NFD form.
+				if runtime.GOOS == "darwin" {
+					path = norm.NFC.String(path)
+				}
+
+				// Check include/exclude matchers.
+				slashpath := filepath.ToSlash(path)
+				if include != nil && !include.Match(slashpath) {
+					d.logger.Infof("  dropping %q due to include\n", slashpath)
+					continue
+				}
+				if exclude != nil && exclude.Match(slashpath) {
+					d.logger.Infof("  dropping %q due to exclude\n", slashpath)
+					continue
+				}
+
+				// Find the first matching matcher (if any).
+				var m *deployconfig.Matcher
+				for _, cur := range matchers {
+					if cur.Matches(slashpath) {
+						m = cur
+						break
+					}
+				}
+				// Apply any additional modifications to the local path, to map it to
+				// the remote path.
+				if mappath != nil {
+					slashpath = mappath(slashpath)
+				}
+				lf, err := newLocalFile(fs, path, slashpath, m, mediaTypes)
+				if err != nil {
+					errs <- err
+					continue
+				}
+				retval.Store(lf.SlashPath, lf)
+			}
+		}()
+	}
+
+	// Walk the directory tree and send paths to workers
 	err := afero.Walk(fs, "", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -502,52 +566,32 @@ func (d *Deployer) walkLocal(fs afero.Fs, matchers []*deployconfig.Matcher, incl
 			}
 			return nil
 		}
-
-		// .DS_Store is an internal MacOS attribute file; skip it.
-		if info.Name() == ".DS_Store" {
-			return nil
-		}
-
-		// When a file system is HFS+, its filepath is in NFD form.
-		if runtime.GOOS == "darwin" {
-			path = norm.NFC.String(path)
-		}
-
-		// Check include/exclude matchers.
-		slashpath := filepath.ToSlash(path)
-		if include != nil && !include.Match(slashpath) {
-			d.logger.Infof("  dropping %q due to include\n", slashpath)
-			return nil
-		}
-		if exclude != nil && exclude.Match(slashpath) {
-			d.logger.Infof("  dropping %q due to exclude\n", slashpath)
-			return nil
-		}
-
-		// Find the first matching matcher (if any).
-		var m *deployconfig.Matcher
-		for _, cur := range matchers {
-			if cur.Matches(slashpath) {
-				m = cur
-				break
-			}
-		}
-		// Apply any additional modifications to the local path, to map it to
-		// the remote path.
-		if mappath != nil {
-			slashpath = mappath(slashpath)
-		}
-		lf, err := newLocalFile(fs, path, slashpath, m, mediaTypes)
-		if err != nil {
-			return err
-		}
-		retval[lf.SlashPath] = lf
+		jobs <- path
 		return nil
 	})
+
+	close(jobs)
+	wg.Wait()
+	close(errs)
+
+	// Check for any errors from workers
+	for err := range errs {
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
-	return retval, nil
+
+	// Convert sync.Map to regular map
+	result := make(map[string]*localFile)
+	retval.Range(func(key, value interface{}) bool {
+		result[key.(string)] = value.(*localFile)
+		return true
+	})
+	return result, nil
 }
 
 // stripIndexHTML remaps keys matching "<dir>/index.html" to "<dir>/".

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -623,7 +623,7 @@ func TestEndToEndSync(t *testing.T) {
 				localFs:    test.fs,
 				bucket:     test.bucket,
 				mediaTypes: media.DefaultTypes,
-				cfg:        deployconfig.DeployConfig{MaxDeletes: -1},
+				cfg:        deployconfig.DeployConfig{Workers: 2, MaxDeletes: -1},
 			}
 
 			// Initial deployment should sync remote with local.
@@ -706,7 +706,7 @@ func TestMaxDeletes(t *testing.T) {
 				localFs:    test.fs,
 				bucket:     test.bucket,
 				mediaTypes: media.DefaultTypes,
-				cfg:        deployconfig.DeployConfig{MaxDeletes: -1},
+				cfg:        deployconfig.DeployConfig{Workers: 2, MaxDeletes: -1},
 			}
 
 			// Sync remote with local.
@@ -836,7 +836,7 @@ func TestIncludeExclude(t *testing.T) {
 			}
 			deployer := &Deployer{
 				localFs: fsTest.fs,
-				cfg:     deployconfig.DeployConfig{MaxDeletes: -1}, bucket: fsTest.bucket,
+				cfg:     deployconfig.DeployConfig{Workers: 2, MaxDeletes: -1}, bucket: fsTest.bucket,
 				target:     tgt,
 				mediaTypes: media.DefaultTypes,
 			}
@@ -893,7 +893,7 @@ func TestIncludeExcludeRemoteDelete(t *testing.T) {
 			}
 			deployer := &Deployer{
 				localFs: fsTest.fs,
-				cfg:     deployconfig.DeployConfig{MaxDeletes: -1}, bucket: fsTest.bucket,
+				cfg:     deployconfig.DeployConfig{Workers: 2, MaxDeletes: -1}, bucket: fsTest.bucket,
 				mediaTypes: media.DefaultTypes,
 			}
 
@@ -945,7 +945,7 @@ func TestCompression(t *testing.T) {
 			deployer := &Deployer{
 				localFs:    test.fs,
 				bucket:     test.bucket,
-				cfg:        deployconfig.DeployConfig{MaxDeletes: -1, Matchers: []*deployconfig.Matcher{{Pattern: ".*", Gzip: true, Re: regexp.MustCompile(".*")}}},
+				cfg:        deployconfig.DeployConfig{Workers: 2, MaxDeletes: -1, Matchers: []*deployconfig.Matcher{{Pattern: ".*", Gzip: true, Re: regexp.MustCompile(".*")}}},
 				mediaTypes: media.DefaultTypes,
 			}
 
@@ -1000,7 +1000,7 @@ func TestMatching(t *testing.T) {
 			deployer := &Deployer{
 				localFs:    test.fs,
 				bucket:     test.bucket,
-				cfg:        deployconfig.DeployConfig{MaxDeletes: -1, Matchers: []*deployconfig.Matcher{{Pattern: "^subdir/aaa$", Force: true, Re: regexp.MustCompile("^subdir/aaa$")}}},
+				cfg:        deployconfig.DeployConfig{Workers: 2, MaxDeletes: -1, Matchers: []*deployconfig.Matcher{{Pattern: "^subdir/aaa$", Force: true, Re: regexp.MustCompile("^subdir/aaa$")}}},
 				mediaTypes: media.DefaultTypes,
 			}
 
@@ -1097,5 +1097,6 @@ func verifyRemote(ctx context.Context, bucket *blob.Bucket, local []*fileData) (
 func newDeployer() *Deployer {
 	return &Deployer{
 		logger: loggers.NewDefault(),
+		cfg:    deployconfig.DeployConfig{Workers: 2},
 	}
 }


### PR DESCRIPTION
### What is the purpose?

During hugo deploy we run `walkLocal` which iterates over the filesystem. At larger scale deploys I've noticed this can be slow. 
This PR attempts to improve the performance by using a worker pool

### Why?

To help improve deploy times 

### Example

Before my changes (just log changes)
![2](https://github.com/user-attachments/assets/0c884fbd-baac-482b-bc2f-f7fbbc892e5a)

After my changes
![1](https://github.com/user-attachments/assets/63b20b52-fddf-4954-ae73-50b83771fede)
