### PR TITLE
config: Fix cacade per language in hugo.toml regression

### DIFF
--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -915,10 +915,9 @@ func (c *Configs) Init(logger loggers.Logger) error {
 	// avoid initializing the same config more than once.
 	for i, l := range c.Languages {
 		langConfig := c.LanguageConfigMap[l.Lang]
-		sitesMatrix := sitesmatrix.NewIntSetsBuilder(c.ConfiguredDimensions).WithLanguageIndices(i).WithAllIfNotSet().Build()
 		for _, s := range allDecoderSetups {
 			if getInitializer := s.getInitializer; getInitializer != nil {
-				if err := getInitializer(langConfig).InitConfig(logger, sitesMatrix, c.ConfiguredDimensions); err != nil {
+				if err := getInitializer(langConfig).InitConfig(logger, nil, c.ConfiguredDimensions); err != nil {
 					return err
 				}
 			}

--- a/hugolib/cascade_test.go
+++ b/hugolib/cascade_test.go
@@ -367,20 +367,26 @@ Resource: {{ .Name }}|p1: {{ .Params.p1 }}|
 }
 
 // Issue 14310
+// Issue 14321
 func TestCascadeIssue14310(t *testing.T) {
 	t.Parallel()
 
 	files := `
 -- hugo.toml --
-disableKinds = ['home','rss','sitemap','taxonomy','term']
+disableKinds = ['home', 'rss', 'sitemap', 'taxonomy', 'term']
 defaultContentLanguage = 'en'
 defaultContentLanguageInSubdir = true
 [languages.en]
-weight = 1
+  weight = 1
 [languages.de]
-weight = 2
+  weight = 2
+[[cascade]]
+  [cascade.params]
+    size = 'medium'
+  [cascade.target]
+    kind = 'page'
 -- layouts/all.html --
-{{ .Params.color }}
+|color: {{ .Params.color }}|size: {{ .Params.size }}|
 -- content/s1/_index.de.md --
 ---
 title: s1 (de)
@@ -407,6 +413,6 @@ title: p1 (en)
 
 	b := Test(t, files)
 
-	b.AssertFileContent("public/en/s1/p1/index.html", "red (en)")
-	b.AssertFileContent("public/de/s1/p1/index.html", "red (de)") // fails: file contains "red (en)"
+	b.AssertFileContent("public/en/s1/p1/index.html", "|color: red (en)|size: medium|") // fails: file contains "|color: red (en)|size: |"
+	b.AssertFileContent("public/de/s1/p1/index.html", "|color: red (de)|size: medium|")
 }


### PR DESCRIPTION
An onfurtunate side effect of the fix in v0.153.4.

Fixes #14321
