### PR TITLE
commands: Skip chmod for files without owner-write permission

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -1160,14 +1160,14 @@ func (s *staticSyncer) syncsStaticEvents(staticEvents []fsnotify.Event) error {
 	return err
 }
 
+// chmodFilter is a ChmodFilter for static syncing.
+// Returns true to skip syncing permissions for directories and files without
+// owner-write permission. The primary use case is files from the module cache (0444).
 func chmodFilter(dst, src os.FileInfo) bool {
-	// Hugo publishes data from multiple sources, potentially
-	// with overlapping directory structures. We cannot sync permissions
-	// for directories as that would mean that we might end up with write-protected
-	// directories inside /public.
-	// One example of this would be syncing from the Go Module cache,
-	// which have 0555 directories.
-	return src.IsDir()
+	if src.IsDir() {
+		return true
+	}
+	return src.Mode().Perm()&0o200 == 0
 }
 
 func cleanErrorLog(content string) string {

--- a/testscripts/commands/hugo__static_issue14507.txt
+++ b/testscripts/commands/hugo__static_issue14507.txt
@@ -1,0 +1,27 @@
+hugo
+
+# Verify published files are writable.
+[!windows] exec sh -c 'test -w public/a.txt'
+[!windows] exec sh -c 'test -w public/sitemap.xml'
+
+[windows] exec cmd /c attrib public\a.txt
+[windows] ! stdout 'R.*public'
+[windows] exec cmd /c attrib public\sitemap.xml
+[windows] ! stdout 'R.*public'
+
+-- hugo.toml --
+baseURL = 'https://example.org/'
+disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+
+[[module.imports]]
+path = 'github.com/gohugoio/hugoTestModule2'
+-- content/_index.md --
+---
+title: home
+---
+-- layouts/all.html --
+{{ .Title }}
+-- go.mod --
+module github.com/gohugoio/tests/testIssue14507
+
+go 1.23


### PR DESCRIPTION
When syncing static files, do not sync permissions for files without owner-write permission. 

Fixes #14507


To Do

- [x] Replace `github.com/jmooring/hugo-module-forum-topic-56376` with `github.com/gohugoio/hugoTestModule2` in `testscripts/commands/hugo__static_issue14507.txt` after <https://github.com/gohugoio/hugoTestModule2/pull/2> is merged.
