### PR TITLE
Remove unnecessary error check

### DIFF
--- a/tpl/strings/truncate.go
+++ b/tpl/strings/truncate.go
@@ -67,9 +67,7 @@ func (ns *Namespace) Truncate(s any, options ...any) (template.HTML, error) {
 	default:
 		return "", errors.New("too many arguments passed to truncate")
 	}
-	if err != nil {
-		return "", errors.New("text to truncate must be a string")
-	}
+
 	text, err := cast.ToStringE(textParam)
 	if err != nil {
 		return "", errors.New("text must be a string")


### PR DESCRIPTION
While inspecting the Truncate function to gain some inspiration, I noticed it has an unnecessary error check.

This PR specifically targets the following blob:
https://github.com/gohugoio/hugo/blob/3aa22b09425ab9e4e4d79c328ae16692cb3df736/tpl/strings/truncate.go#L70C1-L76C3

```go
if err != nil {
	return "", errors.New("text to truncate must be a string")
}
text, err := cast.ToStringE(textParam)
if err != nil {
	return "", errors.New("text must be a string")
}
```

The previous error might have belonged to an old piece of code, but as it stands - it will always be `nil`.