### PR TITLE
skip livereload.js injection if no tags found

### DIFF
--- a/testscripts/commands/server.txt
+++ b/testscripts/commands/server.txt
@@ -24,6 +24,7 @@ myenv = "theproduction"
 -- config/development/params.toml --
 myenv = "thedevelopment"
 -- layouts/index.html --
+<!DOCTYPE html>
 <body>
 Title: {{ .Title }}|BaseURL: {{ site.BaseURL }}|ServerPort: {{ site.ServerPort }}|myenv: {{ .Site.Params.myenv }}|Env: {{ hugo.Environment }}|IsServer: {{ hugo.IsServer }}|
 </body>

--- a/transform/livereloadinject/livereloadinject.go
+++ b/transform/livereloadinject/livereloadinject.go
@@ -49,6 +49,15 @@ func New(baseURL *url.URL) transform.Transformer {
 			idx += len(ignoredSyntax.Find(b[idx:]))
 			idx += len(tag.Find(b[idx:]))
 		}
+		if idx == 0 {
+			// doctype is required for HTML5, we did not find it,
+			// and neither did we find html or head tags, so
+			// skip injection.
+			// This allows us to render partial HTML documents to be used in
+			// e.g. JS frameworks.
+			ft.To().Write(b)
+			return nil
+		}
 
 		path := strings.TrimSuffix(baseURL.Path, "/")
 

--- a/transform/livereloadinject/livereloadinject_test.go
+++ b/transform/livereloadinject/livereloadinject_test.go
@@ -59,12 +59,12 @@ func TestLiveReloadInject(t *testing.T) {
 		c.Assert(apply("<!doctype html>after"), qt.Equals, "<!doctype html>"+expectBase+"after")
 	})
 
-	c.Run("Inject before other elements if all else omitted", func(c *qt.C) {
-		c.Assert(apply("<title>after</title>"), qt.Equals, expectBase+"<title>after</title>")
+	c.Run("Inject nothing if no doctype, html or head found", func(c *qt.C) {
+		c.Assert(apply("<title>after</title>"), qt.Equals, "<title>after</title>")
 	})
 
-	c.Run("Inject before text content if all else omitted", func(c *qt.C) {
-		c.Assert(apply("after"), qt.Equals, expectBase+"after")
+	c.Run("Inject nothing if no tag found", func(c *qt.C) {
+		c.Assert(apply("after"), qt.Equals, "after")
 	})
 
 	c.Run("Inject after HeAd tag MiXed CaSe", func(c *qt.C) {


### PR DESCRIPTION
building hugo site with root index.html that serves react app with react-router-dom that contains menu, header, footer and breadcrump and other pages that are build inside`internal` folder that contain only parts of html bodies that are expected to be rendered inside root react app body and livereload.js script is not expected to be injected inside these parts. added condition that ignores injection of livereload.js is no relevant tags found