### PR TITLE
modules: Add support for direct version module imports in hugo.toml

### DIFF
--- a/modules/client_test.go
+++ b/modules/client_test.go
@@ -227,7 +227,7 @@ func TestClientConfigToEnv(t *testing.T) {
 
 	env := ccfg.toEnv()
 
-	c.Assert(env, qt.DeepEquals, []string{"PWD=/mywork", "GO111MODULE=on", "GOPATH=/mycache", "GOWORK=", filepath.FromSlash("GOCACHE=/mycache/pkg/mod")})
+	c.Assert(env, qt.DeepEquals, []string{"PWD=/mywork", "GO111MODULE=on", "GOFLAGS=-modcacherw", "GOPATH=/mycache", "GOWORK=", filepath.FromSlash("GOCACHE=/mycache/pkg/mod")})
 
 	ccfg = ClientConfig{
 		WorkingDir: "/mywork",
@@ -246,6 +246,7 @@ func TestClientConfigToEnv(t *testing.T) {
 	c.Assert(env, qt.DeepEquals, []string{
 		"PWD=/mywork",
 		"GO111MODULE=on",
+		"GOFLAGS=-modcacherw",
 		"GOPATH=/mycache",
 		"GOWORK=myworkspace",
 		filepath.FromSlash("GOCACHE=/mycache/pkg/mod"),

--- a/modules/collect_test.go
+++ b/modules/collect_test.go
@@ -32,7 +32,7 @@ func TestPathKey(t *testing.T) {
 		{"github.com/foo/v3d", "github.com/foo/v3d"},
 		{"MyTheme", "mytheme"},
 	} {
-		c.Assert(pathKey(test.in), qt.Equals, test.expect)
+		c.Assert(pathBase(test.in), qt.Equals, test.expect)
 	}
 }
 

--- a/modules/config.go
+++ b/modules/config.go
@@ -377,6 +377,11 @@ func (v HugoVersion) IsValid() bool {
 type Import struct {
 	// Module path
 	Path string
+
+	// The common case is to leave this empty and let Go Modules resolve the version.
+	// Can be set to a version query, e.g. "v1.2.3", ">=v1.2.0", "latest", which will
+	// make this a direct dependency.
+	Version string
 	// Set when Path is replaced in project config.
 	pathProjectReplaced bool
 	// Ignore any config in config.toml (will still follow imports).

--- a/modules/modules_integration_test.go
+++ b/modules/modules_integration_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules_test
+
+import (
+	"testing"
+
+	"github.com/gohugoio/hugo/hugolib"
+)
+
+func TestModuleImportWithVersion(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org"
+[[module.imports]]
+path    = "github.com/bep/hugo-mod-misc/dummy-content"
+version = "v0.2.0"
+[[module.imports]]
+path    = "github.com/bep/hugo-mod-misc/dummy-content"
+version = "v0.1.0"
+[[module.imports.mounts]]
+source = "content"
+target = "content/v1"
+-- layouts/all.html --
+Title: {{ .Title }}|Summary: {{ .Summary }}|
+Deps: {{ range hugo.Deps}}{{ printf "%s@%s" .Path .Version }}|{{ end }}$
+
+
+`
+
+	b := hugolib.Test(t, files, hugolib.TestOptWithOSFs()).Build()
+
+	b.AssertFileContent("public/index.html", "Deps: project@|github.com/bep/hugo-mod-misc/dummy-content@v0.2.0|github.com/bep/hugo-mod-misc/dummy-content@v0.1.0|$")
+
+	b.AssertFileContent("public/blog/music/autumn-leaves/index.html", "Autumn Leaves is a popular jazz standard") // v0.2.0
+	b.AssertFileContent("public/v1/blog/music/autumn-leaves/index.html", "Lorem markdownum, placidi peremptis")   // v0.1.0
+}

--- a/testscripts/commands/mod__hugodirectsum.txt
+++ b/testscripts/commands/mod__hugodirectsum.txt
@@ -1,0 +1,15 @@
+hugo mod graph
+stdout 'foo'
+grep 'github.com/bep/hugo-mod-nop v1.0.0 h1:NRDMRPCD\+4dw5K8XvaZURvZJCfBMCifkRe6C6x6W4II=' hugo.direct.sum
+
+-- hugo.toml --
+baseURL = "https://example.org"
+[[module.imports]]
+path    = "github.com/bep/hugo-mod-nop"
+version = "v1.0.0"
+-- layouts/all.html --
+All.
+-- go.mod --
+module foo
+
+go 1.24.0

--- a/testscripts/commands/mod__hugodirectsum_tamper.txt
+++ b/testscripts/commands/mod__hugodirectsum_tamper.txt
@@ -1,0 +1,16 @@
+! hugo
+stderr 'checksum mismatch'
+
+-- hugo.toml --
+baseURL = "https://example.org"
+[[module.imports]]
+path    = "github.com/bep/hugo-mod-nop"
+version = "v1.0.0"
+-- layouts/all.html --
+All.
+-- go.mod --
+module foo
+
+go 1.24.0
+-- hugo.direct.sum --
+github.com/bep/hugo-mod-nop v1.0.0 h1:NRDMRPCD+4dw5K8XvaZURvZJCfBMCifkRe6C6x6W4Ix=

--- a/testscripts/commands/mod__tamper_gosum.txt
+++ b/testscripts/commands/mod__tamper_gosum.txt
@@ -1,0 +1,22 @@
+
+# We're not testing Go's security here, so we just edit the go.sum and verifies that the build fails.
+
+! hugo
+stderr 'checksum mismatch'
+
+
+-- hugo.toml --
+baseURL = "https://example.org"
+[[module.imports]]
+path    = "github.com/bep/hugo-mod-nop"
+-- layouts/all.html --
+All.
+-- go.mod --
+module foo
+
+go 1.24.0
+
+require github.com/bep/hugo-mod-nop v1.0.0 // indirect
+-- go.sum --
+github.com/bep/hugo-mod-nop v1.0.0 h1:NRDMRPCD+4dw5K8XvaZURvZJCfBMCifkRe6C6x6W4II=
+github.com/bep/hugo-mod-nop v1.0.0/go.mod h1:6cqjOCVJHP6+aQ+5IYvaS9j8BfIVksAct4xzl9OnmIX=

--- a/testscripts/commands/mod_vendor__versions.txt
+++ b/testscripts/commands/mod_vendor__versions.txt
@@ -1,0 +1,102 @@
+dostounix golden/vendor.txt
+
+hugo mod vendor
+cmp _vendor/modules.txt golden/vendor.txt
+lsr _vendor
+stdout 'github.com/bep/hugo-mod-misc/dummy-content@%3C%3Dv0.1.0/config.toml'
+stdout 'github.com/bep/hugo-mod-misc/dummy-content@v0.2.0/config.toml'
+stdout 'github.com/bep/hugo-mod-misc/dummy-content@v0.2.0/content/blog/music/all-of-me/index.md'
+stdout 'github.com/bep/hugo-mod-misc/dummy-content@v0.2.0/content/blog/music/blue-bossa/index.md'
+stdout 'github.com/bep/hugo-mod-misc/dummy-content@%3C%3Dv0.1.0/content/blog/music/all-of-me/index.md'
+! stdout 'github.com/bep/hugo-mod-misc/dummy-content@%3C%3Dv0.1.0/content/blog/music/blue-bossa/index.md' # not mounted
+
+hugo mod graph
+stdout 'project github.com/bep/hugo-mod-misc/dummy-content@v0.2.0' 
+stdout 'project github.com/bep/hugo-mod-misc/dummy-content@v0.1.0'
+
+hugo config mounts
+[unix] cmpenv stdout golden/mounts.json
+
+-- hugo.toml --
+baseURL = "https://example.org"
+[[module.imports]]
+path    = "github.com/bep/hugo-mod-misc/dummy-content"
+version = "v0.2.0"
+[[module.imports]]
+path    = "github.com/bep/hugo-mod-misc/dummy-content"
+version = "<=v0.1.0"
+[[module.imports.mounts]]
+source = "content/blog/music/all-of-me"
+target = "content/all"
+-- layouts/all.html --
+Title: {{ .Title }}|Summary: {{ .Summary }}|
+Deps: {{ range hugo.Deps}}{{ printf "%s@%s" .Path .Version }}|{{ end }}$
+
+
+-- golden/vendor.txt --
+# github.com/bep/hugo-mod-misc/dummy-content@v0.2.0 v0.2.0
+# github.com/bep/hugo-mod-misc/dummy-content@%3C%3Dv0.1.0 v0.1.0
+-- golden/mounts.json --
+{
+   "path": "project",
+   "version": "",
+   "time": "0001-01-01T00:00:00Z",
+   "owner": "",
+   "dir": "$WORK",
+   "mounts": [
+      {
+         "source": "content",
+         "target": "content"
+      },
+      {
+         "source": "data",
+         "target": "data"
+      },
+      {
+         "source": "layouts",
+         "target": "layouts"
+      },
+      {
+         "source": "i18n",
+         "target": "i18n"
+      },
+      {
+         "source": "archetypes",
+         "target": "archetypes"
+      },
+      {
+         "source": "assets",
+         "target": "assets"
+      },
+      {
+         "source": "static",
+         "target": "static"
+      }
+   ]
+}
+{
+   "path": "github.com/bep/hugo-mod-misc/dummy-content",
+   "version": "v0.2.0",
+   "time": "0001-01-01T00:00:00Z",
+   "owner": "project",
+   "dir": "$WORK/_vendor/github.com/bep/hugo-mod-misc/dummy-content@v0.2.0/",
+   "mounts": [
+      {
+         "source": "content",
+         "target": "content"
+      }
+   ]
+}
+{
+   "path": "github.com/bep/hugo-mod-misc/dummy-content",
+   "version": "v0.1.0",
+   "time": "0001-01-01T00:00:00Z",
+   "owner": "project",
+   "dir": "$WORK/_vendor/github.com/bep/hugo-mod-misc/dummy-content@%3C%3Dv0.1.0/",
+   "mounts": [
+      {
+         "source": "content/blog/music/all-of-me",
+         "target": "content/all"
+      }
+   ]
+}


### PR DESCRIPTION
Fixes #13964

## Notes

* `version` can be blank or set to a Go Module [version query](https://go.dev/ref/mod#version-queries). It's recommended to stick to tagged version values following [Go Modules version numbering scheme](https://go.dev/doc/modules/version-numbers), e.g. `v1.0.0`. This enables [module caching](https://gohugo.io/configuration/caches/) and you avoid having to download the module every time you run `hugo`. Also see [module vendoring](https://gohugo.io/commands/hugo_mod_vendor/#hugo-mod-vendor).
* If `version` is set, we call it a direct dependency, in contrast to dependencies managed by Go Modules.
* With only direct dependencies (including its transitive dependencies), you don't need a `go.mod`.  For transitive dependencies, see [noimports](https://gohugo.io/configuration/module/#ignoreimports).
* You can import the same `path` multiple times with different values of `version`, but you need to think about how to mount the different versions into your project. But note that in the first version of this new feature you can only have one import per resolved version of a given `path`, but each import can have multiple mount definitions. Also see the [nomounts].(https://gohugo.io/configuration/module/#nomounts)  config setting.
* The command `hugo mod get` will only work on module imports without a `version` set, so for these you either need to edit the config file or set a loose [version query](https://go.dev/ref/mod#version-queries) (e.g. `main`, `latest`, `>v1.0.0`) . Note that Go Module's Minimum Version Selection (MVS) is not relevant for these imports.


## TODOs

- [x] vendoring with `hugo mod vendor`. 
- [x] `go.sum`; imports with `version` set will not en up in `go.{mod,sum}`. The first can be a good thing (because you don't need a `go.mod` file for simpler setups). But without a `sum` entry, we don't get the security it gives, which I think is worth going the extra mile. I think that the tooling for this should be relatively straight forward and that we could create an extra `hugo.direct.sum` (#13971 will give us a `hugo.sum`) file for these entries).
- [x] Decide how the path printed in `go mod graph`, `hugo config mounts`, `vendor.txt` should look like this;  I think the pattern I currently use for vendoring will be OK and give the most flexibility re. `--ignoreVendorPaths` matching and would make it unique. See example below.
- [x] Add some tests.

Sample `vendor.txt`:

```
# github.com/bep/hugo-mod-misc/dummy-content v0.3.0
# github.com/bep/hugo-mod-misc/dummy-content@v0.1.0 v0.1.0
# github.com/bep/hugo-mod-misc/dummy-content@v0.2.0 v0.2.0
```
The entries resolved via a `version` in config have a pseudo path constructed with `[path]@[resolved version]`.


