### PR TITLE
Optimize memory allocations for sites matrix vector stores

### DIFF
--- a/common/paths/pathparser.go
+++ b/common/paths/pathparser.go
@@ -54,7 +54,7 @@ type PathParser struct {
 
 	// Below gets created on demand.
 	initOnce         sync.Once
-	sitesMatrixCache *maps.Cache[string, sitesmatrix.VectorStore] // Maps language code to sites matrix vector store.
+	sitesMatrixCache *maps.Cache[string, sitesmatrix.VectorStore] // Maps language index to sites matrix vector store.
 }
 
 func (pp *PathParser) init() {

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -878,6 +878,10 @@ func (c *Configs) Init(logger loggers.Logger) error {
 		ConfiguredRoles:     c.Base.Roles.Config,
 	}
 
+	if err := c.ConfiguredDimensions.Init(); err != nil {
+		return err
+	}
+
 	intSetsCfg := sitesmatrix.IntSetsConfig{
 		ApplyDefaults: sitesmatrix.IntSetsConfigApplyDefaultsIfNotSet,
 	}

--- a/hugolib/content_map_page_assembler.go
+++ b/hugolib/content_map_page_assembler.go
@@ -575,7 +575,7 @@ func (a *allPagesAssembler) doCreatePages(prefix string) error {
 				func() error {
 					if i := len(missingVectorsForHomeOrRootSection); i > 0 {
 						// Pick one, the rest will be created later.
-						vec := missingVectorsForHomeOrRootSection.Sample()
+						vec := missingVectorsForHomeOrRootSection.VectorSample()
 
 						kind := kinds.KindSection
 						if s == "" {

--- a/hugolib/content_map_page_contentnode.go
+++ b/hugolib/content_map_page_contentnode.go
@@ -426,12 +426,25 @@ func (n contentNodesMap) sample() contentNode {
 }
 
 func (n contentNodesMap) siteVectors() sitesmatrix.VectorIterator {
-	return sitesmatrix.VectorIteratorFunc(func(yield func(v sitesmatrix.Vector) bool) bool {
-		for k := range n {
-			if !yield(k) {
-				return false
-			}
+	return n
+}
+
+func (n contentNodesMap) ForEachVector(yield func(v sitesmatrix.Vector) bool) bool {
+	for v := range n {
+		if !yield(v) {
+			return false
 		}
-		return true
-	})
+	}
+	return true
+}
+
+func (n contentNodesMap) LenVectors() int {
+	return len(n)
+}
+
+func (n contentNodesMap) VectorSample() sitesmatrix.Vector {
+	for v := range n {
+		return v
+	}
+	panic("no vectors")
 }

--- a/hugolib/roles/roles.go
+++ b/hugolib/roles/roles.go
@@ -76,6 +76,10 @@ type RolesInternal struct {
 	Sorted      []RoleInternal
 }
 
+func (r RolesInternal) Len() int {
+	return len(r.Sorted)
+}
+
 func (r RolesInternal) IndexDefault() int {
 	for i, role := range r.Sorted {
 		if role.Default {

--- a/hugolib/versions/versions.go
+++ b/hugolib/versions/versions.go
@@ -78,6 +78,10 @@ type VersionsInternal struct {
 	Sorted []VersionInternal
 }
 
+func (r VersionsInternal) Len() int {
+	return len(r.Sorted)
+}
+
 func (r VersionsInternal) IndexDefault() int {
 	for i, version := range r.Sorted {
 		if version.Default {

--- a/langs/config.go
+++ b/langs/config.go
@@ -92,6 +92,10 @@ func (ls LanguagesInternal) ResolveIndex(name string) int {
 	panic(fmt.Sprintf("no language found for name %q", name))
 }
 
+func (ls LanguagesInternal) Len() int {
+	return len(ls.Sorted)
+}
+
 // IndexMatch returns an iterator for the roles that match the filter.
 func (ls LanguagesInternal) IndexMatch(match predicate.P[string]) (iter.Seq[int], error) {
 	return func(yield func(i int) bool) {


### PR DESCRIPTION
By

* Using shared values for some common setups (e.g. the single site in single site setups) and single vector stores.
* Adding a fast path to IntSets.HasAnyVector for the common case of single vector input.

```
AssembleDeepSiteWithManySections/depth=3/sectionsPerLevel=2/pagesPerSection=100-10   31.62m ± 46%   30.68m ± 42%  ~ (p=0.310 n=6)

                                                                                   │ master.bench │          perfcommon.bench          │
                                                                                   │     B/op     │     B/op      vs base              │
AssembleDeepSiteWithManySections/depth=3/sectionsPerLevel=2/pagesPerSection=100-10   31.98Mi ± 0%   31.24Mi ± 0%  -2.30% (p=0.002 n=6)

                                                                                   │ master.bench │         perfcommon.bench          │
                                                                                   │  allocs/op   │  allocs/op   vs base              │
AssembleDeepSiteWithManySections/depth=3/sectionsPerLevel=2/pagesPerSection=100-10    460.9k ± 0%   419.9k ± 0%  -8.90% (p=0.002 n=6)
````
