### PR TITLE
Revert "resources/page: Fix slugorcontentbasename for section pages"

### DIFF
--- a/resources/page/permalinks.go
+++ b/resources/page/permalinks.go
@@ -336,11 +336,6 @@ func (l PermalinkExpander) pageToPermalinkSectionSlugs(p Page, attr string) (str
 
 // pageToPermalinkContentBaseName returns the URL-safe form of the content base name.
 func (l PermalinkExpander) pageToPermalinkContentBaseName(p Page, _ string) (string, error) {
-	// For section pages with _index.md files, return empty string to match the behavior of pageToPermalinkFilename.
-	// Sections without files should use their directory name.
-	if p.PathInfo().IsBranchBundle() && p.File() != nil {
-		return "", nil
-	}
 	return l.urlize(p.PathInfo().Unnormalized().BaseNameNoIdentifier()), nil
 }
 

--- a/resources/page/permalinks_integration_test.go
+++ b/resources/page/permalinks_integration_test.go
@@ -457,39 +457,3 @@ title: aBc
 	b = hugolib.Test(t, files)
 	b.AssertFileExists("public/aBc/index.html", true)
 }
-
-// Issue 14104
-func TestIssue14104(t *testing.T) {
-	t.Parallel()
-
-	files := `
--- hugo.toml --
-[permalinks.page]
-foo = "/:sections[1:]/:slugorcontentbasename/"
-[permalinks.section]
-foo = "/:sections[1:]/:slugorcontentbasename/"
--- content/foo/_index.md --
----
-title: Foo
----
--- content/foo/bar/_index.md --
----
-title: Bar
----
--- content/foo/bar/somepage.md --
----
-title: Some Page
----
--- layouts/list.html --
-List|{{ .Kind }}|{{ .RelPermalink }}|
--- layouts/single.html --
-Single|{{ .Kind }}|{{ .RelPermalink }}|
-`
-
-	b := hugolib.Test(t, files)
-
-	// Section page should be at /bar/index.html, not /bar/bar/index.html
-	b.AssertFileContent("public/bar/index.html", "List|section|/bar/|")
-	// Regular page should be at /bar/somepage/index.html
-	b.AssertFileContent("public/bar/somepage/index.html", "Single|page|/bar/somepage/|")
-}


### PR DESCRIPTION
This reverts commit 25c7c18f9f8862f756835d3ac3faa4f114c344f6.

See #14104
See #14325
