### PR TITLE
resources/page: Fix slugorcontentbasename for section pages

### DIFF
--- a/resources/page/permalinks.go
+++ b/resources/page/permalinks.go
@@ -336,6 +336,11 @@ func (l PermalinkExpander) pageToPermalinkSectionSlugs(p Page, attr string) (str
 
 // pageToPermalinkContentBaseName returns the URL-safe form of the content base name.
 func (l PermalinkExpander) pageToPermalinkContentBaseName(p Page, _ string) (string, error) {
+	// For section pages with _index.md files, return empty string to match the behavior of pageToPermalinkFilename.
+	// Sections without files should use their directory name.
+	if p.PathInfo().IsBranchBundle() && p.File() != nil {
+		return "", nil
+	}
 	return l.urlize(p.PathInfo().Unnormalized().BaseNameNoIdentifier()), nil
 }
 

--- a/resources/page/permalinks_integration_test.go
+++ b/resources/page/permalinks_integration_test.go
@@ -457,3 +457,39 @@ title: aBc
 	b = hugolib.Test(t, files)
 	b.AssertFileExists("public/aBc/index.html", true)
 }
+
+// Issue 14104
+func TestIssue14104(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+[permalinks.page]
+foo = "/:sections[1:]/:slugorcontentbasename/"
+[permalinks.section]
+foo = "/:sections[1:]/:slugorcontentbasename/"
+-- content/foo/_index.md --
+---
+title: Foo
+---
+-- content/foo/bar/_index.md --
+---
+title: Bar
+---
+-- content/foo/bar/somepage.md --
+---
+title: Some Page
+---
+-- layouts/_default/list.html --
+List|{{ .Kind }}|{{ .RelPermalink }}|
+-- layouts/_default/single.html --
+Single|{{ .Kind }}|{{ .RelPermalink }}|
+`
+
+	b := hugolib.Test(t, files)
+
+	// Section page should be at /bar/index.html, not /bar/bar/index.html
+	b.AssertFileContent("public/bar/index.html", "List|section|/bar/|")
+	// Regular page should be at /bar/somepage/index.html
+	b.AssertFileContent("public/bar/somepage/index.html", "Single|page|/bar/somepage/|")
+}


### PR DESCRIPTION
## Summary

This PR fixes the `slugorcontentbasename` permalink token creating an extra subdirectory for section pages (`_index.md` files).

## Problem

When using `slugorcontentbasename` in permalinks for section pages, an extra subdirectory was created. For example:

```yaml
permalinks:
  section:
    foo: /:sections[1:]/:slugorcontentbasename/
```

With content at `content/foo/bar/_index.md`, this would generate `/bar/bar/index.html` instead of the expected `/bar/index.html`.

The deprecated `slugorfilename` token worked correctly by returning an empty string for `_index.md` files.

## Solution

Added special handling in `pageToPermalinkContentBaseName` to return an empty string for section pages (`_index.md` files), matching the behavior of `pageToPermalinkFilename`.

## Testing

- Added integration test `TestIssue14104` to verify the fix
- All existing tests pass
- Tested with the reproduction repository from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #14104