### PR TITLE
Fix slow server startup of very big content trees

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -401,9 +401,7 @@ func (r *rootCommand) Run(ctx context.Context, cd *simplecobra.Commandeer, args 
 
 	watchGroups := helpers.ExtractAndGroupRootPaths(watchDirs)
 
-	for _, group := range watchGroups {
-		r.Printf("Watching for changes in %s\n", group)
-	}
+	r.Printf("Watching for changes in %s\n", strings.Join(watchGroups, ", "))
 	watcher, err := b.newWatcher(r.poll, watchDirs...)
 	if err != nil {
 		return err

--- a/commands/server.go
+++ b/commands/server.go
@@ -492,9 +492,7 @@ func (c *serverCommand) Run(ctx context.Context, cd *simplecobra.Commandeer, arg
 
 		watchGroups := helpers.ExtractAndGroupRootPaths(watchDirs)
 
-		for _, group := range watchGroups {
-			c.r.Printf("Watching for changes in %s\n", group)
-		}
+		c.r.Printf("Watching for changes in %s\n", strings.Join(watchGroups, ", "))
 		watcher, err := c.newWatcher(c.r.poll, watchDirs...)
 		if err != nil {
 			return err

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -355,35 +354,23 @@ func TestExtractAndGroupRootPaths(t *testing.T) {
 		filepath.FromSlash("/c/d/e"),
 	}
 
-	inCopy := make([]string, len(in))
-	copy(inCopy, in)
-
 	result := helpers.ExtractAndGroupRootPaths(in)
 
 	c := qt.New(t)
-	c.Assert(fmt.Sprint(result), qt.Equals, filepath.FromSlash("[/a/b/{c,e} /c/d/e]"))
-
-	// Make sure the original is preserved
-	c.Assert(in, qt.DeepEquals, inCopy)
+	c.Assert(result, qt.DeepEquals, []string{"/a/b/{c,e}", "/c/d/e"})
 }
 
-func TestExtractRootPaths(t *testing.T) {
-	tests := []struct {
-		input    []string
-		expected []string
-	}{{
-		[]string{
-			filepath.FromSlash("a/b"), filepath.FromSlash("a/b/c/"), "b",
-			filepath.FromSlash("/c/d"), filepath.FromSlash("d/"), filepath.FromSlash("//e//"),
-		},
-		[]string{"a", "a", "b", "c", "d", "e"},
-	}}
-
-	for _, test := range tests {
-		output := helpers.ExtractRootPaths(test.input)
-		if !reflect.DeepEqual(output, test.expected) {
-			t.Errorf("Expected %#v, got %#v\n", test.expected, output)
+func BenchmarkExtractAndGroupRootPaths(b *testing.B) {
+	in := []string{}
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 1000; j++ {
+			in = append(in, fmt.Sprintf("/a/b/c/s%d/p%d", i, j))
 		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		helpers.ExtractAndGroupRootPaths(in)
 	}
 }
 


### PR DESCRIPTION
As in content trees with 10 thousand of directories and more.

A benchmark with the bottle neck code in `helpers.ExtractAndGroupRootPaths`:

```
                            │ cmp20251125.bench │ fix-extractandgrouproot-14211.bench │
                            │      sec/op       │    sec/op     vs base               │
ExtractAndGroupRootPaths-10     1282818.8µ ± 8%   493.8µ ± 38%  -99.96% (p=0.002 n=6)

                            │ cmp20251125.bench │ fix-extractandgrouproot-14211.bench │
                            │       B/op        │     B/op      vs base               │
ExtractAndGroupRootPaths-10       3343.8Ki ± 0%   146.3Ki ± 0%  -95.63% (p=0.002 n=6)

                            │ cmp20251125.bench │ fix-extractandgrouproot-14211.bench │
                            │     allocs/op     │  allocs/op    vs base               │
ExtractAndGroupRootPaths-10        20.043k ± 0%    2.979k ± 0%  -85.14% (p=0.002 n=6)
```

For test project that started this (a 60k directory conent tree), the server startup with no rendering, wen from 1.5 minutes to less than 4 seconds:

```
hugop server --renderSegments none                        main ✚ ✖ ✱ ◼
Watching for changes in /Users/bep/dev/sites/hugotestsites/60k/content/{section0,section1,section10,section100,section101,section102,section103,section104,section105,section106,...}
Watching for changes in /Users/bep/dev/sites/hugotestsites/60k/layouts/_default
Watching for config changes in /Users/bep/dev/sites/hugotestsites/60k/config.toml
Start building sites …
hugo v0.153.0-DEV-7e27c303904ed8b221d6a5a4fc9a764bb7b2935b darwin/arm64 BuildDate=2025-11-25T15:02:58Z

                  │ EN
──────────────────┼────
 Pages            │  0
 Paginator pages  │  0
 Non-page files   │  0
 Static files     │  0
 Processed images │  0
 Aliases          │  0
 Cleaned          │  0

Built in 3884 ms
Environment: "development"
Serving pages from disk
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at //localhost:1313/ (bind address 127.0.0.1)
Press Ctrl+C to stop
```

Fixes https://github.com/gohugoio/hugo/issues/14211