### PR TITLE
minifiers: Update deprecation handling

### DIFF
--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -170,10 +170,16 @@ func (l configLoader) applyDefaultConfig() error {
 }
 
 func (l configLoader) normalizeCfg(cfg config.Provider) error {
-	if b, ok := cfg.Get("minifyOutput").(bool); ok && b {
-		cfg.Set("minify.minifyOutput", true)
-	} else if b, ok := cfg.Get("minify").(bool); ok && b {
-		cfg.Set("minify", maps.Params{"minifyOutput": true})
+	if b, ok := cfg.Get("minifyOutput").(bool); ok {
+		hugo.Deprecate("site config minifyOutput", "Use minify.minifyOutput instead.", "v0.150.0")
+		if b {
+			cfg.Set("minify.minifyOutput", true)
+		}
+	} else if b, ok := cfg.Get("minify").(bool); ok {
+		hugo.Deprecate("site config minify", "Use minify.minifyOutput instead.", "v0.150.0")
+		if b {
+			cfg.Set("minify", maps.Params{"minifyOutput": true})
+		}
 	}
 
 	return nil

--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -238,6 +238,7 @@ chroma:
   - Aliases:
     - docker
     - dockerfile
+    - containerfile
     Name: Docker
   - Aliases:
     - dtd
@@ -300,6 +301,12 @@ chroma:
     - gdscript3
     - gd3
     Name: GDScript3
+  - Aliases:
+    - gemtext
+    - gmi
+    - gmni
+    - gemini
+    Name: Gemtext
   - Aliases:
     - genshi
     - kid
@@ -456,6 +463,8 @@ chroma:
   - Aliases:
     - llvm
     Name: LLVM
+  - Aliases: null
+    Name: lox
   - Aliases:
     - lua
     - luau
@@ -561,6 +570,9 @@ chroma:
     - nsi
     - nsh
     Name: NSIS
+  - Aliases:
+    - nu
+    Name: Nu
   - Aliases:
     - objective-c
     - objectivec
@@ -1478,8 +1490,9 @@ config:
     tdewolff:
       css:
         inline: false
-        keepCSS2: true
+        keepCSS2: false
         precision: 0
+        version: 0
       html:
         keepComments: false
         keepConditionalComments: false
@@ -2093,6 +2106,11 @@ tpl:
         - - '{{ slice "a" "b" "c" "d" "e" "f" | complement (slice "b" "c") (slice
             "d" "e") }}'
           - '[a f]'
+      D:
+        Aliases: null
+        Args: null
+        Description: ""
+        Examples: null
       Delimit:
         Aliases:
         - delimit

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/fsync v0.10.1
 	github.com/spf13/pflag v1.0.7
-	github.com/tdewolff/minify/v2 v2.24.0
+	github.com/tdewolff/minify/v2 v2.24.2
 	github.com/tdewolff/parse/v2 v2.8.3
 	github.com/tetratelabs/wazero v1.9.0
 	github.com/yuin/goldmark v1.7.13

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tdewolff/minify/v2 v2.24.0 h1:m6j8VXvgUtmkavubzHbaNTXi9tw3hjIMZbdc57SRdvI=
-github.com/tdewolff/minify/v2 v2.24.0/go.mod h1:uqtSu3w0+anqk4ofcsuLPZ8tV8yAZL1r/ILWYYl2j3c=
+github.com/tdewolff/minify/v2 v2.24.1 h1:9ZLg8Bnb4a7RxJtOi7WCpHrfHdNZBBzS7vNRQ4NwLW4=
+github.com/tdewolff/minify/v2 v2.24.1/go.mod h1:1JrCtoZXaDbqioQZfk3Jdmr0GPJKiU7c1Apmb+7tCeE=
+github.com/tdewolff/minify/v2 v2.24.2 h1:vnY3nTulEAbCAAlxTxPPDkzG24rsq31SOzp63yT+7mo=
+github.com/tdewolff/minify/v2 v2.24.2/go.mod h1:1JrCtoZXaDbqioQZfk3Jdmr0GPJKiU7c1Apmb+7tCeE=
 github.com/tdewolff/parse/v2 v2.8.3 h1:5VbvtJ83cfb289A1HzRA9sf02iT8YyUwN84ezjkdY1I=
 github.com/tdewolff/parse/v2 v2.8.3/go.mod h1:Hwlni2tiVNKyzR1o6nUs4FOF07URA+JLBLd6dlIXYqo=
 github.com/tdewolff/test v1.0.11 h1:FdLbwQVHxqG16SlkGveC0JVyrJN62COWTRyUFzfbtBE=

--- a/minifiers/config_test.go
+++ b/minifiers/config_test.go
@@ -42,62 +42,87 @@ func TestConfig(t *testing.T) {
 	c.Assert(conf.Tdewolff.HTML.KeepWhitespace, qt.Equals, false)
 	// default value
 	c.Assert(conf.Tdewolff.HTML.KeepEndTags, qt.Equals, true)
-	c.Assert(conf.Tdewolff.CSS.KeepCSS2, qt.Equals, true)
+	c.Assert(conf.Tdewolff.CSS.Version, qt.Equals, 0)
 
 	// `enable` flags
 	c.Assert(conf.DisableHTML, qt.Equals, false)
 	c.Assert(conf.DisableXML, qt.Equals, true)
 }
 
-func TestConfigLegacy(t *testing.T) {
+func TestConfigDeprecations(t *testing.T) {
 	c := qt.New(t)
+
+	// Test default values of deprecated root keys.
 	v := config.New()
-
-	// This was a bool < Hugo v0.58.
-	v.Set("minify", true)
-
+	v.Set("minify", false)
 	conf := testconfig.GetTestConfigs(nil, v).Base.Minify
+	c.Assert(conf.MinifyOutput, qt.Equals, false)
+
+	v = config.New()
+	v.Set("minifyoutput", false)
+	conf = testconfig.GetTestConfigs(nil, v).Base.Minify
+	c.Assert(conf.MinifyOutput, qt.Equals, false)
+
+	// Test non-default values of deprecated root keys.
+	v = config.New()
+	v.Set("minify", true)
+	conf = testconfig.GetTestConfigs(nil, v).Base.Minify
+	c.Assert(conf.MinifyOutput, qt.Equals, true)
+
+	v = config.New()
+	v.Set("minifyoutput", true)
+	conf = testconfig.GetTestConfigs(nil, v).Base.Minify
 	c.Assert(conf.MinifyOutput, qt.Equals, true)
 }
 
-func TestConfigNewCommentOptions(t *testing.T) {
+func TestConfigUpstreamDeprecations(t *testing.T) {
 	c := qt.New(t)
-	v := config.New()
 
-	// setting the old options should automatically set the new options
+	// Test default values of deprecated keys.
+	v := config.New()
 	v.Set("minify", map[string]any{
 		"tdewolff": map[string]any{
+			"css": map[string]any{
+				"decimals": 0,
+				"keepcss2": true,
+			},
 			"html": map[string]any{
-				"keepConditionalComments": false,
+				"keepconditionalcomments": true,
 			},
 			"svg": map[string]any{
-				"decimal": "5",
+				"decimals": 0,
 			},
 		},
 	})
 
 	conf := testconfig.GetTestConfigs(nil, v).Base.Minify
 
-	c.Assert(conf.Tdewolff.HTML.KeepSpecialComments, qt.Equals, false)
-	c.Assert(conf.Tdewolff.SVG.Precision, qt.Equals, 5)
+	c.Assert(conf.Tdewolff.CSS.Precision, qt.Equals, 0)
+	c.Assert(conf.Tdewolff.CSS.Version, qt.Equals, 2)
+	c.Assert(conf.Tdewolff.HTML.KeepSpecialComments, qt.Equals, true)
+	c.Assert(conf.Tdewolff.SVG.Precision, qt.Equals, 0)
 
-	// the new values should win, regardless of the contents of the old values
+	// Test non-default values of deprecated keys.
 	v = config.New()
 	v.Set("minify", map[string]any{
 		"tdewolff": map[string]any{
+			"css": map[string]any{
+				"decimals": 6,
+				"keepcss2": false,
+			},
 			"html": map[string]any{
-				"keepConditionalComments": false,
-				"keepSpecialComments":     true,
+				"keepconditionalcomments": false,
 			},
 			"svg": map[string]any{
-				"decimal":   "5",
-				"precision": "10",
+				"decimals": 7,
 			},
 		},
 	})
 
 	conf = testconfig.GetTestConfigs(nil, v).Base.Minify
 
-	c.Assert(conf.Tdewolff.HTML.KeepSpecialComments, qt.Equals, true)
-	c.Assert(conf.Tdewolff.SVG.Precision, qt.Equals, 10)
+	c.Assert(conf.Tdewolff.CSS.Precision, qt.Equals, 6)
+	c.Assert(conf.Tdewolff.CSS.Version, qt.Equals, 0)
+	c.Assert(conf.Tdewolff.HTML.KeepSpecialComments, qt.Equals, false)
+	c.Assert(conf.Tdewolff.SVG.Precision, qt.Equals, 7)
 }

--- a/minifiers/minifiers_test.go
+++ b/minifiers/minifiers_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gohugoio/hugo/minifiers"
 	"github.com/gohugoio/hugo/output"
 	"github.com/spf13/afero"
-	"github.com/tdewolff/minify/v2/html"
 )
 
 func TestNew(t *testing.T) {
@@ -165,52 +164,4 @@ func TestBugs(t *testing.T) {
 		c.Assert(m.Minify(test.tp, &b, strings.NewReader(test.rawString)), qt.IsNil)
 		c.Assert(b.String(), qt.Equals, test.expectedMinString)
 	}
-}
-
-// Renamed to Precision in v2.7.0. Check that we support both.
-func TestDecodeConfigDecimalIsNowPrecision(t *testing.T) {
-	c := qt.New(t)
-	v := config.New()
-	v.Set("minify", map[string]any{
-		"disablexml": true,
-		"tdewolff": map[string]any{
-			"css": map[string]any{
-				"decimal": 3,
-			},
-			"svg": map[string]any{
-				"decimal": 3,
-			},
-		},
-	})
-
-	conf := testconfig.GetTestConfigs(nil, v).Base.Minify
-
-	c.Assert(conf.Tdewolff.CSS.Precision, qt.Equals, 3)
-}
-
-// Issue 9456
-func TestDecodeConfigKeepWhitespace(t *testing.T) {
-	c := qt.New(t)
-	v := config.New()
-	v.Set("minify", map[string]any{
-		"tdewolff": map[string]any{
-			"html": map[string]any{
-				"keepEndTags": false,
-			},
-		},
-	})
-
-	conf := testconfig.GetTestConfigs(nil, v).Base.Minify
-
-	c.Assert(conf.Tdewolff.HTML, qt.DeepEquals,
-		html.Minifier{
-			KeepComments:        false,
-			KeepSpecialComments: true,
-			KeepDefaultAttrVals: true,
-			KeepDocumentTags:    true,
-			KeepEndTags:         false,
-			KeepQuotes:          false,
-			KeepWhitespace:      false,
-		},
-	)
 }


### PR DESCRIPTION
1. With `minify.tdewolff.css` and `minify.tdewolff.svg`, check for `decimals` instead of `decimal`

2. Add deprecation messages for:

    - `minify.tdewolff.css.decimals`
    - `minify.tdewolff.svg.decimals`
    - `minify.tdewolff.html.keepconditionalcomments`
    - config root `minify` (bool)
    - config root `minifyoutput` (bool)

3. Deprecate `minify.tdewolff.css.keepcss2` in favor of `minify.tdewolff.css.version`

4. Refactor minify configuration tests

Closes #11893
Closes #13947
Closes #13948