### PR TITLE
tpl/tplimpl: Remove trailing slash from void elements

### DIFF
--- a/tpl/tplimpl/embedded/templates/_server/error.html
+++ b/tpl/tplimpl/embedded/templates/_server/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Hugo Server: Error</title>
     <style type="text/css">
       body {
@@ -65,7 +65,7 @@
       <div class="error">
         {{ highlight .Error "apl" (printf "linenos=false,noclasses=true,style=%s" $codeStyle ) }}
       </div>
-      <hr />
+      <hr>
       {{ range $i, $e := .Files }}
         {{ if not .ErrorContext }}
           {{ continue }}
@@ -78,7 +78,7 @@
           >
         {{ end }}
         {{ highlight (delimit .ErrorContext.Lines "\n") $lexer $params }}
-        <hr />
+        <hr>
       {{ end }}
       <p class="version">{{ .Version }}</p>
       <a href="">Reload Page</a>

--- a/tpl/tplimpl/embedded/templates/alias.html
+++ b/tpl/tplimpl/embedded/templates/alias.html
@@ -3,7 +3,7 @@
   <head>
     <title>{{ .Permalink }}</title>
     {{ with .OutputFormats.Canonical }}<link rel="{{ .Rel }}" href="{{ .Permalink }}">{{ end }}
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
   </head>
 </html>


### PR DESCRIPTION
Trailing slashes on void elements trigger HTML validation messages such as:

<img width="627" height="146" alt="image" src="https://github.com/user-attachments/assets/a566de68-d6ff-466a-b939-7edc11760f54" />

I suspect this was inadvertently added when formatting the template with  the `prettier-plugin-go-template` plugin. This can be avoided by adding the `@awmottaz/prettier-plugin-void-html` prettier plugin.
