### PR TITLE
Fix some default site redirect woes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+tpl/tplimpl/embedded/templates/**

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -607,12 +607,13 @@ type RootConfig struct {
 	DefaultOutputFormat string
 
 	// Disable generation of redirect to the default language when DefaultContentLanguageInSubdir is enabled.
-	// Note that this currently is an alias for DisableDefaultDimensionRedirect introduced in v0.154.4.
+	// Note that this currently is an alias for DisableDefaultSiteRedirect introduced in v0.154.5.
 	// It's not obvious how a more fine grained setup would work.
 	DisableDefaultLanguageRedirect bool
 
-	// Disable generation of redirect to the default dimension when DefaultContentRoleInSubdir or DefaultContentVersionInSubdir or DefaultContentLanguageInSubdir is enabled.
-	DisableDefaultDimensionRedirect bool
+	// Disable generation of redirects to the default site when DefaultContentRoleInSubdir or DefaultContentVersionInSubdir or DefaultContentLanguageInSubdir is enabled.
+	// The default site is the site is the combination of defaultContentLanguage, defaultContentVersion and defaultContentRole.
+	DisableDefaultSiteRedirect bool
 
 	// Disable creation of alias redirect pages.
 	DisableAliases bool

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -138,7 +138,8 @@ func (s *Site) resolveDimensionNames() types.Strings3 {
 }
 
 type siteLanguageVersionRole struct {
-	siteVector sitesmatrix.Vector
+	siteVector        sitesmatrix.Vector
+	isDefaultLanguage bool
 
 	roleInternal roles.RoleInternal
 	role         roles.Role
@@ -184,6 +185,10 @@ func (s siteLanguageVersionRole) Role() roles.Role {
 
 func (s siteLanguageVersionRole) Version() versions.Version {
 	return s.version
+}
+
+func (s siteLanguageVersionRole) isDefault() bool {
+	return s.isDefaultLanguage && s.roleInternal.Default && s.versionInternal.Default
 }
 
 func (s *Site) Debug() {
@@ -341,7 +346,8 @@ func NewHugoSites(cfg deps.DepsCfg) (*HugoSites, error) {
 			frontmatterHandler: frontmatterHandler,
 			store:              hstore.NewScratch(),
 			siteLanguageVersionRole: &siteLanguageVersionRole{
-				siteVector: sitesmatrix.Vector{i, 0, 0},
+				isDefaultLanguage: language.IsDefault(),
+				siteVector:        sitesmatrix.Vector{i, 0, 0},
 			},
 		}
 

--- a/hugolib/sitesmatrix/sitematrix_integration_test.go
+++ b/hugolib/sitesmatrix/sitematrix_integration_test.go
@@ -1281,8 +1281,23 @@ defaultContentLanguageInSubDir = true
 defaultContentVersionInSubDir = true
 defaultContentRoleInSubDir = true
 disableDefaultLanguageRedirect = false
-disableDefaultDimensionRedirect = false
+disableDefaultSiteRedirect = false
 defaultContentLanguage = "en"
+defaultContentVersion = "v1.0.0"
+defaultContentRole = "guest"
+[languages]
+[languages.en]
+weight = 2
+[languages.nn]
+weight = 1
+[versions]
+[versions."v1.0.0"]
+weight = 2
+[versions."v2.0.0"]
+weight = 1
+[roles]
+[roles.guest]
+[roles.member]
 [outputs]
 home = [ 'rss', 'amp', 'html']
 -- layouts/home.html --
@@ -1334,7 +1349,7 @@ func TestSitesMatrixRedirectsDisableDefaultLanguageRedirect(t *testing.T) {
 	}
 
 	runTest(strings.ReplaceAll(files, "disableDefaultLanguageRedirect = false", "disableDefaultLanguageRedirect = true"))
-	runTest(strings.ReplaceAll(files, "disableDefaultDimensionRedirect = false", "disableDefaultDimensionRedirect = true"))
+	runTest(strings.ReplaceAll(files, "disableDefaultSiteRedirect = false", "disableDefaultSiteRedirect = true"))
 }
 
 func TestSitesMatrixRedirectsDefaultContentVersionInBase(t *testing.T) {
@@ -1361,7 +1376,7 @@ defaultContentLanguageInSubDir = true
 defaultContentVersionInSubDir = true
 defaultContentRoleInSubDir = true
 disableDefaultLanguageRedirect = false
-disableDefaultDimensionRedirect = false
+disableDefaultSiteRedirect = false
 defaultContentLanguage = "en"
 [languages]
 [languages.en]
@@ -1383,4 +1398,35 @@ Home.
 	b.AssertFileContent("public/en/guest/index.html", "url=https://en.example.org/guest/v1.0.0/\"")
 	b.AssertFileContent("public/en/guest/v1.0.0/index.html", "Home.")
 	b.AssertFileContent("public/en/guest/v1.0.0/amp/index.html", "Home.")
+}
+
+func TestSitesMatrixRedirectsDefaultContentLanguageInBase(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.yml --
+baseURL: https://example.org
+disableKinds: [taxonomy]
+defaultContentVersionInSubDir: true
+defaultContentRoleInSubDir: true
+defaultContentLanguage: en
+languages:
+  en:
+    languageName: English
+  bn:
+    languageName: Bengali
+  fr:
+    languageName: French
+-- layouts/all.html --
+All.
+
+`
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/guest/v1.0.0/en/index.html", "url=https://example.org/guest/v1.0.0/\"", `lang="en"`)
+
+	files = strings.ReplaceAll(files, "defaultContentVersionInSubDir: true", "defaultContentVersionInSubDir: false")
+
+	b = hugolib.Test(t, files)
+	b.AssertFileContent("public/guest/en/index.html", "url=https://example.org/guest/\"")
 }

--- a/tpl/tplimpl/embedded/templates/alias.html
+++ b/tpl/tplimpl/embedded/templates/alias.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="{{ site.Language.LanguageCode }}">
   <head>
     <title>{{ .Permalink }}</title>


### PR DESCRIPTION
* The fix for #14357 yesterday sadly had the assumption that default language/version/role always was the first site in the sites matrix. This is common, but not always true.
* Also, that fix forgot to add a redirect the other way when `defaultContentLanguageInSubdir` was disabled, e.g. from `/en/` to `/`.
* This commit also renames config option `DisableDefaultDimensionRedirect` to `DisableDefaultSiteRedirect`. This is stricly a breaking change, but it's only been out for a day, and the old name didn't make much sense.

Fixes #14361
