### PR TITLE
commands: Fix --panicOnWarning flag having no effect with module version warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 * Never export symbols that's not needed outside of the package.
 * Avoid global state at (almost) all cost.
 * This is a project with a long history; assume that a similiar problem has been solved before, look hard for helper functions before creating new ones.
+* In tests, use `qt` matchers (e.g. `b.Assert(err, qt.ErrorMatches, ...)`) instead of raw `if`/`t.Fatal` checks.
 * Use `./check.sh ./somepackage/...` when iterating.
 * Use `./check.sh` when you're done.
 

--- a/hugolib/integrationtest_builder.go
+++ b/hugolib/integrationtest_builder.go
@@ -879,12 +879,18 @@ func (s *IntegrationTestBuilder) initBuilder() error {
 			w = &s.logBuff
 		}
 
+		var logHookLast func(e *logg.Entry) error
+		if s.Cfg.PanicOnWarning {
+			logHookLast = loggers.PanicOnWarningHook
+		}
+
 		logger := loggers.New(
 			loggers.Options{
 				StdOut:        w,
 				StdErr:        w,
 				Level:         s.Cfg.LogLevel,
 				DistinctLevel: logg.LevelWarn,
+				HandlerPost:   logHookLast,
 			},
 		)
 
@@ -1142,6 +1148,9 @@ type IntegrationTestConfig struct {
 
 	// The log level to use.
 	LogLevel logg.Level
+
+	// Whether to panic on warnings.
+	PanicOnWarning bool
 
 	// Whether it needs the real file system (e.g. for js.Build tests).
 	NeedsOsFS bool

--- a/testscripts/commands/hugo__paniconwarning_mod.txt
+++ b/testscripts/commands/hugo__paniconwarning_mod.txt
@@ -1,0 +1,13 @@
+! hugo --panicOnWarning
+
+stderr 'is not compatible with this Hugo'
+
+-- hugo.toml --
+baseURL="https://example.org"
+
+[module]
+[module.hugoVersion]
+min = "0.148.0"
+max = "0.148.0"
+-- layouts/all.html --
+All.


### PR DESCRIPTION
The --panicOnWarning flag was not wired into the root command's logger,
so warnings emitted during config loading (such as module version
incompatibility warnings) would not trigger a panic.

Bind the panicOnWarning flag to the rootCommand struct and set the
PanicOnWarningHook on the logger created in createLogger.

Fixes #14524

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
