### PR TITLE
docs: fix deprecated Wikipedia link for allowlist in GetRemote

### DIFF
--- a/docs/content/en/functions/resources/GetRemote.md
+++ b/docs/content/en/functions/resources/GetRemote.md
@@ -234,7 +234,7 @@ Note that the entry above is:
 - An array of [regular expressions](g)
 
 [`try`]: /functions/go-template/try
-[allowlist]: https://en.wikipedia.org/wiki/Whitelist
+[allowlist]: https://en.wikipedia.org/wiki/Allowlist
 [configure file caches]: /configuration/caches/
 [Content-Type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
 [error handling]: #error-handling


### PR DESCRIPTION
The `[allowlist]` reference link in GetRemote.md points to `https://en.wikipedia.org/wiki/Whitelist`, which Wikipedia has deprecated and renamed to Allowlist. This PR updates the URL to `https://en.wikipedia.org/wiki/Allowlist` to match the current article location.

*This PR was identified and generated with AI assistance (Claude Code).*