### PR TITLE
Misc deprecations

### DIFF
--- a/resources/resource_transformers/tocss/scss/scss_integration_test.go
+++ b/resources/resource_transformers/tocss/scss/scss_integration_test.go
@@ -462,3 +462,26 @@ target = "assets/sass"
 
 	b.AssertFileContent("public/index.html", ".foo1{color:red}.bar1{color:blue}.foo2{color:red}.bar2{color:blue}")
 }
+
+func TestLibsassDeprecatedIssue14261(t *testing.T) {
+	// This cannot be run in parallel because of global state in log deprecation handling.
+	if !scss.Supports() {
+		t.Skip()
+	}
+
+	files := `
+-- assets/scss/main.scss --
+body {
+	background-color: #fff;
+}
+-- hugo.toml --
+-- layouts/home.html --
+{{ $cssOpts := (dict  "transpiler" "libsass") }}
+{{ $r := resources.Get "scss/main.scss" |  toCSS $cssOpts  }}
+{{ $r.RelPermalink }}
+	`
+
+	b := hugolib.Test(t, files, hugolib.TestOptOsFs(), hugolib.TestOptInfo())
+
+	b.AssertLogContains("deprecated: css.Sass: libsass was deprecated in Hugo v0.153.0")
+}

--- a/tpl/css/css.go
+++ b/tpl/css/css.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/common/types/css"
@@ -91,7 +92,7 @@ func (ns *Namespace) Sass(args ...any) (resource.Resource, error) {
 		targetPath string
 		err        error
 		ok         bool
-		transpiler = sass.TranspilerLibSass
+		transpiler = sass.TranspilerLibSass // Deprecated default. Will be dartsass in future versions. See below.
 	)
 
 	r, targetPath, ok = resourcehelpers.ResolveIfFirstArgIsString(args)
@@ -106,7 +107,10 @@ func (ns *Namespace) Sass(args ...any) (resource.Resource, error) {
 	if m != nil {
 		if t, _, found := maps.LookupEqualFold(m, "transpiler"); found {
 			switch t {
-			case sass.TranspilerDart, sass.TranspilerLibSass:
+			case sass.TranspilerDart:
+				transpiler = cast.ToString(t)
+			case sass.TranspilerLibSass:
+				hugo.Deprecate("css.Sass: libsass", "Use dartsass instead. See https://gohugo.io/functions/css/sass/#dart-sass", "v0.153.0")
 				transpiler = cast.ToString(t)
 			default:
 				return nil, fmt.Errorf("unsupported transpiler %q; valid values are %q or %q", t, sass.TranspilerLibSass, sass.TranspilerDart)


### PR DESCRIPTION
The upstream library is now EOL and the repo is archived. Also, it's time for us to move away from the extended CGO build and for Hugo users not already done that, move to https://gohugo.io/functions/css/sass/#dart-sass

https://github.com/sass/libsass

Closes #14261
