### PR TITLE
tpl: Fix language resolution for markdown shortcodes

### DIFF
--- a/tpl/tplimpl/render_hook_integration_test.go
+++ b/tpl/tplimpl/render_hook_integration_test.go
@@ -304,3 +304,38 @@ custom image render hook: {{ .Text }}|{{ .Destination }}
 		})
 	}
 }
+
+func TestRenderHookMultilingual(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = 'https://example.org/'
+defaultContentLanguage = 'en'
+[markup.goldmark.renderHooks.image]
+enableDefault = false
+[languages.en]
+weight = 1
+[languages.tr]
+weight = 2
+-- content/p1.en.md --
+---
+title: p1
+---
+![alt](img.jpg)
+-- content/p1.tr.md --
+---
+title: p1
+---
+![alt](img.jpg)
+-- layouts/_markup/render-image.tr.html --
+TR-IMAGE
+-- layouts/_default/single.html --
+{{ .Content }}
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/p1/index.html", "<img src=\"img.jpg\" alt=\"alt\">")
+	b.AssertFileContent("public/tr/p1/index.html", "TR-IMAGE")
+}

--- a/tpl/tplimpl/shortcodes_integration_test.go
+++ b/tpl/tplimpl/shortcodes_integration_test.go
@@ -858,3 +858,89 @@ Content: {{ .Content }}|sc1: {{ .HasShortcode "sc1" }}|sc2: {{ .HasShortcode "sc
 	b.AssertFileContent("public/en/p1/index.html", " |sc1: true|sc2: false|inc: true|")
 	b.AssertFileContent("public/sv/p1/index.html", " |sc1: false|sc2: true|inc: true|")
 }
+
+func TestShortcodeMultilingualHTML(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = 'https://example.org/'
+defaultContentLanguage = 'tr'
+defaultContentLanguageInSubdir = true
+[languages.tr]
+weight = 1
+[languages.en]
+weight = 2
+-- content/posts/test-post.tr.md --
++++
+title = 'Test Post TR'
++++
+
+{{< myhtml >}}
+-- content/posts/test-post.en.md --
++++
+title = 'Test Post EN'
++++
+
+{{< myhtml >}}
+-- layouts/_shortcodes/myhtml.en.html --
+HTML-EN
+-- layouts/_shortcodes/myhtml.tr.html --
+HTML-TR
+-- layouts/_default/single.html --
+{{ .Content }}
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/tr/posts/test-post/index.html",
+		"HTML-TR",
+	)
+
+	b.AssertFileContent("public/en/posts/test-post/index.html",
+		"HTML-EN",
+	)
+}
+
+func TestShortcodeMultilingualMarkdown(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = 'https://example.org/'
+defaultContentLanguage = 'tr'
+defaultContentLanguageInSubdir = true
+[languages.tr]
+weight = 1
+[languages.en]
+weight = 2
+-- content/posts/test-post.tr.md --
++++
+title = 'Test Post TR'
++++
+
+{{% mymd %}}
+-- content/posts/test-post.en.md --
++++
+title = 'Test Post EN'
++++
+
+{{% mymd %}}
+-- layouts/_shortcodes/mymd.en.md --
+MD-EN
+-- layouts/_shortcodes/mymd.tr.md --
+MD-TR
+-- layouts/_default/single.html --
+{{ .Content }}
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/tr/posts/test-post/index.html",
+		"MD-TR",
+	)
+
+	b.AssertFileContent("public/en/posts/test-post/index.html",
+		"MD-EN",
+	)
+}

--- a/tpl/tplimpl/templatedescriptor.go
+++ b/tpl/tplimpl/templatedescriptor.go
@@ -71,6 +71,12 @@ func (s descriptorHandler) compareDescriptors(category Category, this, other Tem
 	w := this.doCompare(category, other, sitesMatrixThis, sitesMatrixOther)
 
 	if w.w1 <= 0 {
+		if sitesMatrixOther != nil {
+			if sitesMatrixThis == nil || !sitesMatrixOther.HasAnyVector(sitesMatrixThis) {
+				return w
+			}
+		}
+
 		if category == CategoryMarkup && (this.Variant1 == other.Variant1) && (this.Variant2 == other.Variant2 || this.Variant2 != "" && other.Variant2 == "") {
 			// See issue 13242.
 			if this.OutputFormat != other.OutputFormat && this.OutputFormat == s.opts.DefaultOutputFormat {


### PR DESCRIPTION
Fixes #14098

I've found that the language resolution discrepancy between HTML and Markdown files was due to the `weight.w1` being set to 1 prematurely in `tpl/tplimpl/templatedescriptor.go:89` as the `AlwaysAllowPlainText` value is true for Markdown files. I've fixed the issue by adding a sitesMatrix check a bit before in the stack and returning early.  

I took quite bit of help from Claude Code when writing the integration tests for both issue reproduction and preventing regression in the future.