### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/helpers/general.go
+++ b/helpers/general.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -228,17 +229,7 @@ func compareStringSlices(a, b []string) bool {
 		return false
 	}
 
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-
-	return true
+	return slices.Equal(a, b)
 }
 
 // SliceToLower goes through the source slice and lowers all values.

--- a/navigation/menu_cache.go
+++ b/navigation/menu_cache.go
@@ -28,7 +28,7 @@ func (entry menuCacheEntry) matches(menuList []Menu) bool {
 		return false
 	}
 	for i, m := range menuList {
-		if !menuEqual(m, entry.in[i]) {
+		if !slices.Equal(m, entry.in[i]) {
 			return false
 		}
 	}
@@ -44,21 +44,6 @@ func newMenuCache() *menuCache {
 type menuCache struct {
 	sync.RWMutex
 	m map[string][]menuCacheEntry
-}
-
-// menuEqual checks if two menus are equal.
-func menuEqual(m1, m2 Menu) bool {
-	if len(m1) != len(m2) {
-		return false
-	}
-
-	for i := range m1 {
-		if m1[i] != m2[i] {
-			return false
-		}
-	}
-
-	return true
 }
 
 // get retrieves a menu from the cache based on the provided key and menuLists.

--- a/navigation/menu_cache_test.go
+++ b/navigation/menu_cache_test.go
@@ -14,6 +14,7 @@
 package navigation
 
 import (
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -64,8 +65,8 @@ func TestMenuCache(t *testing.T) {
 				l1.Unlock()
 				m2, c2 := c1.get("k1", nil, m)
 				c.Assert(c2, qt.Equals, true)
-				c.Assert(menuEqual(m, m2), qt.Equals, true)
-				c.Assert(menuEqual(m, menu), qt.Equals, true)
+				c.Assert(slices.Equal(m, m2), qt.Equals, true)
+				c.Assert(slices.Equal(m, menu), qt.Equals, true)
 				c.Assert(m, qt.Not(qt.IsNil))
 
 				l2.Lock()


### PR DESCRIPTION

In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).