### PR TITLE
markup/goldmark: Enhance footnote extension with auto-prefixing option

### DIFF
--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -1238,7 +1238,9 @@ config:
             enable: false
           superscript:
             enable: false
-        footnote: true
+        footnote:
+          enable: true
+          enableAutoIDPrefix: false
         linkify: true
         linkifyProtocol: https
         passthrough:

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -794,11 +794,9 @@ func (p *pageMeta) newContentConverter(ps *pageState, markup string) (converter.
 		return converter.NopConverter, fmt.Errorf("no content renderer found for markup %q, page: %s", markup, ps.getPageInfoForError())
 	}
 
-	var id string
 	var filename string
 	var path string
 	if p.f != nil {
-		id = p.f.UniqueID()
 		filename = p.f.Filename()
 		path = p.f.Path()
 	} else {
@@ -822,7 +820,7 @@ func (p *pageMeta) newContentConverter(ps *pageState, markup string) (converter.
 		converter.DocumentContext{
 			Document:       doc,
 			DocumentLookup: documentLookup,
-			DocumentID:     id,
+			DocumentID:     hashing.XxHashFromStringHexEncoded(p.Path()),
 			DocumentName:   path,
 			Filename:       filename,
 		},

--- a/markup/goldmark/goldmark_config/config.go
+++ b/markup/goldmark/goldmark_config/config.go
@@ -40,7 +40,10 @@ var Default = Config{
 			RightAngleQuote:  "&raquo;",
 			Apostrophe:       "&rsquo;",
 		},
-		Footnote:        true,
+		Footnote: Footnote{
+			Enable:             true,
+			EnableAutoIDPrefix: false,
+		},
 		DefinitionList:  true,
 		Table:           true,
 		Strikethrough:   true,
@@ -152,7 +155,7 @@ type LinkRenderHook struct {
 
 type Extensions struct {
 	Typographer    Typographer
-	Footnote       bool
+	Footnote       Footnote
 	DefinitionList bool
 	Extras         Extras
 	Passthrough    Passthrough
@@ -164,6 +167,12 @@ type Extensions struct {
 	LinkifyProtocol string
 	TaskList        bool
 	CJK             CJK
+}
+
+// Footnote holds footnote configuration.
+type Footnote struct {
+	Enable             bool
+	EnableAutoIDPrefix bool
 }
 
 // Typographer holds typographer configuration.

--- a/markup/markup_config/config.go
+++ b/markup/markup_config/config.go
@@ -86,20 +86,26 @@ func normalizeConfig(m map[string]any) {
 		}
 	}
 
-	// Changed from a bool in 0.112.0.
+	// Handle changes to the Goldmark configuration.
 	v, err = maps.GetNestedParam("goldmark.extensions", ".", m)
 	if err == nil {
 		vm := maps.ToStringMap(v)
-		const typographerKey = "typographer"
-		if vv, found := vm[typographerKey]; found {
-			if vvb, ok := vv.(bool); ok {
-				if !vvb {
-					vm[typographerKey] = goldmark_config.Typographer{
-						Disable: true,
-					}
-				} else {
-					delete(vm, typographerKey)
-				}
+
+		// We changed the typographer extension config from a bool to a struct in 0.112.0.
+		migrateGoldmarkConfig(vm, "typographer", goldmark_config.Typographer{Disable: true})
+
+		// We changed the footnote extension config from a bool to a struct in 0.151.0.
+		migrateGoldmarkConfig(vm, "footnote", goldmark_config.Footnote{Enable: false})
+	}
+}
+
+func migrateGoldmarkConfig(vm map[string]any, key string, falseVal any) {
+	if vv, found := vm[key]; found {
+		if vvb, ok := vv.(bool); ok {
+			if !vvb {
+				vm[key] = falseVal
+			} else {
+				delete(vm, key)
 			}
 		}
 	}

--- a/markup/markup_config/config_test.go
+++ b/markup/markup_config/config_test.go
@@ -52,14 +52,16 @@ func TestConfig(t *testing.T) {
 		c.Assert(conf.AsciidocExt.Extensions[0], qt.Equals, "asciidoctor-html5s")
 	})
 
-	c.Run("Decode legacy typographer", func(c *qt.C) {
+	// We changed the typographer extension config from a bool to a struct in 0.112.0.
+	// We changed the footnote extension config from a bool to a struct in 0.151.0.
+	c.Run("Decode legacy Goldmark configs", func(c *qt.C) {
 		c.Parallel()
 		v := config.New()
 
-		// typographer was changed from a bool to a struct in 0.112.0.
 		v.Set("markup", map[string]any{
 			"goldmark": map[string]any{
 				"extensions": map[string]any{
+					"footnote":    false,
 					"typographer": false,
 				},
 			},
@@ -68,11 +70,13 @@ func TestConfig(t *testing.T) {
 		conf, err := Decode(v)
 
 		c.Assert(err, qt.IsNil)
+		c.Assert(conf.Goldmark.Extensions.Footnote.Enable, qt.Equals, false)
 		c.Assert(conf.Goldmark.Extensions.Typographer.Disable, qt.Equals, true)
 
 		v.Set("markup", map[string]any{
 			"goldmark": map[string]any{
 				"extensions": map[string]any{
+					"footnote":    true,
 					"typographer": true,
 				},
 			},
@@ -81,6 +85,7 @@ func TestConfig(t *testing.T) {
 		conf, err = Decode(v)
 
 		c.Assert(err, qt.IsNil)
+		c.Assert(conf.Goldmark.Extensions.Footnote.Enable, qt.Equals, true)
 		c.Assert(conf.Goldmark.Extensions.Typographer.Disable, qt.Equals, false)
 		c.Assert(conf.Goldmark.Extensions.Typographer.Ellipsis, qt.Equals, "&hellip;")
 	})


### PR DESCRIPTION
This commit introduces a new option, `enableAutoIDPrefix`, to the Goldmark footnote extension. When enabled, it prepends a unique prefix to footnote IDs, preventing clashes when multiple documents are rendered together. This prefix is unique to each logical path, which means that the prefix is not unique across content dimensions such as language. This change also refactors the extension's configuration from a boolean to a struct.

Closes #8045