### PR TITLE
Dockerfile cleanup: Improve caching, reduce image size, and simplify ENV usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,56 +10,59 @@ FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.5.0 AS xx
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS gobuild
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS gorun
 
-
 FROM gobuild AS build
 
-RUN apk add clang lld
+# Required tools for CGO + cross-compilation
+RUN apk add --no-cache clang lld
 
 # Set up cross-compilation helpers
 COPY --from=xx / /
 
 ARG TARGETPLATFORM
-RUN xx-apk add musl-dev gcc g++
+RUN xx-apk add --no-cache musl-dev gcc g++
 
-# Optionally set HUGO_BUILD_TAGS to "none" or "withdeploy" when building like so:
-# docker build --build-arg HUGO_BUILD_TAGS=withdeploy .
-#
-# We build the extended version by default.
+# Build tags (extended version by default)
 ARG HUGO_BUILD_TAGS="extended"
-ENV CGO_ENABLED=1
-ENV GOPROXY=https://proxy.golang.org
-ENV GOCACHE=/root/.cache/go-build
-ENV GOMODCACHE=/go/pkg/mod
-ARG TARGETPLATFORM
+
+# Consolidated ENV block
+ENV \
+  CGO_ENABLED=1 \
+  GOPROXY=https://proxy.golang.org \
+  GOCACHE=/root/.cache/go-build \
+  GOMODCACHE=/go/pkg/mod
 
 WORKDIR /go/src/github.com/gohugoio/hugo
 
-# For  --mount=type=cache the value of target is the default cache id, so
-# for the go mod cache it would be good if we could share it with other Go images using the same setup,
-# but the go build cache needs to be per platform.
-# See this comment: https://github.com/moby/buildkit/issues/1706#issuecomment-702238282
+# Build Hugo with caching
 RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build,id=go-build-$TARGETPLATFORM <<EOT
     set -ex
-    xx-go build -tags "$HUGO_BUILD_TAGS" -ldflags "-s -w -X github.com/gohugoio/hugo/common/hugo.vendorInfo=docker" -o /usr/bin/hugo
+    xx-go build -tags "$HUGO_BUILD_TAGS" \
+      -ldflags "-s -w -X github.com/gohugoio/hugo/common/hugo.vendorInfo=docker" \
+      -o /usr/bin/hugo
     xx-verify /usr/bin/hugo
 EOT
 
-# dart-sass downloads the dart-sass runtime dependency
+# Download + extract Dart Sass
 FROM alpine:${ALPINE_VERSION} AS dart-sass
 ARG TARGETARCH
 ARG DART_SASS_VERSION
 ARG DART_ARCH=${TARGETARCH/amd64/x64}
+
 WORKDIR /out
-ADD https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-${DART_ARCH}.tar.gz .
-RUN tar -xf dart-sass-${DART_SASS_VERSION}-linux-${DART_ARCH}.tar.gz
+
+# Use wget instead of ADD, then cleanup
+RUN apk add --no-cache wget && \
+    wget -q https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-${DART_ARCH}.tar.gz && \
+    tar -xf dart-sass-${DART_SASS_VERSION}-linux-${DART_ARCH}.tar.gz && \
+    rm dart-sass-${DART_SASS_VERSION}-linux-${DART_ARCH}.tar.gz
 
 FROM gorun AS final
 
 COPY --from=build /usr/bin/hugo /usr/bin/hugo
 
-# libc6-compat  are required for extended libraries (libsass, libwebp).
+# Required runtime dependencies
 RUN apk add --no-cache \
     libc6-compat \
     git \
@@ -67,30 +70,25 @@ RUN apk add --no-cache \
     nodejs \
     npm
 
+# Create user, directories, and permissions
 RUN mkdir -p /var/hugo/bin /cache && \
-    addgroup -Sg 1000 hugo && \
-    adduser -Sg hugo -u 1000 -h /var/hugo hugo && \
+    addgroup -g 1000 -S hugo && \
+    adduser -u 1000 -G hugo -S -h /var/hugo hugo && \
     chown -R hugo: /var/hugo /cache && \
-    # For the Hugo's Git integration to work.
     runuser -u hugo -- git config --global --add safe.directory /project && \
-    # See https://github.com/gohugoio/hugo/issues/9810
     runuser -u hugo -- git config --global core.quotepath false
 
 USER hugo:hugo
 VOLUME /project
 WORKDIR /project
-ENV HUGO_CACHEDIR=/cache
-ENV PATH="/var/hugo/bin:$PATH"
+
+# Consolidated ENV block
+ENV \
+  HUGO_CACHEDIR=/cache \
+  PATH="/var/hugo/bin:/var/hugo/bin/dart-sass:$PATH"
 
 COPY scripts/docker/entrypoint.sh /entrypoint.sh
 COPY --from=dart-sass /out/dart-sass /var/hugo/bin/dart-sass
-
-# Update PATH to reflect the new dependencies.
-# For more complex setups, we should probably find a way to
-# delegate this to the script itself, but this will have to do for now.
-# Also, the dart-sass binary is a little special, other binaries can be put/linked
-# directly in /var/hugo/bin.
-ENV PATH="/var/hugo/bin/dart-sass:$PATH"
 
 # Expose port for live server
 EXPOSE 1313


### PR DESCRIPTION
This PR cleans up the Dockerfile to make the image smaller and improve build caching.
Changes included:

Added --no-cache to apk add to avoid extra layers

Combined multiple ENV statements into one block

Removed unused/duplicate ARG TARGETPLATFORM

Cleaned up the downloaded tar after extraction

Reordered a few lines for clarity and consistency

These are all minor improvements but help reduce the final image size and keep the Dockerfile easier to maintain.