### PR TITLE
refactor: Deprecate language configuration and template methods

### DIFF
--- a/commands/import.go
+++ b/commands/import.go
@@ -127,7 +127,7 @@ func (i *importCommand) createConfigFromJekyll(fs afero.Fs, inpath string, kind 
 	in := map[string]any{
 		"baseURL":            baseURL,
 		"title":              title,
-		"languageCode":       "en-us",
+		"locale":             "en-us",
 		"disablePathToLower": true,
 	}
 

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -399,6 +399,65 @@ func (c *Config) CompileConfig(logger loggers.Logger) error {
 		return err
 	}
 
+	// Legacy language values.
+	if c.LanguageCode != "" {
+		if !c.isLanguageClone {
+			hugo.DeprecateWithLogger("project config key languageCode", "Use locale instead.", "v0.158.0", logger.Logger())
+		}
+		if c.Locale == "" {
+			c.Locale = c.LanguageCode
+		}
+		c.LanguageCode = ""
+	}
+	for k, v := range c.Languages.Config.LanguageConfigs {
+		//lint:ignore SA1019 Keep as adapter for now.
+		if v.LanguageCode != "" {
+			if !c.isLanguageClone {
+				hugo.DeprecateWithLogger(fmt.Sprintf("project config key languages.%s.languageCode", k), fmt.Sprintf("Use languages.%s.locale instead.", k), "v0.158.0", logger.Logger())
+			}
+			if v.Locale == "" {
+				//lint:ignore SA1019 Keep as adapter for now.
+				v.Locale = v.LanguageCode
+			}
+			//lint:ignore SA1019 Keep as adapter for now.
+			v.LanguageCode = ""
+		}
+		//lint:ignore SA1019 Keep as adapter for now.
+		if v.LanguageName != "" {
+			if !c.isLanguageClone {
+				hugo.DeprecateWithLogger(fmt.Sprintf("project config key languages.%s.languageName", k), fmt.Sprintf("Use languages.%s.label instead.", k), "v0.158.0", logger.Logger())
+			}
+			if v.Label == "" {
+				//lint:ignore SA1019 Keep as adapter for now.
+				v.Label = v.LanguageName
+			}
+			//lint:ignore SA1019 Keep as adapter for now.
+			v.LanguageName = ""
+		}
+		//lint:ignore SA1019 Keep as adapter for now.
+		if v.LanguageDirection != "" {
+			if !c.isLanguageClone {
+				hugo.DeprecateWithLogger(fmt.Sprintf("project config key languages.%s.languageDirection", k), fmt.Sprintf("Use languages.%s.direction instead.", k), "v0.158.0", logger.Logger())
+			}
+			if v.Direction == "" {
+				//lint:ignore SA1019 Keep as adapter for now.
+				v.Direction = v.LanguageDirection
+			}
+			//lint:ignore SA1019 Keep as adapter for now.
+			v.LanguageDirection = ""
+		}
+
+		c.Languages.Config.LanguageConfigs[k] = v
+		// Sorted is a snapshot of LanguageConfigs taken at decode time; keep it
+		// in sync so Configs.Init, which reads from Sorted, sees the migrated values.
+		for i, s := range c.Languages.Config.Sorted {
+			if s.Name == k {
+				c.Languages.Config.Sorted[i].LanguageConfig = v
+				break
+			}
+		}
+	}
+
 	// Legacy privacy values.
 	if c.Privacy.Twitter.Disable {
 		hugo.DeprecateWithLogger("project config key privacy.twitter.disable", "Use privacy.x.disable instead.", "v0.141.0", logger.Logger())
@@ -671,8 +730,11 @@ type RootConfig struct {
 	// The configured environment. Default is "development" for server and "production" for build.
 	Environment string
 
-	// The default language code.
-	LanguageCode string
+	// Deprecated: Use Locale instead.
+	LanguageCode string `json:"-"`
+
+	// The default locale.
+	Locale string
 
 	// Enable if the site content has CJK language (Chinese, Japanese, or Korean). This affects how Hugo counts words.
 	HasCJKLanguage bool
@@ -843,7 +905,7 @@ func (c *Configs) Init(sourceFs afero.Fs, logger loggers.Logger) error {
 		if !found {
 			return fmt.Errorf("invalid language configuration for %q", f.Name)
 		}
-		language, err := langs.NewLanguage(f.Name, c.Base.DefaultContentLanguage, v.TimeZone, f.LanguageConfig)
+		language, err := langs.NewLanguage(f.Name, c.Base.DefaultContentLanguage, v.TimeZone, f.LanguageConfig, logger)
 		if err != nil {
 			return err
 		}

--- a/config/allconfig/alldecoders.go
+++ b/config/allconfig/alldecoders.go
@@ -226,27 +226,17 @@ var allDecoderSetups = map[string]decodeWeight{
 		key: "languages",
 		decode: func(d decodeWeight, p decodeConfig) error {
 			m := hmaps.CleanConfigStringMap(p.p.GetStringMap(d.key))
-			if len(m) == 1 {
-				// In v0.112.4 we moved this to the language config, but it's very commmon for mono language sites to have this at the top level.
-				var first hmaps.Params
-				var ok bool
-				for _, v := range m {
-					first, ok = v.(hmaps.Params)
-					if ok {
-						break
-					}
-				}
-				if first != nil {
-					if _, found := first["languagecode"]; !found {
-						first["languagecode"] = p.p.GetString("languagecode")
-					}
-				}
-			}
+			// Root-level locale/languageCode is passed to DecodeConfig so it can
+			// be applied to the default content language inside langs.DecodeConfig.
+			// They are passed separately so that an explicit per-lang languageCode
+			// can override a root-level languageCode (but not a root-level locale).
+			rootLocale := p.p.GetString("locale")
+			rootLanguageCode := p.p.GetString("languagecode")
 			var (
 				err                    error
 				defaultContentLanguage string
 			)
-			p.c.Languages, defaultContentLanguage, err = langs.DecodeConfig(p.c.RootConfig.DefaultContentLanguage, p.c.RootConfig.DisableLanguages, m)
+			p.c.Languages, defaultContentLanguage, err = langs.DecodeConfig(p.c.RootConfig.DefaultContentLanguage, rootLocale, rootLanguageCode, p.c.RootConfig.DisableLanguages, m)
 			if err != nil {
 				return fmt.Errorf("failed to decode languages config: %w", err)
 			}

--- a/create/skeletons/skeletons.go
+++ b/create/skeletons/skeletons.go
@@ -42,9 +42,9 @@ func CreateTheme(createpath string, sourceFs afero.Fs, format string) error {
 	format = strings.ToLower(format)
 
 	projectConfig := map[string]any{
-		"baseURL":      "https://example.org/",
-		"languageCode": "en-US",
-		"title":        "My New Hugo Project",
+		"baseURL": "https://example.org/",
+		"locale":  "en-US",
+		"title":   "My New Hugo Project",
 		"menus": map[string]any{
 			"main": []any{
 				map[string]any{
@@ -122,9 +122,9 @@ func CreateProject(createpath string, sourceFs afero.Fs, force bool, format stri
 	}
 
 	projectConfig := map[string]any{
-		"baseURL":      "https://example.org/",
-		"title":        "My New Hugo Project",
-		"languageCode": "en-us",
+		"baseURL": "https://example.org/",
+		"locale":  "en-us",
+		"title":   "My New Hugo Project",
 	}
 
 	err := createProjectConfig(sourceFs, createpath, projectConfig, format)

--- a/create/skeletons/theme/layouts/baseof.html
+++ b/create/skeletons/theme/layouts/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.Language.LanguageCode }}" dir="{{ or site.Language.LanguageDirection `ltr` }}">
+<html lang="{{ site.Language.Locale }}" dir="{{ or site.Language.Direction `ltr` }}">
 <head>
   {{ partial "head.html" . }}
 </head>

--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -1262,16 +1262,16 @@ config:
       hint: photo
       method: 2
       useSharpYuv: false
-  languageCode: ''
   languages:
     en:
+      direction: ''
       disabled: false
-      languageCode: ''
-      languageDirection: ''
-      languageName: ''
+      label: ''
+      locale: ''
       title: ''
       weight: 0
   layoutDir: layouts
+  locale: ''
   mainSections: null
   markup:
     asciiDocExt:

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -638,8 +638,10 @@ func (s *Site) Config() page.SiteConfig {
 	}
 }
 
+// Deprecated: Use .Language.Locale instead.
 func (s *Site) LanguageCode() string {
-	return s.Language().LanguageCode()
+	hugo.DeprecateWithLogger(".Site.LanguageCode", "Use .Site.Language.Locale instead.", "v0.158.0", s.Language().Logger())
+	return s.Language().Locale()
 }
 
 // Returns all sites for all dimensions.

--- a/hugolib/sitesmatrix/sitematrix_integration_test.go
+++ b/hugolib/sitesmatrix/sitematrix_integration_test.go
@@ -912,7 +912,7 @@ weight = 4
 {{ .AddResource (dict "path" "hello.txt" "title" "Hello" "content" $contentTextEnglish "sites" (dict "matrix"  $en )) }}
 {{ .AddResource (dict "path" "hello.txt" "title" "Hello" "content" $contentTextSwedish "sites" (dict "matrix"  $sv )) }}
 {{ .AddResource (dict "path" "hello.txt" "title" "Hello" "content" $contentTextDanish "sites" (dict "matrix"  $da )) }}
- 
+
 -- layouts/all.html --
 {{ $hello := .Resources.Get "hello.txt" }}
 All. {{ .Title }}|{{ .Site.Language.Name }}|hello: {{ with $hello }}{{ .RelPermalink }}: {{ .Content }}|{{ end }}|
@@ -1109,7 +1109,7 @@ Rotate(version): {{ with .Rotate "version" }}{{ range . }}{{ template "printp" .
 Rotate(role): {{ with .Rotate "role" }}{{ range . }}{{ template "printp" . }}|{{ end }}{{ end }}$
 {{ define "printp" }}{{ .RelPermalink }}:{{ with .Site }}{{ template "prints" . }}{{ end }}{{ end }}
 {{ define "prints" }}/l:{{ .Language.Name }}/v:{{ .Version.Name }}/r:{{ .Role.Name }}{{ end }}
- 
+
 `
 	}
 
@@ -1180,12 +1180,12 @@ target = 'content'
 	b.Assert(toJSONAndMap(conf.Languages), qt.DeepEquals,
 		map[string]any{
 			"en": map[string]any{
-				"Disabled":          bool(false),
-				"LanguageCode":      "",
-				"LanguageDirection": "",
-				"LanguageName":      "",
-				"Title":             "",
-				"Weight":            float64(0),
+				"Direction": "",
+				"Disabled":  bool(false),
+				"Label":     "",
+				"Locale":    "",
+				"Title":     "",
+				"Weight":    float64(0),
 			},
 		})
 

--- a/langs/i18n/translationProvider.go
+++ b/langs/i18n/translationProvider.go
@@ -133,11 +133,11 @@ func (tp *TranslationProvider) CloneResource(dst, src *deps.Deps) error {
 }
 
 // getTranslateFunc returns the translation function for the language in Deps.
-// We first try the language code (e.g. "en-US"), then the language key (e.g. "en").
+// We first try the locale (e.g. "en-US"), then the language key (e.g. "en").
 func (tp *TranslationProvider) getTranslateFunc(dst *deps.Deps) func(ctx context.Context, translationID string, templateData any) string {
 	l := dst.Conf.Language().(*langs.Language)
-	if lc := l.LanguageCode(); lc != "" {
-		if fn, ok := tp.t.Lookup(strings.ToLower(lc)); ok {
+	if locale := l.Locale(); locale != "" {
+		if fn, ok := tp.t.Lookup(strings.ToLower(locale)); ok {
 			return fn
 		}
 	}

--- a/langs/language.go
+++ b/langs/language.go
@@ -22,8 +22,11 @@ import (
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"
 
+	"github.com/bep/logg"
 	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/htime"
+	"github.com/gohugoio/hugo/common/hugo"
+	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/hugolib/sitesmatrix"
 	"github.com/gohugoio/locales"
 	translators "github.com/gohugoio/localescompressed"
@@ -55,6 +58,8 @@ type Language struct {
 
 	// This is just an alias of Site.Params.
 	params hmaps.Params
+
+	logger loggers.Logger
 }
 
 // Name is an alias for Lang.
@@ -62,12 +67,19 @@ func (l *Language) Name() string {
 	return l.Lang
 }
 
+func (l *Language) Logger() logg.Logger {
+	if l.logger == nil {
+		return loggers.Log().Logger()
+	}
+	return l.logger.Logger()
+}
+
 func (l *Language) IsDefault() bool {
 	return l.isDefault
 }
 
 // NewLanguage creates a new language.
-func NewLanguage(lang, defaultContentLanguage, timeZone string, languageConfig LanguageConfig) (*Language, error) {
+func NewLanguage(lang, defaultContentLanguage, timeZone string, languageConfig LanguageConfig, logger loggers.Logger) (*Language, error) {
 	translator := translators.GetTranslator(lang)
 	if translator == nil {
 		translator = translators.GetTranslator(defaultContentLanguage)
@@ -103,6 +115,7 @@ func NewLanguage(lang, defaultContentLanguage, timeZone string, languageConfig L
 		collator1:      coll1,
 		collator2:      coll2,
 		isDefault:      lang == defaultContentLanguage,
+		logger:         logger,
 	}
 
 	return l, l.loadLocation(timeZone)
@@ -121,11 +134,46 @@ func (l *Language) Params() hmaps.Params {
 	return l.params
 }
 
+// Deprecated: Use Locale instead.
 func (l *Language) LanguageCode() string {
+	hugo.DeprecateWithLogger(".Language.LanguageCode", "Use .Language.Locale instead.", "v0.158.0", l.Logger())
+	return l.Locale()
+}
+
+func (l *Language) Locale() string {
+	if l.LanguageConfig.Locale != "" {
+		return l.LanguageConfig.Locale
+	}
 	if l.LanguageConfig.LanguageCode != "" {
 		return l.LanguageConfig.LanguageCode
 	}
 	return l.Lang
+}
+
+// Deprecated: Use Direction instead.
+func (l *Language) LanguageDirection() string {
+	hugo.DeprecateWithLogger(".Language.LanguageDirection", "Use .Language.Direction instead.", "v0.158.0", l.Logger())
+	return l.Direction()
+}
+
+func (l *Language) Direction() string {
+	if l.LanguageConfig.Direction != "" {
+		return l.LanguageConfig.Direction
+	}
+	return l.LanguageConfig.LanguageDirection
+}
+
+// Deprecated: Use Label instead.
+func (l *Language) LanguageName() string {
+	hugo.DeprecateWithLogger(".Language.LanguageName", "Use .Language.Label instead.", "v0.158.0", l.Logger())
+	return l.Label()
+}
+
+func (l *Language) Label() string {
+	if l.LanguageConfig.Label != "" {
+		return l.LanguageConfig.Label
+	}
+	return l.LanguageConfig.LanguageName
 }
 
 func (l *Language) loadLocation(tzStr string) error {

--- a/langs/language_test.go
+++ b/langs/language_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/gohugoio/hugo/common/loggers"
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"
 )
@@ -73,4 +74,30 @@ func BenchmarkCollator(b *testing.B) {
 			}
 		})
 	})
+}
+
+// TestLanguageLegacyFieldFallbacks verifies that Locale(), Direction(), and
+// Label() fall back to legacy LanguageConfig fields when the canonical fields
+// are not set. This matters for programmatic construction that bypasses the
+// allconfig migration (which normally copies legacy→canonical and clears them).
+func TestLanguageLegacyFieldFallbacks(t *testing.T) {
+	c := qt.New(t)
+
+	l, err := NewLanguage("en", "en", "UTC", LanguageConfig{
+		LanguageCode:      "en-US",
+		LanguageName:      "English",
+		LanguageDirection: "ltr",
+	}, loggers.NewDefault())
+	c.Assert(err, qt.IsNil)
+	c.Assert(l.Locale(), qt.Equals, "en-US")
+	c.Assert(l.Label(), qt.Equals, "English")
+	c.Assert(l.Direction(), qt.Equals, "ltr")
+
+	// Deprecated methods must not panic when logger is nil (no logger provided
+	// at construction). They delegate through Logger() which has a nil guard.
+	lNoLogger, err := NewLanguage("en", "en", "UTC", LanguageConfig{}, nil)
+	c.Assert(err, qt.IsNil)
+	_ = lNoLogger.LanguageCode()
+	_ = lNoLogger.LanguageName()
+	_ = lNoLogger.LanguageDirection()
 }

--- a/resources/page/site.go
+++ b/resources/page/site.go
@@ -19,12 +19,14 @@ import (
 
 	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstore"
+	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/config/privacy"
 	"github.com/gohugoio/hugo/config/services"
 	"github.com/gohugoio/hugo/hugolib/roles"
 	"github.com/gohugoio/hugo/hugolib/versions"
 	"github.com/gohugoio/hugo/identity"
 
+	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/config"
 
 	"github.com/gohugoio/hugo/langs"
@@ -71,7 +73,7 @@ type Site interface {
 	// Returns the configured title for this Site.
 	Title() string
 
-	// Deprecated: Use .Language.LanguageCode instead.
+	// Deprecated: Use .Language.Locale instead.
 	LanguageCode() string
 
 	// Returns the configured copyright information for this Site.
@@ -224,7 +226,8 @@ func (s *siteWrapper) Title() string {
 }
 
 func (s *siteWrapper) LanguageCode() string {
-	return s.s.LanguageCode()
+	hugo.DeprecateWithLogger(".Site.LanguageCode", "Use .Site.Language.Locale instead.", "v0.158.0", s.s.Language().Logger())
+	return s.s.Language().Locale()
 }
 
 func (s *siteWrapper) Copyright() string {
@@ -330,8 +333,10 @@ func (t testSite) Title() string {
 	return "foo"
 }
 
+// Deprecated: Use .Language.Locale instead.
 func (t testSite) LanguageCode() string {
-	return t.l.Lang
+	hugo.DeprecateWithLogger(".Site.LanguageCode", "Use .Site.Language.Locale instead.", "v0.158.0", t.l.Logger())
+	return t.l.Locale()
 }
 
 func (t testSite) Copyright() string {
@@ -450,11 +455,13 @@ func NewDummyHugoSite(conf config.AllProvider) Site {
 	opts := HugoInfoOptions{
 		Conf: conf,
 	}
+	l, err := langs.NewLanguage("en", "en", "", langs.LanguageConfig{}, loggers.NewDefault())
+	if err != nil {
+		panic(err)
+	}
 	return testSite{
 		h: NewHugoInfo(opts),
-		l: &langs.Language{
-			Lang: "en",
-		},
+		l: l,
 	}
 }
 

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstore"
+	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/hugofs"
@@ -61,6 +62,7 @@ func newTestPageWithFile(filename string) *testPage {
 		langs.LanguageConfig{
 			LanguageName: "English",
 		},
+		loggers.NewDefault(),
 	)
 	if err != nil {
 		panic(err)

--- a/tpl/tplimpl/embedded/templates/_partials/opengraph.html
+++ b/tpl/tplimpl/embedded/templates/_partials/opengraph.html
@@ -12,7 +12,7 @@
   <meta property="og:description" content="{{ trim . "\n\r\t " }}">
 {{- end }}
 
-{{- with or .Params.locale site.Language.LanguageCode }}
+{{- with or .Params.locale site.Language.Locale }}
   <meta property="og:locale" content="{{ replace . `-` `_` }}">
 {{- end }}
 

--- a/tpl/tplimpl/embedded/templates/alias.html
+++ b/tpl/tplimpl/embedded/templates/alias.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.Language.LanguageCode }}">
+<html lang="{{ site.Language.Locale }}">
   <head>
     <title>{{ .Permalink }}</title>
     {{ with .OutputFormats.Canonical }}<link rel="{{ .Rel }}" href="{{ .Permalink }}">{{ end }}

--- a/tpl/tplimpl/embedded/templates/rss.xml
+++ b/tpl/tplimpl/embedded/templates/rss.xml
@@ -37,7 +37,7 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo</generator>
-    <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
+    <language>{{ site.Language.Locale }}</language>{{ with $authorEmail }}
     <managingEditor>{{.}}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
     <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}
     <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}

--- a/tpl/tplimpl/embedded/templates/sitemap.xml
+++ b/tpl/tplimpl/embedded/templates/sitemap.xml
@@ -10,12 +10,12 @@
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
     <xhtml:link
                 rel="alternate"
-                hreflang="{{ .Language.LanguageCode }}"
+                hreflang="{{ .Language.Locale }}"
                 href="{{ .Permalink }}"
                 />{{ end }}
     <xhtml:link
                 rel="alternate"
-                hreflang="{{ .Language.LanguageCode }}"
+                hreflang="{{ .Language.Locale }}"
                 href="{{ .Permalink }}"
                 />{{ end }}
   </url>


### PR DESCRIPTION
Configuration:

- `languageCode `     -> `locale` (either in root or per-language)
- `languageName`      -> `label`
- `languageDirection` -> `direction`

Methods:

- `.Language.LanguageCode`      -> `.Language.Locale`
- `.Language.LanguageName`      -> `.Language.Label`
- `.Language.LanguageDirection` -> `.Language.Direction`
- `.Site.LanguageCode`          -> `.Site.Language.Locale`

Example configuration:

```toml
[languages.en]
  direction = 'ltr'
  label     = 'English'
  locale    = 'en-US'
  weight    = 1
```

Closes #14269