### PR TITLE
Fix template change detection for multi-version sites

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -531,17 +531,8 @@ func (h *HugoSites) resetLogs() {
 	}
 }
 
-func (h *HugoSites) withSite(fn func(s *Site) error) error {
-	for _, s := range h.Sites {
-		if err := fn(s); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (h *HugoSites) withPage(fn func(s string, p *pageState) bool) {
-	h.withSite(func(s *Site) error {
+	for s := range h.allSites(nil) {
 		w := &doctree.NodeShiftTreeWalker[contentNode]{
 			Tree:     s.pageMap.treePages,
 			LockType: doctree.LockTypeRead,
@@ -552,8 +543,8 @@ func (h *HugoSites) withPage(fn func(s string, p *pageState) bool) {
 				return radix.WalkContinue, nil
 			},
 		}
-		return w.Walk(context.Background())
-	})
+		_ = w.Walk(context.Background())
+	}
 }
 
 // BuildCfg holds build options used to, as an example, skip the render step.

--- a/hugolib/sitesmatrix/sitematrix_integration_test.go
+++ b/hugolib/sitesmatrix/sitematrix_integration_test.go
@@ -1637,3 +1637,24 @@ Title: {{ .Title }}|Version: {{ .Site.Version.Name }}|
 
 	b.AssertFileContent("public/v1/p1/index.html", "Title: P1 from theme|Version: v1|")
 }
+
+func TestSitesMatrixVersionsEditTemplate(t *testing.T) {
+	files := `
+-- hugo.toml --
+defaultcontentVersion = "v1"
+defaultcontentVersionInSubDir = true
+[versions]
+[versions."v1"]
+[versions."v2"]
+-- layouts/all.html --
+Version: {{ .Site.Version.Name }}|
+`
+
+	b := hugolib.TestRunning(t, files)
+
+	b.AssertFileContent("public/v1/index.html", "Version: v1|")
+
+	b.EditFileReplaceAll("layouts/all.html", "Version:", "Edited version:").Build()
+
+	b.AssertFileContent("public/v1/index.html", "Edited version: v1|")
+}


### PR DESCRIPTION
When templates were edited in a multi-version/role setup, only pages
from the current site slice (h.Sites) were checked for dependencies,
not pages from all sites. Fix by changing withPage to iterate over
all sites using allSites.

Fixes #14461

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
