### PR TITLE
Fix error with _content.gotmpl file with index.md siblings

### DIFF
--- a/hugofs/component_fs.go
+++ b/hugofs/component_fs.go
@@ -206,13 +206,15 @@ func (f *componentFsDir) ReadDirWithContext(ctx context.Context, count int) ([]i
 				}
 				pi := fi.(FileMetaInfo).Meta().PathInfo
 
-				// Everything below a leaf bundle is a resource.
-				isResource := isInLeafBundle && pi.Type() > paths.TypeFile
-				// Every sibling of a leaf bundle is a resource.
-				isResource = isResource || (isCurrentLeafBundle && !pi.IsLeafBundle())
+				if pi.Type() != paths.TypeContentData {
+					// Everything below a leaf bundle is a resource.
+					isResource := isInLeafBundle && pi.Type() > paths.TypeFile
+					// Every sibling of a leaf bundle is a resource.
+					isResource = isResource || (isCurrentLeafBundle && !pi.IsLeafBundle())
 
-				if isResource {
-					paths.ModifyPathBundleTypeResource(pi)
+					if isResource {
+						paths.ModifyPathBundleTypeResource(pi)
+					}
 				}
 			}
 		}

--- a/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
+++ b/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
@@ -873,3 +873,23 @@ baseURL = "https://example.com"
 
 	b.AssertFileContent("public/index.html", "home: My Home!|")
 }
+
+func TestPagesFromGoTmplIssue14299(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ["taxonomy", "term", "rss", "sitemap"]
+baseURL = "https://example.com"
+-- layouts/all.html --
+{{ .Kind }}: {{ .Title }}|
+-- content/_content.gotmpl --
+{{ $a := "foo" }}
+-- content/_index.md --
+-- content/bar/_content.gotmpl --
+{{ $a := "bar" }}
+-- content/bar/index.md --
+`
+	// _content.gotmpl which was siblings of index.md (leaf bundles) was mistakingly classified as a content resource.
+	hugolib.Test(t, files)
+}


### PR DESCRIPTION
Regression introduced in Hugo 0.153.0.

Note that this is a very uncommon setup, but it worked before.

Fixes #14299
