### PR TITLE
paths: ensure _ resolvable as path name

### DIFF
--- a/common/paths/pathparser.go
+++ b/common/paths/pathparser.go
@@ -30,9 +30,17 @@ import (
 )
 
 const (
-	identifierBaseof         = "baseof"
-	identifierCurstomWrapper = "_"
+	identifierBaseof        = "baseof"
+	identifierCustomWrapper = "_"
 )
+
+// isCustomWrapperIdentifier tells whether a supplied path is of the form _xyz_.
+// must have non-empty content between the identifierCustomWrapper's to pass.
+func isCustomWrapperIdentifier(s string) bool {
+	return len(s) > 2*len(identifierCustomWrapper) &&
+		strings.HasPrefix(s, identifierCustomWrapper) &&
+		strings.HasSuffix(s, identifierCustomWrapper)
+}
 
 // PathParser parses and manages paths.
 type PathParser struct {
@@ -188,7 +196,7 @@ func (pp *PathParser) parseIdentifier(component, s string, p *Path, i, lastDot, 
 	id := types.LowHigh[string]{Low: i + 1, High: high}
 	sid := p.s[id.Low:id.High]
 
-	if strings.HasPrefix(sid, identifierCurstomWrapper) && strings.HasSuffix(sid, identifierCurstomWrapper) {
+	if isCustomWrapperIdentifier(sid) {
 		p.identifiersKnown = append(p.identifiersKnown, id)
 		p.posIdentifierCustom = len(p.identifiersKnown) - 1
 		found = true
@@ -775,7 +783,7 @@ func (p *Path) Lang() string {
 }
 
 func (p *Path) Custom() string {
-	return strings.TrimSuffix(strings.TrimPrefix(p.identifierAsString(p.posIdentifierCustom), identifierCurstomWrapper), identifierCurstomWrapper)
+	return strings.TrimSuffix(strings.TrimPrefix(p.identifierAsString(p.posIdentifierCustom), identifierCustomWrapper), identifierCustomWrapper)
 }
 
 func (p *Path) Identifier(i int) string {

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -458,6 +458,33 @@ Content: {{ .Content }}
 	b.AssertFileContent("public/post/nested-a/content-a/index.html", `Content: http://example.com/post/nested-b/content-b/`)
 }
 
+// Issue 14344
+func TestRefUnderscoreSection(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = 'https://example.org/'
+-- layouts/home.html --
+{{ .Content }}
+-- content/_index.md --
+---
+title: home
+---
+{{% ref "definitions/_" %}}
+-- content/definitions/_/_index.md --
+---
+title: underscore
+---
+`
+
+	b := Test(t, files)
+
+	b.AssertFileContent("public/index.html",
+		`https://example.org/definitions/_/`,
+	)
+}
+
 func TestClassCollector(t *testing.T) {
 	for _, minify := range []bool{false, true} {
 		t.Run(fmt.Sprintf("minify-%t", minify), func(t *testing.T) {


### PR DESCRIPTION
Updates the path parser to fix a regression introduced in 264022a ,
after which an underscore could not properly be resolved as a path with
the ref shortcode.

Fixes #14344

🛑 Before submitting this PR

All PRs must be linked to an Issue in this repository, and that Issue must be approved by a project maintainer:

- For a bug, approval means that the "needs triage" label is removed.
- For a proposal, approval means that the "proposal" label is replaced by an "enhancement" label.

PRs without a linked, approved Issue will be closed immediately.

Please review the contribution guide (CONTRIBUTING.md) to understand commit message guidelines and AI assistance disclosures.
