### PR TITLE
static: Preserve .gitignore and .gitattributes in --cleanDestinationDir

### DIFF
--- a/commands/hugobuilder.go
+++ b/commands/hugobuilder.go
@@ -464,7 +464,15 @@ func (c *hugoBuilder) copyStaticTo(sourceFs *filesystems.SourceFilesystem) (uint
 		infol.Logf("removing all files from destination that don't exist in static dirs")
 
 		syncer.DeleteFilter = func(f fsync.FileInfo) bool {
-			return f.IsDir() && strings.HasPrefix(f.Name(), ".")
+			name := f.Name()
+
+			// Keep .gitignore and .gitattributes anywhere
+			if name == ".gitignore" || name == ".gitattributes" {
+				return true
+			}
+
+			// Keep Hugo's original dot-directory behavior
+			return f.IsDir() && strings.HasPrefix(name, ".")
 		}
 	}
 	start := time.Now()


### PR DESCRIPTION
This PR improves the behavior of the --cleanDestinationDir feature when syncing static files.

Currently, Hugo deletes all files in the destination directory except for dot-directories when `CleanDestinationDir` is enabled. This causes important files like `.gitignore` and `.gitattributes` to be removed on each build, which is undesirable.

This change updates the DeleteFilter to also preserve `.gitignore` and `.gitattributes` files while keeping the existing behavior for dot-directories intact.

Fixes #14097 