### PR TITLE
commands: newDocsHelper encode integers as ints in generated YAML

### DIFF
--- a/commands/gen.go
+++ b/commands/gen.go
@@ -249,7 +249,7 @@ url: %s
 					return err
 				}
 				defer f.Close()
-				yamlEnc := yaml.NewEncoder(f)
+				yamlEnc := yaml.NewEncoder(f, yaml.AutoInt())
 				if err := yamlEnc.Encode(m); err != nil {
 					return err
 				}


### PR DESCRIPTION
Previously the [JSON -> map roundtrip ](https://github.com/gohugoio/hugo/blob/e1236e3d0da7daed64819ae2e602793125b2d9cc/commands/gen.go#L240)produced float64 values which caused the YAML encoder to emit integers like 404.0 instead of 404. Use the YAML encoder option yaml.AutoInt() so numbers that are integer-valued (fractional part is zero) are encoded as integers.

This change affects the newDocsHelper command (commands/gen.go) where the docs data is written to docs/data/docs.yaml. After this change generated YAML will contain integer values (e.g. status: 404) instead of floats (e.g. status: 404.0).

Fixes #14122