### PR TITLE
images: Add debug logging to webp encoding/decoding

### DIFF
--- a/resources/images/image.go
+++ b/resources/images/image.go
@@ -124,7 +124,7 @@ func (i *Image) initConfig() error {
 	return nil
 }
 
-func NewImageProcessor(warnl logg.LevelLogger, wasmDispatchers *warpc.Dispatchers, cfg *config.ConfigNamespace[ImagingConfig, ImagingConfigInternal]) (*ImageProcessor, error) {
+func NewImageProcessor(warnl, debugl logg.LevelLogger, wasmDispatchers *warpc.Dispatchers, cfg *config.ConfigNamespace[ImagingConfig, ImagingConfigInternal]) (*ImageProcessor, error) {
 	e := cfg.Config.Imaging.Exif
 	exifDecoder, err := meta.NewDecoder(
 		meta.WithDateDisabled(e.DisableDate),
@@ -154,7 +154,7 @@ func NewImageProcessor(warnl logg.LevelLogger, wasmDispatchers *warpc.Dispatcher
 	if webpCodec == nil {
 		return nil, errors.New("webp codec is not available")
 	}
-	imageCodec := newCodec(webpCodec)
+	imageCodec := newCodec(debugl, webpCodec)
 
 	return &ImageProcessor{
 		Cfg:         cfg,

--- a/resources/resource_spec.go
+++ b/resources/resource_spec.go
@@ -64,7 +64,9 @@ func NewSpec(
 
 	imagesWarnl := logger.WarnCommand("images")
 
-	imaging, err := images.NewImageProcessor(imagesWarnl, wasmDispatchers, imgConfig)
+	imagesDebugl := logger.Debug()
+
+	imaging, err := images.NewImageProcessor(imagesWarnl, imagesDebugl, wasmDispatchers, imgConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds debug-level logging to the WebP image processing pipeline to help diagnose potential hangs or slowness during image transformation.

Changes made:
- Added a `logg.LevelLogger` to the `Codec` struct in `resources/images/codec.go`.
- Updated `NewImageProcessor` to accept and pass the debug logger down to the codec.
- Injected `imagesDebugl` into the Image Processor inside `resources/resource_spec.go`.
- Added `d.logger.Logf` statements before WebP encoding and decoding actions.

**Testing:**
Verified locally using a test site with `{{ $webp := .Resize "200x webp" }}`. When running `hugo --logLevel debug`, the expected output now successfully appears:
`DEBUG webp: encoding image to WebP with opts: map[...]`

Fixes #14337