### PR TITLE
implement update function for slices and maps

### DIFF
--- a/tpl/collections/init.go
+++ b/tpl/collections/init.go
@@ -202,6 +202,11 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.Update,
+			[]string{},
+			[][2]string{},
+		)
+
 		return ns
 	}
 

--- a/tpl/collections/update.go
+++ b/tpl/collections/update.go
@@ -1,0 +1,64 @@
+package collections
+
+import (
+	"fmt"
+	"github.com/gohugoio/hugo/common/types"
+	"github.com/spf13/cast"
+	"reflect"
+)
+
+func (ns *Namespace) Update(index any, value any, mapOrSlice any) (string, error) {
+	vmapOrSlice := reflect.ValueOf(mapOrSlice)
+
+	vmapOrSlice, isNil := indirect(vmapOrSlice)
+	if isNil {
+		return "", fmt.Errorf("can't update a nil value")
+	}
+
+	var err error
+	if vmapOrSlice.Kind() == reflect.Map {
+		err = ns.updateMap(index, value, vmapOrSlice)
+	} else if vmapOrSlice.Kind() == reflect.Slice {
+		err = ns.updateSlice(index, value, vmapOrSlice)
+	} else {
+		return "", fmt.Errorf("target must be a map or a slice, got %T", mapOrSlice)
+	}
+	// This is used in templates, we need to return something.
+	return "", err
+}
+
+func (ns *Namespace) updateMap(index, value any, mapp reflect.Value) error {
+	vindex := reflect.ValueOf(index)
+	if !vindex.Type().AssignableTo(mapp.Type().Key()) {
+		return fmt.Errorf("cannot assign %v as a key in map %v", index, mapp.Type())
+	}
+
+	if types.IsNil(value) {
+		// special case, delete the key
+		mapp.SetMapIndex(vindex, reflect.Value{})
+		return nil
+	}
+
+	vvalue := reflect.ValueOf(value)
+	if !vvalue.Type().AssignableTo(mapp.Type().Elem()) {
+		return fmt.Errorf("cannot assign %v as a value in map %v", value, mapp.Type())
+	}
+
+	mapp.SetMapIndex(vindex, vvalue)
+	return nil
+}
+
+func (ns *Namespace) updateSlice(index, value any, slice reflect.Value) error {
+	vvalue := reflect.ValueOf(value)
+	if !vvalue.Type().AssignableTo(slice.Type().Elem()) {
+		return fmt.Errorf("cannot assign %v as a value in slice %v", value, slice.Type())
+	}
+
+	indexv, err := cast.ToIntE(index)
+	if err != nil {
+		return err
+	}
+
+	slice.Index(indexv).Set(vvalue)
+	return nil
+}

--- a/tpl/collections/update_test.go
+++ b/tpl/collections/update_test.go
@@ -1,0 +1,77 @@
+// Copyright 2019 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collections
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestUpdate(t *testing.T) {
+	ns := newNs()
+
+	for i, test := range []struct {
+		name   string
+		params [3]any
+		expect any
+		isErr  bool
+	}{
+		{
+			"map",
+			[3]any{"c", 3, map[string]any{"a": 1, "b": 2}},
+			map[string]any{"a": 1, "b": 2, "c": 3},
+			false,
+		},
+		{
+			"mapdelete",
+			[3]any{"b", nil, map[string]any{"a": 1, "b": 2}},
+			map[string]any{"a": 1},
+			false,
+		},
+		{
+			"slice",
+			[3]any{1, 100, []any{1, 2, 3}},
+			[]any{1, 100, 3},
+			false,
+		},
+		{
+			"sliceerror",
+			[3]any{[]any{100}, 100, []any{1, 2, 3}},
+			nil,
+			true,
+		},
+	} {
+
+		test := test
+		i := i
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			errMsg := qt.Commentf("[%d] %v", i, test)
+
+			c := qt.New(t)
+
+			result, err := ns.Update(test.params[0], test.params[1], test.params[2])
+
+			if test.isErr {
+				c.Assert(err, qt.Not(qt.IsNil), errMsg)
+				return
+			}
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(result, qt.DeepEquals, test.expect, errMsg)
+		})
+	}
+}

--- a/tpl/collections/update_test.go
+++ b/tpl/collections/update_test.go
@@ -63,7 +63,7 @@ func TestUpdate(t *testing.T) {
 
 			c := qt.New(t)
 
-			result, err := ns.Update(test.params[0], test.params[1], test.params[2])
+			_, err := ns.Update(test.params[0], test.params[1], test.params[2])
 
 			if test.isErr {
 				c.Assert(err, qt.Not(qt.IsNil), errMsg)
@@ -71,7 +71,7 @@ func TestUpdate(t *testing.T) {
 			}
 
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, qt.DeepEquals, test.expect, errMsg)
+			c.Assert(test.params[2], qt.DeepEquals, test.expect, errMsg)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #7232.

I didn't add an alias, for now, because there was some discussion about using `update`, `insert`, `put` or something else.

```
{{ $dict := dict "a" 1 "b" 2 }}
{{ $dict | collections.Update "c" 3 }}
{{/* $dict is { "a": 1, "b": 2, "c": 3 } */}}
```

```
{{ $slice := slice 1, 2, 3 }}
{{ $slice | collections.Update 1 100 }}
{{/* $slice is [1, 100, 3] */}}
```