### PR TITLE
markup/org: add custom org link resolve function for `denote`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/muesli/smartcrop v0.3.0
-	github.com/niklasfasching/go-org v1.8.0
+	github.com/niklasfasching/go-org v1.9.1
 	github.com/olekukonko/tablewriter v1.0.8
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,8 @@ github.com/niklasfasching/go-org v1.8.0 h1:WyGLaajLLp8JbQzkmapZ1y0MOzKuKV47HkZRl
 github.com/niklasfasching/go-org v1.8.0/go.mod h1:e2A9zJs7cdONrEGs3gvxCcaAEpwwPNPG7csDpXckMNg=
 github.com/niklasfasching/go-org v1.9.0 h1:4/Sr68Qx06hjC9MVDB/4etGP67JionLHGscLMOClpnk=
 github.com/niklasfasching/go-org v1.9.0/go.mod h1:ZAGFFkWvUQcpazmi/8nHqwvARpr1xpb+Es67oUGX/48=
+github.com/niklasfasching/go-org v1.9.1 h1:/3s4uTPOF06pImGa2Yvlp24yKXZoTYM+nsIlMzfpg/0=
+github.com/niklasfasching/go-org v1.9.1/go.mod h1:ZAGFFkWvUQcpazmi/8nHqwvARpr1xpb+Es67oUGX/48=
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=

--- a/markup/org/convert.go
+++ b/markup/org/convert.go
@@ -17,6 +17,7 @@ package org
 import (
 	"bytes"
 	"log"
+	"strings"
 
 	"github.com/gohugoio/hugo/identity"
 
@@ -50,6 +51,19 @@ func (c *orgConverter) Convert(ctx converter.RenderContext) (converter.ResultRen
 	config.Log = log.Default() // TODO(bep)
 	config.ReadFile = func(filename string) ([]byte, error) {
 		return afero.ReadFile(c.cfg.ContentFs, filename)
+	}
+	config.ResolveLink = func(protocol string, description []org.Node, link string) org.Node {
+		out := org.RegularLink{
+			Protocol:    protocol,
+			Description: description,
+			URL:         link,
+			AutoLink:    false,
+		}
+		if protocol == "denote" {
+			id := strings.TrimPrefix(link, "denote:")
+			out.URL = "../" + strings.ToLower(id) + "/"
+		}
+		return out
 	}
 	writer := org.NewHTMLWriter()
 	writer.HighlightCodeBlock = func(source, lang string, inline bool, params map[string]string) string {


### PR DESCRIPTION
The go-org library used by hugo to parse `.org` files now supports custom link resolvers. This PR uses the new functionality to add support for [denote](https://protesilaos.com/emacs/denote) style links.

This can be used to publish notes as-is using hugo.

I've written about the details in a blog post [here](https://dominik.suess.wtf/posts/2025/01/02/denote-hugo/).

I don't know if this functionality is too specific to my use case, so I'm happy to discuss alternatives which could be more modular/adaptable to other systems.