### PR TITLE
hugolib: Fix term title when taxonomy name contains spaces

### DIFF
--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -308,7 +308,7 @@ func (m *pageMeta) initLate(s *Site) error {
 		m.singular = tc.singular
 
 		if m.pageConfigSource.Kind == kinds.KindTerm {
-			m.term = paths.TrimLeading(strings.TrimPrefix(m.pathInfo.Unnormalized().Base(), tc.pluralTreeKey))
+			m.term = paths.TrimLeading(strings.TrimPrefix(m.pathInfo.Unnormalized().Base(), "/"+tc.plural))
 		}
 	}
 

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -619,21 +619,32 @@ func TestTaxonomiesSpaceInName(t *testing.T) {
 	files := `
 -- hugo.toml --
 [taxonomies]
-authors = 'book authors'
--- content/p1.md --
+"book author" = "book authors"
+-- content/posts/post1.md --
 ---
-title: Good Omens
-book authors:
-  - Neil Gaiman
-  - Terry Pratchett
+title: Post 1
+book authors: ["Author One"]
+---
+-- content/posts/post2.md --
+---
+title: Post 2
+book authors: ["Author One", "Author Two"]
 ---
 -- layouts/home.html --
 {{- $taxonomy := "book authors" }}
 Len Book Authors: {{ len (index .Site.Taxonomies $taxonomy) }}
+-- layouts/_default/taxonomy.html --
+{{ range .Data.Terms.ByCount }}
+Term: {{ .Term }}|Count: {{ .Count }}|Name: {{ .Name }}|Page title: {{ .Page.Title }}|
+{{ end }}
 `
 	b := Test(t, files)
 
 	b.AssertFileContent("public/index.html", "Len Book Authors: 2")
+	b.AssertFileContent("public/book-authors/index.html",
+		"Term: author one|Count: 2|Name: author one|Page title: Author One|",
+		"Term: author two|Count: 1|Name: author two|Page title: Author Two|",
+	)
 }
 
 func TestTaxonomiesListTermsHome(t *testing.T) {


### PR DESCRIPTION
The pluralTreeKey is normalized (spaces become hyphens), but the
unnormalized path preserves spaces. Use the plural name directly
for prefix trimming on the unnormalized path.

Fixes #13422

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
