### PR TITLE
fix: envStringToVal array parse and add ignorefiles and ignorelogs into case

### DIFF
--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -280,7 +280,14 @@ func (l *configLoader) envValToVal(k string, v any) any {
 
 func (l *configLoader) envStringToVal(k, v string) any {
 	switch k {
-	case "disablekinds", "disablelanguages":
+	case "disablekinds", "disablelanguages", "ignorefiles", "ignorelogs":
+		v = strings.TrimSpace(v)
+		if strings.HasPrefix(v, "[") && strings.HasSuffix(v, "]") {
+			if parsed, err := metadecoders.Default.UnmarshalStringTo(v, []any{}); err == nil {
+				return parsed
+			}
+		}
+
 		if strings.Contains(v, ",") {
 			return strings.Split(v, ",")
 		} else {


### PR DESCRIPTION
## Solution

Extended `envStringToVal()` to handle `ignorefiles` and `ignorelogs` as they are also array type.

Besides, array parsing is enhanced which the given string is also parsed with `UnmarshalStringTo` if it has prefix `[` and suffix `]`.

Here is the fixed result, `hugo` is the latest hugo release, and `../hugo/hugo` is my local build

<img width="1087" height="179" alt="圖片" src="https://github.com/user-attachments/assets/8d190569-6cf9-408f-9c42-6e348cac130c" />


Fixes #13950