### PR TITLE
Allow v1,v2 etc. style version names while still supporting full semver in queries

### DIFF
--- a/common/version/version_test.go
+++ b/common/version/version_test.go
@@ -50,6 +50,11 @@ func TestHugoVersion(t *testing.T) {
 func TestCompareVersions(t *testing.T) {
 	c := qt.New(t)
 
+	parseIgnoreErr := func(s string) Version {
+		v, _ := ParseVersion(s)
+		return v
+	}
+
 	c.Assert(CompareVersions(MustParseVersion("0.20.0"), 0.20), qt.Equals, 0)
 	c.Assert(CompareVersions(MustParseVersion("0.20.0"), float32(0.20)), qt.Equals, 0)
 	c.Assert(CompareVersions(MustParseVersion("0.20.0"), float64(0.20)), qt.Equals, 0)
@@ -69,6 +74,15 @@ func TestCompareVersions(t *testing.T) {
 	c.Assert(CompareVersions(MustParseVersion("0.22.0-DEV"), "0.22"), qt.Equals, 1)
 	c.Assert(CompareVersions(MustParseVersion("0.22.1-DEV"), "0.22"), qt.Equals, -1)
 	c.Assert(CompareVersions(MustParseVersion("0.22.1-DEV"), "0.22.1-DEV"), qt.Equals, 0)
+
+	c.Assert(CompareVersions(parseIgnoreErr("foobar"), "v1.0.0"), qt.Equals, 1)
+	c.Assert(CompareVersions(parseIgnoreErr("v1.0.0"), "foobar"), qt.Equals, -1)
+	c.Assert(CompareVersions(parseIgnoreErr("foobar"), "foobar"), qt.Equals, 0)
+	c.Assert(CompareVersions(parseIgnoreErr("foobar"), parseIgnoreErr("foobar")), qt.Equals, 0)
+	c.Assert(CompareVersions(parseIgnoreErr("a"), "b"), qt.Equals, -1)
+	c.Assert(CompareVersions(parseIgnoreErr("a"), parseIgnoreErr("b")), qt.Equals, -1)
+	c.Assert(CompareVersions(parseIgnoreErr("b"), "a"), qt.Equals, 1)
+	c.Assert(CompareVersions(parseIgnoreErr("b"), parseIgnoreErr("a")), qt.Equals, 1)
 }
 
 func TestParseHugoVersion(t *testing.T) {


### PR DESCRIPTION
This enables a potentially useful workflow partitioning docs into major short versions (v1, v2 etc.). See   https://github.com/bep/hugo-testing-git-versions for a runnable version.

My final setup doesn't need this PR (but I still thinks a good idea):

```toml
[versions]
    [versions.v1]
    [versions.v2]
    [versions.v3]
    [versions.dev]

[module]
    [[module.mounts]]
        source = 'content'
        target = 'content'
        [module.mounts.sites.matrix]
            versions = 'dev'
    [[module.imports]]
        ignoreConfig = true
        path         = 'github.com/bep/hugo-testing-git-versions'
        version      = '<v2.0.0'
        [[module.imports.mounts]]
            source = 'content'
            target = 'content'
            [module.imports.mounts.sites.matrix]
                versions = 'v1'
    [[module.imports]]
        ignoreConfig = true
        path         = 'github.com/bep/hugo-testing-git-versions'
        version      = '<v3.0.0'
        [[module.imports.mounts]]
            source = 'content'
            target = 'content'
            [module.imports.mounts.sites.matrix]
                versions = 'v2'
    [[module.imports]]
        ignoreConfig = true
        path         = 'github.com/bep/hugo-testing-git-versions'
        version      = '<v4.0.0'
        [[module.imports.mounts]]
            source = 'content'
            target = 'content'
            [module.imports.mounts.sites.matrix]
                versions = 'v3'
```

Fixes #14414
