### PR TITLE
markup/tableofcontents: Add pre/post config options

### DIFF
--- a/hugolib/page__content.go
+++ b/hugolib/page__content.go
@@ -670,6 +670,8 @@ func (c *cachedContentScope) contentToC(ctx context.Context) (contentTableOfCont
 					cfg.TableOfContents.StartLevel,
 					cfg.TableOfContents.EndLevel,
 					cfg.TableOfContents.Ordered,
+					cfg.TableOfContents.Pre,
+					cfg.TableOfContents.Post,
 				)
 				return err
 			}


### PR DESCRIPTION
Add Pre and Post configuration options to customize the HTML wrapper around the table of contents.

This allows users to add custom elements like headings for accessibility:

```toml
[markup.tableOfContents]
  pre = '<nav id="TableOfContents"><h2>Contents</h2>'
  post = '</nav>'
```

The pre/post parameters are optional in `ToHTML()` for backward compatibility - existing templates continue to work without changes.

Fixes #8338