### PR TITLE
Adjust the terminal progress reporter a little

### DIFF
--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -1763,7 +1763,7 @@ func (sa *sitePagesAssembler) assembleResources() error {
 			if !sa.h.isRebuild() {
 				if ps.hasRenderableOutput() {
 					// For multi output pages this will not be complete, but will have to do for now.
-					sa.h.buildProgress.numPagesToRender.Add(1)
+					sa.h.progressReporter.numPagesToRender.Add(1)
 				}
 			}
 

--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -64,8 +64,8 @@ func (h *HugoSites) Build(config BuildCfg, events ...fsnotify.Event) error {
 		// Don't show progress for fast builds.
 		d := debounce.New(250 * time.Millisecond)
 		d(func() {
-			h.buildProgress.Start()
-			h.reportProgress(func(*progressReporter) (state terminal.ProgressState, progress float64) {
+			h.progressReporter.Start()
+			h.reportProgress(func() (state terminal.ProgressState, progress float64) {
 				// We don't know how many files to process below, so use the intermediate state as the first progress.
 				return terminal.ProgressIntermediate, 1.0
 			})
@@ -76,7 +76,7 @@ func (h *HugoSites) Build(config BuildCfg, events ...fsnotify.Event) error {
 	infol := h.Log.InfoCommand("build")
 	defer loggers.TimeTrackf(infol, time.Now(), nil, "")
 	defer func() {
-		h.reportProgress(func(*progressReporter) (state terminal.ProgressState, progress float64) {
+		h.reportProgress(func() (state terminal.ProgressState, progress float64) {
 			return terminal.ProgressHidden, 1.0
 		})
 		h.buildCounter.Add(1)
@@ -166,14 +166,14 @@ func (h *HugoSites) Build(config BuildCfg, events ...fsnotify.Event) error {
 			if err := h.process(ctx, infol, conf, init, events...); err != nil {
 				return fmt.Errorf("process: %w", err)
 			}
-			h.reportProgress(func(*progressReporter) (state terminal.ProgressState, progress float64) {
-				return terminal.ProgressNormal, 0.2
+			h.reportProgress(func() (state terminal.ProgressState, progress float64) {
+				return terminal.ProgressNormal, 0.15
 			})
 			if err := h.assemble(ctx, infol, conf); err != nil {
 				return fmt.Errorf("assemble: %w", err)
 			}
-			h.reportProgress(func(*progressReporter) (state terminal.ProgressState, progress float64) {
-				return terminal.ProgressNormal, 0.25
+			h.reportProgress(func() (state terminal.ProgressState, progress float64) {
+				return terminal.ProgressNormal, 0.20
 			})
 
 			return nil

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -360,6 +360,7 @@ func newHugoSites(cfg deps.DepsCfg, d *deps.Deps, pageTrees *pageTrees, sites []
 			data:    lazy.New(),
 			gitInfo: lazy.New(),
 		},
+		progressReporter: &progressReporter{},
 	}
 
 	// Assemble dependencies to be used in hugo.Deps.


### PR DESCRIPTION
Mostly to reduce the amount of OSC 9;4 sequences written to stdout.
