### PR TITLE
For multiple dimensions setups, fix alias handling and multihost publish path

### DIFF
--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -607,7 +607,12 @@ type RootConfig struct {
 	DefaultOutputFormat string
 
 	// Disable generation of redirect to the default language when DefaultContentLanguageInSubdir is enabled.
+	// Note that this currently is an alias for DisableDefaultDimensionRedirect introduced in v0.154.4.
+	// It's not obvious how a more fine grained setup would work.
 	DisableDefaultLanguageRedirect bool
+
+	// Disable generation of redirect to the default dimension when DefaultContentRoleInSubdir or DefaultContentVersionInSubdir or DefaultContentLanguageInSubdir is enabled.
+	DisableDefaultDimensionRedirect bool
 
 	// Disable creation of alias redirect pages.
 	DisableAliases bool

--- a/hugolib/alias.go
+++ b/hugolib/alias.go
@@ -70,6 +70,10 @@ func (a aliasHandler) renderAlias(permalink string, p page.Page, matrix sitesmat
 		return nil, errors.New("no alias template found")
 	}
 
+	if p == nil {
+		p = page.NopPage
+	}
+
 	data := aliasPage{
 		permalink,
 		p,

--- a/hugolib/page__paths.go
+++ b/hugolib/page__paths.go
@@ -160,11 +160,19 @@ func createTargetPathDescriptor(p *pageState) (page.TargetPathDescriptor, error)
 
 	// Add path prefixes.
 	// Add any role first, as that is a natural candidate for external ACL checks.
+	// For multihost sites, the file path needs to start with the language code.
+	if s.h.Conf.IsMultihost() {
+		addPrefix(s.getLanguageTargetPathLang(true), "")
+	}
 	rolePrefix := s.getPrefixRole()
 	addPrefix(rolePrefix, rolePrefix)
 	versionPrefix := s.getPrefixVersion()
 	addPrefix(versionPrefix, versionPrefix)
-	addPrefix(s.getLanguageTargetPathLang(alwaysInSubDir), s.getLanguagePermalinkLang(alwaysInSubDir))
+	if s.h.Conf.IsMultihost() {
+		addPrefix("", s.getLanguagePermalinkLang(alwaysInSubDir))
+	} else {
+		addPrefix(s.getLanguageTargetPathLang(alwaysInSubDir), s.getLanguagePermalinkLang(alwaysInSubDir))
+	}
 
 	if desc.URL != "" && strings.IndexByte(desc.URL, ':') >= 0 {
 		// Attempt to parse and expand an url

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1056,7 +1056,7 @@ func (s *siteRefLinker) refLink(ref string, source any, relative bool, outputFor
 		if outputFormat != "" {
 			o := target.OutputFormats().Get(outputFormat)
 
-			if o == nil {
+			if o.IsZero() {
 				s.logNotFound(refURL.Path, fmt.Sprintf("output format %q", outputFormat), p, pos)
 				return s.notFoundURL, nil
 			}
@@ -1767,10 +1767,6 @@ func (s *Site) render(ctx *siteRenderContext) (err error) {
 	}
 
 	if !ctx.shouldRenderStandalonePage("") {
-		return
-	}
-
-	if err = s.renderMainLanguageRedirect(); err != nil {
 		return
 	}
 

--- a/resources/page/page_outputformat.go
+++ b/resources/page/page_outputformat.go
@@ -18,12 +18,15 @@ package page
 import (
 	"strings"
 
+	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/output"
 )
 
 // OutputFormats holds a list of the relevant output formats for a given page.
 type OutputFormats []OutputFormat
+
+var _ types.Zeroer = OutputFormat{}
 
 // OutputFormat links to a representation of a resource.
 type OutputFormat struct {
@@ -65,6 +68,11 @@ func (o OutputFormat) RelPermalink() string {
 	return o.relPermalink
 }
 
+// IsZero checks whether this OutputFormat is the zero value.
+func (o OutputFormat) IsZero() bool {
+	return o.Format.Name == ""
+}
+
 func NewOutputFormat(relPermalink, permalink string, isCanonical bool, f output.Format) OutputFormat {
 	isUserConfigured := true
 	for _, d := range output.DefaultFormats {
@@ -84,12 +92,24 @@ func NewOutputFormat(relPermalink, permalink string, isCanonical bool, f output.
 }
 
 // Get gets a OutputFormat given its name, i.e. json, html etc.
-// It returns nil if none found.
-func (o OutputFormats) Get(name string) *OutputFormat {
+// It returns a zero OutputFormat if not found.
+func (o OutputFormats) Get(name string) OutputFormat {
 	for _, f := range o {
 		if strings.EqualFold(f.Format.Name, name) {
-			return &f
+			return f
 		}
 	}
-	return nil
+	return OutputFormat{}
+}
+
+// Canonical returns the first canonical OutputFormat for this page,
+// or a zero OutputFormat if not found.
+func (o OutputFormats) Canonical() OutputFormat {
+	const canonical = "canonical"
+	for _, f := range o {
+		if strings.EqualFold(f.Rel, canonical) {
+			return f
+		}
+	}
+	return OutputFormat{}
 }

--- a/resources/page/page_paths.go
+++ b/resources/page/page_paths.go
@@ -432,6 +432,7 @@ func (p *pagePathBuilder) PathDirBase() string {
 
 func (p *pagePathBuilder) PathFile() string {
 	dir := p.Path(0)
+
 	if p.prefixPath != "" {
 		dir = "/" + p.prefixPath + dir
 	}

--- a/tpl/tplimpl/embedded/templates/alias.html
+++ b/tpl/tplimpl/embedded/templates/alias.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="{{ site.Language.LanguageCode }}">
   <head>
     <title>{{ .Permalink }}</title>
-    <link rel="canonical" href="{{ .Permalink }}">
-    <meta charset="utf-8">
+    {{ with .OutputFormats.Canonical }}<link rel="{{ .Rel }}" href="{{ .Permalink }}">{{ end }}
+    <meta charset="utf-8" />
     <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
   </head>
 </html>


### PR DESCRIPTION
* The alias handling was left as is when we added new dimensions in v0.152.0, which meant that if you had `defaultContentVersionInSubDir=true` set, the alias page in the root would not be correctly created.
* Also, if you had multihost setup with multiple dimensions, the publish would be incorrect: The language key was added last instead of first.
* The home page alias handling is reworked and made more robust, which also fixes some subtle issues:

* It now supports redircects for multiple HTML output formats for the home page.
* We skip creating aliases for disabled home pages.
* With potentially multiple output formats with one of them canonical, we added a new  `Canonical` method to the `Page.OutputFormats`, which allows you to do this in a template:

```handlebars
{{ with .OutputFormats.Canonical }}<link rel="{{ .Rel }}" href="{{ .Permalink }}">{{ end }}
```

Fixes #14354
Fixes #14356