### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -1034,7 +1034,6 @@ func (c *serverCommand) serve() error {
 	defer cancel()
 	wg2, ctx := errgroup.WithContext(ctx)
 	for _, srv := range servers {
-		srv := srv
 		wg2.Go(func() error {
 			return srv.Shutdown(ctx)
 		})

--- a/common/hashing/hashing_test.go
+++ b/common/hashing/hashing_test.go
@@ -38,7 +38,6 @@ func TestXxHashFromReaderPara(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for i := range 10 {
-		i := i
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/common/para/para_test.go
+++ b/common/para/para_test.go
@@ -52,7 +52,6 @@ func TestPara(t *testing.T) {
 		var result []int
 		var mu sync.Mutex
 		for i := range n {
-			i := i
 			r.Run(func() error {
 				mu.Lock()
 				defer mu.Unlock()

--- a/config/defaultConfigProvider_test.go
+++ b/config/defaultConfigProvider_test.go
@@ -334,7 +334,6 @@ func TestDefaultConfigProvider(t *testing.T) {
 		}
 
 		for i := range 20 {
-			i := i
 			r.Run(func() error {
 				const v = 42
 				k := fmt.Sprintf("k%d", i)

--- a/create/content_test.go
+++ b/create/content_test.go
@@ -74,7 +74,6 @@ func TestNewContentFromFile(t *testing.T) {
 	c := qt.New(t)
 
 	for i, cas := range cases {
-		cas := cas
 
 		c.Run(cas.name, func(c *qt.C) {
 			c.Parallel()

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -720,7 +720,6 @@ themeconfigdirparam: {{ site.Params.themeconfigdirparam }}
 `
 
 	for _, configName := range []string{"hugo.toml", "config.toml"} {
-		configName := configName
 		t.Run(configName, func(t *testing.T) {
 			t.Parallel()
 

--- a/hugolib/content_map_test.go
+++ b/hugolib/content_map_test.go
@@ -545,7 +545,6 @@ Path: {{ .Path }}|{{.Kind }}
 `
 
 	for _, format := range []string{"toml", "yaml", "json"} {
-		format := format
 		t.Run(format, func(t *testing.T) {
 			t.Parallel()
 

--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -332,7 +332,6 @@ Image: ![alt-"<>&](/destination-"<> 'title-"<>&')
 `
 
 	for _, enabled := range []bool{true, false} {
-		enabled := enabled
 		t.Run(fmt.Sprint(enabled), func(t *testing.T) {
 			t.Parallel()
 			b := Test(t, strings.ReplaceAll(files, "ENABLE", fmt.Sprint(enabled)))

--- a/hugolib/doctree/nodeshiftree_test.go
+++ b/hugolib/doctree/nodeshiftree_test.go
@@ -194,7 +194,6 @@ func TestTreePara(t *testing.T) {
 	)
 
 	for i := range 8 {
-		i := i
 		r.Run(func() error {
 			a := &testValue{ID: "/a"}
 			lock := tree.Lock(true)

--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -322,7 +322,6 @@ func (h *HugoSites) assemble(ctx context.Context, l logg.LevelLogger, bcfg *Buil
 
 	g, _ := h.workersSite.Start(ctx)
 	for _, s := range assemblers {
-		s := s
 		g.Run(func() error {
 			return s.assemblePagesStep1(ctx)
 		})
@@ -727,7 +726,6 @@ func (h *HugoSites) postProcess(l logg.LevelLogger) error {
 
 	filenames := h.Deps.BuildState.GetFilenamesWithPostPrefix()
 	for _, filename := range filenames {
-		filename := filename
 		g.Run(func() error {
 			return handleFile(filename)
 		})

--- a/hugolib/page_permalink_test.go
+++ b/hugolib/page_permalink_test.go
@@ -64,8 +64,6 @@ func TestPermalink(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		i := i
-		test := test
 		t.Run(fmt.Sprintf("%s-%d", test.file, i), func(t *testing.T) {
 			t.Parallel()
 			c := qt.New(t)

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1090,7 +1090,6 @@ func TestPageWithDate(t *testing.T) {
 
 func TestPageWithFrontMatterConfig(t *testing.T) {
 	for _, dateHandler := range []string{":filename", ":fileModTime"} {
-		dateHandler := dateHandler
 		t.Run(fmt.Sprintf("dateHandler=%q", dateHandler), func(t *testing.T) {
 			t.Parallel()
 			c := qt.New(t)

--- a/hugolib/resource_chain_test.go
+++ b/hugolib/resource_chain_test.go
@@ -578,7 +578,6 @@ XML: {{ $xml.body }}
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			if !test.shouldRun() {
 				t.Skip()

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -101,8 +101,6 @@ title: "Shortcodes Galore!"
 		{"inline", `{{< my.inline >}}Hi{{< /my.inline >}}`, regexpCheck("my.inline;inline:true;closing:true;inner:{Hi};")},
 	} {
 
-		test := test
-
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			c := qt.New(t)
@@ -644,7 +642,6 @@ String: {{ . | safeHTML }}
 
 func TestInlineShortcodes(t *testing.T) {
 	for _, enableInlineShortcodes := range []bool{true, false} {
-		enableInlineShortcodes := enableInlineShortcodes
 		t.Run(fmt.Sprintf("enableInlineShortcodes=%t", enableInlineShortcodes),
 			func(t *testing.T) {
 				t.Parallel()

--- a/hugolib/site_output_test.go
+++ b/hugolib/site_output_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestSiteWithPageOutputs(t *testing.T) {
 	for _, outputs := range [][]string{{"html", "json", "calendar"}, {"json"}} {
-		outputs := outputs
 		t.Run(fmt.Sprintf("%v", outputs), func(t *testing.T) {
 			t.Parallel()
 			doTestSiteWithPageOutputs(t, outputs)

--- a/hugolib/site_sections_test.go
+++ b/hugolib/site_sections_test.go
@@ -286,7 +286,6 @@ PAG|{{ .Title }}|{{ $sect.InSection . }}
 	home := s.getPageOldVersion(kinds.KindHome)
 
 	for _, test := range tests {
-		test := test
 		tt.Run(fmt.Sprintf("sections %s", test.sections), func(c *qt.C) {
 			c.Parallel()
 			sections := strings.Split(test.sections, ",")

--- a/hugolib/template_test.go
+++ b/hugolib/template_test.go
@@ -186,7 +186,6 @@ func TestTemplateLookupOrder(t *testing.T) {
 		},
 	} {
 
-		this := this
 		if this.name != "Variant 1" {
 			continue
 		}

--- a/internal/warpc/warpc.go
+++ b/internal/warpc/warpc.go
@@ -435,7 +435,6 @@ func newDispatcher[Q, R any](opts Options) (*dispatcherPool[Q, R], error) {
 	run := func() error {
 		g, ctx := errgroup.WithContext(ctx)
 		for _, c := range inOuts {
-			c := c
 			g.Go(func() error {
 				var errBuff bytes.Buffer
 				ctx := context.WithoutCancel(ctx)

--- a/lazy/init_test.go
+++ b/lazy/init_test.go
@@ -204,7 +204,6 @@ func TestInitBranchOrder(t *testing.T) {
 	ctx := context.Background()
 
 	for _, v := range inits {
-		v := v
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/markup/goldmark/autoid_test.go
+++ b/markup/goldmark/autoid_test.go
@@ -74,7 +74,6 @@ tabspace
 	}
 
 	for i, input := range testlines {
-		input := input
 		expect := expectlines[i]
 		c.Run(input, func(c *qt.C) {
 			b := []byte(input)

--- a/markup/goldmark/codeblocks/codeblocks_integration_test.go
+++ b/markup/goldmark/codeblocks/codeblocks_integration_test.go
@@ -336,7 +336,6 @@ Common
 	}{
 		{"issue-9819", "asdf\n: {#myid}"},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			b := hugolib.NewIntegrationTestBuilder(

--- a/resources/images/color_test.go
+++ b/resources/images/color_test.go
@@ -43,7 +43,6 @@ func TestHexStringToColor(t *testing.T) {
 		{"777", color.RGBA{R: 0x77, G: 0x77, B: 0x77, A: 0xff}},
 	} {
 
-		test := test
 		c.Run(test.arg, func(c *qt.C) {
 			c.Parallel()
 
@@ -78,7 +77,6 @@ func TestColorToHexString(t *testing.T) {
 		{color.RGBA{R: 0x42, G: 0x87, B: 0xf5, A: 0x80}, "#4287f580"},
 	} {
 
-		test := test
 		c.Run(test.expect, func(c *qt.C) {
 			c.Parallel()
 

--- a/source/content_directory_test.go
+++ b/source/content_directory_test.go
@@ -56,7 +56,6 @@ func TestIgnoreDotFilesAndDirectories(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		test := test
 		c.Run(fmt.Sprintf("[%d] %s", i, test.path), func(c *qt.C) {
 			c.Parallel()
 			v := config.New()

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -195,8 +195,6 @@ func TestDictionary(t *testing.T) {
 		{[]any{5, "b"}, false},
 		{[]any{"a", "b", "c"}, false},
 	} {
-		i := i
-		test := test
 		c.Run(fmt.Sprint(i), func(c *qt.C) {
 			c.Parallel()
 			errMsg := qt.Commentf("[%d] %v", i, test.values)

--- a/tpl/collections/merge_test.go
+++ b/tpl/collections/merge_test.go
@@ -137,9 +137,6 @@ func TestMerge(t *testing.T) {
 		{"all nil", []any{nil, nil}, nil, true},
 	} {
 
-		test := test
-		i := i
-
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			errMsg := qt.Commentf("[%d] %v", i, test)


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore