### PR TITLE
github: Allow AsciiDoc content in tests to render diagrams

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,16 +47,24 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@44511735964dcb71245e7e55f72539531f7bc0eb # v1.257.0
         with:
-          ruby-version: "2.7"
-          bundler-cache: true #
+          ruby-version: "3.4.5"
+      - name: Install gems
+        run: |
+          gem install asciidoctor -v "2.0.26"
+          gem install asciidoctor-diagram -v "3.0.1"
+          gem install asciidoctor-diagram-plantuml -v "1.2025.3"
+      - name: Install Java # required by asciidoctor-diagram-plantuml
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          distribution: temurin
+          java-version: "25"
+          java-package: jre
       - name: Install Python
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: "3.x"
       - name: Install Mage
         run: go install github.com/magefile/mage@v1.15.0
-      - name: Install asciidoctor
-        uses: reitzig/actions-asciidoctor@c642db5eedd1d729bb8c92034770d0b2f769eda6 # v2.0.2
       - name: Install docutils
         run: |
           pip install docutils


### PR DESCRIPTION
Changes:

- Install Asciidoctor as a gem
- Install Asciidoctor diagram gems
- Install JRE (required by asciidoctor-diagram-plantuml)

These changes were prompted by #14094.