### PR TITLE
Fix hugo new content issue #12599 by patching config

### DIFF
--- a/commands/new.go
+++ b/commands/new.go
@@ -53,7 +53,9 @@ Ensure you run this within the root directory of your site.`,
 					if len(args) < 1 {
 						return newUserError("path needs to be provided")
 					}
-					h, err := r.Hugo(flagsToCfg(cd, nil))
+					cfg := flagsToCfg(cd, nil)
+					cfg.Set("BuildFuture", true)
+					h, err := r.Hugo(cfg)
 					if err != nil {
 						return err
 					}

--- a/testscripts/commands/new_content.txt
+++ b/testscripts/commands/new_content.txt
@@ -4,4 +4,24 @@ hugo new content --kind post post/first-post.md
 ! exists resources
 grep 'draft = true' content/post/first-post.md
 
+# Issue 12599
+cd $WORK
 
+hugo new site --format toml --force issue-12599
+cp hugo.toml issue-12599/hugo.toml
+cd issue-12599
+hugo new content content/s1/2099-12-31-p1.md
+hugo -DF
+grep 'DATE _2099-12-31_' public/s1/p1/index.html
+grep 'SLUG _p1_' public/s1/p1/index.html
+grep 'TITLE _2099 12 31 P1_' public/s1/p1/index.html
+
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+[frontmatter]
+date = [':filename', ':default']
+publishDate = [':filename', ':default']
+-- issue-12599/layouts/all.html --
+DATE _{{ .Date.Format "2006-01-02" }}_
+SLUG _{{ .Slug }}_
+TITLE _{{ .Title }}_


### PR DESCRIPTION
The command `hugo new content` crashes under the following conditions:

- Configure Hugo to extract the publish date from file names
- Create new content with the file name containing a future date
  (relative to UTC)

The stack trace looks something like this:

```
goroutine 8 [running]:
testing.tRunner.func1.2({0x1038aef00, 0x140005af770})
        /nix/store/ps3admpzmc1ryvn9q7sw5xfd94dkrb3f-go-1.24.3/share/go/src/testing/testing.go:1734 +0x1ac
testing.tRunner.func1()
        /nix/store/ps3admpzmc1ryvn9q7sw5xfd94dkrb3f-go-1.24.3/share/go/src/testing/testing.go:1737 +0x334
panic({0x1038aef00?, 0x140005af770?})
        /nix/store/ps3admpzmc1ryvn9q7sw5xfd94dkrb3f-go-1.24.3/share/go/src/runtime/panic.go:792 +0x124
github.com/gohugoio/hugo/create.(*contentBuilder).applyArcheType(0x140006740c0, {0x140007c6090, 0x2c}, {0x0, 0x0})
        /Users/debian/projects/hugo/hugo/create/content.go:275 +0x2ac
github.com/gohugoio/hugo/create.(*contentBuilder).buildFile(0x140006740c0)
        /Users/debian/projects/hugo/hugo/create/content.go:244 +0x168
github.com/gohugoio/hugo/create.NewContent.func1()
        /Users/debian/projects/hugo/hugo/create/content.go:105 +0x1dc
github.com/gohugoio/hugo/create.NewContent(0x140007189a0, {0x1032fe4c1, 0x8}, {0x10338192e, 0x24}, 0x0)
        /Users/debian/projects/hugo/hugo/create/content.go:108 +0x478
github.com/gohugoio/hugo/create_test.TestNewContentFutureDate(0x14000103c00)
        /Users/debian/projects/hugo/hugo/create/content_test.go:147 +0x5dc
testing.tRunner(0x14000103c00, 0x103b5f710)
        /nix/store/ps3admpzmc1ryvn9q7sw5xfd94dkrb3f-go-1.24.3/share/go/src/testing/testing.go:1792 +0xe4
created by testing.(*T).Run in goroutine 1
        /nix/store/ps3admpzmc1ryvn9q7sw5xfd94dkrb3f-go-1.24.3/share/go/src/testing/testing.go:1851 +0x374
```

When Hugo searches for all sites that it should regard, it ignores
posts with future publishing dates. This makes sense for building sites.

When the `hugo new content` is running, it first creates your content file
(such as `content/posts/2050-12-31-page/index.md`) and
then populates it with the corresponding archetype content. This is
typically a `.md` file from the `archetype/` directory. Populating the new
content file only works when this page is part of the Hugo page
collection. This is where it goes wrong.

To decide whether hugo should include a page, it evaluates `shouldBuild`
in `hugolib/site.go`. Usually, `s.Conf.BuildFuture()` evaluates to
false and Hugo drops the page since its publish date is in the future.
For building pages, this is reasonable pages. For populating pages with
archetype content, this leads to the stack trace mentioned before.

The exact cause of this issue was hard to track down, since populating
the available pages and populating a single page with an archetype
template are separate steps. By the time the `hugo new content` command
calls the `(b *contentBuilder) applyArcheType` method, it's already too late.
`p := b.h.GetContentPage(contentFilename)` in `applyArcheType` evaluates
to `p := nil`.

To fix this behavior, I propose setting `BuildFuture` to true when
running the `content` sub-command of `hugo new`.

An alternative approach to fixing this is by perhaps enhancing
`GetContentPage` to accept a second argument `includeFuturePages`.
This would still mean that the way `h.Sites` (evaluated in
`(h *HugoSites) withPage`) would need to include future pages.