### PR TITLE
fix: typos in comments

### DIFF
--- a/config/allconfig/docshelper.go
+++ b/config/allconfig/docshelper.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gohugoio/hugo/docshelper"
 )
 
-// This is is just some helpers used to create some JSON used in the Hugo docs.
+// This is just some helpers used to create some JSON used in the Hugo docs.
 func init() {
 	docsProvider := func() docshelper.DocProvider {
 		cfg := config.New()

--- a/helpers/docshelper.go
+++ b/helpers/docshelper.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gohugoio/hugo/docshelper"
 )
 
-// This is is just some helpers used to create some JSON used in the Hugo docs.
+// This is just some helpers used to create some JSON used in the Hugo docs.
 func init() {
 	docsProvider := func() docshelper.DocProvider {
 		var chromaLexers []any

--- a/output/docshelper.go
+++ b/output/docshelper.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gohugoio/hugo/docshelper"
 )
 
-// This is is just some helpers used to create some JSON used in the Hugo docs.
+// This is just some helpers used to create some JSON used in the Hugo docs.
 func init() {
 	docsProvider := func() docshelper.DocProvider {
 		return docshelper.DocProvider{

--- a/parser/pageparser/pagelexer_shortcode.go
+++ b/parser/pageparser/pagelexer_shortcode.go
@@ -33,7 +33,7 @@ var (
 	rightDelimScNoMarkup   = []byte(">}}")
 	leftDelimScWithMarkup  = []byte("{{%")
 	rightDelimScWithMarkup = []byte("%}}")
-	leftComment            = []byte("/*") // comments in this context us used to to mark shortcodes as "not really a shortcode"
+	leftComment            = []byte("/*") // comments in this context us used to mark shortcodes as "not really a shortcode"
 	rightComment           = []byte("*/")
 )
 

--- a/related/inverted_index.go
+++ b/related/inverted_index.go
@@ -331,7 +331,7 @@ type SearchOpts struct {
 	// The indices to search in.
 	Indices []string
 
-	// Fragments holds a a list of special keywords that is used
+	// Fragments holds a list of special keywords that is used
 	// for indices configured as type "fragments".
 	// This will match the fragment identifiers of the documents.
 	Fragments []string


### PR DESCRIPTION
Fix typos in comments:
- `is is` → `is` (x3)
- `a a` → `a`
- `to to` → `to` (x3)