### PR TITLE
Remove disableDate and disableLatLong from MetaConfig

### DIFF
--- a/hugolib/config_test.go
+++ b/hugolib/config_test.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/bep/logg"
 	"github.com/gohugoio/hugo/common/hmaps"
-	"github.com/gohugoio/hugo/htesting"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/config/allconfig"
+	"github.com/gohugoio/hugo/htesting"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/spf13/afero"

--- a/resources/images/config.go
+++ b/resources/images/config.go
@@ -573,14 +573,6 @@ type MetaConfig struct {
 	// Use ["**"] to include all fields.
 	Fields []string
 
-	// Hugo extracts the "photo taken" date/time into .Date by default.
-	// Set this to true to turn it off.
-	DisableDate bool
-
-	// Hugo extracts the "photo taken where" (GPS latitude and longitude) into
-	// .Long and .Lat. Set this to true to turn it off.
-	DisableLatLong bool
-
 	// Which metadata sources to include.
 	// Valid values are "exif", "iptc", "xmp".
 	// Default is ["exif", "iptc"] (XMP is excluded for performance reasons).

--- a/resources/images/image.go
+++ b/resources/images/image.go
@@ -139,8 +139,6 @@ func NewImageProcessor(warnl logg.LevelLogger, wasmDispatchers *warpc.Dispatcher
 
 	m := cfg.Config.Imaging.Meta
 	metaDecoder, err := meta.NewDecoder(
-		meta.WithDateDisabled(m.DisableDate),
-		meta.WithLatLongDisabled(m.DisableLatLong),
 		meta.WithFields(m.Fields),
 		meta.WithSources(m.Sources...),
 		meta.WithWarnLogger(warnl),

--- a/resources/images/meta/meta.go
+++ b/resources/images/meta/meta.go
@@ -313,15 +313,6 @@ func (d *Decoder) DecodeMeta(filename string, format imagemeta.ImageFormat, r io
 	}
 
 	shouldHandleTag := func(ti imagemeta.TagInfo) bool {
-		// Always include time and GPS tags (needed for Date, Lat, Long extraction).
-		// These may be in EXIF, XMP, or IPTC depending on the image.
-		if !d.noDate && isTimeTag(ti.Tag) {
-			return true
-		}
-		if !d.noLatLong && isGPSTag(ti.Tag) {
-			return true
-		}
-
 		// For EXIF, only include tags from IFD0 (skip thumbnail data).
 		if ti.Source == imagemeta.EXIF {
 			if !strings.HasPrefix(ti.Namespace, "IFD0") {
@@ -359,16 +350,8 @@ func (d *Decoder) DecodeMeta(filename string, format imagemeta.ImageFormat, r io
 		return nil, err
 	}
 
-	var tm time.Time
-	var lat, long float64
-
-	if !d.noDate {
-		tm, _ = tagInfos.GetDateTime()
-	}
-
-	if !d.noLatLong {
-		lat, long, _ = tagInfos.GetLatLong()
-	}
+	tm, _ := tagInfos.GetDateTime()
+	lat, long, _ := tagInfos.GetLatLong()
 
 	exifTags := make(map[string]any)
 	iptcTags := make(map[string]any)


### PR DESCRIPTION
Since the meta config is new (and exif config is deprecated), remove
these options from MetaConfig. Users can use the fields filter for
fine-grained control over which metadata fields to include.

The existing exif config options are preserved for backward compatibility.

Closes #14437

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
