### PR TITLE
testscripts/commands: Update 'future' date to far future

### DIFF
--- a/testscripts/commands/list.txt
+++ b/testscripts/commands/list.txt
@@ -3,7 +3,7 @@
 hugo list drafts
 ! stderr .
 stdout 'path,slug,title,date,expiryDate,publishDate,draft,permalink'
-stdout 'content/draft.md,draft,The Draft,2019-01-01T00:00:00Z,2032-01-01T00:00:00Z,2018-01-01T00:00:00Z,true,https://example.org/draft/'
+stdout 'content/draft.md,draft,The Draft,2019-01-01T00:00:00Z,2090-01-01T00:00:00Z,2018-01-01T00:00:00Z,true,https://example.org/draft/'
 stdout 'draftexpired.md'
 stdout 'draftfuture.md'
 ! stdout '/expired.md'


### PR DESCRIPTION
In Debian, we've tested a rebuild of all packages at a given date in the future. The date is estimated to be three years after the release of our next stable distribution. The system clock of the building machine has been set to 2030-08-09. On that date, the test of the 'hugo list' command fails.

See https://bugs.debian.org/1127121 for details.

Fixes #14486