### PR TITLE
hugolib: Change duplicate content path warning to an info log

### DIFF
--- a/hugolib/content_map_test.go
+++ b/hugolib/content_map_test.go
@@ -279,9 +279,9 @@ P1: {{ $p1.Title }}|{{ $p1.Params.foo }}|{{ $p1.File.Filename }}|
 `
 
 	for range 3 {
-		b := Test(t, files, TestOptWarn())
+		b := Test(t, files, TestOptInfo())
 
-		b.AssertLogContains("WARN  Duplicate content path: \"/p1\"")
+		b.AssertLogContains("INFO  Duplicate content path: \"/p1\"")
 
 		// There's multiple content files sharing the same logical path and language.
 		// This is a little arbitrary, but we have to pick one and prefer the Markdown version.

--- a/hugolib/pages_capture.go
+++ b/hugolib/pages_capture.go
@@ -334,7 +334,7 @@ func (c *pagesCollector) collectDirDir(path string, root hugofs.FileMetaInfo, in
 			baseLang := hstrings.Strings2{pi.Base(), meta.Lang}
 			if fi2, ok := seen[baseLang]; ok {
 				if c.h.Configs.Base.PrintPathWarnings && !c.h.isRebuild() {
-					c.logger.Warnf("Duplicate content path: %q file: %q file: %q", pi.Base(), fi2.Meta().Filename, meta.Filename)
+					c.logger.Infof("Duplicate content path: %q file: %q file: %q", pi.Base(), fi2.Meta().Filename, meta.Filename)
 				}
 				continue
 			}


### PR DESCRIPTION
Improves #13993