### PR TITLE
hugolib: Fix automatic section pages not replaced by sites.complements

### DIFF
--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -388,7 +388,7 @@ func (m *pageMap) getPagesInSection(q pageMapQueryPagesInSection) page.Pages {
 
 		if err == nil {
 			if q.IncludeSelf {
-				if n := m.treePages.Get(q.Path); n != nil {
+				if n := m.treePages.GetWithFallback(q.Path); n != nil {
 					if p, ok := n.(*pageState); ok && include(p) {
 						pas = append(pas, p)
 					}

--- a/hugolib/doctree/nodeshifttree.go
+++ b/hugolib/doctree/nodeshifttree.go
@@ -338,6 +338,22 @@ func (r *NodeShiftTree[T]) Get(s string) T {
 	return t
 }
 
+// GetWithFallback is like Get but uses the fallback/complement mechanism
+// when finding a node for the current site vector.
+func (r *NodeShiftTree[T]) GetWithFallback(s string) T {
+	s = cleanKey(s)
+	v, ok := r.tree.Get(s)
+	if !ok {
+		var t T
+		return t
+	}
+	if v, ok := r.shift(v, true); ok {
+		return v
+	}
+	var t T
+	return t
+}
+
 func (r *NodeShiftTree[T]) ForEeachInDimension(s string, dims sitesmatrix.Vector, d int, f func(T) bool) {
 	s = cleanKey(s)
 	v, ok := r.tree.Get(s)


### PR DESCRIPTION
When a home page or section page in language A is backed by a file and
language B has no content file for that section, the automatic page for
language B was not replaced by the complement from language A. This
happened because:

1. The content node shifter returned auto pages (not backed by files) as
   exact matches without trying complement fallback.
2. findContentNodeForSiteVector immediately returned auto pages as exact
   matches without considering file-backed complements.
3. getPagesInSection used Get (no fallback) for IncludeSelf, preventing
   complement resolution for home/section pages.

Fix by preferring file-backed complement pages over auto pages in the
shift and lookup mechanisms, and using fallback for self-inclusion.

Fixes #14540

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
