### PR TITLE
cache/filecache: Fix resolution of :resourceDir token

### DIFF
--- a/cache/filecache/filecache_config.go
+++ b/cache/filecache/filecache_config.go
@@ -236,7 +236,7 @@ func DecodeConfig(fs afero.Fs, bcfg config.BaseConfig, m map[string]any) (Config
 func resolveDirPlaceholder(fs afero.Fs, bcfg config.BaseConfig, placeholder string) (cacheDir string, isResource bool, err error) {
 	switch strings.ToLower(placeholder) {
 	case ":resourcedir":
-		return "", true, nil
+		return bcfg.ResourceDir, true, nil
 	case ":cachedir":
 		return bcfg.CacheDir, false, nil
 	case ":project":

--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -168,8 +168,9 @@ func (l configLoader) applyConfigAliases() error {
 func (l configLoader) applyDefaultConfig() error {
 	defaultSettings := maps.Params{
 		// These dirs are used early/before we build the config struct.
-		"themesDir": "themes",
-		"configDir": "config",
+		"themesDir":   "themes",
+		"configDir":   "config",
+		"resourceDir": "resources",
 	}
 
 	l.cfg.SetDefaults(defaultSettings)
@@ -400,9 +401,10 @@ func (l *configLoader) loadConfigMain(d ConfigSourceDescriptor) (config.LoadConf
 	workingDir := filepath.Clean(l.cfg.GetString("workingDir"))
 
 	l.BaseConfig = config.BaseConfig{
-		WorkingDir: workingDir,
-		CacheDir:   l.cfg.GetString("cacheDir"),
-		ThemesDir:  paths.AbsPathify(workingDir, l.cfg.GetString("themesDir")),
+		WorkingDir:  workingDir,
+		CacheDir:    l.cfg.GetString("cacheDir"),
+		ThemesDir:   paths.AbsPathify(workingDir, l.cfg.GetString("themesDir")),
+		ResourceDir: paths.AbsPathify(workingDir, l.cfg.GetString("resourceDir")),
 	}
 
 	var err error

--- a/config/commonConfig.go
+++ b/config/commonConfig.go
@@ -32,10 +32,11 @@ import (
 )
 
 type BaseConfig struct {
-	WorkingDir string
-	CacheDir   string
-	ThemesDir  string
-	PublishDir string
+	WorkingDir  string
+	CacheDir    string
+	ThemesDir   string
+	PublishDir  string
+	ResourceDir string
 }
 
 type CommonDirs struct {


### PR DESCRIPTION
This is a first pass at resolving #14165, but three existing tests fail. This isn't as simple as I had hoped.

I clearly don't understand the relationship between `resourceDir` and `resourcesGenDir`. 
