### PR TITLE
Add modulequeries file cache for module version queries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,6 @@ jobs:
         name: Test
         run: |
           mage -v test
-          go clean -i -testcache
         env:
           HUGO_BUILD_TAGS: extended,withdeploy
       - if: matrix.os == 'ubuntu-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ imports.*
 dist/
 public/
 .DS_Store 
+cache/filecache/_gen/

--- a/cache/filecache/filecache_config.go
+++ b/cache/filecache/filecache_config.go
@@ -40,13 +40,14 @@ var defaultCacheConfig = FileCacheConfig{
 }
 
 const (
-	CacheKeyGetJSON     = "getjson"
-	CacheKeyGetCSV      = "getcsv"
-	CacheKeyImages      = "images"
-	CacheKeyAssets      = "assets"
-	CacheKeyModules     = "modules"
-	CacheKeyGetResource = "getresource"
-	CacheKeyMisc        = "misc"
+	CacheKeyGetJSON       = "getjson"
+	CacheKeyGetCSV        = "getcsv"
+	CacheKeyImages        = "images"
+	CacheKeyAssets        = "assets"
+	CacheKeyModules       = "modules"
+	CacheKeyModuleQueries = "modulequeries"
+	CacheKeyGetResource   = "getresource"
+	CacheKeyMisc          = "misc"
 )
 
 type Configs map[string]FileCacheConfig
@@ -66,6 +67,10 @@ func (c Configs) CacheDirMisc() string {
 var defaultCacheConfigs = Configs{
 	CacheKeyModules: {
 		MaxAge: -1,
+		Dir:    ":cacheDir/modules",
+	},
+	CacheKeyModuleQueries: {
+		MaxAge: 24 * time.Hour,
 		Dir:    ":cacheDir/modules",
 	},
 	CacheKeyGetJSON: defaultCacheConfig,
@@ -125,6 +130,16 @@ func (f Caches) ImageCache() *Cache {
 // ModulesCache gets the file cache for Hugo Modules.
 func (f Caches) ModulesCache() *Cache {
 	return f[CacheKeyModules]
+}
+
+// ModuleQueriesCache gets the file cache for Hugo Module version queries.
+// Returns nil if not found.
+func (f Caches) ModuleQueriesCache() *Cache {
+	c, ok := f[CacheKeyModuleQueries]
+	if !ok {
+		panic("module queries cache not set")
+	}
+	return c
 }
 
 // AssetsCache gets the file cache for assets (processed resources, SCSS etc.).

--- a/cache/filecache/filecache_config_test.go
+++ b/cache/filecache/filecache_config_test.go
@@ -59,7 +59,7 @@ dir = "/path/to/c4"
 	c.Assert(err, qt.IsNil)
 	fs := afero.NewMemMapFs()
 	decoded := testconfig.GetTestConfigs(fs, cfg).Base.Caches
-	c.Assert(len(decoded), qt.Equals, 7)
+	c.Assert(len(decoded), qt.Equals, 8)
 
 	c2 := decoded["getcsv"]
 	c.Assert(c2.MaxAge.String(), qt.Equals, "11h0m0s")
@@ -106,7 +106,7 @@ dir = "/path/to/c4"
 	c.Assert(err, qt.IsNil)
 	fs := afero.NewMemMapFs()
 	decoded := testconfig.GetTestConfigs(fs, cfg).Base.Caches
-	c.Assert(len(decoded), qt.Equals, 7)
+	c.Assert(len(decoded), qt.Equals, 8)
 
 	for _, v := range decoded {
 		c.Assert(v.MaxAge, qt.Equals, time.Duration(0))
@@ -129,7 +129,7 @@ func TestDecodeConfigDefault(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	decoded := testconfig.GetTestConfigs(fs, cfg).Base.Caches
-	c.Assert(len(decoded), qt.Equals, 7)
+	c.Assert(len(decoded), qt.Equals, 8)
 
 	imgConfig := decoded[filecache.CacheKeyImages]
 	jsonConfig := decoded[filecache.CacheKeyGetJSON]

--- a/cache/filecache/filecache_pruner_test.go
+++ b/cache/filecache/filecache_pruner_test.go
@@ -55,9 +55,12 @@ dir = ":resourceDir/_gen"
 
 	for _, name := range []string{filecache.CacheKeyGetCSV, filecache.CacheKeyGetJSON, filecache.CacheKeyAssets, filecache.CacheKeyImages} {
 		msg := qt.Commentf("cache: %s", name)
-		p := newPathsSpec(t, afero.NewMemMapFs(), configStr)
-		caches, err := filecache.NewCaches(p)
+		fs := afero.NewMemMapFs()
+		p := newPathsSpec(t, fs, configStr)
+		fileCachConfig := p.Cfg.GetConfigSection("caches").(filecache.Configs)
+		caches, err := filecache.NewCaches(fileCachConfig, fs)
 		c.Assert(err, qt.IsNil)
+		caches.SetResourceFs(fs)
 		cache := caches[name]
 		for i := range 10 {
 			id := fmt.Sprintf("i%d", i)
@@ -84,8 +87,9 @@ dir = ":resourceDir/_gen"
 			}
 		}
 
-		caches, err = filecache.NewCaches(p)
+		caches, err = filecache.NewCaches(fileCachConfig, fs)
 		c.Assert(err, qt.IsNil)
+		caches.SetResourceFs(fs)
 		cache = caches[name]
 		// Touch one and then prune.
 		cache.GetOrCreateBytes("i5", func() ([]byte, error) {

--- a/cache/filecache/filecache_test.go
+++ b/cache/filecache/filecache_test.go
@@ -78,9 +78,11 @@ dir = ":cacheDir/c"
 		configStr = strings.Replace(configStr, "\\", winPathSep, -1)
 
 		p := newPathsSpec(t, osfs, configStr)
+		fileCachConfig := p.Cfg.GetConfigSection("caches").(filecache.Configs)
 
-		caches, err := filecache.NewCaches(p)
+		caches, err := filecache.NewCaches(fileCachConfig, p.Fs.Source)
 		c.Assert(err, qt.IsNil)
+		caches.SetResourceFs(p.SourceFs)
 
 		cache := caches.Get("GetJSON")
 		c.Assert(cache, qt.Not(qt.IsNil))
@@ -149,7 +151,7 @@ dir = ":cacheDir/c"
 		r.Close()
 		c.Assert(string(b), qt.Equals, "Hugo is great!")
 
-		info, b, err = caches.ImageCache().GetBytes("mykey")
+		info, b, err = caches.ImageCache().GetItemBytes("mykey")
 		c.Assert(err, qt.IsNil)
 		c.Assert(info.Name, qt.Equals, "mykey")
 		c.Assert(string(b), qt.Equals, "Hugo is great!")
@@ -179,9 +181,10 @@ dir = "/cache/c"
 `
 
 	p := newPathsSpec(t, afero.NewMemMapFs(), configStr)
-
-	caches, err := filecache.NewCaches(p)
+	fileCachConfig := p.Cfg.GetConfigSection("caches").(filecache.Configs)
+	caches, err := filecache.NewCaches(fileCachConfig, p.Fs.Source)
 	c.Assert(err, qt.IsNil)
+	caches.SetResourceFs(p.Fs.Source)
 
 	const cacheName = "getjson"
 

--- a/common/hashing/hashing.go
+++ b/common/hashing/hashing.go
@@ -87,11 +87,13 @@ func XXHashFromString(s string) (uint64, error) {
 	return h.Sum64(), nil
 }
 
-// XxHashFromStringHexEncoded calculates the xxHash for the given string
+// XxHashFromStringHexEncoded calculates the xxHash for the given strings
 // and returns the hash as a hex encoded string.
-func XxHashFromStringHexEncoded(f string) string {
+func XxHashFromStringHexEncoded(s ...string) string {
 	h := xxhash.New()
-	h.WriteString(f)
+	for _, f := range s {
+		h.WriteString(f)
+	}
 	hash := h.Sum(nil)
 	return hex.EncodeToString(hash)
 }

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -822,6 +822,7 @@ type Configs struct {
 
 	Modules       modules.Modules
 	ModulesClient *modules.Client
+	FileCaches    filecache.Caches
 
 	// All below is set in Init.
 	Languages                 langs.Languages
@@ -852,7 +853,7 @@ func (c *Configs) IsZero() bool {
 	return c == nil || len(c.Languages) == 0
 }
 
-func (c *Configs) Init(logger loggers.Logger) error {
+func (c *Configs) Init(sourceFs afero.Fs, logger loggers.Logger) error {
 	var languages langs.Languages
 
 	for _, f := range c.Base.Languages.Config.Sorted {
@@ -1154,10 +1155,16 @@ func fromLoadConfigResult(fs afero.Fs, logger loggers.Logger, res config.LoadCon
 		l.CommonDirs.CacheDir = bcfg.CacheDir
 	}
 
+	caches, err := filecache.NewCaches(all.Caches, fs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file caches from configuration: %w", err)
+	}
+
 	cm := &Configs{
 		Base:              all,
 		LanguageConfigMap: langConfigMap,
 		LoadingInfo:       res,
+		FileCaches:        caches,
 		IsMultihost:       isMultihost,
 	}
 

--- a/config/allconfig/configlanguage.go
+++ b/config/allconfig/configlanguage.go
@@ -25,9 +25,8 @@ import (
 )
 
 type ConfigLanguage struct {
-	config     *Config
-	baseConfig config.BaseConfig
-
+	config        *Config
+	baseConfig    config.BaseConfig
 	m             *Configs
 	language      *langs.Language
 	languageIndex int
@@ -121,6 +120,10 @@ func (c ConfigLanguage) Timeout() time.Duration {
 
 func (c ConfigLanguage) BaseConfig() config.BaseConfig {
 	return c.baseConfig
+}
+
+func (c ConfigLanguage) FileCaches() any {
+	return c.m.FileCaches
 }
 
 func (c ConfigLanguage) Dirs() config.CommonDirs {

--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -95,7 +95,7 @@ func LoadConfig(d ConfigSourceDescriptor) (configs *Configs, err error) {
 	configs.Modules = moduleConfig.AllModules
 	configs.ModulesClient = modulesClient
 
-	if err := configs.Init(d.Logger); err != nil {
+	if err := configs.Init(d.Fs, d.Logger); err != nil {
 		return nil, fmt.Errorf("failed to init config: %w", err)
 	}
 
@@ -477,6 +477,7 @@ func (l *configLoader) loadModules(configs *Configs, ignoreModuleDoesNotExist bo
 		PublishDir:               publishDir,
 		Environment:              l.Environment,
 		CacheDir:                 conf.Caches.CacheDirModules(),
+		ModuleQueriesCache:       configs.FileCaches.ModuleQueriesCache(),
 		ModuleConfig:             conf.Module,
 		IgnoreVendor:             ignoreVendor,
 		IgnoreModuleDoesNotExist: ignoreModuleDoesNotExist,

--- a/config/configProvider.go
+++ b/config/configProvider.go
@@ -41,6 +41,7 @@ type AllProvider interface {
 	Dirs() CommonDirs
 	Quiet() bool
 	DirsBase() CommonDirs
+	FileCaches() any
 	ContentTypes() ContentTypesProvider
 	GetConfigSection(string) any
 	GetConfig() any

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -260,10 +260,10 @@ func (d *Deps) Init() error {
 		common = d.ResourceSpec.SpecCommon
 	}
 
-	fileCaches, err := filecache.NewCaches(d.PathSpec)
-	if err != nil {
-		return fmt.Errorf("failed to create file caches from configuration: %w", err)
-	}
+	d.Cfg.BaseConfig()
+
+	fileCaches := d.Cfg.FileCaches().(filecache.Caches)
+	fileCaches.SetResourceFs(d.BaseFs.ResourcesCache)
 
 	resourceSpec, err := resources.NewSpec(d.PathSpec, common, d.WasmDispatchers, fileCaches, d.MemCache, d.BuildState, d.Log, d, d.ExecHelper, d.BuildClosers, d.BuildState)
 	if err != nil {

--- a/modules/collect.go
+++ b/modules/collect.go
@@ -391,14 +391,11 @@ func (c *collector) addAndRecurse(owner *moduleAdapter) error {
 		pk := pathVersionKey{path: tc.Path(), version: tc.Version()}
 		seenInCurrent := seen[pk]
 		if seenInCurrent {
-			// Only one import of the same module per project.
-			if owner.projectMod {
-				// In Hugo v0.150.0 we introduced direct dependencies, and it may be tempting to import the same version
-				// with different mount setups. We may allow that in the future, but we need to get some experience first.
-				// For now, we just warn. The user needs to add multiple mount points in the same import.
-				c.logger.Warnf("module with path %q is imported for the same version %q more than once", tc.Path(), tc.Version())
+			// Only one import of the same module per project, unless this is the main project.
+			if !owner.projectMod {
+				c.logger.Warnf("module with path %q is imported for the same version %q more than once; this is currently only allowed in the main project's config.", tc.Path(), tc.Version())
+				continue
 			}
-			continue
 		}
 		seen[pk] = true
 

--- a/resources/resource_cache.go
+++ b/resources/resource_cache.go
@@ -111,7 +111,7 @@ func (c *ResourceCache) getFromFile(key string) (filecache.ItemInfo, io.ReadClos
 	var meta transformedResourceMetadata
 	filenameMeta, filenameContent := c.getFilenames(key)
 
-	_, jsonContent, _ := c.fileCache.GetBytes(filenameMeta)
+	jsonContent, _ := c.fileCache.GetBytes(filenameMeta)
 	if jsonContent == nil {
 		return filecache.ItemInfo{}, nil, meta, false
 	}

--- a/resources/resource_transformers/babel/babel_integration_test.go
+++ b/resources/resource_transformers/babel/babel_integration_test.go
@@ -67,9 +67,9 @@ Transpiled3: {{ $transpiled.Permalink }}
 	"scripts": {},
 
 	"devDependencies": {
-	"@babel/cli": "7.8.4",
-	"@babel/core": "7.9.0",	
-	"@babel/preset-env": "7.9.5"
+	"@babel/cli": "7.28.6",
+	"@babel/core": "7.28.6",
+	"@babel/preset-env": "7.28.6"
 	}
 }
 


### PR DESCRIPTION
This adds a new file cache named 'modulequeries' with a 24h maxAge
that caches JSON responses from 'go mod download -json' when querying
module versions with constraints (e.g., version = "<v3.0.0").

On subsequent builds, if the cached JSON exists and the module
directory it references is non-empty, the cached result is used
directly, skipping the costly VCS interaction entirely.

Fixes #14417
