### PR TITLE
tpl/debug: add debug.List

### DIFF
--- a/tpl/debug/debug.go
+++ b/tpl/debug/debug.go
@@ -172,25 +172,34 @@ func (ns *Namespace) List(val any) []string {
 
 	v := reflect.ValueOf(val)
 	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
 		v = v.Elem()
 	}
 
 	switch v.Kind() {
 	case reflect.Struct:
+		seen := make(map[string]struct{})
 		var names []string
 		t := v.Type()
 		for i := range t.NumField() {
 			f := t.Field(i)
 			if f.IsExported() {
+				seen[f.Name] = struct{}{}
 				names = append(names, f.Name)
 			}
 		}
-		// Also check methods on the original (pointer) value.
-		pt := reflect.TypeOf(val)
-		for i := range pt.NumMethod() {
-			m := pt.Method(i)
-			if m.IsExported() {
-				names = append(names, m.Name)
+		// Include methods from both value and pointer receiver sets.
+		for _, mt := range []reflect.Type{t, reflect.PointerTo(t)} {
+			for i := range mt.NumMethod() {
+				m := mt.Method(i)
+				if m.IsExported() {
+					if _, ok := seen[m.Name]; !ok {
+						seen[m.Name] = struct{}{}
+						names = append(names, m.Name)
+					}
+				}
 			}
 		}
 		sort.Strings(names)

--- a/tpl/debug/debug.go
+++ b/tpl/debug/debug.go
@@ -16,6 +16,8 @@ package debug
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -159,6 +161,50 @@ func (t *timer) Stop() string {
 	})
 	// This is used in templates, we need to return something.
 	return ""
+}
+
+// List returns the exported field and method names of a struct or pointer to a struct,
+// or the keys of a map, as a sorted string slice.
+func (ns *Namespace) List(val any) []string {
+	if val == nil {
+		return nil
+	}
+
+	v := reflect.ValueOf(val)
+	for v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		var names []string
+		t := v.Type()
+		for i := range t.NumField() {
+			f := t.Field(i)
+			if f.IsExported() {
+				names = append(names, f.Name)
+			}
+		}
+		// Also check methods on the original (pointer) value.
+		pt := reflect.TypeOf(val)
+		for i := range pt.NumMethod() {
+			m := pt.Method(i)
+			if m.IsExported() {
+				names = append(names, m.Name)
+			}
+		}
+		sort.Strings(names)
+		return names
+	case reflect.Map:
+		var keys []string
+		for _, k := range v.MapKeys() {
+			keys = append(keys, fmt.Sprint(k.Interface()))
+		}
+		sort.Strings(keys)
+		return keys
+	default:
+		return nil
+	}
 }
 
 // Internal template func, used in tests only.

--- a/tpl/debug/debug_integration_test.go
+++ b/tpl/debug/debug_integration_test.go
@@ -73,6 +73,29 @@ Page: {{ debug.List . | jsonify }}
 	b.AssertFileContent("public/p1/index.html", `"Title"`)
 }
 
+func TestDebugListNil(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+disableKinds = ["taxonomy", "term"]
+-- content/p1.md --
+---
+title: "Test"
+---
+-- layouts/page.html --
+NilResult: {{ debug.List nil | jsonify }}
+
+`
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+		},
+	).Build()
+
+	b.AssertFileContent("public/p1/index.html", `NilResult: null`)
+}
+
 func TestDebugDumpPage(t *testing.T) {
 	files := `
 -- hugo.toml --

--- a/tpl/debug/debug_integration_test.go
+++ b/tpl/debug/debug_integration_test.go
@@ -44,6 +44,35 @@ disableKinds = ["taxonomy", "term"]
 	b.AssertLogContains("timer:  name foo count 5 duration")
 }
 
+func TestDebugList(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+disableKinds = ["taxonomy", "term"]
+-- content/p1.md --
+---
+title: "The First"
+---
+-- layouts/page.html --
+Map: {{ $m := dict "Hugo" "Rocks" "Zed" "Last" "Alpha" "First" }}
+Keys: {{ debug.List $m | jsonify }}
+Page: {{ debug.List . | jsonify }}
+
+`
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:           t,
+			TxtarString: files,
+		},
+	).Build()
+
+	b.AssertFileContent("public/p1/index.html",
+		`Keys: ["Alpha","Hugo","Zed"]`,
+	)
+	// Page should list exported fields and methods.
+	b.AssertFileContent("public/p1/index.html", `"Title"`)
+}
+
 func TestDebugDumpPage(t *testing.T) {
 	files := `
 -- hugo.toml --

--- a/tpl/debug/init.go
+++ b/tpl/debug/init.go
@@ -58,6 +58,11 @@ func init() {
 			[][2]string{},
 		)
 
+		ns.AddMethodMapping(ctx.List,
+			nil,
+			[][2]string{},
+		)
+
 		ns.AddMethodMapping(ctx.Timer,
 			nil,
 			[][2]string{},


### PR DESCRIPTION
Fixes #9148. Add debug.List template function that returns a sorted string slice of exported field/method names for structs or keys for maps. Non-recursive. All tests pass.