### PR TITLE
Fix template lookup to prefer first suffix when media type has multiple suffixes

### DIFF
--- a/tpl/tplimpl/templatedescriptor.go
+++ b/tpl/tplimpl/templatedescriptor.go
@@ -31,6 +31,7 @@ type TemplateDescriptor struct {
 	// Group 2.
 	OutputFormat string // rss, csv ...
 	MediaType    string // text/html, text/plain, ...
+	Suffix       string // The specific suffix used in the template filename, e.g. "html", "xml".
 
 	SitesHash uint64
 
@@ -89,6 +90,17 @@ func (s descriptorHandler) compareDescriptors(category Category, this, other Tem
 		if category == CategoryShortcode {
 			if (this.IsPlainText == other.IsPlainText || !other.IsPlainText) || this.AlwaysAllowPlainText {
 				w.w1 = 1
+			}
+		}
+	}
+
+	// Prefer templates with the suffix matching the first suffix of the media type.
+	// See issue 13877.
+	if w.w1 > 0 && other.Suffix != "" && this.MediaType == other.MediaType {
+		if mt, found := s.opts.MediaTypes.GetByType(this.MediaType); found {
+			if other.Suffix == mt.FirstSuffix.Suffix {
+				// Add a small weight bonus to prefer the first suffix.
+				w.w1++
 			}
 		}
 	}

--- a/tpl/tplimpl/templatestore.go
+++ b/tpl/tplimpl/templatestore.go
@@ -1543,6 +1543,7 @@ func (s *TemplateStore) insertTemplates(include func(fi hugofs.FileMetaInfo) boo
 		desc.OutputFormat = outputFormat.Name
 		desc.IsPlainText = outputFormat.IsPlainText
 		desc.MediaType = mediaType.Type
+		desc.Suffix = k.ext
 		desc.SitesHash = fi.Meta().SitesMatrix.MustHash()
 
 		ti, err := s.insertTemplate2(pi, fi, targetPath, category, SubCategoryMain, desc, fi.Meta().SitesMatrix, true, true, s.treeMain)
@@ -1780,6 +1781,7 @@ func (s *TemplateStore) toKeyCategoryAndDescriptor(p *paths.Path, fi hugofs.File
 		SitesHash:          vactorStore.MustHash(),
 		OutputFormat:       p.OutputFormat(),
 		MediaType:          mediaType.Type,
+		Suffix:             p.Ext(),
 		Kind:               p.Kind(),
 		LayoutFromTemplate: p.Layout(),
 		IsPlainText:        outputFormat.IsPlainText,

--- a/tpl/tplimpl/templatestore_integration_test.go
+++ b/tpl/tplimpl/templatestore_integration_test.go
@@ -1576,3 +1576,40 @@ layouts/p1/page.html
 
 	b.AssertFileContent("public/p1/index.html", "layouts/p1/page.html")
 }
+
+// TestIssue13877 tests that when a media type has multiple suffixes,
+// only the first suffix is considered for template lookup.
+// https://github.com/gohugoio/hugo/issues/13877
+func TestIssue13877(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "http://example.com/"
+[mediaTypes.'text/html']
+suffixes = ['b','a','d','c']
+-- content/p1.md --
+---
+title: p1
+---
+Content
+-- layouts/_default/single.html.b --
+Template B (first suffix)
+-- layouts/_default/single.html.a --
+Template A
+-- layouts/_default/single.html.c --
+Template C
+-- layouts/_default/single.html.d --
+Template D
+-- layouts/_default/baseof.html --
+Base: {{ block "main" . }}default main{{ end }}
+`
+
+	b := hugolib.Test(t, files)
+
+	// The page should be published to .b (first suffix)
+	b.AssertFileExists("public/p1/index.b", true)
+
+	// The template with the first suffix (.b) should be used
+	b.AssertFileContent("public/p1/index.b", "Template B (first suffix)")
+}


### PR DESCRIPTION
Fixes #13877. When a media type has multiple suffixes defined (e.g. ['b','a','d','c']), only the first suffix should be considered for template lookup as documented.

Previously, the template selection would incorrectly use the last (alphabetically sorted) suffix instead of the first. This fix:

1. Adds a Suffix field to TemplateDescriptor to track the specific suffix used in the template filename
2. Sets the Suffix field when creating template descriptors
3. Updates the template comparison logic to prefer templates whose suffix matches the media type's FirstSuffix

This ensures that templates like page.html.b are preferred over page.html.d when 'b' is the first suffix defined for the media type.