### PR TITLE
Rename common/maps to common/hmaps

### DIFF
--- a/cache/filecache/filecache_config.go
+++ b/cache/filecache/filecache_config.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/config"
 
 	"github.com/mitchellh/mapstructure"
@@ -154,7 +154,7 @@ func DecodeConfig(fs afero.Fs, bcfg config.BaseConfig, m map[string]any) (Config
 	_, isOsFs := fs.(*afero.OsFs)
 
 	for k, v := range m {
-		if _, ok := v.(maps.Params); !ok {
+		if _, ok := v.(hmaps.Params); !ok {
 			continue
 		}
 		cc := defaultCacheConfig

--- a/commands/config.go
+++ b/commands/config.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/bep/simplecobra"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/config/allconfig"
 	"github.com/gohugoio/hugo/hugolib/sitesmatrix"
 	"github.com/gohugoio/hugo/modules"
@@ -95,7 +95,7 @@ func (c *configCommand) Run(ctx context.Context, cd *simplecobra.Commandeer, arg
 		if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
 			return err
 		}
-		maps.ConvertFloat64WithNoDecimalsToInt(m)
+		hmaps.ConvertFloat64WithNoDecimalsToInt(m)
 		switch format {
 		case "yaml":
 			return parser.InterfaceToConfig(m, metadecoders.YAML, os.Stdout)

--- a/commands/hugobuilder.go
+++ b/commands/hugobuilder.go
@@ -31,11 +31,11 @@ import (
 	"github.com/bep/simplecobra"
 	"github.com/fsnotify/fsnotify"
 	"github.com/gohugoio/hugo/common/herrors"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/htime"
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/common/terminal"
 	"github.com/gohugoio/hugo/common/types"
@@ -1077,7 +1077,7 @@ func (c *hugoBuilder) loadConfig(cd *simplecobra.Commandeer, running bool) error
 	}
 	cfg.Set("environment", c.r.environment)
 
-	cfg.Set("internal", maps.Params{
+	cfg.Set("internal", hmaps.Params{
 		"running":        running,
 		"watch":          watch,
 		"verbose":        c.r.isVerbose(),

--- a/commands/import.go
+++ b/commands/import.go
@@ -29,9 +29,9 @@ import (
 	"unicode"
 
 	"github.com/bep/simplecobra"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/htime"
 	"github.com/gohugoio/hugo/common/hugio"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/hugofs"
 	"github.com/gohugoio/hugo/parser"
@@ -190,7 +190,7 @@ func (c *importCommand) createSiteFromJekyll(jekyllRoot, targetDir string, jekyl
 }
 
 func (c *importCommand) convertJekyllContent(m any, content string) (string, error) {
-	metadata, _ := maps.ToStringMapE(m)
+	metadata, _ := hmaps.ToStringMapE(m)
 
 	lines := strings.Split(content, "\n")
 	var resultLines []string
@@ -246,7 +246,7 @@ func (c *importCommand) convertJekyllContent(m any, content string) (string, err
 }
 
 func (c *importCommand) convertJekyllMetaData(m any, postName string, postDate time.Time, draft bool) (any, error) {
-	metadata, err := maps.ToStringMapE(m)
+	metadata, err := hmaps.ToStringMapE(m)
 	if err != nil {
 		return nil, err
 	}

--- a/common/hexec/exec.go
+++ b/common/hexec/exec.go
@@ -27,8 +27,8 @@ import (
 	"sync"
 
 	"github.com/bep/logg"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/config/security"
 )
@@ -102,7 +102,7 @@ func New(cfg security.Config, workingDir string, log loggers.Logger) *Exec {
 		workingDir:        workingDir,
 		infol:             log.InfoCommand("exec"),
 		baseEnviron:       baseEnviron,
-		newNPXRunnerCache: maps.NewCache[string, func(arg ...any) (Runner, error)](),
+		newNPXRunnerCache: hmaps.NewCache[string, func(arg ...any) (Runner, error)](),
 	}
 }
 
@@ -121,7 +121,7 @@ type Exec struct {
 	// os.Environ filtered by the Exec.OsEnviron whitelist filter.
 	baseEnviron []string
 
-	newNPXRunnerCache *maps.Cache[string, func(arg ...any) (Runner, error)]
+	newNPXRunnerCache *hmaps.Cache[string, func(arg ...any) (Runner, error)]
 	npxInit           sync.Once
 	npxAvailable      bool
 }

--- a/common/hmaps/cache.go
+++ b/common/hmaps/cache.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"sync"

--- a/common/hmaps/cache_test.go
+++ b/common/hmaps/cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"testing"

--- a/common/hmaps/map.go
+++ b/common/hmaps/map.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"iter"

--- a/common/hmaps/map_test.go
+++ b/common/hmaps/map_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"testing"

--- a/common/hmaps/maps.go
+++ b/common/hmaps/maps.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"fmt"

--- a/common/hmaps/maps_test.go
+++ b/common/hmaps/maps_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"fmt"

--- a/common/hmaps/ordered.go
+++ b/common/hmaps/ordered.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"slices"

--- a/common/hmaps/ordered_test.go
+++ b/common/hmaps/ordered_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"testing"

--- a/common/hmaps/orderedintset.go
+++ b/common/hmaps/orderedintset.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"fmt"

--- a/common/hmaps/orderedintset_test.go
+++ b/common/hmaps/orderedintset_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"testing"

--- a/common/hmaps/params.go
+++ b/common/hmaps/params.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"errors"

--- a/common/hmaps/params_test.go
+++ b/common/hmaps/params_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Hugo Authors. All rights reserved.
+// Copyright 2026 The Hugo Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package maps
+package hmaps
 
 import (
 	"testing"

--- a/common/hreflect/helpers.go
+++ b/common/hreflect/helpers.go
@@ -20,8 +20,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/htime"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/types"
 )
 
@@ -355,7 +355,7 @@ func IsNil(v reflect.Value) bool {
 
 var contextInterface = reflect.TypeOf((*context.Context)(nil)).Elem()
 
-var isContextCache = maps.NewCache[reflect.Type, bool]()
+var isContextCache = hmaps.NewCache[reflect.Type, bool]()
 
 type k string
 

--- a/common/paths/pathparser.go
+++ b/common/paths/pathparser.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/hugofs/files"
 	"github.com/gohugoio/hugo/hugolib/sitesmatrix"
@@ -54,12 +54,12 @@ type PathParser struct {
 
 	// Below gets created on demand.
 	initOnce         sync.Once
-	sitesMatrixCache *maps.Cache[string, sitesmatrix.VectorStore] // Maps language index to sites matrix vector store.
+	sitesMatrixCache *hmaps.Cache[string, sitesmatrix.VectorStore] // Maps language index to sites matrix vector store.
 }
 
 func (pp *PathParser) init() {
 	pp.initOnce.Do(func() {
-		pp.sitesMatrixCache = maps.NewCache[string, sitesmatrix.VectorStore]()
+		pp.sitesMatrixCache = hmaps.NewCache[string, sitesmatrix.VectorStore]()
 	})
 }
 

--- a/config/allconfig/alldecoders.go
+++ b/config/allconfig/alldecoders.go
@@ -22,9 +22,9 @@ import (
 	"github.com/gohugoio/hugo/langs"
 
 	"github.com/gohugoio/hugo/cache/httpcache"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/config/privacy"
@@ -196,7 +196,7 @@ var allDecoderSetups = map[string]decodeWeight{
 		key: "outputs",
 		decode: func(d decodeWeight, p decodeConfig) error {
 			defaults := createDefaultOutputFormats(p.c.OutputFormats.Config)
-			m := maps.CleanConfigStringMap(p.p.GetStringMap("outputs"))
+			m := hmaps.CleanConfigStringMap(p.p.GetStringMap("outputs"))
 			p.c.Outputs = make(map[string][]string)
 			for k, v := range m {
 				s := types.ToStringSlicePreserveString(v)
@@ -225,13 +225,13 @@ var allDecoderSetups = map[string]decodeWeight{
 	"languages": {
 		key: "languages",
 		decode: func(d decodeWeight, p decodeConfig) error {
-			m := maps.CleanConfigStringMap(p.p.GetStringMap(d.key))
+			m := hmaps.CleanConfigStringMap(p.p.GetStringMap(d.key))
 			if len(m) == 1 {
 				// In v0.112.4 we moved this to the language config, but it's very commmon for mono language sites to have this at the top level.
-				var first maps.Params
+				var first hmaps.Params
 				var ok bool
 				for _, v := range m {
-					first, ok = v.(maps.Params)
+					first, ok = v.(hmaps.Params)
 					if ok {
 						break
 					}
@@ -266,7 +266,7 @@ var allDecoderSetups = map[string]decodeWeight{
 		key: "versions",
 		decode: func(d decodeWeight, p decodeConfig) error {
 			var err error
-			m := maps.CleanConfigStringMap(p.p.GetStringMap(d.key))
+			m := hmaps.CleanConfigStringMap(p.p.GetStringMap(d.key))
 			p.c.Versions, err = versions.DecodeConfig(p.c.RootConfig.DefaultContentVersion, m)
 			return err
 		},
@@ -278,7 +278,7 @@ var allDecoderSetups = map[string]decodeWeight{
 				err                error
 				defaultContentRole string
 			)
-			m := maps.CleanConfigStringMap(p.p.GetStringMap(d.key))
+			m := hmaps.CleanConfigStringMap(p.p.GetStringMap(d.key))
 			p.c.Roles, defaultContentRole, err = roles.DecodeConfig(p.c.RootConfig.DefaultContentRole, m)
 			p.c.RootConfig.DefaultContentRole = defaultContentRole
 
@@ -289,7 +289,7 @@ var allDecoderSetups = map[string]decodeWeight{
 	"params": {
 		key: "params",
 		decode: func(d decodeWeight, p decodeConfig) error {
-			p.c.Params = maps.CleanConfigStringMap(p.p.GetStringMap("params"))
+			p.c.Params = hmaps.CleanConfigStringMap(p.p.GetStringMap("params"))
 			if p.c.Params == nil {
 				p.c.Params = make(map[string]any)
 			}
@@ -335,7 +335,7 @@ var allDecoderSetups = map[string]decodeWeight{
 		key: "taxonomies",
 		decode: func(d decodeWeight, p decodeConfig) error {
 			if p.p.IsSet(d.key) {
-				p.c.Taxonomies = maps.CleanConfigStringMapString(p.p.GetStringMapString(d.key))
+				p.c.Taxonomies = hmaps.CleanConfigStringMapString(p.p.GetStringMapString(d.key))
 			}
 			return nil
 		},
@@ -447,7 +447,7 @@ var allDecoderSetups = map[string]decodeWeight{
 	"author": {
 		key: "author",
 		decode: func(d decodeWeight, p decodeConfig) error {
-			p.c.Author = maps.CleanConfigStringMap(p.p.GetStringMap(d.key))
+			p.c.Author = hmaps.CleanConfigStringMap(p.p.GetStringMap(d.key))
 			return nil
 		},
 		internalOrDeprecated: true,
@@ -455,7 +455,7 @@ var allDecoderSetups = map[string]decodeWeight{
 	"social": {
 		key: "social",
 		decode: func(d decodeWeight, p decodeConfig) error {
-			p.c.Social = maps.CleanConfigStringMapString(p.p.GetStringMapString(d.key))
+			p.c.Social = hmaps.CleanConfigStringMapString(p.p.GetStringMapString(d.key))
 			return nil
 		},
 		internalOrDeprecated: true,
@@ -469,8 +469,8 @@ var allDecoderSetups = map[string]decodeWeight{
 				p.c.UglyURLs = vv
 			case string:
 				p.c.UglyURLs = vv == "true"
-			case maps.Params:
-				p.c.UglyURLs = cast.ToStringMapBool(maps.CleanConfigStringMap(vv))
+			case hmaps.Params:
+				p.c.UglyURLs = cast.ToStringMapBool(hmaps.CleanConfigStringMap(vv))
 			default:
 				p.c.UglyURLs = cast.ToStringMapBool(v)
 			}

--- a/config/allconfig/docshelper.go
+++ b/config/allconfig/docshelper.go
@@ -14,7 +14,7 @@
 package allconfig
 
 import (
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/docshelper"
 )
@@ -27,12 +27,12 @@ func init() {
 			if v.internalOrDeprecated {
 				continue
 			}
-			cfg.Set(configRoot, make(maps.Params))
+			cfg.Set(configRoot, make(hmaps.Params))
 		}
-		lang := maps.Params{
-			"en": maps.Params{
-				"menus":  maps.Params{},
-				"params": maps.Params{},
+		lang := hmaps.Params{
+			"en": hmaps.Params{
+				"menus":  hmaps.Params{},
+				"params": hmaps.Params{},
 			},
 		}
 		cfg.Set("languages", lang)

--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -25,9 +25,9 @@ import (
 	"github.com/gobwas/glob"
 	"github.com/gohugoio/hugo/common/herrors"
 	"github.com/gohugoio/hugo/common/hexec"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/config"
@@ -166,7 +166,7 @@ func (l configLoader) applyConfigAliases() error {
 }
 
 func (l configLoader) applyDefaultConfig() error {
-	defaultSettings := maps.Params{
+	defaultSettings := hmaps.Params{
 		// These dirs are used early/before we build the config struct.
 		"themesDir": "themes",
 		"configDir": "config",
@@ -186,7 +186,7 @@ func (l configLoader) normalizeCfg(cfg config.Provider) error {
 	} else if b, ok := cfg.Get("minify").(bool); ok {
 		hugo.Deprecate("site config minify", "Use minify.minifyOutput instead.", "v0.150.0")
 		if b {
-			cfg.Set("minify", maps.Params{"minifyOutput": true})
+			cfg.Set("minify", hmaps.Params{"minifyOutput": true})
 		}
 	}
 
@@ -240,7 +240,7 @@ func (l configLoader) applyOsEnvOverrides(environ []string) error {
 	}
 
 	for _, env := range hugoEnv {
-		existing, nestedKey, owner, err := maps.GetNestedParamFn(env.Key, delim, l.cfg.Get)
+		existing, nestedKey, owner, err := hmaps.GetNestedParamFn(env.Key, delim, l.cfg.Get)
 		if err != nil {
 			return err
 		}
@@ -547,7 +547,7 @@ func (l configLoader) loadConfig(configName string) (string, error) {
 }
 
 func (l configLoader) deleteMergeStrategies() (err error) {
-	l.cfg.WalkParams(func(params ...maps.KeyParams) bool {
+	l.cfg.WalkParams(func(params ...hmaps.KeyParams) bool {
 		params[len(params)-1].Params.DeleteMergeStrategy()
 		return false
 	})

--- a/config/configLoader.go
+++ b/config/configLoader.go
@@ -20,11 +20,11 @@ import (
 	"strings"
 
 	"github.com/gohugoio/hugo/common/herrors"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/parser"
 
 	"github.com/gohugoio/hugo/common/paths"
 
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/parser/metadecoders"
 	"github.com/spf13/afero"
 )
@@ -222,11 +222,11 @@ func LoadConfigFromDir(sourceFs afero.Fs, configDir, environment string) (Provid
 	return cfg, dirnames, nil
 }
 
-var keyAliases maps.KeyRenamer
+var keyAliases hmaps.KeyRenamer
 
 func init() {
 	var err error
-	keyAliases, err = maps.NewKeyRenamer(
+	keyAliases, err = hmaps.NewKeyRenamer(
 		// Before 0.53 we used singular for "menu".
 		"{menu,languages/*/menu}", "menus",
 	)

--- a/config/configProvider.go
+++ b/config/configProvider.go
@@ -16,7 +16,7 @@ package config
 import (
 	"time"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/common/urls"
@@ -96,7 +96,7 @@ type Provider interface {
 	GetString(key string) string
 	GetInt(key string) int
 	GetBool(key string) bool
-	GetParams(key string) maps.Params
+	GetParams(key string) hmaps.Params
 	GetStringMap(key string) map[string]any
 	GetStringMapString(key string) map[string]string
 	GetStringSlice(key string) []string
@@ -104,9 +104,9 @@ type Provider interface {
 	Set(key string, value any)
 	Keys() []string
 	Merge(key string, value any)
-	SetDefaults(params maps.Params)
+	SetDefaults(params hmaps.Params)
 	SetDefaultMergeStrategy()
-	WalkParams(walkFn func(params ...maps.KeyParams) bool)
+	WalkParams(walkFn func(params ...hmaps.KeyParams) bool)
 	IsSet(key string) bool
 }
 

--- a/config/defaultConfigProvider_test.go
+++ b/config/defaultConfigProvider_test.go
@@ -22,9 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/para"
-
-	"github.com/gohugoio/hugo/common/maps"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -48,7 +47,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 		c.Assert(cfg.Get(k), qt.Equals, v)
 		c.Assert(cfg.GetInt(k), qt.Equals, v)
 
-		c.Assert(cfg.Get(""), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get(""), qt.DeepEquals, hmaps.Params{
 			"foo": 42,
 		})
 	})
@@ -60,7 +59,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 			"bar": "baz",
 		})
 
-		c.Assert(cfg.Get("foo"), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get("foo"), qt.DeepEquals, hmaps.Params{
 			"bar": "baz",
 		})
 
@@ -76,14 +75,14 @@ func TestDefaultConfigProvider(t *testing.T) {
 		})
 		cfg.Set("a.c", "cv")
 
-		c.Assert(cfg.Get("a"), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get("a"), qt.DeepEquals, hmaps.Params{
 			"b": "bv",
 			"c": "cv",
 		})
 		c.Assert(cfg.Get("a.c"), qt.Equals, "cv")
 
 		cfg.Set("b.a", "av")
-		c.Assert(cfg.Get("b"), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get("b"), qt.DeepEquals, hmaps.Params{
 			"a": "av",
 		})
 
@@ -91,7 +90,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 			"b": "bv",
 		})
 
-		c.Assert(cfg.Get("b"), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get("b"), qt.DeepEquals, hmaps.Params{
 			"a": "av",
 			"b": "bv",
 		})
@@ -105,7 +104,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 			"b": "bv2",
 		})
 
-		c.Assert(cfg.Get(""), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get(""), qt.DeepEquals, hmaps.Params{
 			"a": "av2",
 			"b": "bv2",
 		})
@@ -118,7 +117,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 			"b": "bv2",
 		})
 
-		c.Assert(cfg.Get(""), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get(""), qt.DeepEquals, hmaps.Params{
 			"a": "av",
 			"b": "bv2",
 		})
@@ -137,7 +136,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 			},
 		})
 
-		c.Assert(cfg.Get("foo"), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get("foo"), qt.DeepEquals, hmaps.Params{
 			"a": "av",
 			"b": "bv2",
 		})
@@ -155,7 +154,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 			"c": "cv2",
 		})
 
-		c.Assert(cfg.Get("a"), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get("a"), qt.DeepEquals, hmaps.Params{
 			"b": "bv",
 			"c": "cv2",
 		})
@@ -169,7 +168,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 			"b": "bv2",
 		})
 
-		c.Assert(cfg.Get(""), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get(""), qt.DeepEquals, hmaps.Params{
 			"a": "av",
 		})
 	})
@@ -192,11 +191,11 @@ func TestDefaultConfigProvider(t *testing.T) {
 			"e": "ev2",
 		})
 
-		c.Assert(cfg.Get("a"), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get("a"), qt.DeepEquals, hmaps.Params{
 			"e":      "ev2",
-			"_merge": maps.ParamsMergeStrategyShallow,
+			"_merge": hmaps.ParamsMergeStrategyShallow,
 			"b":      "bv",
-			"c": maps.Params{
+			"c": hmaps.Params{
 				"b": "bv",
 			},
 		})
@@ -221,15 +220,15 @@ func TestDefaultConfigProvider(t *testing.T) {
 				"b": left,
 			})
 
-			cfg.Merge("", maps.Params{
-				"b": maps.Params{
+			cfg.Merge("", hmaps.Params{
+				"b": hmaps.Params{
 					"c": "cv2",
 					"d": "dv2",
 				},
 			})
 
-			c.Assert(cfg.Get(""), qt.DeepEquals, maps.Params{
-				"b": maps.Params{
+			c.Assert(cfg.Get(""), qt.DeepEquals, hmaps.Params{
+				"b": hmaps.Params{
 					"c": "cv1",
 					"d": "dv2",
 				},
@@ -267,8 +266,8 @@ func TestDefaultConfigProvider(t *testing.T) {
 
 				cfg.Merge("a", right)
 
-				c.Assert(cfg.Get(""), qt.DeepEquals, maps.Params{
-					"a": maps.Params{
+				c.Assert(cfg.Get(""), qt.DeepEquals, hmaps.Params{
+					"a": hmaps.Params{
 						"b": "bv1",
 						"c": "cv2",
 					},
@@ -292,7 +291,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 			},
 		})
 
-		c.Assert(cfg.Get(""), qt.DeepEquals, maps.Params{
+		c.Assert(cfg.Get(""), qt.DeepEquals, hmaps.Params{
 			"b": "bv",
 		})
 	})
@@ -341,7 +340,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 					return err
 				}
 
-				m := maps.Params{
+				m := hmaps.Params{
 					"new": 42,
 				}
 
@@ -371,8 +370,8 @@ func TestDefaultConfigProvider(t *testing.T) {
 		cfg := New()
 		k := "foo"
 
-		cfg.Set(k, maps.Params{k: true})
-		c.Assert(cfg.GetParams(k), qt.DeepEquals, maps.Params{
+		cfg.Set(k, hmaps.Params{k: true})
+		c.Assert(cfg.GetParams(k), qt.DeepEquals, hmaps.Params{
 			k: true,
 		})
 
@@ -384,8 +383,8 @@ func TestDefaultConfigProvider(t *testing.T) {
 		k := "foo"
 		k2 := "bar"
 
-		cfg.Set(k, maps.Params{k: struct{}{}})
-		cfg.Set(k2, maps.Params{k2: struct{}{}})
+		cfg.Set(k, hmaps.Params{k: struct{}{}})
+		cfg.Set(k2, hmaps.Params{k2: struct{}{}})
 
 		c.Assert(len(cfg.Keys()), qt.Equals, 2)
 
@@ -401,11 +400,11 @@ func TestDefaultConfigProvider(t *testing.T) {
 	c.Run("WalkParams", func(c *qt.C) {
 		cfg := New()
 
-		cfg.Set("x", maps.Params{})
-		cfg.Set("y", maps.Params{})
+		cfg.Set("x", hmaps.Params{})
+		cfg.Set("y", hmaps.Params{})
 
 		var got []string
-		cfg.WalkParams(func(params ...maps.KeyParams) bool {
+		cfg.WalkParams(func(params ...hmaps.KeyParams) bool {
 			got = append(got, params[len(params)-1].Key)
 			return false
 		})
@@ -417,7 +416,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 		c.Assert(got, qt.DeepEquals, want)
 
 		cfg = New()
-		cfg.WalkParams(func(params ...maps.KeyParams) bool {
+		cfg.WalkParams(func(params ...hmaps.KeyParams) bool {
 			return true
 		})
 
@@ -429,7 +428,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 	c.Run("SetDefaults", func(c *qt.C) {
 		cfg := New()
 
-		cfg.SetDefaults(maps.Params{
+		cfg.SetDefaults(hmaps.Params{
 			"foo": "bar",
 			"bar": "baz",
 		})

--- a/config/namespace_test.go
+++ b/config/namespace_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -32,7 +32,7 @@ func TestNamespace(t *testing.T) {
 		map[string]any{"foo": "bar"},
 		func(v any) (*tstNsExt, any, error) {
 			t := &tstNsExt{}
-			m, err := maps.ToStringMapE(v)
+			m, err := hmaps.ToStringMapE(v)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/config/testconfig/testconfig.go
+++ b/config/testconfig/testconfig.go
@@ -17,7 +17,7 @@ package testconfig
 import (
 	_ "unsafe"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/config/allconfig"
 	"github.com/gohugoio/hugo/deps"
@@ -84,7 +84,7 @@ func GetTestConfigSectionFromStruct(section string, v any) config.AllProvider {
 	if err != nil {
 		panic(err)
 	}
-	p := maps.Params{
+	p := hmaps.Params{
 		section: config.FromTOMLConfigString(string(data)).Get(""),
 	}
 	cfg := config.NewFrom(p)

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -28,8 +28,8 @@ import (
 	"github.com/gohugoio/hugo/cache/dynacache"
 	"github.com/gohugoio/hugo/cache/filecache"
 	"github.com/gohugoio/hugo/common/hexec"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/config/allconfig"
@@ -173,8 +173,8 @@ func (d *Deps) Init() error {
 			d.BuildState.DeferredExecutionsGroupedByRenderingContext = make(map[tpl.RenderingContext]*DeferredExecutions)
 		}
 		d.BuildState.DeferredExecutions = &DeferredExecutions{
-			Executions:              maps.NewCache[string, *tpl.DeferredExecution](),
-			FilenamesWithPostPrefix: maps.NewCache[string, bool](),
+			Executions:              hmaps.NewCache[string, *tpl.DeferredExecution](),
+			FilenamesWithPostPrefix: hmaps.NewCache[string, bool](),
 		}
 	}
 
@@ -464,10 +464,10 @@ type Counters struct {
 type DeferredExecutions struct {
 	// A set of filenames in /public that
 	// contains a post-processing prefix.
-	FilenamesWithPostPrefix *maps.Cache[string, bool]
+	FilenamesWithPostPrefix *hmaps.Cache[string, bool]
 
 	// Maps a placeholder to a deferred execution.
-	Executions *maps.Cache[string, *tpl.DeferredExecution]
+	Executions *hmaps.Cache[string, *tpl.DeferredExecution]
 }
 
 var _ identity.SignalRebuilder = (*BuildState)(nil)
@@ -480,8 +480,8 @@ func (b *BuildState) StartStageRender(stage tpl.RenderingContext) {
 func (b *BuildState) StopStageRender(stage tpl.RenderingContext) {
 	b.DeferredExecutionsGroupedByRenderingContext[stage] = b.DeferredExecutions
 	b.DeferredExecutions = &DeferredExecutions{
-		Executions:              maps.NewCache[string, *tpl.DeferredExecution](),
-		FilenamesWithPostPrefix: maps.NewCache[string, bool](),
+		Executions:              hmaps.NewCache[string, *tpl.DeferredExecution](),
+		FilenamesWithPostPrefix: hmaps.NewCache[string, bool](),
 	}
 }
 

--- a/hugofs/hglob/glob.go
+++ b/hugofs/hglob/glob.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/gobwas/glob"
 	"github.com/gobwas/glob/syntax"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/identity"
 )
 
@@ -32,9 +32,9 @@ var (
 	isWindows        = runtime.GOOS == "windows"
 	defaultGlobCache = &pathGlobCache{
 		isWindows: isWindows,
-		cache:     maps.NewCache[string, globErr](),
+		cache:     hmaps.NewCache[string, globErr](),
 	}
-	dotGlobCache = maps.NewCache[string, globErr]()
+	dotGlobCache = hmaps.NewCache[string, globErr]()
 )
 
 type globErr struct {
@@ -47,7 +47,7 @@ type pathGlobCache struct {
 	isWindows bool
 
 	// Cache
-	cache *maps.Cache[string, globErr]
+	cache *hmaps.Cache[string, globErr]
 }
 
 // GetGlobDot returns a glob.Glob that matches the given pattern, using '.' as the path separator.

--- a/hugofs/rootmapping_fs_test.go
+++ b/hugofs/rootmapping_fs_test.go
@@ -21,7 +21,7 @@ import (
 
 	iofs "io/fs"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/hugofs/hglob"
 	"github.com/gohugoio/hugo/hugolib/sitesmatrix"
@@ -556,5 +556,5 @@ func TestRootMappingFileFilter(t *testing.T) {
 var testDims = sitesmatrix.NewTestingDimensions([]string{"en", "no"}, []string{"v1", "v2", "v3"}, []string{"admin", "editor", "viewer", "guest"})
 
 func sitesMatrixForLangs(langs ...int) *sitesmatrix.IntSets {
-	return sitesmatrix.NewIntSetsBuilder(testDims).WithSets(maps.NewOrderedIntSet(langs...), nil, nil).Build()
+	return sitesmatrix.NewIntSetsBuilder(testDims).WithSets(hmaps.NewOrderedIntSet(langs...), nil, nil).Build()
 }

--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -20,11 +20,11 @@ import (
 	"testing"
 
 	"github.com/bep/logg"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/config/allconfig"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/spf13/afero"
 )
 
@@ -53,8 +53,8 @@ title = "English Comments Title"
 	enSite := b.H.Sites[0]
 	b.Assert(enSite.Title(), qt.Equals, "English Title")
 	b.Assert(enSite.Home().Title(), qt.Equals, "English Title")
-	b.Assert(enSite.Params(), qt.DeepEquals, maps.Params{
-		"comments": maps.Params{
+	b.Assert(enSite.Params(), qt.DeepEquals, hmaps.Params{
+		"comments": hmaps.Params{
 			"color": "blue",
 			"title": "English Comments Title",
 		},
@@ -424,13 +424,13 @@ name = "menu-theme"
 
 		got := b.H.Configs.Base
 
-		b.Assert(got.Params, qt.DeepEquals, maps.Params{
-			"b": maps.Params{
+		b.Assert(got.Params, qt.DeepEquals, hmaps.Params{
+			"b": hmaps.Params{
 				"b1": "b1 main",
-				"c": maps.Params{
+				"c": hmaps.Params{
 					"bc1": "bc1 main",
 					"bc2": "bc2 theme",
-					"d":   maps.Params{"bcd1": string("bcd1 theme")},
+					"d":   hmaps.Params{"bcd1": string("bcd1 theme")},
 				},
 				"b2": "b2 theme",
 			},
@@ -447,11 +447,11 @@ name = "menu-theme"
 		got := b.H.Configs.Base.Params
 
 		// Shallow merge, only add new keys to params.
-		b.Assert(got, qt.DeepEquals, maps.Params{
+		b.Assert(got, qt.DeepEquals, hmaps.Params{
 			"p1": "p1 main",
-			"b": maps.Params{
+			"b": hmaps.Params{
 				"b1": "b1 main",
-				"c": maps.Params{
+				"c": hmaps.Params{
 					"bc1": "bc1 main",
 				},
 			},
@@ -468,7 +468,7 @@ name = "menu-theme"
 
 		got := b.H.Configs.Base.Params
 
-		b.Assert(got, qt.DeepEquals, maps.Params{
+		b.Assert(got, qt.DeepEquals, hmaps.Params{
 			"p1": "p1 theme",
 		})
 	})
@@ -534,7 +534,7 @@ t3: {{ .Site.Params.t3 }}
 
 	got := b.H.Configs.Base.Params
 
-	b.Assert(got, qt.DeepEquals, maps.Params{
+	b.Assert(got, qt.DeepEquals, hmaps.Params{
 		"m1": "mv1",
 		"m2": "mv2",
 		"t1": "tv1",

--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bep/logg"
 	"github.com/gohugoio/go-radix"
 	"github.com/gohugoio/hugo/cache/dynacache"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/common/predicate"
@@ -38,8 +39,6 @@ import (
 	"github.com/gohugoio/hugo/identity"
 	"github.com/gohugoio/hugo/output"
 	"github.com/gohugoio/hugo/resources"
-
-	"github.com/gohugoio/hugo/common/maps"
 
 	"github.com/gohugoio/hugo/resources/kinds"
 	"github.com/gohugoio/hugo/resources/page"
@@ -100,7 +99,7 @@ type pageMap struct {
 	cacheContentPlain      *dynacache.Partition[string, *resources.StaleValue[contentPlainPlainWords]]
 	contentTableOfContents *dynacache.Partition[string, *resources.StaleValue[contentTableOfContents]]
 
-	contentDataFileSeenItems *maps.Cache[string, map[uint64]bool]
+	contentDataFileSeenItems *hmaps.Cache[string, map[uint64]bool]
 
 	cfg contentMapConfig
 }
@@ -710,7 +709,7 @@ func newPageMap(s *Site, mcache *dynacache.Cache, pageTrees *pageTrees) *pageMap
 		cacheContentPlain:      dynacache.GetOrCreatePartition[string, *resources.StaleValue[contentPlainPlainWords]](mcache, fmt.Sprintf("/cont/pla/%s", languageVersionRole), dynacache.OptionsPartition{Weight: 70, ClearWhen: dynacache.ClearOnChange}),
 		contentTableOfContents: dynacache.GetOrCreatePartition[string, *resources.StaleValue[contentTableOfContents]](mcache, fmt.Sprintf("/cont/toc/%s", languageVersionRole), dynacache.OptionsPartition{Weight: 70, ClearWhen: dynacache.ClearOnChange}),
 
-		contentDataFileSeenItems: maps.NewCache[string, map[uint64]bool](),
+		contentDataFileSeenItems: hmaps.NewCache[string, map[uint64]bool](),
 
 		cfg: contentMapConfig{
 			lang:                 s.Lang(),
@@ -756,13 +755,13 @@ func newPageMap(s *Site, mcache *dynacache.Cache, pageTrees *pageTrees) *pageMap
 func newContentTreeTreverseIndex(init func(get func(key any) (contentNode, bool), set func(key any, val contentNode))) *contentTreeReverseIndex {
 	return &contentTreeReverseIndex{
 		initFn: init,
-		mm:     maps.NewCache[any, contentNode](),
+		mm:     hmaps.NewCache[any, contentNode](),
 	}
 }
 
 type contentTreeReverseIndex struct {
 	initFn func(get func(key any) (contentNode, bool), set func(key any, val contentNode))
-	mm     *maps.Cache[any, contentNode]
+	mm     *hmaps.Cache[any, contentNode]
 }
 
 func (c *contentTreeReverseIndex) Reset() {

--- a/hugolib/content_map_page_assembler.go
+++ b/hugolib/content_map_page_assembler.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/gohugoio/go-radix"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/hugofs/files"
@@ -54,9 +54,9 @@ type allPagesAssembler struct {
 	rwRoot *doctree.NodeShiftTreeWalker[contentNode] // walks resources.
 
 	// Walking state.
-	seenTerms        *maps.Map[term, sitesmatrix.Vectors]
-	droppedPages     *maps.Map[*Site, []string] // e.g. drafts, expired, future.
-	seenRootSections *maps.Map[string, bool]
+	seenTerms        *hmaps.Map[term, sitesmatrix.Vectors]
+	droppedPages     *hmaps.Map[*Site, []string] // e.g. drafts, expired, future.
+	seenRootSections *hmaps.Map[string, bool]
 	seenHome         bool // set before we fan out to multiple goroutines.
 }
 
@@ -75,7 +75,7 @@ func newAllPagesAssembler(
 	pw := rw.Extend()
 	pw.Tree = m.treePages
 
-	seenRootSections := maps.NewMap[string, bool]()
+	seenRootSections := hmaps.NewMap[string, bool]()
 	seenRootSections.Set("", true) // home.
 
 	return &allPagesAssembler{
@@ -83,8 +83,8 @@ func newAllPagesAssembler(
 		h:                          h,
 		m:                          m,
 		assembleChanges:            assembleChanges,
-		seenTerms:                  maps.NewMap[term, sitesmatrix.Vectors](),
-		droppedPages:               maps.NewMap[*Site, []string](),
+		seenTerms:                  hmaps.NewMap[term, sitesmatrix.Vectors](),
+		droppedPages:               hmaps.NewMap[*Site, []string](),
 		seenRootSections:           seenRootSections,
 		assembleSectionsInParallel: true,
 		pwRoot:                     pw,

--- a/hugolib/doctree/support.go
+++ b/hugolib/doctree/support.go
@@ -21,7 +21,7 @@ import (
 
 	radix "github.com/gohugoio/go-radix"
 	"github.com/gohugoio/hugo/common/collections"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/hugolib/sitesmatrix"
 )
 
@@ -70,7 +70,7 @@ func (ctx *WalkContext[T]) Data() *SimpleThreadSafeTree[any] {
 
 func (ctx *WalkContext[T]) initDataRaw() {
 	ctx.dataRawInit.Do(func() {
-		ctx.dataRaw = maps.NewCache[sitesmatrix.Vector, *SimpleThreadSafeTree[any]]()
+		ctx.dataRaw = hmaps.NewCache[sitesmatrix.Vector, *SimpleThreadSafeTree[any]]()
 	})
 }
 
@@ -215,7 +215,7 @@ type WalkContext[T any] struct {
 	data     *SimpleThreadSafeTree[any]
 	dataInit sync.Once
 
-	dataRaw     *maps.Cache[sitesmatrix.Vector, *SimpleThreadSafeTree[any]]
+	dataRaw     *hmaps.Cache[sitesmatrix.Vector, *SimpleThreadSafeTree[any]]
 	dataRawInit sync.Once
 
 	eventHandlersMu sync.Mutex

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -38,10 +38,10 @@ import (
 	"github.com/gohugoio/hugo/output"
 	"github.com/gohugoio/hugo/parser/metadecoders"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hsync"
 	"github.com/gohugoio/hugo/common/htime"
 	"github.com/gohugoio/hugo/common/hugo"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/para"
 	"github.com/gohugoio/hugo/common/terminal"
 	"github.com/gohugoio/hugo/common/types"
@@ -95,11 +95,11 @@ type HugoSites struct {
 	// Now the different page dimensions (e.g. language) are built-in to the page trees above.
 	// But we sill need to support the overridden translationKey, but that should
 	// be relatively rare and low volume.
-	translationKeyPages *maps.SliceCache[page.Page]
+	translationKeyPages *hmaps.SliceCache[page.Page]
 
 	pageTrees                    *pageTrees
-	previousPageTreesWalkContext *doctree.WalkContext[contentNode]    // Set for rebuilds only.
-	previousSeenTerms            *maps.Map[term, sitesmatrix.Vectors] // Set for rebuilds only.
+	previousPageTreesWalkContext *doctree.WalkContext[contentNode]     // Set for rebuilds only.
+	previousSeenTerms            *hmaps.Map[term, sitesmatrix.Vectors] // Set for rebuilds only.
 
 	printUnusedTemplatesInit sync.Once
 	printPathWarningsInit    sync.Once

--- a/hugolib/integrationtest_builder.go
+++ b/hugolib/integrationtest_builder.go
@@ -26,8 +26,8 @@ import (
 	"github.com/gohugoio/hugo/common/herrors"
 	"github.com/gohugoio/hugo/common/hexec"
 	"github.com/gohugoio/hugo/common/himage"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/config/allconfig"
@@ -858,12 +858,12 @@ func (s *IntegrationTestBuilder) initBuilder() error {
 		}
 
 		if s.Cfg.Running {
-			flags.Set("internal", maps.Params{
+			flags.Set("internal", hmaps.Params{
 				"running": s.Cfg.Running,
 				"watch":   s.Cfg.Running,
 			})
 		} else if s.Cfg.Watching {
-			flags.Set("internal", maps.Params{
+			flags.Set("internal", hmaps.Params{
 				"watch": s.Cfg.Watching,
 			})
 		}

--- a/hugolib/page__content.go
+++ b/hugolib/page__content.go
@@ -29,9 +29,9 @@ import (
 	"github.com/bep/logg"
 
 	"github.com/gohugoio/hugo/common/herrors"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugio"
 	"github.com/gohugoio/hugo/common/hugo"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/predicate"
 	"github.com/gohugoio/hugo/common/types/hstring"
 	"github.com/gohugoio/hugo/helpers"
@@ -114,7 +114,7 @@ func (m *pageMeta) newCachedContent(s *Site) (*cachedContent, error) {
 		StaleInfo:   m,
 		pi:          m.pi,
 		enableEmoji: s.conf.EnableEmoji,
-		scopes:      maps.NewCache[string, *cachedContentScope](),
+		scopes:      hmaps.NewCache[string, *cachedContentScope](),
 	}
 	var hasName predicate.P[string] = m.pi.shortcodeParseInfo.hasName
 	c.hasShortcode.Store(&hasName)
@@ -136,7 +136,7 @@ type cachedContent struct {
 	// Whether the content has a given shortcode name.
 	hasShortcode atomic.Pointer[predicate.P[string]]
 
-	scopes *maps.Cache[string, *cachedContentScope]
+	scopes *hmaps.Cache[string, *cachedContentScope]
 }
 
 func (c *cachedContent) getOrCreateScope(scope string, pco *pageContentOutput) *cachedContentScope {

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -15,12 +15,11 @@ package hugolib
 
 import (
 	"fmt"
+	"maps"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
-
-	xmaps "maps"
 
 	"github.com/bep/logg"
 	"github.com/gobuffalo/flect"
@@ -36,10 +35,10 @@ import (
 
 	"github.com/gohugoio/hugo/common/hashing"
 	"github.com/gohugoio/hugo/common/hiter"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugio"
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/helpers"
@@ -373,7 +372,7 @@ func (s *Site) newPageMetaFromPageMetasource(ms *pageMetaSource) (*pageMeta, err
 	m := &pageMeta{
 		pageMetaSource: ms,
 		pageConfig: &pagemeta.PageConfigLate{
-			Params: make(maps.Params),
+			Params: make(hmaps.Params),
 		},
 	}
 	return m, nil
@@ -470,7 +469,7 @@ func (m *pageMeta) IsPage() bool {
 	return m.Kind() == kinds.KindPage
 }
 
-func (m *pageMeta) Params() maps.Params {
+func (m *pageMeta) Params() hmaps.Params {
 	return m.pageConfig.Params
 }
 
@@ -524,17 +523,17 @@ func (m *pageMeta) Weight() int {
 func (ps *pageState) setMetaPost(cascades *page.PageMatcherParamsConfigs) error {
 	if ps.m.pageConfigSource.Frontmatter != nil {
 		if ps.m.pageConfigSource.IsFromContentAdapter {
-			ps.m.pageConfig.ContentAdapterData = xmaps.Clone(ps.m.pageConfigSource.Frontmatter)
+			ps.m.pageConfig.ContentAdapterData = maps.Clone(ps.m.pageConfigSource.Frontmatter)
 		} else {
-			ps.m.pageConfig.Params = xmaps.Clone(ps.m.pageConfigSource.Frontmatter)
+			ps.m.pageConfig.Params = maps.Clone(ps.m.pageConfigSource.Frontmatter)
 		}
 	}
 
 	if ps.m.pageConfig.Params == nil {
-		ps.m.pageConfig.Params = make(maps.Params)
+		ps.m.pageConfig.Params = make(hmaps.Params)
 	}
 	if ps.m.pageConfigSource.IsFromContentAdapter && ps.m.pageConfig.ContentAdapterData == nil {
-		ps.m.pageConfig.ContentAdapterData = make(maps.Params)
+		ps.m.pageConfig.ContentAdapterData = make(hmaps.Params)
 	}
 
 	// Cascade defined on itself has higher priority than inherited ones.
@@ -660,7 +659,7 @@ params:
 		loki := strings.ToLower(k)
 
 		if loki == "params" {
-			vv, err := maps.ToStringMapE(v)
+			vv, err := hmaps.ToStringMapE(v)
 			if err != nil {
 				return err
 			}
@@ -753,7 +752,7 @@ params:
 			}
 			pcfg.Params[loki] = pcfg.Aliases
 		case "sitemap":
-			pcfg.Sitemap, err = config.DecodeSitemap(ps.s.conf.Sitemap, maps.ToStringMap(v))
+			pcfg.Sitemap, err = config.DecodeSitemap(ps.s.conf.Sitemap, hmaps.ToStringMap(v))
 			if err != nil {
 				return fmt.Errorf("failed to decode sitemap config in front matter: %s", err)
 			}
@@ -771,7 +770,7 @@ params:
 			switch vv := v.(type) {
 			case []map[any]any:
 				for _, vvv := range vv {
-					resources = append(resources, maps.ToStringMap(vvv))
+					resources = append(resources, hmaps.ToStringMap(vvv))
 				}
 			case []map[string]any:
 				resources = append(resources, vv...)
@@ -779,7 +778,7 @@ params:
 				for _, vvv := range vv {
 					switch vvvv := vvv.(type) {
 					case map[any]any:
-						resources = append(resources, maps.ToStringMap(vvvv))
+						resources = append(resources, hmaps.ToStringMap(vvvv))
 					case map[string]any:
 						resources = append(resources, vvvv)
 					}

--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/text"
 	"github.com/gohugoio/hugo/identity"
 	"github.com/gohugoio/hugo/tpl/tplimpl"
@@ -67,7 +67,7 @@ func newPageContentOutput(po *pageOutput) (*pageContentOutput, error) {
 	cp := &pageContentOutput{
 		po:           po,
 		renderHooks:  &renderHooks{},
-		otherOutputs: maps.NewCache[uint64, *pageContentOutput](),
+		otherOutputs: hmaps.NewCache[uint64, *pageContentOutput](),
 	}
 	return cp, nil
 }
@@ -83,7 +83,7 @@ type pageContentOutput struct {
 
 	// Other pages involved in rendering of this page,
 	// typically included with .RenderShortcodes.
-	otherOutputs *maps.Cache[uint64, *pageContentOutput]
+	otherOutputs *hmaps.Cache[uint64, *pageContentOutput]
 
 	contentRenderedVersion uint32      // Incremented on reset.
 	contentRendered        atomic.Bool // Set on content render.

--- a/hugolib/pagesfromdata/pagesfromgotmpl.go
+++ b/hugolib/pagesfromdata/pagesfromgotmpl.go
@@ -20,8 +20,8 @@ import (
 	"path/filepath"
 
 	"github.com/gohugoio/hugo/common/hashing"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstore"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/hugofs"
@@ -65,7 +65,7 @@ type pagesFromDataTemplateContext struct {
 }
 
 func (p *pagesFromDataTemplateContext) toPathSitesMap(v any) (string, map[string]any, map[string]any, error) {
-	m, err := maps.ToStringMapE(v)
+	m, err := hmaps.ToStringMapE(v)
 	if err != nil {
 		return "", nil, nil, err
 	}
@@ -75,7 +75,7 @@ func (p *pagesFromDataTemplateContext) toPathSitesMap(v any) (string, map[string
 		return "", nil, nil, fmt.Errorf("invalid path %q", path)
 	}
 
-	sites := maps.ToStringMap(m["sites"])
+	sites := hmaps.ToStringMap(m["sites"])
 
 	return path, sites, m, nil
 }
@@ -161,7 +161,7 @@ func NewPagesFromTemplate(opts PagesFromTemplateOptions) *PagesFromTemplate {
 		PagesFromTemplateOptions: opts,
 		PagesFromTemplateDeps:    opts.DepsFromSite(opts.Site),
 		buildState: &BuildState{
-			sourceInfosCurrent: maps.NewCache[string, *sourceInfo](),
+			sourceInfosCurrent: hmaps.NewCache[string, *sourceInfo](),
 		},
 		store: hstore.NewScratch(),
 	}
@@ -231,8 +231,8 @@ type BuildState struct {
 	NumPagesAdded     uint64
 	NumResourcesAdded uint64
 
-	sourceInfosCurrent  *maps.Cache[string, *sourceInfo]
-	sourceInfosPrevious *maps.Cache[string, *sourceInfo]
+	sourceInfosCurrent  *hmaps.Cache[string, *sourceInfo]
+	sourceInfosPrevious *hmaps.Cache[string, *sourceInfo]
 }
 
 func (b *BuildState) hash(v any) uint64 {
@@ -304,7 +304,7 @@ func (b *BuildState) resolveDeletedPaths() {
 
 func (b *BuildState) PrepareNextBuild() {
 	b.sourceInfosPrevious = b.sourceInfosCurrent
-	b.sourceInfosCurrent = maps.NewCache[string, *sourceInfo]()
+	b.sourceInfosCurrent = hmaps.NewCache[string, *sourceInfo]()
 	b.StaleVersion = 0
 	b.DeletedPaths = nil
 	b.ChangedIdentities = nil
@@ -317,7 +317,7 @@ func (p PagesFromTemplate) CloneForSite(s page.Site) *PagesFromTemplate {
 	p.PagesFromTemplateOptions.Site = s
 	p.PagesFromTemplateDeps = p.PagesFromTemplateOptions.DepsFromSite(s)
 	p.buildState = &BuildState{
-		sourceInfosCurrent: maps.NewCache[string, *sourceInfo](),
+		sourceInfosCurrent: hmaps.NewCache[string, *sourceInfo](),
 	}
 	return &p
 }

--- a/hugolib/segments/segments.go
+++ b/hugolib/segments/segments.go
@@ -18,9 +18,9 @@ import (
 	"strings"
 
 	"github.com/gobwas/glob"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/predicate"
 	"github.com/gohugoio/hugo/config"
 	hglob "github.com/gohugoio/hugo/hugofs/hglob"
@@ -276,14 +276,14 @@ func getGlob(s string) (glob.Glob, error) {
 
 func DecodeSegments(in map[string]any, segmentsToRender []string, logger loggers.Logger) (*config.ConfigNamespace[map[string]SegmentConfig, *Segments], error) {
 	buildConfig := func(in any) (*Segments, any, error) {
-		m, err := maps.ToStringMapE(in)
+		m, err := hmaps.ToStringMapE(in)
 		if err != nil {
 			return nil, nil, err
 		}
 		if m == nil {
 			m = map[string]any{}
 		}
-		m = maps.CleanConfigStringMap(m)
+		m = hmaps.CleanConfigStringMap(m)
 
 		var segmentCfg map[string]SegmentConfig
 		if err := mapstructure.WeakDecode(m, &segmentCfg); err != nil {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime"
 	"net/url"
 	"os"
@@ -32,13 +33,13 @@ import (
 	"github.com/bep/logg"
 	"github.com/gohugoio/go-radix"
 	"github.com/gohugoio/hugo/cache/dynacache"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstore"
 	"github.com/gohugoio/hugo/common/hsync"
 	"github.com/gohugoio/hugo/common/htime"
 	"github.com/gohugoio/hugo/common/hugio"
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/para"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/config"
@@ -54,8 +55,6 @@ import (
 	"github.com/gohugoio/hugo/langs/i18n"
 	"github.com/gohugoio/hugo/modules"
 	"github.com/gohugoio/hugo/resources"
-
-	xmaps "maps"
 
 	"github.com/gohugoio/hugo/tpl/tplimpl"
 	"github.com/gohugoio/hugo/tpl/tplimplinit"
@@ -478,7 +477,7 @@ func newHugoSites(
 			dynacache.OptionsPartition{Weight: 10, ClearWhen: dynacache.ClearOnRebuild},
 		),
 		cacheContentSource:      dynacache.GetOrCreatePartition[uint64, *resources.StaleValue[[]byte]](d.MemCache, "/cont/src", dynacache.OptionsPartition{Weight: 70, ClearWhen: dynacache.ClearOnChange}),
-		translationKeyPages:     maps.NewSliceCache[page.Page](),
+		translationKeyPages:     hmaps.NewSliceCache[page.Page](),
 		currentSite:             first[0],
 		skipRebuildForFilenames: make(map[string]bool),
 		init:                    &hugoSitesInit{},
@@ -669,7 +668,7 @@ func (s *Site) Lastmod() time.Time {
 }
 
 // Returns the Params configured for this site.
-func (s *Site) Params() maps.Params {
+func (s *Site) Params() hmaps.Params {
 	return s.conf.Params
 }
 
@@ -1140,7 +1139,7 @@ func (w *WhatChanged) Changes() []identity.Identity {
 	if w == nil || w.ids == nil {
 		return nil
 	}
-	return slices.Collect(xmaps.Keys(w.ids))
+	return slices.Collect(maps.Keys(w.ids))
 }
 
 func (w *WhatChanged) Drain() []identity.Identity {

--- a/hugolib/sitesmatrix/vectorstores_test.go
+++ b/hugolib/sitesmatrix/vectorstores_test.go
@@ -18,7 +18,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/gohugoio/hugo/common/hashing"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/hugolib/sitesmatrix"
 )
 
@@ -31,27 +31,27 @@ func TestIntSets(t *testing.T) {
 	testDims := newTestDims()
 
 	sets := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(1, 2),
-		maps.NewOrderedIntSet(1, 2, 3),
-		maps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2),
+		hmaps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2, 3),
 	).Build()
 
 	sets2 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(1, 2),
-		maps.NewOrderedIntSet(1, 2, 3),
-		maps.NewOrderedIntSet(1, 2, 4),
+		hmaps.NewOrderedIntSet(1, 2),
+		hmaps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2, 4),
 	).Build()
 
 	sets3 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(2, 1),
-		maps.NewOrderedIntSet(1, 2, 3),
-		maps.NewOrderedIntSet(2, 1, 4),
+		hmaps.NewOrderedIntSet(2, 1),
+		hmaps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(2, 1, 4),
 	).Build()
 
 	sets4 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(3, 4, 5),
-		maps.NewOrderedIntSet(3, 4, 5),
-		maps.NewOrderedIntSet(3, 4, 5),
+		hmaps.NewOrderedIntSet(3, 4, 5),
+		hmaps.NewOrderedIntSet(3, 4, 5),
+		hmaps.NewOrderedIntSet(3, 4, 5),
 	).Build()
 
 	c.Assert(hashing.HashStringHex(sets), qt.Equals, "790f6004619934ff")
@@ -68,24 +68,24 @@ func TestIntSets(t *testing.T) {
 	c.Assert(sets.EqualsVector(sets), qt.Equals, true)
 	c.Assert(sets.EqualsVector(
 		sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-			maps.NewOrderedIntSet(1, 2),
-			maps.NewOrderedIntSet(1, 2, 3),
-			maps.NewOrderedIntSet(1, 2, 3),
+			hmaps.NewOrderedIntSet(1, 2),
+			hmaps.NewOrderedIntSet(1, 2, 3),
+			hmaps.NewOrderedIntSet(1, 2, 3),
 		).Build(),
 	), qt.Equals, true)
 	c.Assert(sets.EqualsVector(
 		sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-			maps.NewOrderedIntSet(1, 2, 3),
-			maps.NewOrderedIntSet(1, 2, 3, 4),
-			maps.NewOrderedIntSet(1, 2, 3, 4),
+			hmaps.NewOrderedIntSet(1, 2, 3),
+			hmaps.NewOrderedIntSet(1, 2, 3, 4),
+			hmaps.NewOrderedIntSet(1, 2, 3, 4),
 		).Build(),
 	), qt.Equals, false)
 
 	c.Assert(sets.EqualsVector(
 		sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-			maps.NewOrderedIntSet(1, 2),
-			maps.NewOrderedIntSet(1, 2, 3),
-			maps.NewOrderedIntSet(2, 3, 4),
+			hmaps.NewOrderedIntSet(1, 2),
+			hmaps.NewOrderedIntSet(1, 2, 3),
+			hmaps.NewOrderedIntSet(2, 3, 4),
 		).Build(),
 	), qt.Equals, false)
 
@@ -126,17 +126,17 @@ func TestIntSetsComplement(t *testing.T) {
 		testDims := newTestDims()
 
 		self := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-			maps.NewOrderedIntSet(test.left.v0...),
-			maps.NewOrderedIntSet(test.left.v1...),
-			maps.NewOrderedIntSet(test.left.v2...),
+			hmaps.NewOrderedIntSet(test.left.v0...),
+			hmaps.NewOrderedIntSet(test.left.v1...),
+			hmaps.NewOrderedIntSet(test.left.v2...),
 		).Build()
 
 		var input []sitesmatrix.VectorProvider
 		for _, v := range test.input {
 			input = append(input, sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-				maps.NewOrderedIntSet(v.v0...),
-				maps.NewOrderedIntSet(v.v1...),
-				maps.NewOrderedIntSet(v.v2...),
+				hmaps.NewOrderedIntSet(v.v0...),
+				hmaps.NewOrderedIntSet(v.v1...),
+				hmaps.NewOrderedIntSet(v.v2...),
 			).Build())
 		}
 
@@ -262,15 +262,15 @@ func TestIntSetsComplementOfComplement(t *testing.T) {
 	testDims := newTestDims()
 
 	sets1 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(1),
-		maps.NewOrderedIntSet(1),
-		maps.NewOrderedIntSet(1),
+		hmaps.NewOrderedIntSet(1),
+		hmaps.NewOrderedIntSet(1),
+		hmaps.NewOrderedIntSet(1),
 	).Build()
 
 	sets2 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(1, 2),
-		maps.NewOrderedIntSet(1),
-		maps.NewOrderedIntSet(1, 3),
+		hmaps.NewOrderedIntSet(1, 2),
+		hmaps.NewOrderedIntSet(1),
+		hmaps.NewOrderedIntSet(1, 3),
 	).Build()
 
 	c1 := sets2.Complement(sets1)
@@ -296,27 +296,27 @@ func BenchmarkIntSetsComplement(b *testing.B) {
 	testDims := newTestDims()
 
 	sets1 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(1, 2, 3),
-		maps.NewOrderedIntSet(1, 2, 3),
-		maps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2, 3),
 	).Build()
 
 	sets1Copy := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(1, 2, 3),
-		maps.NewOrderedIntSet(1, 2, 3),
-		maps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2, 3),
 	).Build()
 
 	sets2 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(1, 2, 3, 4),
-		maps.NewOrderedIntSet(1, 2, 3, 4),
-		maps.NewOrderedIntSet(1, 2, 3, 4, 6),
+		hmaps.NewOrderedIntSet(1, 2, 3, 4),
+		hmaps.NewOrderedIntSet(1, 2, 3, 4),
+		hmaps.NewOrderedIntSet(1, 2, 3, 4, 6),
 	).Build()
 
 	setsLanguage1 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(1),
-		maps.NewOrderedIntSet(1),
-		maps.NewOrderedIntSet(1),
+		hmaps.NewOrderedIntSet(1),
+		hmaps.NewOrderedIntSet(1),
+		hmaps.NewOrderedIntSet(1),
 	).Build()
 
 	b.ResetTimer()
@@ -361,21 +361,21 @@ func BenchmarkSets(b *testing.B) {
 	testDims := newTestDims()
 
 	sets1 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(1, 2),
-		maps.NewOrderedIntSet(1, 2, 3),
-		maps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2),
+		hmaps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2, 3),
 	).Build()
 
 	sets1Copy := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(1, 2),
-		maps.NewOrderedIntSet(1, 2, 3),
-		maps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2),
+		hmaps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2, 3),
 	).Build()
 
 	sets2 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(1, 2, 3),
-		maps.NewOrderedIntSet(1, 2, 3, 4),
-		maps.NewOrderedIntSet(1, 2, 3, 4),
+		hmaps.NewOrderedIntSet(1, 2, 3),
+		hmaps.NewOrderedIntSet(1, 2, 3, 4),
+		hmaps.NewOrderedIntSet(1, 2, 3, 4),
 	).Build()
 
 	v1 := sitesmatrix.Vector{1, 2, 3}
@@ -385,9 +385,9 @@ func BenchmarkSets(b *testing.B) {
 	b.Run("Build", func(b *testing.B) {
 		for b.Loop() {
 			_ = sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-				maps.NewOrderedIntSet(1, 2),
-				maps.NewOrderedIntSet(1, 2, 3),
-				maps.NewOrderedIntSet(1, 2, 3),
+				hmaps.NewOrderedIntSet(1, 2),
+				hmaps.NewOrderedIntSet(1, 2, 3),
+				hmaps.NewOrderedIntSet(1, 2, 3),
 			).Build()
 		}
 	})
@@ -484,17 +484,17 @@ func TestVectorStoreMap(t *testing.T) {
 
 	c.Run("Complement", func(c *qt.C) {
 		v1 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-			maps.NewOrderedIntSet(1, 3),
-			maps.NewOrderedIntSet(1),
-			maps.NewOrderedIntSet(1, 3),
+			hmaps.NewOrderedIntSet(1, 3),
+			hmaps.NewOrderedIntSet(1),
+			hmaps.NewOrderedIntSet(1, 3),
 		).Build()
 
 		m := v1.ToVectorStoreMap()
 
 		v2 := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-			maps.NewOrderedIntSet(1, 2),
-			maps.NewOrderedIntSet(1),
-			maps.NewOrderedIntSet(1, 3),
+			hmaps.NewOrderedIntSet(1, 2),
+			hmaps.NewOrderedIntSet(1),
+			hmaps.NewOrderedIntSet(1, 3),
 		).Build()
 
 		complement := m.Complement(v2)
@@ -509,9 +509,9 @@ func TestVectorStoreMap(t *testing.T) {
 func BenchmarkHasAnyVectorSingle(b *testing.B) {
 	testDims := newTestDims()
 	set := sitesmatrix.NewIntSetsBuilder(testDims).WithSets(
-		maps.NewOrderedIntSet(0),
-		maps.NewOrderedIntSet(0),
-		maps.NewOrderedIntSet(0),
+		hmaps.NewOrderedIntSet(0),
+		hmaps.NewOrderedIntSet(0),
+		hmaps.NewOrderedIntSet(0),
 	).Build()
 
 	v := sitesmatrix.Vector{0, 0, 0}

--- a/internal/js/api.go
+++ b/internal/js/api.go
@@ -16,14 +16,14 @@ package js
 import (
 	"context"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/resources/resource"
 )
 
 // BatcherClient is used to do JS batch operations.
 type BatcherClient interface {
 	New(id string) (Batcher, error)
-	Store() *maps.Cache[string, Batcher]
+	Store() *hmaps.Cache[string, Batcher]
 }
 
 // BatchPackage holds a group of JavaScript resources.

--- a/internal/js/esbuild/batch.go
+++ b/internal/js/esbuild/batch.go
@@ -31,9 +31,9 @@ import (
 
 	"github.com/evanw/esbuild/pkg/api"
 	"github.com/gohugoio/hugo/cache/dynacache"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hsync"
 	"github.com/gohugoio/hugo/common/hugio"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/helpers"
@@ -74,8 +74,8 @@ func NewBatcherClient(deps *deps.Deps) (js.BatcherClient, error) {
 		d:            deps,
 		buildClient:  NewBuildClient(deps.BaseFs.Assets, deps.ResourceSpec),
 		createClient: create.New(deps.ResourceSpec),
-		batcherStore: maps.NewCache[string, js.Batcher](),
-		bundlesStore: maps.NewCache[string, js.BatchPackage](),
+		batcherStore: hmaps.NewCache[string, js.Batcher](),
+		bundlesStore: hmaps.NewCache[string, js.BatchPackage](),
 	}
 
 	deps.BuildEndListeners.Add(func(...any) bool {
@@ -196,8 +196,8 @@ type BatcherClient struct {
 	createClient *create.Client
 	buildClient  *BuildClient
 
-	batcherStore *maps.Cache[string, js.Batcher]
-	bundlesStore *maps.Cache[string, js.BatchPackage]
+	batcherStore *hmaps.Cache[string, js.Batcher]
+	bundlesStore *hmaps.Cache[string, js.BatchPackage]
 }
 
 // New creates a new Batcher with the given ID.
@@ -279,7 +279,7 @@ func (c *BatcherClient) New(id string) (js.Batcher, error) {
 	return b, nil
 }
 
-func (c *BatcherClient) Store() *maps.Cache[string, js.Batcher] {
+func (c *BatcherClient) Store() *hmaps.Cache[string, js.Batcher] {
 	return c.batcherStore
 }
 
@@ -435,15 +435,15 @@ func (b *batcher) doBuild(ctx context.Context) (*Package, error) {
 	}
 
 	state := struct {
-		importResource        *maps.Cache[string, resource.Resource]
-		resultResource        *maps.Cache[string, resource.Resource]
-		importerImportContext *maps.Cache[string, importContext]
-		pathGroup             *maps.Cache[string, string]
+		importResource        *hmaps.Cache[string, resource.Resource]
+		resultResource        *hmaps.Cache[string, resource.Resource]
+		importerImportContext *hmaps.Cache[string, importContext]
+		pathGroup             *hmaps.Cache[string, string]
 	}{
-		importResource:        maps.NewCache[string, resource.Resource](),
-		resultResource:        maps.NewCache[string, resource.Resource](),
-		importerImportContext: maps.NewCache[string, importContext](),
-		pathGroup:             maps.NewCache[string, string](),
+		importResource:        hmaps.NewCache[string, resource.Resource](),
+		resultResource:        hmaps.NewCache[string, resource.Resource](),
+		importerImportContext: hmaps.NewCache[string, importContext](),
+		pathGroup:             hmaps.NewCache[string, string](),
 	}
 
 	multihostBasePaths := b.client.d.ResourceSpec.MultihostTargetBasePaths

--- a/internal/js/esbuild/options.go
+++ b/internal/js/esbuild/options.go
@@ -19,8 +19,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugio"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/identity"
 
@@ -299,7 +299,7 @@ func (opts *Options) compile() (err error) {
 
 	var defines map[string]string
 	if opts.Defines != nil {
-		defines = maps.ToStringMapString(opts.Defines)
+		defines = hmaps.ToStringMapString(opts.Defines)
 	}
 
 	var drop api.Drop

--- a/internal/js/esbuild/resolve.go
+++ b/internal/js/esbuild/resolve.go
@@ -18,16 +18,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/evanw/esbuild/pkg/api"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/hugofs"
 	"github.com/gohugoio/hugo/identity"
 	"github.com/gohugoio/hugo/resources"
 	"github.com/gohugoio/hugo/resources/resource"
 	"github.com/spf13/afero"
-	"slices"
 )
 
 const (
@@ -132,12 +132,12 @@ func ResolveResource(impPath string, resourceGetter resource.ResourceGetter) (r 
 }
 
 func newFSResolver(fs afero.Fs) *fsResolver {
-	return &fsResolver{fs: fs, resolved: maps.NewCache[string, *hugofs.FileMeta]()}
+	return &fsResolver{fs: fs, resolved: hmaps.NewCache[string, *hugofs.FileMeta]()}
 }
 
 type fsResolver struct {
 	fs       afero.Fs
-	resolved *maps.Cache[string, *hugofs.FileMeta]
+	resolved *hmaps.Cache[string, *hugofs.FileMeta]
 }
 
 func (r *fsResolver) resolveComponent(impPath string) *hugofs.FileMeta {

--- a/internal/warpc/warpc.go
+++ b/internal/warpc/warpc.go
@@ -30,9 +30,9 @@ import (
 
 	"github.com/bep/textandbinarywriter"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/hugio"
-	"github.com/gohugoio/hugo/common/maps"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/tetratelabs/wazero"
@@ -253,7 +253,7 @@ func (d *dispatcher[Q, R]) newCall(q Message[Q]) (*call[Q, R], error) {
 	if err := q.init(); err != nil {
 		return nil, err
 	}
-	responseKinds := maps.NewMap[string, bool]()
+	responseKinds := hmaps.NewMap[string, bool]()
 	for _, rk := range q.Header.ResponseKinds {
 		responseKinds.Set(rk, true)
 	}
@@ -424,7 +424,7 @@ func (d *dispatcher[Q, R]) pendingCall(id uint32) *call[Q, R] {
 type call[Q, R any] struct {
 	request       Message[Q]
 	response      Message[R]
-	responseKinds *maps.Map[string, bool]
+	responseKinds *hmaps.Map[string, bool]
 	err           error
 	donec         chan *call[Q, R]
 }

--- a/langs/language.go
+++ b/langs/language.go
@@ -22,8 +22,8 @@ import (
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/htime"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/hugolib/sitesmatrix"
 	"github.com/gohugoio/locales"
 	translators "github.com/gohugoio/localescompressed"
@@ -54,7 +54,7 @@ type Language struct {
 	isDefault bool
 
 	// This is just an alias of Site.Params.
-	params maps.Params
+	params hmaps.Params
 }
 
 // Name is an alias for Lang.
@@ -114,7 +114,7 @@ var DeprecationFunc = func(item, alternative string, err bool) {}
 // Params returns the language params.
 // Note that this is the same as the Site.Params, but we keep it here for legacy reasons.
 // Deprecated: Use the site.Params instead.
-func (l *Language) Params() maps.Params {
+func (l *Language) Params() hmaps.Params {
 	// TODO(bep) Remove this for now as it created a little too much noise. Need to think about this.
 	// See https://github.com/gohugoio/hugo/issues/11025
 	// DeprecationFunc(".Language.Params", paramsDeprecationWarning, false)
@@ -167,7 +167,7 @@ func (l Languages) AsIndexSet() map[string]int {
 // Internal access to unexported Language fields.
 // This construct is to prevent them from leaking to the templates.
 
-func SetParams(l *Language, params maps.Params) {
+func SetParams(l *Language, params hmaps.Params) {
 	l.params = params
 }
 

--- a/markup/goldmark/convert_test.go
+++ b/markup/goldmark/convert_test.go
@@ -31,9 +31,9 @@ import (
 
 	"github.com/gohugoio/hugo/markup/markup_config"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugio"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 
 	"github.com/gohugoio/hugo/markup/converter"
 
@@ -398,7 +398,7 @@ func TestConvertAttributes(t *testing.T) {
 			}
 			data, err := toml.Marshal(mconf)
 			c.Assert(err, qt.IsNil)
-			m := maps.Params{
+			m := hmaps.Params{
 				"markup": config.FromTOMLConfigString(string(data)).Get(""),
 			}
 			conf := testconfig.GetTestConfig(nil, config.NewFrom(m))

--- a/markup/markup_config/config.go
+++ b/markup/markup_config/config.go
@@ -14,7 +14,7 @@
 package markup_config
 
 import (
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/markup/asciidocext/asciidocext_config"
 	"github.com/gohugoio/hugo/markup/goldmark/goldmark_config"
@@ -52,7 +52,7 @@ func Decode(cfg config.Provider) (conf Config, err error) {
 	if m == nil {
 		return
 	}
-	m = maps.CleanConfigStringMap(m)
+	m = hmaps.CleanConfigStringMap(m)
 
 	normalizeConfig(m)
 
@@ -73,9 +73,9 @@ func Decode(cfg config.Provider) (conf Config, err error) {
 }
 
 func normalizeConfig(m map[string]any) {
-	v, err := maps.GetNestedParam("goldmark.parser", ".", m)
+	v, err := hmaps.GetNestedParam("goldmark.parser", ".", m)
 	if err == nil {
-		vm := maps.ToStringMap(v)
+		vm := hmaps.ToStringMap(v)
 		// Changed from a bool in 0.81.0
 		if vv, found := vm["attribute"]; found {
 			if vvb, ok := vv.(bool); ok {
@@ -87,9 +87,9 @@ func normalizeConfig(m map[string]any) {
 	}
 
 	// Handle changes to the Goldmark configuration.
-	v, err = maps.GetNestedParam("goldmark.extensions", ".", m)
+	v, err = hmaps.GetNestedParam("goldmark.extensions", ".", m)
 	if err == nil {
-		vm := maps.ToStringMap(v)
+		vm := hmaps.ToStringMap(v)
 
 		// We changed the typographer extension config from a bool to a struct in 0.112.0.
 		migrateGoldmarkConfig(vm, "typographer", goldmark_config.Typographer{Disable: true})

--- a/media/config.go
+++ b/media/config.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/config"
 
@@ -180,7 +180,7 @@ func DecodeContentTypes(in map[string]any, types Types) (*config.ConfigNamespace
 	buildConfig := func(v any) (ContentTypes, any, error) {
 		var s map[string]ContentTypeConfig
 		c := DefaultContentTypes
-		m, err := maps.ToStringMapE(v)
+		m, err := hmaps.ToStringMapE(v)
 		if err != nil {
 			return c, nil, err
 		}
@@ -188,7 +188,7 @@ func DecodeContentTypes(in map[string]any, types Types) (*config.ConfigNamespace
 			s = defaultContentTypesConfig
 		} else {
 			s = make(map[string]ContentTypeConfig)
-			m = maps.CleanConfigStringMap(m)
+			m = hmaps.CleanConfigStringMap(m)
 			for k, v := range m {
 				var ctc ContentTypeConfig
 				if err := mapstructure.WeakDecode(v, &ctc); err != nil {
@@ -221,16 +221,16 @@ func DecodeContentTypes(in map[string]any, types Types) (*config.ConfigNamespace
 // DecodeTypes decodes the given map of media types.
 func DecodeTypes(in map[string]any) (*config.ConfigNamespace[map[string]MediaTypeConfig, Types], error) {
 	buildConfig := func(v any) (Types, any, error) {
-		m, err := maps.ToStringMapE(v)
+		m, err := hmaps.ToStringMapE(v)
 		if err != nil {
 			return nil, nil, err
 		}
 		if m == nil {
 			m = map[string]any{}
 		}
-		m = maps.CleanConfigStringMap(m)
+		m = hmaps.CleanConfigStringMap(m)
 		// Merge with defaults.
-		maps.MergeShallow(m, defaultMediaTypesConfig)
+		hmaps.MergeShallow(m, defaultMediaTypesConfig)
 
 		var types Types
 
@@ -242,8 +242,8 @@ func DecodeTypes(in map[string]any) (*config.ConfigNamespace[map[string]MediaTyp
 			if err := mapstructure.WeakDecode(v, &mediaType); err != nil {
 				return nil, nil, err
 			}
-			mm := maps.ToStringMap(v)
-			suffixes, _, found := maps.LookupEqualFold(mm, "suffixes")
+			mm := hmaps.ToStringMap(v)
+			suffixes, _, found := hmaps.LookupEqualFold(mm, "suffixes")
 			if found {
 				mediaType.SuffixesCSV = strings.TrimSpace(strings.ToLower(strings.Join(cast.ToStringSlice(suffixes), ",")))
 			}

--- a/minifiers/config.go
+++ b/minifiers/config.go
@@ -16,8 +16,8 @@ package minifiers
 import (
 	"fmt"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugo"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/spf13/cast"
 
 	"github.com/mitchellh/mapstructure"
@@ -88,17 +88,17 @@ func DecodeConfig(v any) (conf MinifyConfig, err error) {
 		return
 	}
 
-	m := maps.ToStringMap(v)
+	m := hmaps.ToStringMap(v)
 
 	// Handle deprecations.
 	if td, found := m["tdewolff"]; found {
-		tdm := maps.ToStringMap(td)
+		tdm := hmaps.ToStringMap(td)
 
 		// Decimals was renamed to Precision in tdewolff/minify v2.7.0.
 		// https://github.com/tdewolff/minify/commit/2fed4401348ce36bd6c20e77335a463e69d94386
 		for _, key := range []string{"css", "svg"} {
 			if v, found := tdm[key]; found {
-				vm := maps.ToStringMap(v)
+				vm := hmaps.ToStringMap(v)
 				ko := "decimals"
 				kn := "precision"
 				if vv, found := vm[ko]; found {
@@ -121,7 +121,7 @@ func DecodeConfig(v any) (conf MinifyConfig, err error) {
 		// KeepConditionalComments was renamed to KeepSpecialComments in tdewolff/minify v2.20.13.
 		// https://github.com/tdewolff/minify/commit/342cbc1974162db0ad3327f7a42a623b2cd3ebbc
 		if v, found := tdm["html"]; found {
-			vm := maps.ToStringMap(v)
+			vm := hmaps.ToStringMap(v)
 			ko := "keepconditionalcomments"
 			kn := "keepspecialcomments"
 			if vv, found := vm[ko]; found {
@@ -140,7 +140,7 @@ func DecodeConfig(v any) (conf MinifyConfig, err error) {
 		// KeepCSS2 was deprecated in favor of Version in tdewolff/minify v2.24.1.
 		// https://github.com/tdewolff/minify/commit/57e3ebe0e6914b82c9ab0849a14f86bc29cd2ebf
 		if v, found := tdm["css"]; found {
-			vm := maps.ToStringMap(v)
+			vm := hmaps.ToStringMap(v)
 			ko := "keepcss2"
 			kn := "version"
 			if vv, found := vm[ko]; found {

--- a/modules/collect.go
+++ b/modules/collect.go
@@ -28,14 +28,13 @@ import (
 
 	"github.com/bep/debounce"
 	"github.com/gohugoio/hugo/common/herrors"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/common/version"
 	"golang.org/x/mod/module"
 
 	"github.com/spf13/cast"
-
-	"github.com/gohugoio/hugo/common/maps"
 
 	"github.com/gohugoio/hugo/parser/metadecoders"
 
@@ -494,7 +493,7 @@ LOOP:
 		if err != nil {
 			c.logger.Warnf("Failed to read module config for %q in %q: %s", tc.Path(), themeTOML, err)
 		} else {
-			maps.PrepareParams(themeCfg)
+			hmaps.PrepareParams(themeCfg)
 		}
 	}
 

--- a/modules/npm/package_builder.go
+++ b/modules/npm/package_builder.go
@@ -21,14 +21,13 @@ import (
 	"io/fs"
 	"strings"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugio"
 
 	"github.com/gohugoio/hugo/hugofs/files"
 
 	"github.com/gohugoio/hugo/hugofs"
 	"github.com/spf13/afero"
-
-	"github.com/gohugoio/hugo/common/maps"
 
 	"github.com/gohugoio/hugo/helpers"
 )
@@ -130,7 +129,7 @@ func Pack(sourceFs, assetsWithDuplicatesPreservedFs afero.Fs) error {
 	var commentsm map[string]any
 	comments, found := b.originalPackageJSON["comments"]
 	if found {
-		commentsm = maps.ToStringMap(comments)
+		commentsm = hmaps.ToStringMap(comments)
 	} else {
 		commentsm = make(map[string]any)
 	}
@@ -213,7 +212,7 @@ func (b *packageBuilder) addm(source string, m map[string]any) {
 	// These packages will be added by order of import (project, module1, module2...),
 	// so that should at least give the project control over the situation.
 	if devDeps, found := m[devDependenciesKey]; found {
-		mm := maps.ToStringMapString(devDeps)
+		mm := hmaps.ToStringMapString(devDeps)
 		for k, v := range mm {
 			if _, added := b.devDependencies[k]; !added {
 				b.devDependencies[k] = v
@@ -223,7 +222,7 @@ func (b *packageBuilder) addm(source string, m map[string]any) {
 	}
 
 	if deps, found := m[dependenciesKey]; found {
-		mm := maps.ToStringMapString(deps)
+		mm := hmaps.ToStringMapString(deps)
 		for k, v := range mm {
 			if _, added := b.dependencies[k]; !added {
 				b.dependencies[k] = v

--- a/navigation/menu.go
+++ b/navigation/menu.go
@@ -19,7 +19,7 @@ import (
 	"slices"
 	"sort"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/compare"
 	"github.com/gohugoio/hugo/config"
@@ -89,7 +89,7 @@ type Page interface {
 	IsPage() bool
 	IsSection() bool
 	IsAncestor(other any) bool
-	Params() maps.Params
+	Params() hmaps.Params
 }
 
 // Menu is a collection of menu entries.
@@ -158,7 +158,7 @@ type MenuConfig struct {
 	Weight     int
 	Title      string
 	// User defined params.
-	Params maps.Params
+	Params hmaps.Params
 }
 
 // For internal use.
@@ -279,11 +279,11 @@ func DecodeConfig(in any) (*config.ConfigNamespace[map[string]MenuConfig, Menus]
 			return ret, map[string]any{}, nil
 		}
 
-		menus, err := maps.ToStringMapE(in)
+		menus, err := hmaps.ToStringMapE(in)
 		if err != nil {
 			return ret, nil, err
 		}
-		menus = maps.CleanConfigStringMap(menus)
+		menus = hmaps.CleanConfigStringMap(menus)
 
 		for name, menu := range menus {
 			m, err := cast.ToSliceE(menu)
@@ -295,7 +295,7 @@ func DecodeConfig(in any) (*config.ConfigNamespace[map[string]MenuConfig, Menus]
 					if err := mapstructure.WeakDecode(entry, &menuConfig); err != nil {
 						return ret, nil, err
 					}
-					maps.PrepareParams(menuConfig.Params)
+					hmaps.PrepareParams(menuConfig.Params)
 					menuEntry := MenuEntry{
 						Menu:       name,
 						MenuConfig: menuConfig,

--- a/navigation/pagemenus.go
+++ b/navigation/pagemenus.go
@@ -16,7 +16,7 @@ package navigation
 import (
 	"fmt"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/mitchellh/mapstructure"
 
@@ -74,7 +74,7 @@ func PageMenusFromPage(ms any, p Page) (PageMenus, error) {
 	}
 
 	// Could be a structured menu entry
-	menus, err := maps.ToStringMapE(ms)
+	menus, err := hmaps.ToStringMapE(ms)
 	if err != nil {
 		return pm, wrapErr(err)
 	}
@@ -82,7 +82,7 @@ func PageMenusFromPage(ms any, p Page) (PageMenus, error) {
 	for name, menu := range menus {
 		menuEntry := MenuEntry{Menu: name}
 		if menu != nil {
-			ime, err := maps.ToStringMapE(menu)
+			ime, err := hmaps.ToStringMapE(menu)
 			if err != nil {
 				return pm, wrapErr(err)
 			}

--- a/output/config.go
+++ b/output/config.go
@@ -19,7 +19,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/media"
 	"github.com/mitchellh/mapstructure"
@@ -42,11 +42,11 @@ func DecodeConfig(mediaTypes media.Types, in any) (*config.ConfigNamespace[map[s
 		f := make(Formats, len(DefaultFormats))
 		copy(f, DefaultFormats)
 		if in != nil {
-			m, err := maps.ToStringMapE(in)
+			m, err := hmaps.ToStringMapE(in)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed convert config to map: %s", err)
 			}
-			m = maps.CleanConfigStringMap(m)
+			m = hmaps.CleanConfigStringMap(m)
 
 			for k, v := range m {
 				found := false

--- a/parser/metadecoders/decoder.go
+++ b/parser/metadecoders/decoder.go
@@ -25,7 +25,7 @@ import (
 	"unsafe"
 
 	"github.com/gohugoio/hugo/common/herrors"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/niklasfasching/go-org/org"
 
 	xml "github.com/clbanning/mxj/v2"
@@ -120,7 +120,7 @@ func (d Decoder) UnmarshalStringTo(data string, typ any) (any, error) {
 	switch typ.(type) {
 	case string:
 		return data, nil
-	case map[string]any, maps.Params:
+	case map[string]any, hmaps.Params:
 		format := d.FormatFromContentString(data)
 		return d.UnmarshalToMap([]byte(data), format)
 	case []any:

--- a/related/inverted_index.go
+++ b/related/inverted_index.go
@@ -18,16 +18,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
-	xmaps "maps"
-
 	"github.com/gohugoio/hugo/common/collections"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/compare"
 	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/spf13/cast"
@@ -557,7 +556,7 @@ func norm(num, min, max int) int {
 }
 
 // DecodeConfig decodes a slice of map into Config.
-func DecodeConfig(m maps.Params) (Config, error) {
+func DecodeConfig(m hmaps.Params) (Config, error) {
 	if m == nil {
 		return Config{}, errors.New("no related config provided")
 	}
@@ -590,7 +589,7 @@ func DecodeConfig(m maps.Params) (Config, error) {
 			c.Indices[i].Type = TypeBasic
 		}
 		if !validTypes[c.Indices[i].Type] {
-			return c, fmt.Errorf("invalid index type %q. Must be one of %v", c.Indices[i].Type, xmaps.Keys(validTypes))
+			return c, fmt.Errorf("invalid index type %q. Must be one of %v", c.Indices[i].Type, maps.Keys(validTypes))
 		}
 		if icfg.CardinalityThreshold < 0 || icfg.CardinalityThreshold > 100 {
 			return Config{}, errors.New("cardinalityThreshold threshold must be between 0 and 100")

--- a/resources/images/config.go
+++ b/resources/images/config.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"github.com/gohugoio/hugo/common/hashing"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/media"
 	"github.com/mitchellh/mapstructure"
@@ -162,12 +162,12 @@ func DecodeConfig(in map[string]any) (*config.ConfigNamespace[ImagingConfig, Ima
 	}
 
 	buildConfig := func(in any) (ImagingConfigInternal, any, error) {
-		m, err := maps.ToStringMapE(in)
+		m, err := hmaps.ToStringMapE(in)
 		if err != nil {
 			return ImagingConfigInternal{}, nil, err
 		}
 		// Merge in the defaults.
-		maps.MergeShallow(m, defaultImaging)
+		hmaps.MergeShallow(m, defaultImaging)
 
 		var i ImagingConfigInternal
 		if err := mapstructure.Decode(m, &i.Imaging); err != nil {

--- a/resources/images/filters.go
+++ b/resources/images/filters.go
@@ -19,8 +19,8 @@ import (
 	"image/color"
 	"strings"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugio"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/resources/resource"
 	"github.com/makeworld-the-better-one/dither/v2"
 	"github.com/mitchellh/mapstructure"
@@ -83,9 +83,9 @@ func (*Filters) Text(text string, options ...any) gift.Filter {
 		linespacing: 2,
 	}
 
-	var opt maps.Params
+	var opt hmaps.Params
 	if len(options) > 0 {
-		opt = maps.MustToParamsAndPrepare(options[0])
+		opt = hmaps.MustToParamsAndPrepare(options[0])
 		for option, v := range opt {
 			switch option {
 			case "color":

--- a/resources/page/page_matcher.go
+++ b/resources/page/page_matcher.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 
 	"github.com/gohugoio/hugo/common/hashing"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/hugofs/hglob"
 	"github.com/gohugoio/hugo/hugolib/sitesmatrix"
@@ -121,8 +121,8 @@ func checkCascadePattern(logger loggers.Logger, m PageMatcher) {
 	}
 }
 
-func AddLangToCascadeTargetMap(lang string, m maps.Params) {
-	maps.SetNestedParamIfNotSet("target.sites.matrix.languages", ".", lang, m)
+func AddLangToCascadeTargetMap(lang string, m hmaps.Params) {
+	hmaps.SetNestedParamIfNotSet("target.sites.matrix.languages", ".", lang, m)
 }
 
 func DecodeCascadeConfig(in any) (*PageMatcherParamsConfigs, error) {
@@ -133,7 +133,7 @@ func DecodeCascadeConfig(in any) (*PageMatcherParamsConfigs, error) {
 			return CascadeConfig{}, []map[string]any{}, nil
 		}
 
-		ms, err := maps.ToSliceStringMap(in)
+		ms, err := hmaps.ToSliceStringMap(in)
 		if err != nil {
 			return CascadeConfig{}, nil, err
 		}
@@ -141,7 +141,7 @@ func DecodeCascadeConfig(in any) (*PageMatcherParamsConfigs, error) {
 		var cfgs []PageMatcherParamsConfig
 
 		for _, m := range ms {
-			m = maps.CleanConfigStringMap(m)
+			m = hmaps.CleanConfigStringMap(m)
 			var (
 				c   PageMatcherParamsConfig
 				err error
@@ -192,10 +192,10 @@ type cascadeConfigDecoder struct{}
 func (d cascadeConfigDecoder) mapToPageMatcherParamsConfig(m map[string]any) (PageMatcherParamsConfig, error) {
 	var pcfg PageMatcherParamsConfig
 	if pcfg.Fields == nil {
-		pcfg.Fields = make(maps.Params)
+		pcfg.Fields = make(hmaps.Params)
 	}
 	if pcfg.Params == nil {
-		pcfg.Params = make(maps.Params)
+		pcfg.Params = make(hmaps.Params)
 	}
 
 	for k, v := range m {
@@ -207,7 +207,7 @@ func (d cascadeConfigDecoder) mapToPageMatcherParamsConfig(m map[string]any) (Pa
 			}
 			pcfg.Target = target
 		case "params":
-			params := maps.ToStringMap(v)
+			params := hmaps.ToStringMap(v)
 			for k, v := range params {
 				if _, found := pcfg.Params[k]; !found {
 					pcfg.Params[k] = v
@@ -271,25 +271,25 @@ type CascadeConfig struct {
 
 type PageMatcherParamsConfig struct {
 	// Apply Params to all Pages matching Target.
-	Params maps.Params
+	Params hmaps.Params
 	// Fields holds all fields but Params.
-	Fields maps.Params
+	Fields hmaps.Params
 	// Target is the PageMatcher that this config applies to.
 	Target PageMatcher
 }
 
 func (p *PageMatcherParamsConfig) init() error {
-	maps.PrepareParams(p.Params)
-	maps.PrepareParams(p.Fields)
+	hmaps.PrepareParams(p.Params)
+	hmaps.PrepareParams(p.Fields)
 
 	return nil
 }
 
 func (p *PageMatcherParamsConfig) hasSitesMatrix() bool {
 	if m, ok := p.Fields["sites"]; ok {
-		mm := maps.ToStringMap(m)
+		mm := hmaps.ToStringMap(m)
 		if sm, found := mm["matrix"]; found {
-			mmm := maps.ToStringMap(sm)
+			mmm := hmaps.ToStringMap(sm)
 			return len(mmm) > 0
 		}
 	}

--- a/resources/page/page_matcher_test.go
+++ b/resources/page/page_matcher_test.go
@@ -17,9 +17,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/hugolib/sitesmatrix"
 
 	qt "github.com/frankban/quicktest"
@@ -87,18 +87,18 @@ func TestPageMatcher(t *testing.T) {
 			return v
 		}
 		c.Assert(fn(map[string]any{"_target": map[string]any{"kind": "page"}, "foo": "bar"}), qt.DeepEquals, PageMatcherParamsConfig{
-			Params: maps.Params{},
-			Fields: maps.Params{
+			Params: hmaps.Params{},
+			Fields: hmaps.Params{
 				"foo": "bar",
 			},
 			Target: PageMatcher{Path: "", Kind: "page", Lang: "", Environment: ""},
 		})
 
 		c.Assert(fn(map[string]any{"target": map[string]any{"kind": "page"}, "params": map[string]any{"foo": "bar"}}), qt.DeepEquals, PageMatcherParamsConfig{
-			Params: maps.Params{
+			Params: hmaps.Params{
 				"foo": "bar",
 			},
-			Fields: maps.Params{},
+			Fields: hmaps.Params{},
 			Target: PageMatcher{Path: "", Kind: "page", Lang: "", Environment: ""},
 		})
 	})
@@ -134,10 +134,10 @@ func TestDecodeCascadeConfig(t *testing.T) {
 	c.Assert(got.c[0].Config.Cascades, qt.HasLen, 2)
 	first := got.c[0].Config.Cascades[0]
 	c.Assert(first, qt.DeepEquals, PageMatcherParamsConfig{
-		Params: maps.Params{
+		Params: hmaps.Params{
 			"a": "av",
 		},
-		Fields: maps.Params{},
+		Fields: hmaps.Params{},
 		Target: PageMatcher{
 			Kind:        "page",
 			Sites:       sitesmatrix.Sites{},
@@ -147,11 +147,11 @@ func TestDecodeCascadeConfig(t *testing.T) {
 
 	c.Assert(got.c[0].SourceStructure, qt.DeepEquals, []PageMatcherParamsConfig{
 		{
-			Params: maps.Params{"a": string("av")},
-			Fields: maps.Params{},
+			Params: hmaps.Params{"a": string("av")},
+			Fields: hmaps.Params{},
 			Target: PageMatcher{Kind: "page", Environment: "production"},
 		},
-		{Params: maps.Params{"b": string("bv")}, Fields: maps.Params{}, Target: PageMatcher{Kind: "page"}},
+		{Params: hmaps.Params{"b": string("bv")}, Fields: hmaps.Params{}, Target: PageMatcher{Kind: "page"}},
 	})
 
 	got, err = DecodeCascadeConfig(nil)

--- a/resources/page/page_nop.go
+++ b/resources/page/page_nop.go
@@ -29,9 +29,9 @@ import (
 
 	"github.com/gohugoio/hugo/navigation"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstore"
 	"github.com/gohugoio/hugo/common/hugo"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/source"
 
@@ -320,7 +320,7 @@ func (p *nopPage) Param(key any) (any, error) {
 	return nil, nil
 }
 
-func (p *nopPage) Params() maps.Params {
+func (p *nopPage) Params() hmaps.Params {
 	return nil
 }
 

--- a/resources/page/pagemeta/page_frontmatter.go
+++ b/resources/page/pagemeta/page_frontmatter.go
@@ -20,12 +20,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hreflect"
 	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/htime"
 	"github.com/gohugoio/hugo/common/hugio"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/hugofs"
 	"github.com/gohugoio/hugo/hugofs/files"
@@ -104,7 +104,7 @@ func (pcfg *PageConfigEarly) SetMetaPreFromMap(ext string, frontmatter map[strin
 
 func (pcfg *PageConfigEarly) setFromFrontMatter(frontmatter map[string]any) error {
 	// Needed for case insensitive fetching of params values.
-	maps.PrepareParams(frontmatter)
+	hmaps.PrepareParams(frontmatter)
 	pcfg.Frontmatter = frontmatter
 
 	if v, found := frontmatter[pageMetaKeyMarkup]; found {
@@ -122,7 +122,7 @@ func (pcfg *PageConfigEarly) setFromFrontMatter(frontmatter map[string]any) erro
 func (p *PageConfigEarly) setCascadeEarlyValueIfNotSet(key string, value any) (done bool) {
 	switch key {
 	case pageMetaKeySites:
-		p.Sites.SetFromParamsIfNotSet(value.(maps.Params))
+		p.Sites.SetFromParamsIfNotSet(value.(hmaps.Params))
 	}
 
 	return !p.Sites.Matrix.IsZero()
@@ -137,7 +137,7 @@ type PageConfigEarly struct {
 	Sites   sitesmatrix.Sites
 	Content Source // Content holds the content for this page.
 
-	Frontmatter maps.Params `mapstructure:"-" json:"-"` // The original front matter or content adapter map.
+	Frontmatter hmaps.Params `mapstructure:"-" json:"-"` // The original front matter or content adapter map.
 
 	// Compiled values.
 	SitesMatrixAndComplements `mapstructure:"-" json:"-"`
@@ -151,7 +151,7 @@ type PageConfigEarly struct {
 type PageConfigLate struct {
 	Dates Dates `json:"-"` // Dates holds the four core dates for this page.
 	DatesStrings
-	Params maps.Params // User defined params.
+	Params hmaps.Params // User defined params.
 
 	Title          string   // The title of the page.
 	LinkTitle      string   // The link title of the page.
@@ -438,9 +438,9 @@ func (p *PageConfigLate) Compile(e *PageConfigEarly, logger loggers.Logger, outp
 	}
 
 	if p.Params == nil {
-		p.Params = make(maps.Params)
+		p.Params = make(hmaps.Params)
 	} else {
-		maps.PrepareParams(p.Params)
+		hmaps.PrepareParams(p.Params)
 	}
 
 	if len(p.Outputs) > 0 {
@@ -466,7 +466,7 @@ type ResourceConfig struct {
 	Path    string
 	Name    string
 	Title   string
-	Params  maps.Params
+	Params  hmaps.Params
 	Content Source
 	Sites   sitesmatrix.Sites
 
@@ -486,7 +486,7 @@ func (rc *ResourceConfig) Validate() error {
 
 func (rc *ResourceConfig) Compile(basePath string, fim hugofs.FileMetaInfo, conf config.AllProvider, mediaTypes media.Types) error {
 	if rc.Params != nil {
-		maps.PrepareParams(rc.Params)
+		hmaps.PrepareParams(rc.Params)
 	}
 
 	// Note that NormalizePathStringBasic will make sure that we don't preserve the unnormalized path.

--- a/resources/page/permalinks.go
+++ b/resources/page/permalinks.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstrings"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/resources/kinds"
 )
@@ -41,7 +41,7 @@ type PermalinkExpander struct {
 
 	urlize func(uri string) string
 
-	patternCache *maps.Cache[string, func(Page) (string, error)]
+	patternCache *hmaps.Cache[string, func(Page) (string, error)]
 }
 
 // Time for checking date formats. Every field is different than the
@@ -83,7 +83,7 @@ func (p PermalinkExpander) callback(attr string) (pageToPermaAttribute, bool) {
 func NewPermalinkExpander(urlize func(uri string) string, patterns map[string]map[string]string) (PermalinkExpander, error) {
 	p := PermalinkExpander{
 		urlize:       urlize,
-		patternCache: maps.NewCache[string, func(Page) (string, error)](),
+		patternCache: hmaps.NewCache[string, func(Page) (string, error)](),
 	}
 
 	p.knownPermalinkAttributes = map[string]pageToPermaAttribute{
@@ -494,7 +494,7 @@ func DecodePermalinksConfig(m map[string]any) (map[string]map[string]string, err
 	permalinksConfig[kinds.KindTaxonomy] = make(map[string]string)
 	permalinksConfig[kinds.KindTerm] = make(map[string]string)
 
-	config := maps.CleanConfigStringMap(m)
+	config := hmaps.CleanConfigStringMap(m)
 	for k, v := range config {
 		switch v := v.(type) {
 		case string:
@@ -505,7 +505,7 @@ func DecodePermalinksConfig(m map[string]any) (map[string]map[string]string, err
 			permalinksConfig[kinds.KindPage][k] = v
 			permalinksConfig[kinds.KindTerm][k] = v
 
-		case maps.Params:
+		case hmaps.Params:
 			// [permalinks.key]
 			//   xyz = ???
 

--- a/resources/page/site.go
+++ b/resources/page/site.go
@@ -16,8 +16,8 @@ package page
 import (
 	"time"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstore"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/config/privacy"
 	"github.com/gohugoio/hugo/config/services"
 	"github.com/gohugoio/hugo/hugolib/roles"
@@ -105,7 +105,7 @@ type Site interface {
 	MainSections() []string
 
 	// Returns the Params configured for this site.
-	Params() maps.Params
+	Params() hmaps.Params
 
 	// Param is a convenience method to do lookups in Params.
 	Param(key any) (any, error)
@@ -308,7 +308,7 @@ func (s *siteWrapper) MainSections() []string {
 	return s.s.MainSections()
 }
 
-func (s *siteWrapper) Params() maps.Params {
+func (s *siteWrapper) Params() hmaps.Params {
 	return s.s.Params()
 }
 
@@ -472,7 +472,7 @@ func (t testSite) BaseURL() string {
 	return ""
 }
 
-func (t testSite) Params() maps.Params {
+func (t testSite) Params() hmaps.Params {
 	return nil
 }
 

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/gohugoio/hugo/navigation"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstore"
 	"github.com/gohugoio/hugo/common/hugo"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/hugofs"
@@ -398,7 +398,7 @@ func (p *testPage) Param(key any) (any, error) {
 	return resource.Param(p, nil, key)
 }
 
-func (p *testPage) Params() maps.Params {
+func (p *testPage) Params() hmaps.Params {
 	return p.params
 }
 

--- a/resources/postpub/postpub.go
+++ b/resources/postpub/postpub.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/spf13/cast"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hreflect"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/resources/resource"
 )
@@ -169,7 +169,7 @@ func (r *PostPublishResource) Title() string {
 	return r.field("Title")
 }
 
-func (r *PostPublishResource) Params() maps.Params {
+func (r *PostPublishResource) Params() hmaps.Params {
 	panic(r.fieldNotSupported("Params"))
 }
 

--- a/resources/resource.go
+++ b/resources/resource.go
@@ -29,13 +29,13 @@ import (
 
 	"github.com/gohugoio/hugo/common/hashing"
 	"github.com/gohugoio/hugo/common/herrors"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hsync"
 	"github.com/gohugoio/hugo/common/paths"
 
 	"github.com/gohugoio/hugo/media"
 
 	"github.com/gohugoio/hugo/common/hugio"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/resources/resource"
 
 	"github.com/gohugoio/hugo/helpers"
@@ -91,7 +91,7 @@ type ResourceSourceDescriptor struct {
 	Data map[string]any
 
 	// The Params to associate with this resource.
-	Params maps.Params
+	Params hmaps.Params
 
 	// Delay publishing until either Permalink or RelPermalink is called. Maybe never.
 	LazyPublish bool
@@ -122,7 +122,7 @@ func (fd *ResourceSourceDescriptor) init(r *Spec) error {
 	}
 
 	if fd.Params == nil {
-		fd.Params = make(maps.Params)
+		fd.Params = make(hmaps.Params)
 	}
 
 	if fd.Path == nil {
@@ -498,7 +498,7 @@ func (l *genericResource) NameNormalized() string {
 	return l.sd.NameNormalized
 }
 
-func (l *genericResource) Params() maps.Params {
+func (l *genericResource) Params() hmaps.Params {
 	return l.params
 }
 

--- a/resources/resource/params.go
+++ b/resources/resource/params.go
@@ -14,20 +14,19 @@
 package resource
 
 import (
-	"github.com/gohugoio/hugo/common/maps"
-
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/spf13/cast"
 )
 
-func Param(r ResourceParamsProvider, fallback maps.Params, key any) (any, error) {
+func Param(r ResourceParamsProvider, fallback hmaps.Params, key any) (any, error) {
 	keyStr, err := cast.ToStringE(key)
 	if err != nil {
 		return nil, err
 	}
 
 	if fallback == nil {
-		return maps.GetNestedParam(keyStr, ".", r.Params())
+		return hmaps.GetNestedParam(keyStr, ".", r.Params())
 	}
 
-	return maps.GetNestedParam(keyStr, ".", r.Params(), fallback)
+	return hmaps.GetNestedParam(keyStr, ".", r.Params(), fallback)
 }

--- a/resources/resource/resource_helpers.go
+++ b/resources/resource/resource_helpers.go
@@ -17,8 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gohugoio/hugo/common/maps"
-
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/pelletier/go-toml/v2"
 
@@ -38,7 +37,7 @@ func GetParamToLower(r Resource, key string) any {
 }
 
 func getParam(r Resource, key string, stringToLower bool) any {
-	v, err := maps.GetNestedParam(key, ".", r.Params())
+	v, err := hmaps.GetNestedParam(key, ".", r.Params())
 
 	if v == nil || err != nil {
 		return nil

--- a/resources/resource/resources.go
+++ b/resources/resource/resources.go
@@ -20,8 +20,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hreflect"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/hugofs/hglob"
 	"github.com/spf13/cast"
@@ -330,7 +330,7 @@ func NewCachedResourceGetter(os ...any) *cachedResourceGetter {
 	}
 
 	return &cachedResourceGetter{
-		cache:    maps.NewCache[string, Resource](),
+		cache:    hmaps.NewCache[string, Resource](),
 		delegate: getters,
 	}
 }
@@ -352,7 +352,7 @@ var (
 )
 
 type cachedResourceGetter struct {
-	cache    *maps.Cache[string, Resource]
+	cache    *hmaps.Cache[string, Resource]
 	delegate ResourceGetter
 }
 

--- a/resources/resource/resourcetypes.go
+++ b/resources/resource/resourcetypes.go
@@ -16,7 +16,7 @@ package resource
 import (
 	"context"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/langs"
 	"github.com/gohugoio/hugo/media"
@@ -139,7 +139,7 @@ type NameNormalizedProvider interface {
 
 type ResourceParamsProvider interface {
 	// Params set in front matter for this resource.
-	Params() maps.Params
+	Params() hmaps.Params
 }
 
 type ResourceDataProvider interface {

--- a/resources/resource_factories/create/remote.go
+++ b/resources/resource_factories/create/remote.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"math/rand"
 	"mime"
 	"net/http"
@@ -26,14 +27,12 @@ import (
 	"strings"
 	"time"
 
-	gmaps "maps"
-
 	"github.com/gohugoio/httpcache"
 	"github.com/gohugoio/hugo/common/hashing"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/hugio"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/tasks"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/config"
@@ -172,12 +171,12 @@ func (c *Client) FromRemote(uri string, optionsm map[string]any) (resource.Resou
 	}
 
 	method := "GET"
-	if s, _, ok := maps.LookupEqualFold(optionsm, "method"); ok {
+	if s, _, ok := hmaps.LookupEqualFold(optionsm, "method"); ok {
 		method = strings.ToUpper(s.(string))
 	}
 	isHeadMethod := method == "HEAD"
 
-	optionsm = gmaps.Clone(optionsm)
+	optionsm = maps.Clone(optionsm)
 	userKey, optionsKey := remoteResourceKeys(uri, optionsm)
 
 	// A common pattern is to use the key in the options map as
@@ -323,7 +322,7 @@ func (c *Client) validateFromRemoteArgs(uri string, options fromRemoteOptions) e
 
 func remoteResourceKeys(uri string, optionsm map[string]any) (string, string) {
 	var userKey string
-	if key, k, found := maps.LookupEqualFold(optionsm, "key"); found {
+	if key, k, found := hmaps.LookupEqualFold(optionsm, "key"); found {
 		userKey = hashing.HashString(key)
 		delete(optionsm, k)
 	}

--- a/resources/resource_metadata.go
+++ b/resources/resource_metadata.go
@@ -28,7 +28,7 @@ import (
 
 	maps0 "maps"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/paths"
 )
 
@@ -60,7 +60,7 @@ type metaResource struct {
 	changed bool
 	title   string
 	name    string
-	params  maps.Params
+	params  hmaps.Params
 }
 
 func (r *metaResource) Name() string {
@@ -71,7 +71,7 @@ func (r *metaResource) Title() string {
 	return r.title
 }
 
-func (r *metaResource) Params() maps.Params {
+func (r *metaResource) Params() hmaps.Params {
 	return r.params
 }
 
@@ -209,9 +209,9 @@ func assignMetadata(metadata []map[string]any, ma *metaResource) error {
 
 			params, found := meta["params"]
 			if found {
-				m := maps.ToStringMap(params)
+				m := hmaps.ToStringMap(params)
 				// Needed for case insensitive fetching of params values
-				maps.PrepareParams(m)
+				hmaps.PrepareParams(m)
 				ma.updateParams(m)
 			}
 		}

--- a/resources/transform.go
+++ b/resources/transform.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gohugoio/hugo/common/constants"
 	"github.com/gohugoio/hugo/common/hashing"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/identity"
 
@@ -36,7 +37,6 @@ import (
 
 	"github.com/gohugoio/hugo/common/herrors"
 	"github.com/gohugoio/hugo/common/hugio"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/resources/internal"
 	"github.com/gohugoio/hugo/resources/resource"
 
@@ -133,7 +133,7 @@ type ResourceTransformationCtx struct {
 	// to be simple types, as it needs to be serialized to JSON and back.
 	Data map[string]any
 
-	// This is used to publish additional artifacts, e.g. source maps.
+	// This is used to publish additional artifacts, e.g. source hhmaps.
 	// We may improve this.
 	OpenResourcePublisher func(relTargetPath string) (io.WriteCloser, error)
 }
@@ -310,7 +310,7 @@ func (r *resourceAdapter) NameNormalized() string {
 	return r.target.(resource.NameNormalizedProvider).NameNormalized()
 }
 
-func (r *resourceAdapter) Params() maps.Params {
+func (r *resourceAdapter) Params() hmaps.Params {
 	r.init(false, false)
 	return r.metaProvider.Params()
 }

--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -25,9 +25,9 @@ import (
 	"time"
 
 	"github.com/gohugoio/hugo/common/collections"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hreflect"
 	"github.com/gohugoio/hugo/common/hstore"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/langs"
@@ -43,7 +43,7 @@ func New(deps *deps.Deps) *Namespace {
 	}
 	loc := langs.GetLocation(language)
 
-	dCache := maps.NewCacheWithOptions[dKey, []int](maps.CacheOptions{Size: 100})
+	dCache := hmaps.NewCacheWithOptions[dKey, []int](hmaps.CacheOptions{Size: 100})
 
 	return &Namespace{
 		loc:      loc,
@@ -57,7 +57,7 @@ func New(deps *deps.Deps) *Namespace {
 type Namespace struct {
 	loc      *time.Location
 	sortComp *compare.Namespace
-	dCache   *maps.Cache[dKey, []int]
+	dCache   *hmaps.Cache[dKey, []int]
 	deps     *deps.Deps
 }
 

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/config/testconfig"
 
 	qt "github.com/frankban/quicktest"
@@ -912,10 +912,10 @@ type TstX struct {
 }
 
 type TstParams struct {
-	params maps.Params
+	params hmaps.Params
 }
 
-func (x TstParams) Params() maps.Params {
+func (x TstParams) Params() hmaps.Params {
 	return x.params
 }
 

--- a/tpl/collections/index.go
+++ b/tpl/collections/index.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/spf13/cast"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hreflect"
-	"github.com/gohugoio/hugo/common/maps"
 )
 
 // Index returns the result of indexing its first argument by the following
@@ -63,7 +63,7 @@ func (ns *Namespace) doIndex(item any, args ...any) (any, error) {
 		indices = args
 	}
 
-	lowerm, ok := item.(maps.Params)
+	lowerm, ok := item.(hmaps.Params)
 	if ok {
 		return lowerm.GetNested(cast.ToStringSlice(indices)...), nil
 	}

--- a/tpl/collections/index_test.go
+++ b/tpl/collections/index_test.go
@@ -17,9 +17,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gohugoio/hugo/common/maps"
-
 	qt "github.com/frankban/quicktest"
+	"github.com/gohugoio/hugo/common/hmaps"
 )
 
 func TestIndex(t *testing.T) {
@@ -47,8 +46,8 @@ func TestIndex(t *testing.T) {
 		{map[string]map[string]string{"a": {"b": "c"}}, []any{"a", "b"}, "c", false},
 		{[]map[string]map[string]string{{"a": {"b": "c"}}}, []any{0, "a", "b"}, "c", false},
 		{map[string]map[string]any{"a": {"b": []string{"c", "d"}}}, []any{"a", "b", 1}, "d", false},
-		{maps.Params{"a": "av"}, []any{"A"}, "av", false},
-		{maps.Params{"a": map[string]any{"b": "bv"}}, []any{"A", "B"}, "bv", false},
+		{hmaps.Params{"a": "av"}, []any{"A"}, "av", false},
+		{hmaps.Params{"a": map[string]any{"b": "bv"}}, []any{"A", "B"}, "bv", false},
 
 		// These used to be errors.
 		// See issue 10489.

--- a/tpl/collections/merge.go
+++ b/tpl/collections/merge.go
@@ -19,8 +19,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hreflect"
-	"github.com/gohugoio/hugo/common/maps"
 )
 
 // Merge creates a copy of the final parameter in params and merges the preceding
@@ -92,7 +92,7 @@ func mergeMap(dst, src reflect.Value) reflect.Value {
 	out := reflect.MakeMap(dst.Type())
 
 	// If the destination is Params, we must lower case all keys.
-	_, lowerCase := dst.Interface().(maps.Params)
+	_, lowerCase := dst.Interface().(hmaps.Params)
 
 	k := reflect.New(dst.Type().Key()).Elem()
 	v := reflect.New(dst.Type().Elem()).Elem()

--- a/tpl/collections/merge_test.go
+++ b/tpl/collections/merge_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/parser"
 	"github.com/gohugoio/hugo/parser/metadecoders"
 
@@ -78,24 +78,24 @@ func TestMerge(t *testing.T) {
 			"params dst",
 			[]any{
 				map[string]any{"a": 42, "c": 3},
-				maps.Params{"a": 1, "b": 2},
+				hmaps.Params{"a": 1, "b": 2},
 			},
-			maps.Params{"a": int(1), "b": int(2), "c": int(3)},
+			hmaps.Params{"a": int(1), "b": int(2), "c": int(3)},
 			false,
 		},
 		{
 			"params dst, upper case src",
 			[]any{
 				map[string]any{"a": 42, "C": 3},
-				maps.Params{"a": 1, "b": 2},
+				hmaps.Params{"a": 1, "b": 2},
 			},
-			maps.Params{"a": int(1), "b": int(2), "c": int(3)},
+			hmaps.Params{"a": int(1), "b": int(2), "c": int(3)},
 			false,
 		},
 		{
 			"params src",
 			[]any{
-				maps.Params{"a": 42, "c": 3},
+				hmaps.Params{"a": 42, "c": 3},
 				map[string]any{"a": 1, "c": 2},
 			},
 			map[string]any{"a": int(1), "c": int(2)},
@@ -104,7 +104,7 @@ func TestMerge(t *testing.T) {
 		{
 			"params src, upper case dst",
 			[]any{
-				maps.Params{"a": 42, "c": 3},
+				hmaps.Params{"a": 42, "c": 3},
 				map[string]any{"a": 1, "C": 2},
 			},
 			map[string]any{"a": int(1), "C": int(2)},
@@ -114,9 +114,9 @@ func TestMerge(t *testing.T) {
 			"nested, params dst",
 			[]any{
 				map[string]any{"a": 42, "c": 3, "b": map[string]any{"d": 55, "e": 66, "f": 3}},
-				maps.Params{"a": 1, "b": maps.Params{"d": 1, "e": 2}},
+				hmaps.Params{"a": 1, "b": hmaps.Params{"d": 1, "e": 2}},
 			},
-			maps.Params{"a": 1, "b": maps.Params{"d": 1, "e": 2, "f": 3}, "c": 3},
+			hmaps.Params{"a": 1, "b": hmaps.Params{"d": 1, "e": 2, "f": 3}, "c": 3},
 			false,
 		},
 		{
@@ -136,7 +136,6 @@ func TestMerge(t *testing.T) {
 		{"different map types", []any{map[int]any{32: "a"}, simpleMap}, nil, true},
 		{"all nil", []any{nil, nil}, nil, true},
 	} {
-
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			errMsg := qt.Commentf("[%d] %v", i, test)

--- a/tpl/collections/querify.go
+++ b/tpl/collections/querify.go
@@ -17,7 +17,7 @@ import (
 	"errors"
 	"net/url"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/spf13/cast"
 )
 
@@ -37,7 +37,7 @@ func (ns *Namespace) Querify(params ...any) (string, error) {
 		switch v := params[0].(type) {
 		case map[string]any: // created with collections.Dictionary
 			return mapToQueryString(v)
-		case maps.Params: // site configuration or page parameters
+		case hmaps.Params: // site configuration or page parameters
 			return mapToQueryString(v)
 		case []string:
 			return stringSliceToQueryString(v)
@@ -66,7 +66,7 @@ func (ns *Namespace) Querify(params ...any) (string, error) {
 // mapToQueryString returns a URL query string derived from the given string
 // map, encoded and sorted by key. The function returns an error if it cannot
 // convert an element value to a string.
-func mapToQueryString[T map[string]any | maps.Params](m T) (string, error) {
+func mapToQueryString[T map[string]any | hmaps.Params](m T) (string, error) {
 	if len(m) == 0 {
 		return "", nil
 	}

--- a/tpl/collections/querify_test.go
+++ b/tpl/collections/querify_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 )
 
 func TestQuerify(t *testing.T) {
@@ -31,9 +31,9 @@ func TestQuerify(t *testing.T) {
 		expect any
 	}{
 		// map
-		{"01", []any{maps.Params{"a": "foo", "b": "bar"}}, `a=foo&b=bar`},
-		{"02", []any{maps.Params{"a": 6, "b": 7}}, `a=6&b=7`},
-		{"03", []any{maps.Params{"a": "foo", "b": 7}}, `a=foo&b=7`},
+		{"01", []any{hmaps.Params{"a": "foo", "b": "bar"}}, `a=foo&b=bar`},
+		{"02", []any{hmaps.Params{"a": 6, "b": 7}}, `a=6&b=7`},
+		{"03", []any{hmaps.Params{"a": "foo", "b": 7}}, `a=foo&b=7`},
 		{"04", []any{map[string]any{"a": "foo", "b": "bar"}}, `a=foo&b=bar`},
 		{"05", []any{map[string]any{"a": 6, "b": 7}}, `a=6&b=7`},
 		{"06", []any{map[string]any{"a": "foo", "b": 7}}, `a=foo&b=7`},
@@ -53,7 +53,7 @@ func TestQuerify(t *testing.T) {
 		// no arguments
 		{"16", []any{}, ``},
 		// errors: zero key length
-		{"17", []any{maps.Params{"": "foo"}}, false},
+		{"17", []any{hmaps.Params{"": "foo"}}, false},
 		{"18", []any{map[string]any{"": "foo"}}, false},
 		{"19", []any{[]string{"", "foo"}}, false},
 		{"20", []any{[]any{"", 6}}, false},

--- a/tpl/collections/sort.go
+++ b/tpl/collections/sort.go
@@ -20,8 +20,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hreflect"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/langs"
 	"github.com/gohugoio/hugo/tpl/compare"
 	"github.com/spf13/cast"
@@ -89,8 +89,8 @@ func (ns *Namespace) Sort(ctx context.Context, l any, args ...any) (any, error) 
 					if !v.IsValid() {
 						continue
 					}
-					// Special handling of lower cased maps.
-					if params, ok := v.Interface().(maps.Params); ok {
+					// Special handling of lower cased hmaps.
+					if params, ok := v.Interface().(hmaps.Params); ok {
 						v = reflect.ValueOf(params.GetNested(path[i+1:]...))
 						break
 					}
@@ -122,8 +122,8 @@ func (ns *Namespace) Sort(ctx context.Context, l any, args ...any) (any, error) 
 					if !v.IsValid() {
 						continue
 					}
-					// Special handling of lower cased maps.
-					if params, ok := v.Interface().(maps.Params); ok {
+					// Special handling of lower cased hmaps.
+					if params, ok := v.Interface().(hmaps.Params); ok {
 						v = reflect.ValueOf(params.GetNested(path[j+1:]...))
 						break
 					}

--- a/tpl/collections/sort_test.go
+++ b/tpl/collections/sort_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 )
 
 type stringsSlice []string
@@ -103,17 +103,17 @@ func TestSort(t *testing.T) {
 		},
 		// Lower case Params, slice
 		{
-			[]TstParams{{params: maps.Params{"color": "indigo"}}, {params: maps.Params{"color": "blue"}}, {params: maps.Params{"color": "green"}}},
+			[]TstParams{{params: hmaps.Params{"color": "indigo"}}, {params: hmaps.Params{"color": "blue"}}, {params: hmaps.Params{"color": "green"}}},
 			".Params.COLOR",
 			"asc",
-			[]TstParams{{params: maps.Params{"color": "blue"}}, {params: maps.Params{"color": "green"}}, {params: maps.Params{"color": "indigo"}}},
+			[]TstParams{{params: hmaps.Params{"color": "blue"}}, {params: hmaps.Params{"color": "green"}}, {params: hmaps.Params{"color": "indigo"}}},
 		},
 		// Lower case Params, map
 		{
-			map[string]TstParams{"1": {params: maps.Params{"color": "indigo"}}, "2": {params: maps.Params{"color": "blue"}}, "3": {params: maps.Params{"color": "green"}}},
+			map[string]TstParams{"1": {params: hmaps.Params{"color": "indigo"}}, "2": {params: hmaps.Params{"color": "blue"}}, "3": {params: hmaps.Params{"color": "green"}}},
 			".Params.CoLoR",
 			"asc",
-			[]TstParams{{params: maps.Params{"color": "blue"}}, {params: maps.Params{"color": "green"}}, {params: maps.Params{"color": "indigo"}}},
+			[]TstParams{{params: hmaps.Params{"color": "blue"}}, {params: hmaps.Params{"color": "green"}}, {params: hmaps.Params{"color": "indigo"}}},
 		},
 		// test map sorting by struct's method
 		{

--- a/tpl/collections/where.go
+++ b/tpl/collections/where.go
@@ -20,9 +20,9 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hreflect"
 	"github.com/gohugoio/hugo/common/hstrings"
-	"github.com/gohugoio/hugo/common/maps"
 )
 
 // Where returns a filtered subset of collection c.
@@ -403,7 +403,7 @@ func (ns *Namespace) checkWhereArray(ctxv, seqv, kv, mv reflect.Value, path []st
 		rvv := seqv.Index(i)
 
 		if kv.Kind() == reflect.String {
-			if params, ok := rvv.Interface().(maps.Params); ok {
+			if params, ok := rvv.Interface().(hmaps.Params); ok {
 				vvv = reflect.ValueOf(params.GetNested(path...))
 			} else {
 				vvv = rvv
@@ -415,7 +415,7 @@ func (ns *Namespace) checkWhereArray(ctxv, seqv, kv, mv reflect.Value, path []st
 					}
 
 					if i < len(path)-1 && vvv.IsValid() {
-						if params, ok := vvv.Interface().(maps.Params); ok {
+						if params, ok := vvv.Interface().(hmaps.Params); ok {
 							// The current path element is the map itself, .Params.
 							vvv = reflect.ValueOf(params.GetNested(path[i+1:]...))
 							break

--- a/tpl/collections/where_test.go
+++ b/tpl/collections/where_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 )
 
 func TestWhere(t *testing.T) {
@@ -176,35 +176,35 @@ func TestWhere(t *testing.T) {
 				{1: "a", 2: "m"},
 			},
 		},
-		// Case insensitive maps.Params
+		// Case insensitive hmaps.Params
 		// Slice of structs
 		{
-			seq: []TstParams{{params: maps.Params{"i": 0, "color": "indigo"}}, {params: maps.Params{"i": 1, "color": "blue"}}, {params: maps.Params{"i": 2, "color": "green"}}, {params: maps.Params{"i": 3, "color": "blue"}}},
+			seq: []TstParams{{params: hmaps.Params{"i": 0, "color": "indigo"}}, {params: hmaps.Params{"i": 1, "color": "blue"}}, {params: hmaps.Params{"i": 2, "color": "green"}}, {params: hmaps.Params{"i": 3, "color": "blue"}}},
 			key: ".Params.COLOR", match: "blue",
-			expect: []TstParams{{params: maps.Params{"i": 1, "color": "blue"}}, {params: maps.Params{"i": 3, "color": "blue"}}},
+			expect: []TstParams{{params: hmaps.Params{"i": 1, "color": "blue"}}, {params: hmaps.Params{"i": 3, "color": "blue"}}},
 		},
 		{
-			seq: []TstParams{{params: maps.Params{"nested": map[string]any{"color": "indigo"}}}, {params: maps.Params{"nested": map[string]any{"color": "blue"}}}},
+			seq: []TstParams{{params: hmaps.Params{"nested": map[string]any{"color": "indigo"}}}, {params: hmaps.Params{"nested": map[string]any{"color": "blue"}}}},
 			key: ".Params.NEsTED.COLOR", match: "blue",
-			expect: []TstParams{{params: maps.Params{"nested": map[string]any{"color": "blue"}}}},
+			expect: []TstParams{{params: hmaps.Params{"nested": map[string]any{"color": "blue"}}}},
 		},
 		{
-			seq: []TstParams{{params: maps.Params{"i": 0, "color": "indigo"}}, {params: maps.Params{"i": 1, "color": "blue"}}, {params: maps.Params{"i": 2, "color": "green"}}, {params: maps.Params{"i": 3, "color": "blue"}}},
+			seq: []TstParams{{params: hmaps.Params{"i": 0, "color": "indigo"}}, {params: hmaps.Params{"i": 1, "color": "blue"}}, {params: hmaps.Params{"i": 2, "color": "green"}}, {params: hmaps.Params{"i": 3, "color": "blue"}}},
 			key: ".Params", match: "blue",
 			expect: []TstParams{},
 		},
 		// Slice of maps
 		{
-			seq: []maps.Params{
+			seq: []hmaps.Params{
 				{"a": "a1", "b": "b1"}, {"a": "a2", "b": "b2"},
 			},
 			key: "B", match: "b2",
-			expect: []maps.Params{
+			expect: []hmaps.Params{
 				{"a": "a2", "b": "b2"},
 			},
 		},
 		{
-			seq: []maps.Params{
+			seq: []hmaps.Params{
 				{
 					"a": map[string]any{
 						"b": "b1",
@@ -217,7 +217,7 @@ func TestWhere(t *testing.T) {
 				},
 			},
 			key: "A.B", match: "b2",
-			expect: []maps.Params{
+			expect: []hmaps.Params{
 				{
 					"a": map[string]any{
 						"b": "b2",
@@ -622,14 +622,14 @@ func TestWhere(t *testing.T) {
 		},
 		{
 			seq: map[string]any{
-				"foo": []any{maps.Params{"a": 1, "b": 2}},
-				"bar": []any{maps.Params{"a": 3, "b": 4}},
-				"zap": []any{maps.Params{"a": 5, "b": 6}},
+				"foo": []any{hmaps.Params{"a": 1, "b": 2}},
+				"bar": []any{hmaps.Params{"a": 3, "b": 4}},
+				"zap": []any{hmaps.Params{"a": 5, "b": 6}},
 			},
 			key: "B", op: ">", match: 3,
 			expect: map[string]any{
-				"bar": []any{maps.Params{"a": 3, "b": 4}},
-				"zap": []any{maps.Params{"a": 5, "b": 6}},
+				"bar": []any{hmaps.Params{"a": 3, "b": 4}},
+				"zap": []any{hmaps.Params{"a": 5, "b": 6}},
 			},
 		},
 	} {

--- a/tpl/css/css.go
+++ b/tpl/css/css.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugo"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/common/types/css"
 	"github.com/gohugoio/hugo/deps"
@@ -105,7 +105,7 @@ func (ns *Namespace) Sass(args ...any) (resource.Resource, error) {
 	}
 
 	if m != nil {
-		if t, _, found := maps.LookupEqualFold(m, "transpiler"); found {
+		if t, _, found := hmaps.LookupEqualFold(m, "transpiler"); found {
 			switch t {
 			case sass.TranspilerDart:
 				transpiler = cast.ToString(t)

--- a/tpl/data/data.go
+++ b/tpl/data/data.go
@@ -22,11 +22,12 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/gohugoio/hugo/cache/filecache"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugo"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/config/security"
 
 	"github.com/gohugoio/hugo/common/types"
@@ -36,7 +37,6 @@ import (
 	"github.com/spf13/cast"
 
 	"github.com/gohugoio/hugo/deps"
-	"slices"
 )
 
 // New returns a new instance of the data-namespaced template functions.
@@ -185,7 +185,7 @@ func toURLAndHeaders(urlParts []any) (string, map[string]any) {
 	}
 
 	// The last argument may be a map.
-	headers, err := maps.ToStringMapE(urlParts[len(urlParts)-1])
+	headers, err := hmaps.ToStringMapE(urlParts[len(urlParts)-1])
 	if err == nil {
 		urlParts = urlParts[:len(urlParts)-1]
 	} else {

--- a/tpl/data/data_test.go
+++ b/tpl/data/data_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/bep/logg"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -241,7 +241,7 @@ func TestHeaders(t *testing.T) {
 		},
 		{
 			`Params`,
-			maps.Params{
+			hmaps.Params{
 				"Accept-Charset": "utf-8",
 			},
 			func(c *qt.C, headers string) {

--- a/tpl/encoding/encoding.go
+++ b/tpl/encoding/encoding.go
@@ -21,8 +21,8 @@ import (
 	"html/template"
 
 	bp "github.com/gohugoio/hugo/bufferpool"
+	"github.com/gohugoio/hugo/common/hmaps"
 
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cast"
 )
@@ -76,7 +76,7 @@ func (ns *Namespace) Jsonify(args ...any) (template.HTML, error) {
 		obj = args[0]
 	case 2:
 		var m map[string]any
-		m, err = maps.ToStringMapE(args[0])
+		m, err = hmaps.ToStringMapE(args[0])
 		if err != nil {
 			break
 		}

--- a/tpl/internal/resourcehelpers/helpers.go
+++ b/tpl/internal/resourcehelpers/helpers.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/resources"
 )
 
@@ -60,7 +60,7 @@ func ResolveArgs(args []any) (resources.ResourceTransformer, map[string]any, err
 		return nil, nil, fmt.Errorf("type %T not supported in Resource transformations", args[0])
 	}
 
-	m, err := maps.ToStringMapE(args[0])
+	m, err := hmaps.ToStringMapE(args[0])
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid options type: %w", err)
 	}

--- a/tpl/openapi/openapi3/openapi3.go
+++ b/tpl/openapi/openapi3/openapi3.go
@@ -27,7 +27,7 @@ import (
 	kopenapi3 "github.com/getkin/kin-openapi/openapi3"
 	"github.com/gohugoio/hugo/cache/dynacache"
 	"github.com/gohugoio/hugo/common/hashing"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/identity"
 	"github.com/gohugoio/hugo/parser/metadecoders"
@@ -81,7 +81,7 @@ func (ns *Namespace) Unmarshal(ctx context.Context, args ...any) (*OpenAPIDocume
 
 	var opts unmarshalOptions
 	if len(args) > 1 {
-		optsm, err := maps.ToStringMapE(args[1])
+		optsm, err := hmaps.ToStringMapE(args[1])
 		if err != nil {
 			return nil, err
 		}

--- a/tpl/resources/resources.go
+++ b/tpl/resources/resources.go
@@ -19,8 +19,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hugo"
-	"github.com/gohugoio/hugo/common/maps"
 
 	"github.com/gohugoio/hugo/tpl/css"
 	"github.com/gohugoio/hugo/tpl/js"
@@ -129,7 +129,7 @@ func (ns *Namespace) GetRemote(args ...any) (resource.Resource, error) {
 		var options map[string]any
 
 		if len(args) > 1 {
-			options, err = maps.ToStringMapE(args[1])
+			options, err = hmaps.ToStringMapE(args[1])
 			if err != nil {
 				return nil, err
 			}

--- a/tpl/tplimpl/template_funcs.go
+++ b/tpl/tplimpl/template_funcs.go
@@ -20,8 +20,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hreflect"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/identity"
 	"github.com/gohugoio/hugo/tpl"
 
@@ -68,7 +68,7 @@ func (t *templateExecHelper) Init(ctx context.Context, tmpl texttemplate.Prepare
 }
 
 func (t *templateExecHelper) GetMapValue(ctx context.Context, tmpl texttemplate.Preparer, receiver, key reflect.Value) (reflect.Value, bool) {
-	if params, ok := receiver.Interface().(maps.Params); ok {
+	if params, ok := receiver.Interface().(hmaps.Params); ok {
 		// Case insensitive.
 		keystr := strings.ToLower(key.String())
 		v, found := params[keystr]
@@ -83,7 +83,7 @@ func (t *templateExecHelper) GetMapValue(ctx context.Context, tmpl texttemplate.
 	return v, v.IsValid()
 }
 
-var typeParams = reflect.TypeOf(maps.Params{})
+var typeParams = reflect.TypeOf(hmaps.Params{})
 
 func (t *templateExecHelper) GetMethod(ctx context.Context, tmpl texttemplate.Preparer, receiver reflect.Value, name string) (method reflect.Value, firstArg reflect.Value) {
 	if strings.EqualFold(name, "mainsections") && receiver.Type() == typeParams && receiver.Pointer() == t.siteParams.Pointer() {

--- a/tpl/tplimpl/templatestore.go
+++ b/tpl/tplimpl/templatestore.go
@@ -37,9 +37,9 @@ import (
 
 	"github.com/gohugoio/hugo/common/collections"
 	"github.com/gohugoio/hugo/common/herrors"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/loggers"
-	"github.com/gohugoio/hugo/common/maps"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/gohugoio/hugo/hugofs"
@@ -126,10 +126,10 @@ func NewStore(opts StoreOptions, siteOpts SiteOptions) (*TemplateStore, error) {
 		storeSite:            configureSiteStorage(siteOpts, opts.Watching),
 		treeMain:             doctree.NewSimpleTree[map[nodeKey]*TemplInfo](),
 		treeShortcodes:       doctree.NewSimpleTree[map[string]map[TemplateDescriptor]*TemplInfo](),
-		templatesByPath:      maps.NewCache[string, *TemplInfo](),
-		shortcodesByName:     maps.NewCache[string, *TemplInfo](),
-		cacheLookupPartials:  maps.NewCache[string, *TemplInfo](),
-		templatesSnapshotSet: maps.NewCache[*parse.Tree, struct{}](),
+		templatesByPath:      hmaps.NewCache[string, *TemplInfo](),
+		shortcodesByName:     hmaps.NewCache[string, *TemplInfo](),
+		cacheLookupPartials:  hmaps.NewCache[string, *TemplInfo](),
+		templatesSnapshotSet: hmaps.NewCache[*parse.Tree, struct{}](),
 
 		// Note that the funcs passed below is just for name validation.
 		tns: newTemplateNamespace(siteOpts.TemplateFuncs),
@@ -437,9 +437,9 @@ type TemplateStore struct {
 
 	treeMain             *doctree.SimpleTree[map[nodeKey]*TemplInfo]
 	treeShortcodes       *doctree.SimpleTree[map[string]map[TemplateDescriptor]*TemplInfo]
-	templatesByPath      *maps.Cache[string, *TemplInfo]
-	shortcodesByName     *maps.Cache[string, *TemplInfo]
-	templatesSnapshotSet *maps.Cache[*parse.Tree, struct{}]
+	templatesByPath      *hmaps.Cache[string, *TemplInfo]
+	shortcodesByName     *hmaps.Cache[string, *TemplInfo]
+	templatesSnapshotSet *hmaps.Cache[*parse.Tree, struct{}]
 
 	dh descriptorHandler
 
@@ -455,7 +455,7 @@ type TemplateStore struct {
 	siteOptsOrig SiteOptions
 
 	// caches. These need to be refreshed when the templates are refreshed.
-	cacheLookupPartials *maps.Cache[string, *TemplInfo]
+	cacheLookupPartials *hmaps.Cache[string, *TemplInfo]
 }
 
 // NewFromOpts creates a new store with the same configuration as the original.

--- a/tpl/tplimpl/templatetransform.go
+++ b/tpl/tplimpl/templatetransform.go
@@ -13,7 +13,7 @@ import (
 	texttemplate "github.com/gohugoio/hugo/tpl/internal/go_templates/texttemplate"
 
 	"github.com/gohugoio/hugo/common/hashing"
-	"github.com/gohugoio/hugo/common/maps"
+	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/tpl"
 	"github.com/mitchellh/mapstructure"
 )
@@ -478,7 +478,7 @@ func (c *templateTransformContext) collectConfig(n *parse.PipeNode) {
 
 	if s, ok := cmd.Args[0].(*parse.StringNode); ok {
 		errMsg := "failed to decode $_hugo_config in template: %w"
-		m, err := maps.ToStringMapE(s.Text)
+		m, err := hmaps.ToStringMapE(s.Text)
 		if err != nil {
 			c.err = fmt.Errorf(errMsg, err)
 			return


### PR DESCRIPTION
Go's stdlid now has a maps package, which is very useful. We have been using imports on the form `xmaps "maps"`, but auto import tools doesn't handle this, which is annoying.

I have been thinking about this for some time, but have been holding back because of all the import changes. However, now is a good time to do this, with very little unmerged code.
