### PR TITLE
resources: Skip integration test if Dart Sass is not installed

### DIFF
--- a/resources/resource_transformers/tocss/dartsass/dartsass_integration_test.go
+++ b/resources/resource_transformers/tocss/dartsass/dartsass_integration_test.go
@@ -645,6 +645,9 @@ T1: {{ $r.Content }}
 
 func TestSilenceDependencyDeprecations(t *testing.T) {
 	t.Parallel()
+	if !dartsass.Supports() {
+		t.Skip()
+	}
 
 	files := `
 -- hugo.toml --


### PR DESCRIPTION
The `dartsass.Supports()` check was inadvertently omitted.
