### PR TITLE
Fix data race when clearing cache in cachebusters

### DIFF
--- a/config/commonConfig.go
+++ b/config/commonConfig.go
@@ -437,7 +437,7 @@ func (c *CacheBuster) CompileConfig(logger loggers.Logger) error {
 			return nil
 		}
 		return func(ss string) bool {
-			match = targetRe.MatchString(ss)
+			match := targetRe.MatchString(ss)
 			matchString := "no match"
 			if match {
 				matchString = "match!"


### PR DESCRIPTION
Hi, first of all, thank you for this powerful tool that has been a great help in both my work and personal life. However, I've been struggling with an issue where, when using Tailwind CSS integrated in `hugo serve` mode, I often encounter situations where I modify classes but the corresponding styles don't display correctly on the page. So, I decided to try and solve this problem. Below is my summary of the issue:

During the cleanup of the cache after writing the `hugo_stats.json` file, Hugo concurrently clears all cache entries in `partitions` that meet the cachebusters rules. There is a data race issue in `/config/CacheBuster.CompileConfig`, and we should save each matching result in an independent variable. Below are some relevant call logics:

In `Cache.ClearMatching`, partition cleanup operations are performed concurrently:
https://github.com/gohugoio/hugo/blob/fd49df8f7a1152a6d303701a92d882a6d82dfce1/cache/dynacache/dynacache.go#L153-L176

The `predicateValue` parameter used in this method is derived from `shouldDelete` in `/hugolib/HugoSites.dynacacheGCCacheBuster`
https://github.com/gohugoio/hugo/blob/fd49df8f7a1152a6d303701a92d882a6d82dfce1/hugolib/content_map_page.go#L882-L896

The `cachebuster` parameter comes from `cacheBusterOr` in `/hugolib/HugoSites.dynacacheGCFilenameIfNotWatchedAndDrainMatching`.
https://github.com/gohugoio/hugo/blob/fd49df8f7a1152a6d303701a92d882a6d82dfce1/hugolib/content_map_page.go#L845-L880

In this function, executing `h.ResourceSpec.BuildConfig().MatchCacheBuster(h.Log, np)` actually yields a result that is constructed in `/config/CacheBuster.CompileConfig`.
https://github.com/gohugoio/hugo/blob/fd49df8f7a1152a6d303701a92d882a6d82dfce1/config/commonConfig.go#L417-L449