### PR TITLE
Remove noindex meta tag from alias.html

### DIFF
--- a/tpl/tplimpl/embedded/templates/alias.html
+++ b/tpl/tplimpl/embedded/templates/alias.html
@@ -3,7 +3,6 @@
   <head>
     <title>{{ .Permalink }}</title>
     <link rel="canonical" href="{{ .Permalink }}">
-    <meta name="robots" content="noindex">
     <meta charset="utf-8">
     <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
   </head>


### PR DESCRIPTION
Google does not behave as expected when an alias is used. It does not index the client-side alias page, but on top of that it also does not index the original page.

Google does not require noindex to be present and since alias pages do not have any content, it makes little sense to provide it. Therefore, this patch removes the line completely.

https://developers.google.com/search/docs/crawling-indexing/301-redirects

---

I have a blog that has 80% of all the content with alias (converted from old format) and it turns out Google does not index any of it. The culprit was the `noindex`, I do not understand why Google does this but this is quite dangerous default behavior of hugo. I [reported this today](https://discourse.gohugo.io/t/google-ignoring-pages-with-alias/55811/8) and I also [found another user](https://discourse.gohugo.io/t/aliases-appear-not-to-work-properly-in-the-new-google-search-console/16246) who had noticed this some time ago.

As I describe in the commit message above, I do not think the `noindex` statement provides any value, the crawler understands that it is being redirected and since there is no content in the alias page, it does make little sense to index it twice.

Thus I propose this change as a prevention from removing content from Google index for no apparent reason. Cheers.

Edit: I have realized there is actually HTML title which contains the original URL, this is actually a bit of information that could be indexed and document found (depending on a search engine implementation). Therefore, it probably makes sense to remove the title so that there is literally no indexable content at all thus there is zero chance actually getting it in the results.