### PR TITLE
hugolib: Don't render default site redirect for non-primary isHTML output formats

### DIFF
--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -217,7 +217,7 @@ func pageRenderer(
 			}
 		}
 
-		if p.IsHome() && p.outputFormat().IsHTML && s.isDefault() {
+		if of := p.outputFormat(); p.IsHome() && of.IsHTML && s.isDefault() && (of.Path != "" || of.Name == "html") {
 			if err = s.renderDefaultSiteRedirect(p); err != nil {
 				if sendErr(err) {
 					continue


### PR DESCRIPTION
When a custom output format has isHTML=true but no Path, renderDefaultSiteRedirect
would derive intermediate redirect paths from homeLink (e.g. /en/foo.html),
creating a spurious redirect at /en/ that overwrites the actual HTML content.

Only render the default site redirect for the canonical "html" format
or for formats with their own Path prefix (e.g. AMP).

The fix came from Claude, but it makes sense. We should probably have a better/stronger definition of what a "canonical HTML output format" is, but this will have to do for now.

Fixes #14482

Co-Authored-By: Joe Mooring <joe.mooring@veriphor.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
