### PR TITLE
internal/warpc: Fix SIGSEGV in Close() when dispatcher fails to start

### DIFF
--- a/internal/warpc/warpc.go
+++ b/internal/warpc/warpc.go
@@ -776,8 +776,10 @@ func (d *lazyDispatcher[Q, R]) start() (Dispatcher[Q, R], error) {
 	d.startOnce.Do(func() {
 		start := time.Now()
 		d.dispatcher, d.startErr = Start[Q, R](d.opts)
-		d.started = true
-		d.opts.Infof("started dispatcher in %s", time.Since(start))
+		if d.startErr == nil {
+			d.started = true
+			d.opts.Infof("started dispatcher in %s", time.Since(start))
+		}
 	})
 	return d.dispatcher, d.startErr
 }


### PR DESCRIPTION
Only set started=true when Start() succeeds, so Close() doesn't
attempt to close a nil dispatcher.

Fixes #14536
