### PR TITLE
tpl: Fix sitemapindex output formatting

### DIFF
--- a/tpl/tplimpl/embedded/templates/sitemapindex.xml
+++ b/tpl/tplimpl/embedded/templates/sitemapindex.xml
@@ -1,11 +1,11 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {{ range . }}
+  {{- range . }}
   <sitemap>
     <loc>{{ .SitemapAbsURL }}</loc>
-    {{ if not .Lastmod.IsZero }}
-      <lastmod>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</lastmod>
-    {{ end }}
+    {{- if not .Lastmod.IsZero }}
+    <lastmod>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</lastmod>
+    {{- end }}
   </sitemap>
-  {{ end }}
+  {{- end }}
 </sitemapindex>


### PR DESCRIPTION
Template `/tpl/tplimpl/embedded/templates/sitemapindex.xml` generates output with unformatted code.

Current output example:
```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  
  <sitemap>
    <loc>https://quadrimus.com/cs/sitemap.xml</loc>
    
      <lastmod>2025-01-29T00:00:00+00:00</lastmod>
    
  </sitemap>
  
  <sitemap>
    <loc>https://quadrimus.com/en/sitemap.xml</loc>
    
      <lastmod>2025-01-29T00:00:00+00:00</lastmod>
    
  </sitemap>
  
</sitemapindex>
```

Expected output example:
```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap>
    <loc>https://quadrimus.com/cs/sitemap.xml</loc>
    <lastmod>2025-01-29T00:00:00+00:00</lastmod>
  </sitemap>
  <sitemap>
    <loc>https://quadrimus.com/en/sitemap.xml</loc>
    <lastmod>2025-01-29T00:00:00+00:00</lastmod>
  </sitemap>
</sitemapindex>
```

https://github.com/gohugoio/hugo/issues/14317