### PR TITLE
Speedup and simplify page assembly for deeper content trees

### DIFF
--- a/common/hstrings/strings.go
+++ b/common/hstrings/strings.go
@@ -97,6 +97,16 @@ func GetOrCompileRegexp(pattern string) (re *regexp.Regexp, err error) {
 	return reCache.getOrCompileRegexp(pattern)
 }
 
+// HasAnyPrefix checks if the string s has any of the prefixes given.
+func HasAnyPrefix(s string, prefixes ...string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // InSlice checks if a string is an element of a slice of strings
 // and returns a boolean value.
 func InSlice(arr []string, el string) bool {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.4.0
 	github.com/alecthomas/chroma/v2 v2.20.0
-	github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c
 	github.com/aws/aws-sdk-go-v2 v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.57.0
 	github.com/bep/clocks v0.5.0
@@ -38,6 +37,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/goccy/go-yaml v1.18.0
 	github.com/gohugoio/go-i18n/v2 v2.1.3-0.20251018145728-cfcc22d823c6
+	github.com/gohugoio/go-radix v1.2.0
 	github.com/gohugoio/hashstructure v0.6.0
 	github.com/gohugoio/httpcache v0.8.0
 	github.com/gohugoio/hugo-goldmark-extensions/extras v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,6 @@ github.com/alecthomas/chroma/v2 v2.20.0 h1:sfIHpxPyR07/Oylvmcai3X/exDlE8+FA820NT
 github.com/alecthomas/chroma/v2 v2.20.0/go.mod h1:e7tViK0xh/Nf4BYHl00ycY6rV7b8iXBksI9E359yNmA=
 github.com/alecthomas/repr v0.5.1 h1:E3G4t2QbHTSNpPKBgMTln5KLkZHLOcU7r37J4pXBuIg=
 github.com/alecthomas/repr v0.5.1/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c h1:651/eoCRnQ7YtSjAnSzRucrJz+3iGEFt+ysraELS81M=
-github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
 github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.40.0 h1:/WMUA0kjhZExjOQN2z3oLALDREea1A7TobfuiBrKlwc=
@@ -276,6 +274,8 @@ github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gohugoio/go-i18n/v2 v2.1.3-0.20251018145728-cfcc22d823c6 h1:pxlAea9eRwuAnt/zKbGqlFO2ZszpIe24YpOVLf+N+4I=
 github.com/gohugoio/go-i18n/v2 v2.1.3-0.20251018145728-cfcc22d823c6/go.mod h1:m5hu1im5Qc7LDycVLvee6MPobJiRLBYHklypFJR0/aE=
+github.com/gohugoio/go-radix v1.2.0 h1:D5GTk8jIoeXirBSc2P4E4NdHKDrenk9k9N0ctU5Yrhg=
+github.com/gohugoio/go-radix v1.2.0/go.mod h1:k6vDa0ebpbpgtzSj9lPGJcA4AZwJ9xUNObUy2vczPFM=
 github.com/gohugoio/hashstructure v0.6.0 h1:7wMB/2CfXoThFYhdWRGv3u3rUM761Cq29CxUW+NltUg=
 github.com/gohugoio/hashstructure v0.6.0/go.mod h1:lapVLk9XidheHG1IQ4ZSbyYrXcaILU1ZEP/+vno5rBQ=
 github.com/gohugoio/httpcache v0.8.0 h1:hNdsmGSELztetYCsPVgjA960zSa4dfEqqF/SficorCU=

--- a/hugolib/content_map.go
+++ b/hugolib/content_map.go
@@ -241,8 +241,8 @@ func (m *pageMap) AddFi(fi hugofs.FileMetaInfo, buildConfig *BuildCfg) (pageSour
 		key := pi.Base()
 		tree := m.treeResources
 
-		commit := tree.Lock(true)
-		defer commit()
+		tree.Lock(true)
+		defer tree.Unlock(true)
 
 		if pi.IsContent() {
 			pm, err := h.newPageMetaSourceFromFile(fi)

--- a/hugolib/doctree/treeshifttree.go
+++ b/hugolib/doctree/treeshifttree.go
@@ -93,8 +93,12 @@ func (t *TreeShiftTreeSlice[T]) Insert(s string, v T) T {
 	return t.tree().Insert(s, v)
 }
 
-func (t *TreeShiftTreeSlice[T]) Lock(lockType LockType) func() {
-	return t.tree().Lock(lockType)
+func (t *TreeShiftTreeSlice[T]) Lock(lockType LockType) {
+	t.tree().Lock(lockType)
+}
+
+func (t *TreeShiftTreeSlice[T]) Unlock(lockType LockType) {
+	t.tree().Unlock(lockType)
 }
 
 func (t *TreeShiftTreeSlice[T]) WalkPrefix(lockType LockType, s string, f func(s string, v T) (bool, error)) error {

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/bep/logg"
+	"github.com/gohugoio/go-radix"
 	"github.com/gohugoio/hugo/cache/dynacache"
 	"github.com/gohugoio/hugo/config/allconfig"
 	"github.com/gohugoio/hugo/hugofs/hglob"
@@ -536,8 +537,11 @@ func (h *HugoSites) withPage(fn func(s string, p *pageState) bool) {
 		w := &doctree.NodeShiftTreeWalker[contentNode]{
 			Tree:     s.pageMap.treePages,
 			LockType: doctree.LockTypeRead,
-			Handle: func(s string, n contentNode) (bool, error) {
-				return fn(s, n.(*pageState)), nil
+			Handle: func(s string, n contentNode) (radix.WalkFlag, error) {
+				if fn(s, n.(*pageState)) {
+					return radix.WalkStop, nil
+				}
+				return radix.WalkContinue, nil
 			},
 		}
 		return w.Walk(context.Background())

--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/bep/debounce"
 	"github.com/bep/logg"
+	"github.com/gohugoio/go-radix"
 	"github.com/gohugoio/hugo/bufferpool"
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/hugofs"
@@ -261,9 +262,9 @@ func (h *HugoSites) initRebuild(config *BuildCfg) error {
 		return errors.New("rebuild called when not in watch mode")
 	}
 
-	h.pageTrees.treePagesResources.WalkPrefixRaw("", func(key string, n contentNode) bool {
+	h.pageTrees.treePagesResources.WalkPrefixRaw("", func(key string, n contentNode) (radix.WalkFlag, contentNode, error) {
 		cnh.resetBuildState(n)
-		return false
+		return radix.WalkContinue, nil, nil
 	})
 
 	for _, s := range h.Sites {

--- a/hugolib/page__tree.go
+++ b/hugolib/page__tree.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gohugoio/go-radix"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/hugolib/doctree"
@@ -167,9 +168,9 @@ func (pt pageTree) Sections() page.Pages {
 		Tree:   tree,
 		Prefix: prefix,
 	}
-	w.Handle = func(ss string, n contentNode) (bool, error) {
+	w.Handle = func(ss string, n contentNode) (radix.WalkFlag, error) {
 		if !cnh.isBranchNode(n) {
-			return false, nil
+			return radix.WalkContinue, nil
 		}
 		if currentBranchPrefix == "" || !strings.HasPrefix(ss, currentBranchPrefix) {
 			if p, ok := n.(*pageState); ok && p.IsSection() && p.m.shouldList(false) && p.Parent() == pt.p {
@@ -179,7 +180,7 @@ func (pt pageTree) Sections() page.Pages {
 			}
 		}
 		currentBranchPrefix = ss + "/"
-		return false, nil
+		return radix.WalkContinue, nil
 	}
 
 	if err := w.Walk(context.Background()); err != nil {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/bep/logg"
+	"github.com/gohugoio/go-radix"
 	"github.com/gohugoio/hugo/cache/dynacache"
 	"github.com/gohugoio/hugo/common/hstore"
 	"github.com/gohugoio/hugo/common/hsync"
@@ -928,7 +929,7 @@ func (s *Site) initRenderFormats() {
 
 	w := &doctree.NodeShiftTreeWalker[contentNode]{
 		Tree: s.pageMap.treePages,
-		Handle: func(key string, n contentNode) (bool, error) {
+		Handle: func(key string, n contentNode) (radix.WalkFlag, error) {
 			if p, ok := n.(*pageState); ok {
 				for _, f := range p.m.pageConfig.ConfiguredOutputFormats {
 					if !formatSet[f.Name] {
@@ -937,7 +938,7 @@ func (s *Site) initRenderFormats() {
 					}
 				}
 			}
-			return false, nil
+			return radix.WalkContinue, nil
 		},
 	}
 

--- a/internal/warpc/build.sh
+++ b/internal/warpc/build.sh
@@ -1,4 +1,3 @@
-# TODO1 clean up when done.
 go generate ./gen
 javy compile js/greet.bundle.js -d -o wasm/greet.wasm
 javy compile js/renderkatex.bundle.js -d -o wasm/renderkatex.wasm

--- a/tpl/tplimpl/templates.go
+++ b/tpl/tplimpl/templates.go
@@ -202,63 +202,6 @@ func (t *templateNamespace) templatesIn(in tpl.Template) iter.Seq[tpl.Template] 
 	}
 }
 
-/*
-
-
-func (t *templateHandler) applyBaseTemplate(overlay, base templateInfo) (tpl.Template, error) {
-	if overlay.isText {
-		var (
-			templ = t.main.getPrototypeText(prototypeCloneIDBaseof).New(overlay.name)
-			err   error
-		)
-
-		if !base.IsZero() {
-			templ, err = templ.Parse(base.template)
-			if err != nil {
-				return nil, base.errWithFileContext("text: base: parse failed", err)
-			}
-		}
-
-		templ, err = texttemplate.Must(templ.Clone()).Parse(overlay.template)
-		if err != nil {
-			return nil, overlay.errWithFileContext("text: overlay: parse failed", err)
-		}
-
-		// The extra lookup is a workaround, see
-		// * https://github.com/golang/go/issues/16101
-		// * https://github.com/gohugoio/hugo/issues/2549
-		// templ = templ.Lookup(templ.Name())
-
-		return templ, nil
-	}
-
-	var (
-		templ = t.main.getPrototypeHTML(prototypeCloneIDBaseof).New(overlay.name)
-		err   error
-	)
-
-	if !base.IsZero() {
-		templ, err = templ.Parse(base.template)
-		if err != nil {
-			return nil, base.errWithFileContext("html: base: parse failed", err)
-		}
-	}
-
-	templ, err = htmltemplate.Must(templ.Clone()).Parse(overlay.template)
-	if err != nil {
-		return nil, overlay.errWithFileContext("html: overlay: parse failed", err)
-	}
-
-	// The extra lookup is a workaround, see
-	// * https://github.com/golang/go/issues/16101
-	// * https://github.com/gohugoio/hugo/issues/2549
-	templ = templ.Lookup(templ.Name())
-
-	return templ, err
-}
-
-*/
-
 var baseTemplateDefineRe = regexp.MustCompile(`^{{-?\s*define`)
 
 // needsBaseTemplate returns true if the first non-comment template block is a

--- a/tpl/tplimpl/templatestore.go
+++ b/tpl/tplimpl/templatestore.go
@@ -269,14 +269,13 @@ func (ti *TemplInfo) SubCategory() SubCategory {
 
 func (ti *TemplInfo) BaseVariantsSeq() iter.Seq[*TemplWithBaseApplied] {
 	return func(yield func(*TemplWithBaseApplied) bool) {
-		ti.baseVariants.Walk(func(key string, v map[TemplateDescriptor]*TemplWithBaseApplied) (bool, error) {
+		for _, v := range ti.baseVariants.All() {
 			for _, vv := range v {
 				if !yield(vv) {
-					return true, nil
+					return
 				}
 			}
-			return false, nil
-		})
+		}
 	}
 }
 


### PR DESCRIPTION
This commit moves to a forked version go-radix (fork source has not had any updates in 3 years.), whith 2 notable changes:

* It's generic (using Go generics) and thus removes a lot of type conversions/assertions.
* It allows nodes to be replaced during walk, which allows to partition the tree for parallel processing without worrying about locking.

For this repo, this means:

* The assembly step now processes nested sections in parallel, which gives a speedup for deep content trees with a slight allocation penalty (see benchmarks below).
* Nodes that needs to be reinserted are inserted directly.
* Also, there are some drive-by fixes of some allocation issues, e.g. avoid wrapping mutexes in returned anonomous functions, a common source of hidden allocations.

```
                                                                                   │ master.bench │           perf-p3.bench            │
                                                                                   │    sec/op    │   sec/op     vs base               │
AssembleDeepSiteWithManySections/depth=1/sectionsPerLevel=1/pagesPerSection=50-10     6.958m ± 3%   7.015m ± 3%        ~ (p=0.589 n=6)
AssembleDeepSiteWithManySections/depth=1/sectionsPerLevel=6/pagesPerSection=100-10    14.25m ± 1%   14.56m ± 8%        ~ (p=0.394 n=6)
AssembleDeepSiteWithManySections/depth=1/sectionsPerLevel=6/pagesPerSection=500-10    48.07m ± 3%   49.23m ± 3%        ~ (p=0.394 n=6)
AssembleDeepSiteWithManySections/depth=2/sectionsPerLevel=6/pagesPerSection=100-10    66.66m ± 4%   66.47m ± 6%        ~ (p=0.485 n=6)
AssembleDeepSiteWithManySections/depth=4/sectionsPerLevel=2/pagesPerSection=100-10    59.57m ± 4%   50.73m ± 5%  -14.85% (p=0.002 n=6)
geomean                                                                               28.54m        27.92m        -2.18%

                                                                                   │ master.bench │           perf-p3.bench            │
                                                                                   │     B/op     │     B/op      vs base              │
AssembleDeepSiteWithManySections/depth=1/sectionsPerLevel=1/pagesPerSection=50-10    4.513Mi ± 0%   4.527Mi ± 0%  +0.33% (p=0.002 n=6)
AssembleDeepSiteWithManySections/depth=1/sectionsPerLevel=6/pagesPerSection=100-10   15.35Mi ± 0%   15.49Mi ± 0%  +0.94% (p=0.002 n=6)
AssembleDeepSiteWithManySections/depth=1/sectionsPerLevel=6/pagesPerSection=500-10   62.50Mi ± 0%   63.19Mi ± 0%  +1.10% (p=0.002 n=6)
AssembleDeepSiteWithManySections/depth=2/sectionsPerLevel=6/pagesPerSection=100-10   86.78Mi ± 0%   87.73Mi ± 0%  +1.09% (p=0.002 n=6)
AssembleDeepSiteWithManySections/depth=4/sectionsPerLevel=2/pagesPerSection=100-10   62.96Mi ± 0%   63.66Mi ± 0%  +1.12% (p=0.002 n=6)
geomean                                                                              29.84Mi        30.11Mi       +0.92%

                                                                                   │ master.bench │           perf-p3.bench           │
                                                                                   │  allocs/op   │  allocs/op   vs base              │
AssembleDeepSiteWithManySections/depth=1/sectionsPerLevel=1/pagesPerSection=50-10     60.44k ± 0%   60.97k ± 0%  +0.87% (p=0.002 n=6)
AssembleDeepSiteWithManySections/depth=1/sectionsPerLevel=6/pagesPerSection=100-10    205.8k ± 0%   211.4k ± 0%  +2.70% (p=0.002 n=6)
AssembleDeepSiteWithManySections/depth=1/sectionsPerLevel=6/pagesPerSection=500-10    831.1k ± 0%   858.3k ± 0%  +3.27% (p=0.002 n=6)
AssembleDeepSiteWithManySections/depth=2/sectionsPerLevel=6/pagesPerSection=100-10    1.157M ± 0%   1.197M ± 0%  +3.41% (p=0.002 n=6)
AssembleDeepSiteWithManySections/depth=4/sectionsPerLevel=2/pagesPerSection=100-10    839.9k ± 0%   867.8k ± 0%  +3.31% (p=0.002 n=6)
geomean                                                                               398.5k        409.3k       +2.71%
```
