### PR TITLE
hugolib: Fix newly created shortcodes not found during server rebuild

### DIFF
--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -1034,7 +1034,9 @@ func (h *HugoSites) processPartialFileEvents(ctx context.Context, l logg.LevelLo
 					changes = append(changes, identity.GenghisKhan)
 				}
 				if strings.Contains(base, "shortcodes") {
-					changes = append(changes, hglob.NewGlobIdentity(fmt.Sprintf("shortcodes/%s*", pathInfo.BaseNameNoIdentifier())))
+					// Add both the shortcode file itself (for template refresh) and a glob for dependent content
+					changes = append(changes, pathInfo)
+					changes = append(changes, hglob.NewGlobIdentity(fmt.Sprintf("/_shortcodes/%s*", pathInfo.BaseNameNoIdentifier())))
 				} else {
 					changes = append(changes, pathInfo)
 				}


### PR DESCRIPTION
When a new shortcode file was added during `hugo server`, the shortcode was detected but not properly registered in the template cache. This caused subsequent content edits using the shortcode to fail with "template for shortcode not found" until the server was restarted.

The issue was that when a shortcode was added, only a glob identity for dependent content was added to the changes list, but not the shortcode file's own pathInfo. This meant RefreshFiles filtered it out and never inserted it into the shortcodesByName cache.

The fix adds the shortcode file's pathInfo to changes (in addition to the glob for dependent content), and corrects the glob pattern from `shortcodes/...` to `/_shortcodes/...` to match the actual path format.

Fixes #14207 

Triaging for this issue was done using Claude Code.