### PR TITLE
docs: :contentbasename and :slugcontentbasename broken for taxonom

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,8 @@ hugo server
 ```
 
 **Note:** We're working on removing the need to run `npm i` for local development. Stay tuned.
+
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.


### PR DESCRIPTION
## Description

v0.153.0 has changed the behavior of the tokens `:contentbasename` and  `:slugcontentbasename` as resolution of #14104. Sorry that I missed the ping on that issue, otherwise we could've caught this be

## Changes Made

- docs: Added contributing section

Fixes #14325
