### PR TITLE
config: remove unused services.instagram settings

### DIFF
--- a/config/services/servicesConfig.go
+++ b/config/services/servicesConfig.go
@@ -30,7 +30,6 @@ const (
 type Config struct {
 	Disqus          Disqus
 	GoogleAnalytics GoogleAnalytics
-	Instagram       Instagram `json:"-"` // the embedded instagram shortcode no longer uses this
 	Twitter         Twitter   `json:"-"` // deprecated in favor of X in v0.141.0
 	X               X
 	RSS             RSS
@@ -46,19 +45,6 @@ type Disqus struct {
 type GoogleAnalytics struct {
 	// The GA tracking ID.
 	ID string
-}
-
-// Instagram holds the functional configuration settings related to the Instagram shortcodes.
-type Instagram struct {
-	// The Simple variant of the Instagram is decorated with Bootstrap 4 card classes.
-	// This means that if you use Bootstrap 4 or want to provide your own CSS, you want
-	// to disable the inline CSS provided by Hugo.
-	DisableInlineCSS bool // this is no longer used by the embedded instagram shortcode
-
-	// App or Client Access Token.
-	// If you are using a Client Access Token, remember that you must combine it with your App ID
-	// using a pipe symbol (<APPID>|<CLIENTTOKEN>) otherwise the request will fail.
-	AccessToken string // this is no longer used by the embedded instagram shortcode
 }
 
 // Twitter holds the functional configuration settings related to the Twitter shortcodes.

--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -1926,9 +1926,6 @@ config:
       shortname: ""
     googleAnalytics:
       id: ""
-    instagram:
-      accessToken: ""
-      disableInlineCSS: false
     rss:
       limit: -1
     twitter:


### PR DESCRIPTION
The embedded Instagram shortcode stopped using services.instagram in v0.123.0.
However, the configuration keys remained exposed via docs.yaml and the Config
struct. This PR removes the unused Instagram config struct and the corresponding
field in services.Config.

This eliminates dead configuration surface, removes stale documentation, and
does not affect any active shortcode functionality. Custom shortcodes relying on
these fields will receive normal evaluation errors (“can't evaluate field …”).
