### PR TITLE
github: Add PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+🛑 Before submitting this PR
+
+All PRs must be linked to an Issue in this repository, and that Issue must be approved by a project maintainer:
+
+- For a bug, approval means that the "needs triage" label is removed.
+- For a proposal, approval means that the "proposal" label is replaced by an "enhancement" label.
+
+PRs without a linked, approved Issue will be closed immediately.
+
+Please review the contribution guide (CONTRIBUTING.md) to understand commit message guidelines and AI assistance disclosures.


### PR DESCRIPTION
When someone submits a PR they will see this:

<img width="676" height="424" alt="image" src="https://github.com/user-attachments/assets/6fb2db11-cbca-4e26-a762-66c9b6ff4ad6" />