### PR TITLE
tpl/tplimpl: Fix image priority in get-page-images

### DIFF
--- a/tpl/tplimpl/embedded/templates/_partials/_funcs/get-page-images.html
+++ b/tpl/tplimpl/embedded/templates/_partials/_funcs/get-page-images.html
@@ -1,6 +1,10 @@
 {{- $imgs := slice }}
 {{- $imgParams := .Params.images }}
 {{- $resources := .Resources.ByType "image" -}}
+{{/* Check for singular image param */}}
+{{- if and (not $imgParams) .Params.image }}
+  {{- $imgParams = slice .Params.image }}
+{{- end }}
 {{/* Find featured image resources if the images parameter is empty. */}}
 {{- if not $imgParams }}
   {{- $featured := $resources.GetMatch "*feature*" -}}


### PR DESCRIPTION
Move singular image param check before featured image lookup so that explicitly set .Params.image takes priority over auto-detected featured/cover/thumbnail images.