### PR TITLE
hugolib: Improve performance of content trees with many sections

### DIFF
--- a/common/collections/stack.go
+++ b/common/collections/stack.go
@@ -13,9 +13,13 @@
 
 package collections
 
-import "slices"
+import (
+	"iter"
+	"slices"
+	"sync"
 
-import "sync"
+	"github.com/gohugoio/hugo/common/hiter"
+)
 
 // Stack is a simple LIFO stack that is safe for concurrent use.
 type Stack[T any] struct {
@@ -58,6 +62,11 @@ func (s *Stack[T]) Len() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.items)
+}
+
+// All returns all items in the stack, from bottom to top.
+func (s *Stack[T]) All() iter.Seq2[int, T] {
+	return hiter.Lock2(slices.All(s.items), s.mu.RLock, s.mu.RUnlock)
 }
 
 func (s *Stack[T]) Drain() []T {

--- a/common/hiter/iter.go
+++ b/common/hiter/iter.go
@@ -38,3 +38,29 @@ func Concat2[K, V any](seqs ...iter.Seq2[K, V]) iter.Seq2[K, V] {
 		}
 	}
 }
+
+// Lock returns an iterator that locks before iterating and unlocks after.
+func Lock[V any](seq iter.Seq[V], lock, unlock func()) iter.Seq[V] {
+	return func(yield func(V) bool) {
+		lock()
+		defer unlock()
+		for e := range seq {
+			if !yield(e) {
+				return
+			}
+		}
+	}
+}
+
+// Lock2 returns an iterator that locks before iterating and unlocks after.
+func Lock2[K, V any](seq iter.Seq2[K, V], lock, unlock func()) iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		lock()
+		defer unlock()
+		for k, v := range seq {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}

--- a/hugolib/content_map_page_contentnodeshifter.go
+++ b/hugolib/content_map_page_contentnodeshifter.go
@@ -146,7 +146,7 @@ func (s *contentNodeShifter) Shift(n contentNode, siteVector sitesmatrix.Vector,
 			return vv, true
 		}
 	default:
-		panic(fmt.Sprintf("Shift: unknown type %T", n))
+		panic(fmt.Sprintf("Shift: unknown type %T for %q", n, n.Path()))
 	}
 
 	if !fallback {

--- a/hugolib/doctree/nodeshiftree_test.go
+++ b/hugolib/doctree/nodeshiftree_test.go
@@ -147,7 +147,7 @@ func TestTreeEvents(t *testing.T) {
 	}
 
 	c.Assert(w.Walk(context.Background()), qt.IsNil)
-	c.Assert(w.WalkContext.HandleEventsAndHooks(), qt.IsNil)
+	c.Assert(w.WalkContext.HandleHooks1AndEventsAndHooks2(), qt.IsNil)
 
 	c.Assert(tree.Get("/a").Weight, eq, 9)
 	c.Assert(tree.Get("/a/s1").Weight, eq, 9)

--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -336,7 +336,7 @@ func (h *HugoSites) assemble(ctx context.Context, l logg.LevelLogger, bcfg *Buil
 	if h.Conf.Watching() {
 		defer func() {
 			// Store previous walk context to detect cascade changes on next rebuild.
-			h.previousPageTreesWalkContext = apa.rw.WalkContext
+			h.previousPageTreesWalkContext = apa.rwRoot.WalkContext
 		}()
 	}
 

--- a/hugolib/hugo_sites_build_test.go
+++ b/hugolib/hugo_sites_build_test.go
@@ -204,6 +204,7 @@ func BenchmarkAssembleDeepSiteWithManySections(b *testing.B) {
 		})
 	}
 
+	runOne(1, 1, 20)
 	runOne(1, 6, 100)
 	runOne(2, 2, 100)
 	runOne(2, 6, 100)

--- a/hugolib/sitesmatrix/sitematrix_integration_test.go
+++ b/hugolib/sitesmatrix/sitematrix_integration_test.go
@@ -1231,3 +1231,27 @@ func BenchmarkSitesMatrixContent(b *testing.B) {
 		}
 	}
 }
+
+// Just a test to test the development of concurrency in page assembly.
+func TestCreateAllPagesPartitionSections(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+disableKinds = ["rss", "sitemap", "taxonomy", "term"]
+-- content/_index.md --
+-- content/s1/_index.md --
+-- content/s1/p1.md --
+-- content/s1/p2.md --
+-- content/s2/_index.md --
+-- content/s2/p1.md --
+-- content/s2_1/_index.md --
+-- content/s2_1/p1.md --
+-- layouts/all.html --
+{{ .Kind }}|{{ .RelPermalink }}|
+`
+
+	for range 3 {
+		b := hugolib.Test(t, files)
+		b.AssertFileContent("public/s1/index.html", "section|/s1/|")
+	}
+}


### PR DESCRIPTION
Hugo's build process is roughly divided into three steps:

1. Process content (walk file system and insert source nodes into content tree)
2. Assemble content (assemble pages and resources according to sites matrix)
3. Render content

In #13679 we consolidated the page creation logic into one place (the assemble step). This made it much simpler to reason about, but it lost us some performance esp. in big content trees.

This commit re-introduces parallelization in the first step in the assemble step by handling each top level section in its own goroutine. This gives significant performance improvements for content trees with many sections.

Compared to master:

````
AssembleDeepSiteWithManySections/depth=2/sectionsPerLevel=2/pagesPerSection=100-10    20.36m ± 3%   17.09m ±  4%  -16.06% (p=0.002 n=6)
AssembleDeepSiteWithManySections/depth=2/sectionsPerLevel=6/pagesPerSection=100-10   107.86m ± 6%   73.94m ±  5%  -31.44% (p=0.002 n=6)
AssembleDeepSiteWithManySections/depth=3/sectionsPerLevel=2/pagesPerSection=100-10    40.33m ± 5%   31.21m ±  7%  -22.61% (p=0.002 n=6)
```
