### PR TITLE
Fix index out of range panic in fileEventsContentPaths

### DIFF
--- a/hugolib/integrationtest_builder.go
+++ b/hugolib/integrationtest_builder.go
@@ -751,6 +751,15 @@ func (s *IntegrationTestBuilder) AddFiles(filenameContent ...string) *Integratio
 	return s
 }
 
+func (s *IntegrationTestBuilder) CreateDirs(dirnames ...string) *IntegrationTestBuilder {
+	for _, dirname := range dirnames {
+		absDir := s.absFilename(filepath.FromSlash(dirname))
+		s.Assert(s.fs.Source.MkdirAll(absDir, 0o777), qt.IsNil)
+		s.createdFiles = append(s.createdFiles, absDir)
+	}
+	return s
+}
+
 func (s *IntegrationTestBuilder) RemoveFiles(filenames ...string) *IntegrationTestBuilder {
 	for _, filename := range filenames {
 		absFilename := s.absFilename(filename)

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1316,15 +1316,18 @@ func (h *HugoSites) fileEventsContentPaths(p []pathChange) []pathChange {
 	// Remove all files below dir.
 	if len(dirs) > 0 {
 		n := 0
-		for _, d := range dirs {
-			dir := d.p.Path() + "/"
-			for _, o := range others {
-				if !strings.HasPrefix(o.p.Path(), dir) {
-					others[n] = o
-					n++
+		for _, o := range others {
+			keep := true
+			for _, d := range dirs {
+				if strings.HasPrefix(o.p.Path(), d.p.Path()+"/") {
+					keep = false
+					break
 				}
 			}
-
+			if keep {
+				others[n] = o
+				n++
+			}
 		}
 		others = others[:n]
 	}


### PR DESCRIPTION
The nested loop had dirs as the outer loop and others as the inner loop
with a single counter, causing n to exceed len(others) when multiple
dirs existed. Swap the loop order so each file in others is checked
against all dirs exactly once.

Fixes #14573

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
