### PR TITLE
fix(snap): Add `desktop` plug to `snapcraft.yaml`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,6 +89,7 @@ apps:
     plugs:
       - home
       - network-bind
+      - desktop
       - removable-media
       - etc-gitconfig
       - gitconfig


### PR DESCRIPTION
Currently, when Hugo is installed as a snap, `hugo serve --openBrowser` fails with the following permissions error:

```
WARN  Failed to open browser: fork/exec /usr/bin/xdg-open: permission denied
```

The solution is to add the `desktop` plug in `snap/snapcraft.yaml`, as done here.

I tested this fix by building/running the snap locally on an Ubuntu Desktop 25.04 virtual machine. I don't think there is any automated testing for the build/functionality of the snap but would be happy to add a test if you can point me in the right direction.

References:

- https://snapcraft.io/docs/desktop-interfaces
- https://askubuntu.com/a/1229462