### PR TITLE
Add List function for struct field names and map keys

### DIFF
--- a/tpl/debug/debug.go
+++ b/tpl/debug/debug.go
@@ -124,10 +124,9 @@ func (ns *Namespace) VisualizeSpaces(val any) string {
 // List returns a string slice of field names and methods for structs/pointers,
 // or keys for maps. This function uses reflection and is non-recursive.
 // For structs and pointers to structs, it returns all exported field names and method names.
-// Note: Method names are collected using reflect.PointerTo(t), which includes both value and pointer receiver methods.
+// Method names include both value and pointer receiver methods.
 // For maps, it returns all keys converted to strings.
 // For other types, it returns an empty slice.
-func (ns *Namespace) List(val any) []string {
 func (ns *Namespace) List(val any) []string {
 	if val == nil {
 		return []string{}

--- a/tpl/debug/debug.go
+++ b/tpl/debug/debug.go
@@ -124,8 +124,10 @@ func (ns *Namespace) VisualizeSpaces(val any) string {
 // List returns a string slice of field names and methods for structs/pointers,
 // or keys for maps. This function uses reflection and is non-recursive.
 // For structs and pointers to structs, it returns all exported field names and method names.
+// Note: Method names are collected using reflect.PointerTo(t), which includes both value and pointer receiver methods.
 // For maps, it returns all keys converted to strings.
 // For other types, it returns an empty slice.
+func (ns *Namespace) List(val any) []string {
 func (ns *Namespace) List(val any) []string {
 	if val == nil {
 		return []string{}

--- a/tpl/debug/debug_integration_test.go
+++ b/tpl/debug/debug_integration_test.go
@@ -73,3 +73,41 @@ Dump: {{ debug.Dump . | safeHTML }}
 	b := hugolib.TestRunning(t, files)
 	b.AssertFileContent("public/index.html", "Dump: {\n  \"Date\": \"2012-03-15T00:00:00Z\"")
 }
+
+func TestDebugList(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+disableLiveReload = true
+-- content/_index.md --
+---
+title: "The Index"
+---
+-- layouts/_default/list.html --
+{{ $dict := dict "name" "Hugo" "version" "0.120" "type" "SSG" }}
+Map Keys: {{ debug.List $dict }}
+
+{{ $page := . }}
+Page Fields: {{ debug.List $page }}
+
+Nil: {{ debug.List nil }}
+String: {{ debug.List "hello" }}
+Number: {{ debug.List 42 }}
+Slice: {{ debug.List (slice 1 2 3) }}
+
+
+`
+	b := hugolib.TestRunning(t, files)
+
+	// Test map keys
+	b.AssertFileContent("public/index.html", "Map Keys: [name type version]")
+
+	// Test that page struct returns field names and methods (should include common page fields)
+	b.AssertFileContent("public/index.html", "Page Fields:")
+
+	// Test edge cases
+	b.AssertFileContent("public/index.html", "Nil: []")
+	b.AssertFileContent("public/index.html", "String: []")
+	b.AssertFileContent("public/index.html", "Number: []")
+	b.AssertFileContent("public/index.html", "Slice: []")
+}

--- a/tpl/debug/debug_integration_test.go
+++ b/tpl/debug/debug_integration_test.go
@@ -94,8 +94,6 @@ Nil: {{ debug.List nil }}
 String: {{ debug.List "hello" }}
 Number: {{ debug.List 42 }}
 Slice: {{ debug.List (slice 1 2 3) }}
-
-
 `
 	b := hugolib.TestRunning(t, files)
 

--- a/tpl/debug/debug_integration_test.go
+++ b/tpl/debug/debug_integration_test.go
@@ -104,6 +104,8 @@ Slice: {{ debug.List (slice 1 2 3) }}
 
 	// Test that page struct returns field names and methods (should include common page fields)
 	b.AssertFileContent("public/index.html", "Page Fields:")
+	b.AssertFileContent("public/index.html", "Title")
+	b.AssertFileContent("public/index.html", "Content")
 
 	// Test edge cases
 	b.AssertFileContent("public/index.html", "Nil: []")

--- a/tpl/debug/init.go
+++ b/tpl/debug/init.go
@@ -40,6 +40,14 @@ func init() {
 			},
 		)
 
+		ns.AddMethodMapping(ctx.List,
+			nil,
+			[][2]string{
+				{`{{ $s := dict "name" "Hugo" "type" "SSG" }}
+{{ debug.List $s }}`, `[name type]`},
+			},
+		)
+
 		return ns
 	}
 


### PR DESCRIPTION
Introduce a List function that retrieves field names and method names from structs or keys from maps using reflection. This addition enhances the debugging capabilities by providing a way to inspect data structures more effectively. Include tests to validate the functionality across various data types.

Resolve #9148