### PR TITLE
Revert deprecation logging for contentDir per language

### DIFF
--- a/hugofs/hugofs_integration_test.go
+++ b/hugofs/hugofs_integration_test.go
@@ -118,3 +118,32 @@ product2/tutorials/tutorial1/index.html
 product2/tutorials/tutorial2/index.html
 `)
 }
+
+func TestContentDirPerLangNoDeprecationPleaseIssue14287(t *testing.T) {
+	files := `
+-- hugo.toml --
+defaultContentLanguage = "en"
+defaultContentLanguageInSubdir = true
+[languages]
+[languages.en]
+contentDir = "content/en"
+[languages.fr]
+contentDir = "content/fr"
+-- content/en/page.md --
+---
+title: "English Page"
+---
+-- content/fr/page.md --
+---
+title: "Page Française"
+---
+-- layouts/all.html --
+Title: {{ .Title }}|
+-- 
+`
+	b := hugolib.Test(t, files, hugolib.TestOptInfo())
+
+	b.AssertFileContent("public/en/page/index.html", "Title: English Page|")
+	b.AssertFileContent("public/fr/page/index.html", "Title: Page Française|")
+	b.AssertLogContains("! deprecated")
+}

--- a/modules/config.go
+++ b/modules/config.go
@@ -157,7 +157,7 @@ func ApplyProjectConfigDefaults(logger logg.Logger, mod Module, cfgs ...config.A
 			}
 
 			if dir != "" {
-				mnt := Mount{Lang: lang, Source: dir, Target: component}
+				mnt := Mount{Source: dir, Target: component, Sites: sites}
 				if err := mnt.init(logger); err != nil {
 					return fmt.Errorf("failed to init mount %q %d: %w", lang, i, err)
 				}
@@ -501,6 +501,7 @@ func (m *Mount) init(logger logg.Logger) error {
 		m.Lang = ""
 
 		hugo.DeprecateWithLogger("module.mounts.lang", "Replaced by the more powerful 'sites.matrix' setting, see https://gohugo.io/configuration/module/#mounts", "v0.153.0", logger)
+
 	}
 
 	m.Sites.Matrix.Languages = hstrings.UniqueStringsReuse(m.Sites.Matrix.Languages)


### PR DESCRIPTION
It was accidentally introduced because we compile it to file mounts, and `lang` on file mounts is deprecated in favor of `sites.matrix`.

But contentDir per language is something we have had for a long time, and is to useful too to deprecate.

Fixes #14287
