### PR TITLE
Reimplement schema partial in JSON-LD to pass spec validation

### DIFF
--- a/tpl/tplimpl/embedded/templates/_partials/schema.html
+++ b/tpl/tplimpl/embedded/templates/_partials/schema.html
@@ -1,56 +1,69 @@
-{{- with or .Title site.Title | plainify }}
-  <meta itemprop="name" content="{{ . }}">
-{{- end }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "{{ with .Params.schemaType }}{{ . }}{{ else }}WebPage{{ end }}",
 
-{{- with or .Description .Summary site.Params.description | plainify | htmlUnescape }}
-  <meta itemprop="description" content="{{ trim . "\n\r\t " }}">
-{{- end }}
+  {{- $title := or .Title site.Title | plainify }}
+  "name": "{{ $title }}",
 
-{{- $ISO8601 := "2006-01-02T15:04:05-07:00" }}
-{{- with .PublishDate }}
-  <meta itemprop="datePublished" {{ .Format $ISO8601 | printf "content=%q" | safeHTMLAttr }}>
-{{- end }}
+  {{- with or .Description .Summary site.Params.description | plainify | htmlUnescape }}
+    "description": "{{ trim . "\n\r\t " }}",
+  {{- end }}
 
-{{- with .Lastmod }}
-  <meta itemprop="dateModified" {{ .Format $ISO8601 | printf "content=%q" | safeHTMLAttr }}>
-{{- end }}
+  {{- $ISO8601 := "2006-01-02T15:04:05-07:00" }}
+  {{- with .PublishDate }}
+  "datePublished": "{{ .Format $ISO8601 }}",
+  {{- end }}
+  {{- with .Lastmod }}
+  "dateModified": "{{ .Format $ISO8601 }}",
+  {{- end }}
+  {{- with .WordCount }}
+  "wordCount": {{ . }},
+  {{- end }}
 
-{{- with .WordCount }}
-  <meta itemprop="wordCount" content="{{ . }}">
-{{- end }}
+  {{- $images := partial "_funcs/get-page-images" . }}
+  {{- with $images }}
+  "image": [
+    {{- range $i, $img := first 6 . -}}
+      "{{ $img.Permalink }}"{{ if lt (add $i 1) (len (first 6 $images)) }},{{ end }}
+    {{- end }}
+  ],
+  {{- end }}
 
-{{- $images := partial "_funcs/get-page-images" . }}
-{{- range first 6 $images }}
-  <meta itemprop="image" content="{{ .Permalink }}">
-{{- end }}
+  {{- /*
+  Keywords precedence:
 
-{{- /*
-Keywords precedence:
+  1. Use "keywords" term page titles.
+  2. Use "keywords" from front matter if "keywords" is not a taxonomy.
+  3. Use "tags" term page titles.
+  4. Use term page titles from all taxonomies.
 
-1. Use "keywords" term page titles.
-2. Use "keywords" from front matter if "keywords" is not a taxonomy.
-3. Use "tags" term page titles.
-4. Use term page titles from all taxonomies.
-
-*/}}
-{{- $keywords := slice }}
-{{- range .GetTerms "keywords" }}
-  {{- $keywords = $keywords | append .Title }}
-{{- else }}
-  {{- with .Keywords }}
-    {{- $keywords = . }}
+  */}}
+  {{- /* Keywords logic */}}
+  {{- $keywords := slice }}
+  {{- range .GetTerms "keywords" }}
+    {{- $keywords = $keywords | append .Title }}
   {{- else }}
-    {{- range .GetTerms "tags" }}
-      {{- $keywords = $keywords | append .Title }}
+    {{- with .Keywords }}
+      {{- $keywords = . }}
     {{- else }}
-      {{- range $taxonomy, $_ := site.Taxonomies }}
-        {{- range $.GetTerms $taxonomy }}
-          {{- $keywords = $keywords | append .Title }}
+      {{- range .GetTerms "tags" }}
+        {{- $keywords = $keywords | append .Title }}
+      {{- else }}
+        {{- range $taxonomy, $_ := site.Taxonomies }}
+          {{- range $.GetTerms $taxonomy }}
+            {{- $keywords = $keywords | append .Title }}
+          {{- end }}
         {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}
-{{- end }}
-{{- with $keywords }}
-  <meta itemprop="keywords" content="{{ delimit . `,` }}">
-{{- end -}}
+  {{- with $keywords }}
+  "keywords": [
+    {{- range $i, $kw := . -}}
+      "{{ $kw }}"{{ if lt (add $i 1) (len $keywords) }},{{ end }}
+    {{- end }}
+  ],
+  {{- end }}
+}
+</script>


### PR DESCRIPTION
The current microdata-style markup does not apply to any particular item and, as a result, fails to pass W3C’s Nu HTML Checker.

This PR reimplements the same semantics in JSON-LD, a self-contained format that is also recommended by Google Search Central.

Closes #7431