### PR TITLE
tpl/lang: Warn when using reserved translation keys

### DIFF
--- a/tpl/lang/lang.go
+++ b/tpl/lang/lang.go
@@ -30,6 +30,20 @@ import (
 	"github.com/spf13/cast"
 )
 
+var reservedTranslationIDs = map[string]string{
+	"id":          "",
+	"description": "",
+	"hash":        "",
+	"leftdelim":   "",
+	"rightdelim":  "",
+	"zero":        "",
+	"one":         "",
+	"two":         "",
+	"few":         "",
+	"many":        "",
+	"other":       "",
+}
+
 // New returns a new instance of the lang-namespaced template functions.
 func New(deps *deps.Deps, translator locales.Translator) *Namespace {
 	return &Namespace{
@@ -58,6 +72,12 @@ func (ns *Namespace) Translate(ctx context.Context, id any, args ...any) (string
 	sid, err := cast.ToStringE(id)
 	if err != nil {
 		return "", err
+	}
+
+	sidParts := strings.Split(sid, ".")
+	translationKey := sidParts[len(sidParts)-1]
+	if _, found := reservedTranslationIDs[translationKey]; found {
+		return "", fmt.Errorf("the key %q is reserved and cannot be used for translation lookups; please consult the lang.Translate documentation for a list of reserved keys", translationKey)
 	}
 
 	return ns.deps.Translate(ctx, sid, templateData), nil


### PR DESCRIPTION
When using a translation key that is reserved in the `go-i18n` package, Hugo will now log an error instead of silently failing.

Fixes #14061

**Please note:** 
- I've looked into adding a test case, but there does not appear to be any tests for the `Translate` method. If wanted, I can add some. But perhaps it won't be needed for a minor change like this. Up to the reviewer(s) 🙂.
- Since translation keys may be multiple levels deep, I did not use `SplitN` with a count of 1.
- I'm intentionally not bounds checking, since an empty string will create an empty slice and won't trigger a runtime exception.