### PR TITLE
tpl/tplimpl: Remove failing Twitter tests

### DIFF
--- a/tpl/tplimpl/shortcodes_integration_test.go
+++ b/tpl/tplimpl/shortcodes_integration_test.go
@@ -573,16 +573,6 @@ title: p5
 
 	filesOriginal := files
 
-	// Test privacy.twitter.simple
-	files = strings.ReplaceAll(filesOriginal, "#CONFIG", "privacy.twitter.simple=true")
-	b = hugolib.Test(t, files)
-	htmlFiles = []string{
-		b.FileContent("public/p2/index.html"),
-		b.FileContent("public/p3/index.html"),
-		b.FileContent("public/p5/index.html"),
-	}
-	b.Assert(htmlFiles, hqt.IsAllElementsEqual)
-
 	// Test privacy.x.simple
 	files = strings.ReplaceAll(filesOriginal, "#CONFIG", "privacy.x.simple=true")
 	b = hugolib.Test(t, files)
@@ -596,19 +586,6 @@ title: p5
 	htmlFiles = []string{
 		b.FileContent("public/p2/index.html"),
 		b.FileContent("public/p3/index.html"),
-	}
-	b.Assert(htmlFiles, hqt.IsAllElementsEqual)
-
-	// Test privacy.twitter.disable
-	files = strings.ReplaceAll(filesOriginal, "#CONFIG", "privacy.twitter.disable = true")
-	b = hugolib.Test(t, files)
-	b.AssertFileContent("public/p1/index.html", "")
-	htmlFiles = []string{
-		b.FileContent("public/p1/index.html"),
-		b.FileContent("public/p2/index.html"),
-		b.FileContent("public/p3/index.html"),
-		b.FileContent("public/p4/index.html"),
-		b.FileContent("public/p4/index.html"),
 	}
 	b.Assert(htmlFiles, hqt.IsAllElementsEqual)
 


### PR DESCRIPTION
In v0.141.0 we deprecated:
- privacy.twitter.simple in favor of privacy.x.simple
- privacy.twitter.disable in favor of privacy.x.disable

Use of those settings is now causing the integration test to fail.