### PR TITLE
restore older uglyurls behavior with configuration setting

### DIFF
--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -686,6 +686,9 @@ type RootConfig struct {
 	// <docsmeta>{"identifiers": ["baseURL"] }</docsmeta>
 	CanonifyURLs bool
 
+	// SectionUglyURLs forces old UglyURLs behavior for sections
+	SectionUglyURLs bool
+
 	// Enable this to make all relative URLs relative to content root. Note that this does not affect absolute URLs.
 	RelativeURLs bool
 

--- a/config/allconfig/configlanguage.go
+++ b/config/allconfig/configlanguage.go
@@ -192,6 +192,10 @@ func (c ConfigLanguage) IsUglyURLs(section string) bool {
 	return c.config.C.IsUglyURLSection(section)
 }
 
+func (c ConfigLanguage) SectionUglyURLs() bool {
+	return c.config.SectionUglyURLs
+}
+
 func (c ConfigLanguage) IgnoreFile(s string) bool {
 	return c.config.C.IgnoreFile(s)
 }

--- a/config/configProvider.go
+++ b/config/configProvider.go
@@ -48,6 +48,7 @@ type AllProvider interface {
 	DisablePathToLower() bool
 	RemovePathAccents() bool
 	IsUglyURLs(section string) bool
+	SectionUglyURLs() bool
 	DefaultContentLanguage() string
 	DefaultContentLanguageInSubdir() bool
 	IsLangDisabled(string) bool

--- a/hugolib/page__paths.go
+++ b/hugolib/page__paths.go
@@ -122,13 +122,14 @@ func createTargetPathDescriptor(p *pageState) (page.TargetPathDescriptor, error)
 	}
 
 	desc := page.TargetPathDescriptor{
-		PathSpec:    d.PathSpec,
-		Kind:        p.Kind(),
-		Path:        pageInfoPage,
-		Section:     pageInfoCurrentSection,
-		UglyURLs:    s.h.Conf.IsUglyURLs(p.Section()),
-		ForcePrefix: s.h.Conf.IsMultihost() || alwaysInSubDir,
-		URL:         pm.pageConfig.URL,
+		PathSpec:        d.PathSpec,
+		Kind:            p.Kind(),
+		Path:            pageInfoPage,
+		Section:         pageInfoCurrentSection,
+		UglyURLs:        s.h.Conf.IsUglyURLs(p.Section()),
+		SectionUglyURLs: s.h.Conf.SectionUglyURLs(),
+		ForcePrefix:     s.h.Conf.IsMultihost() || alwaysInSubDir,
+		URL:             pm.pageConfig.URL,
 	}
 
 	if pm.Slug() != "" {

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -496,23 +496,26 @@ func TestSectionNaming(t *testing.T) {
 	for _, canonify := range []bool{true, false} {
 		for _, uglify := range []bool{true, false} {
 			for _, pluralize := range []bool{true, false} {
-				canonify := canonify
-				uglify := uglify
-				pluralize := pluralize
-				t.Run(fmt.Sprintf("canonify=%t,uglify=%t,pluralize=%t", canonify, uglify, pluralize), func(t *testing.T) {
-					t.Parallel()
-					doTestSectionNaming(t, canonify, uglify, pluralize)
-				})
+				for _, sectionUglify := range []bool{true, false} {
+					canonify := canonify
+					uglify := uglify
+					sectionUglify := sectionUglify
+					pluralize := pluralize
+					t.Run(fmt.Sprintf("canonify=%t,uglify=%t,pluralize=%t,sectionUglify=%t", canonify, uglify, pluralize, sectionUglify), func(t *testing.T) {
+						t.Parallel()
+						doTestSectionNaming(t, canonify, uglify, pluralize, sectionUglify)
+					})
+				}
 			}
 		}
 	}
 }
 
-func doTestSectionNaming(t *testing.T, canonify, uglify, pluralize bool) {
+func doTestSectionNaming(t *testing.T, canonify, uglify, pluralize, sectionUglify bool) {
 	c := qt.New(t)
 
 	expectedPathSuffix := func(kind string) string {
-		isUgly := uglify && (kind == kinds.KindPage || kind == kinds.KindTerm)
+		isUgly := uglify && (sectionUglify || (kind == kinds.KindPage || kind == kinds.KindTerm))
 		if isUgly {
 			return ".html"
 		} else {
@@ -532,6 +535,7 @@ func doTestSectionNaming(t *testing.T, canonify, uglify, pluralize bool) {
 
 	cfg.Set("baseURL", "http://auth/sub/")
 	cfg.Set("uglyURLs", uglify)
+	cfg.Set("sectionUglyURLs", sectionUglify)
 	cfg.Set("pluralizeListTitles", pluralize)
 	cfg.Set("canonifyURLs", canonify)
 

--- a/resources/page/page_paths.go
+++ b/resources/page/page_paths.go
@@ -70,6 +70,9 @@ type TargetPathDescriptor struct {
 
 	// Some types cannot have uglyURLs, even if globally enabled, RSS being one example.
 	UglyURLs bool
+
+	// Forwarded configuration of SectionUglyURLs
+	SectionUglyURLs bool
 }
 
 // TODO(bep) move this type.
@@ -140,7 +143,7 @@ func CreateTargetPaths(d TargetPathDescriptor) (tp TargetPaths) {
 
 	pb.isUgly = (d.UglyURLs || d.Type.Ugly) && !d.Type.NoUgly
 	pb.baseNameSameAsType = !d.Path.IsBundle() && d.BaseName != "" && d.BaseName == d.Type.BaseName
-	indexIsUglyKind := d.Kind == kinds.KindHome || d.Kind == kinds.KindSection || d.Kind == kinds.KindTaxonomy
+	indexIsUglyKind := d.Kind == kinds.KindHome || (!d.SectionUglyURLs && (d.Kind == kinds.KindSection || d.Kind == kinds.KindTaxonomy))
 	indexIsUglyKind = indexIsUglyKind && pb.isUgly
 
 	if d.ExpandedPermalink == "" && pb.baseNameSameAsType {


### PR DESCRIPTION
After #13835 UglyURLs are now working as intended (?) but it did break my site that was relying on uglyUrls and [this](https://vercel.com/docs/project-configuration#cleanurls) on vercel. With this change there is a new configuration key (`sectionUglyURLs`, let me know if you want a different name) to restore the previous behavior. I've also added the needed tests for the feature.