### PR TITLE
tpl/openapi: Add support for OpenAPI external file references

### DIFF
--- a/deps/deps.go
+++ b/deps/deps.go
@@ -417,6 +417,9 @@ type DepsCfg struct {
 	// i18n handling.
 	TranslationProvider ResourceProvider
 
+	// Build triggered by the IntegrationTest framework.
+	IsIntegrationTest bool
+
 	// ChangesFromBuild for changes passed back to the server/watch process.
 	ChangesFromBuild chan []identity.Identity
 }

--- a/hugolib/rebuild_test.go
+++ b/hugolib/rebuild_test.go
@@ -845,7 +845,7 @@ func TestRebuildEditSectionRemoveDate(t *testing.T) {
 func TestRebuildVariations(t *testing.T) {
 	// t.Parallel() not supported, see https://github.com/fortytw2/leaktest/issues/4
 	// This leaktest seems to be a little bit shaky on Travis.
-	if !htesting.IsCI() {
+	if !htesting.IsRealCI() {
 		defer leaktest.CheckTimeout(t, 10*time.Second)()
 	}
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -265,6 +265,14 @@ func NewHugoSites(cfg deps.DepsCfg) (*HugoSites, error) {
 		return nil, err
 	}
 
+	// Prevent leaking goroutines in tests.
+	if cfg.IsIntegrationTest && cfg.ChangesFromBuild != nil {
+		firstSiteDeps.BuildClosers.Add(types.CloserFunc(func() error {
+			close(cfg.ChangesFromBuild)
+			return nil
+		}))
+	}
+
 	batcherClient, err := esbuild.NewBatcherClient(firstSiteDeps)
 	if err != nil {
 		return nil, err

--- a/resources/resource.go
+++ b/resources/resource.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gohugoio/hugo/identity"
 	"github.com/gohugoio/hugo/resources/internal"
+	"github.com/spf13/cast"
 
 	"github.com/gohugoio/hugo/common/hashing"
 	"github.com/gohugoio/hugo/common/herrors"
@@ -701,6 +702,18 @@ func InternalResourceSourcePath(r resource.Resource) string {
 		}
 	}
 	return ""
+}
+
+// InternalResourceSourceContent is used internally to get the source content for a Resource.
+func InternalResourceSourceContent(ctx context.Context, r resource.Resource) (string, error) {
+	if cp, ok := r.(resource.ContentProvider); ok {
+		c, err := cp.Content(ctx)
+		if err != nil {
+			return "", err
+		}
+		return cast.ToStringE(c)
+	}
+	return "", nil
 }
 
 // InternalResourceSourcePathBestEffort is used internally to get the source path for a Resource.

--- a/tpl/openapi/openapi3/init.go
+++ b/tpl/openapi/openapi3/init.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/tpl/internal"
+	resourcestpl "github.com/gohugoio/hugo/tpl/resources"
 )
 
 const name = "openapi3"
@@ -29,6 +30,17 @@ func init() {
 		ns := &internal.TemplateFuncsNamespace{
 			Name:    name,
 			Context: func(cctx context.Context, args ...any) (any, error) { return ctx, nil },
+			OnCreated: func(m map[string]any) {
+				for _, v := range m {
+					switch v := v.(type) {
+					case *resourcestpl.Namespace:
+						ctx.resourcesNs = v
+					}
+				}
+				if ctx.resourcesNs == nil {
+					panic("resources namespace not found")
+				}
+			},
 		}
 
 		ns.AddMethodMapping(ctx.Unmarshal,

--- a/tpl/openapi/openapi3/openapi3_integration_test.go
+++ b/tpl/openapi/openapi3/openapi3_integration_test.go
@@ -14,8 +14,12 @@
 package openapi3_test
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gohugoio/hugo/hugolib"
 )
@@ -49,20 +53,15 @@ paths:
                 type: array
                 items: 
                   type: string
--- config.toml --
+-- hugo.toml --
 baseURL = 'http://example.com/'
--- layouts/index.html --
+disableLiveReload = true
+-- layouts/home.html --
 {{ $api := resources.Get "api/myapi.yaml" | openapi3.Unmarshal }}
 API: {{ $api.Info.Title | safeHTML }}
   `
 
-	b := hugolib.NewIntegrationTestBuilder(
-		hugolib.IntegrationTestConfig{
-			T:           t,
-			Running:     true,
-			TxtarString: files,
-		},
-	).Build()
+	b := hugolib.TestRunning(t, files)
 
 	b.AssertFileContent("public/index.html", `API: Sample API`)
 
@@ -71,4 +70,234 @@ API: {{ $api.Info.Title | safeHTML }}
 		Build()
 
 	b.AssertFileContent("public/index.html", `API: Hugo API`)
+}
+
+// Test data borrowed/adapted from https://github.com/getkin/kin-openapi/tree/master/openapi3/testdata/refInLocalRef
+// The templates below would be simpler if kin-openapi's T would serialize to JSON better, see https://github.com/getkin/kin-openapi/issues/561
+const refLocalTemplate = `
+-- hugo.toml --
+baseURL = 'http://example.com/'
+disableKinds = ["page", "section", "taxonomy", "term", "sitemap", "robotsTXT", "404"]
+disableLiveReload = true
+[HTTPCache]
+[HTTPCache.cache]
+[HTTPCache.cache.for]
+includes = ['**']
+[[HTTPCache.polls]]
+high = '100ms'
+low = '50ms'
+[HTTPCache.polls.for]
+includes = ['**']
+-- assets/api/myapi.json --
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Reference in reference example",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/test/ref/in/ref": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties" : {
+                  "data": {
+                    "$ref": "#/components/schemas/Request"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "messages/response.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Request": {
+        "$ref": "messages/request.json"
+      }
+    }
+  }
+}
+-- assets/api/messages/request.json --
+{
+  "type": "object",
+  "required": [
+    "definition_reference"
+  ],
+  "properties": {
+    "definition_reference": {
+      "$ref": "./data.json"
+    }
+  }
+}
+-- assets/api/messages/response.json --
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "format": "uint64"
+    }
+  }
+}
+-- assets/api/messages/data.json --
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "ref_prop_part": {
+      "$ref": "DATAPART_REF"
+    }
+  }
+}
+-- assets/api/messages/dataPart.json --
+{
+  "type": "object",
+  "properties": {
+    "idPart": {
+      "type": "integer",
+      "format": "int64"
+    }
+  }
+}
+-- layouts/home.html --
+{{ $getremote := dict
+  "method" "post"
+  "key" time.Now.UnixNano
+}}
+{{ $opts := dict
+  "getremote" $getremote
+}}
+{{ with resources.Get "api/myapi.json" }}
+  {{ with openapi3.Unmarshal . $opts }}
+    Title: {{ .Info.Title | safeHTML }}
+    {{ range $k, $v := .Paths.Map }}
+      {{ $post := index $v.Post }}
+      {{ with index $post.RequestBody.Value.Content  }}
+        {{ $mt := (index .   "application/json")}}
+        {{ $data := index $mt.Schema.Value.Properties "data" }}
+        RequestBody: {{ template "printschema" $mt.Schema.Value  }}$
+      {{ end }}
+      {{ $response := index (index $post.Responses.Map "200").Value.Content "application/json" }}
+      Response: {{ template "printschema" $response.Schema.Value }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ define "printschema" }}{{ with .Format}}Format: {{ . }}|{{ end }}{{ with .Properties }} Properties: {{ range $k, $v := . }}{{ $k}}: {{ template "printitems" . -}}{{ end }}{{ end -}}${{ end }}
+{{ define "printitems" }}{{ if eq (printf "%T" .) "*openapi3.SchemaRef" }}{{ template "printschema" .Value  }}{{ else }}{{ template "printitem" . -}}{{ end -}}{{ end }}
+{{ define "printitem" }}{{ printf "%T: %s" . (.|debug.Dump) | safeHTML }}{{ end }}
+
+`
+
+func TestUnmarshalRefLocal(t *testing.T) {
+	files := strings.ReplaceAll(refLocalTemplate, "DATAPART_REF", "./dataPart.json")
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/index.html",
+		`Reference in reference example`,
+		"RequestBody:  Properties: data:  Properties: definition_reference:  Properties: id: Format: int32|$ref_prop_part:  Properties: idPart: Format: int64|$",
+		"Response:  Properties: id: Format: uint64|$",
+	)
+}
+
+func TestUnmarshalRefLocalEdit(t *testing.T) {
+	files := strings.ReplaceAll(refLocalTemplate, "DATAPART_REF", "./dataPart.json")
+
+	b := hugolib.TestRunning(t, files)
+
+	b.AssertFileContent("public/index.html",
+		"RequestBody:  Properties: data:  Properties: definition_reference:  Properties: id: Format: int32|$ref_prop_part:  Properties: idPart: Format: int64|$",
+	)
+
+	b.EditFileReplaceAll("assets/api/messages/dataPart.json", "int64", "int8").Build()
+
+	b.AssertFileContent("public/index.html",
+		"RequestBody:  Properties: data:  Properties: definition_reference:  Properties: id: Format: int32|$ref_prop_part:  Properties: idPart: Format: int8|$",
+	)
+}
+
+func TestUnmarshalRefRemote(t *testing.T) {
+	createFiles := func(t *testing.T) string {
+		counter := 0
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "POST" && r.URL.Path == "/api/messages/dataPart.json" {
+				n := 8
+
+				// This endpoint will also be called by the poller, so we distinguish
+				// between the first and subsequent calls.
+				if counter > 0 {
+					n = 16
+				}
+				counter++
+
+				w.Header().Set("Content-Type", "application/json")
+				response := fmt.Sprintf(`{
+  "type": "object",
+  "properties": {
+    "idPart": {
+      "type": "integer",
+      "format": "int%d"
+    }
+  }
+}`, n)
+				w.Write([]byte(response))
+				return
+			}
+
+			http.Error(w, "Not found", http.StatusNotFound)
+		}))
+
+		t.Cleanup(func() {
+			ts.Close()
+		})
+
+		dataPartRef := ts.URL + "/api/messages/dataPart.json"
+		return strings.ReplaceAll(refLocalTemplate, "DATAPART_REF", dataPartRef)
+	}
+
+	t.Run("Build", func(t *testing.T) {
+		b := hugolib.Test(t, createFiles(t))
+
+		b.AssertFileContent("public/index.html",
+			`Reference in reference example`,
+			"RequestBody:  Properties: data:  Properties: definition_reference:  Properties: id: Format: int32|$ref_prop_part:  Properties: idPart: Format: int8|$",
+			"Response:  Properties: id: Format: uint64|$",
+		)
+	})
+
+	t.Run("Rebuild", func(t *testing.T) {
+		b := hugolib.TestRunning(t, createFiles(t))
+
+		b.AssertFileContent("public/index.html",
+			"idPart: Format: int8|$",
+		)
+
+		// Rebuild triggered by remote polling.
+		time.Sleep(800 * time.Millisecond)
+
+		b.AssertFileContent("public/index.html",
+			"idPart: Format: int16|$",
+		)
+	})
 }


### PR DESCRIPTION
Some notes for the `docs`:

* `openapi3.Unmarshal` now takes a options map as an optional second argument with one option, `getremote` that is https://gohugo.io/functions/resources/getremote/#options  (see example below), which is used when resolving remote references.
* Local references gets resolved in `/assets`: References starting with a `/` resolves from the `/assets` root, others relative to the importer, e.g. `/assets/api` in the example below.

```handlebars
{{ $getremote := dict
  "method" "post"
  "key" now.UnixNano
}}
{{ $opts := dict
  "getremote" $getremote
}}
{{ with resources.Get "api/myapi.json" }}
  {{ with openapi3.Unmarshal . $opts }}
  {{ end }}
{{ end }}
```

Fixes #8067
