### PR TITLE
Cache reflect method lookups used in collections.Where and others

### DIFF
--- a/common/hreflect/helpers_test.go
+++ b/common/hreflect/helpers_test.go
@@ -223,6 +223,18 @@ func (t *testStruct) Method5() string {
 	return "Hugo"
 }
 
+func BenchmarkGetMethodByNameForType(b *testing.B) {
+	tp := reflect.TypeFor[*testStruct]()
+	methods := []string{"Method1", "Method2", "Method3", "Method4", "Method5"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, method := range methods {
+			_ = GetMethodByNameForType(tp, method)
+		}
+	}
+}
+
 func BenchmarkGetMethodByName(b *testing.B) {
 	v := reflect.ValueOf(&testStruct{})
 	methods := []string{"Method1", "Method2", "Method3", "Method4", "Method5"}

--- a/langs/i18n/i18n.go
+++ b/langs/i18n/i18n.go
@@ -158,12 +158,11 @@ func getPluralCount(v any) any {
 			}
 		}
 	default:
-		vv := reflect.Indirect(reflect.ValueOf(v))
-		if vv.Kind() == reflect.Interface && !vv.IsNil() {
-			vv = vv.Elem()
+		vv, isNil := hreflect.IndirectElem(reflect.ValueOf(v))
+		if isNil {
+			return nil
 		}
 		tp := vv.Type()
-
 		if tp.Kind() == reflect.Struct {
 			f := vv.FieldByName(countFieldName)
 			if f.IsValid() {


### PR DESCRIPTION
```bash
                                        │ master.bench │    fix-reflectmethodcache.bench     │
                                        │    sec/op    │    sec/op     vs base               │
WhereSliceOfStructPointersWithMethod-10   592.2µ ± ∞ ¹   390.1µ ± ∞ ¹  -34.14% (p=0.029 n=4)
¹ need >= 6 samples for confidence interval at level 0.95

                                        │  master.bench  │     fix-reflectmethodcache.bench     │
                                        │      B/op      │     B/op       vs base               │
WhereSliceOfStructPointersWithMethod-10   205.14Ki ± ∞ ¹   64.52Ki ± ∞ ¹  -68.55% (p=0.029 n=4)
¹ need >= 6 samples for confidence interval at level 0.95

                                        │ master.bench │    fix-reflectmethodcache.bench     │
                                        │  allocs/op   │  allocs/op    vs base               │
WhereSliceOfStructPointersWithMethod-10   9.003k ± ∞ ¹   4.503k ± ∞ ¹  -49.98% (p=0.029 n=4)
````
