### PR TITLE
testing: Modernize quicktest assertions

### DIFF
--- a/cache/dynacache/dynacache_test.go
+++ b/cache/dynacache/dynacache_test.go
@@ -58,10 +58,10 @@ func TestCache(t *testing.T) {
 
 	opts := OptionsPartition{Weight: 30}
 
-	c.Assert(cache, qt.Not(qt.IsNil))
+	c.Assert(cache, qt.IsNotNil)
 
 	p1 := GetOrCreatePartition[string, testItem](cache, "/aaaa/bbbb", opts)
-	c.Assert(p1, qt.Not(qt.IsNil))
+	c.Assert(p1, qt.IsNotNil)
 
 	p2 := GetOrCreatePartition[string, testItem](cache, "/aaaa/bbbb", opts)
 
@@ -71,7 +71,7 @@ func TestCache(t *testing.T) {
 	c.Assert(p2, qt.Equals, p1)
 
 	p3 := GetOrCreatePartition[string, testItem](cache, "/aaaa/cccc", opts)
-	c.Assert(p3, qt.Not(qt.IsNil))
+	c.Assert(p3, qt.IsNotNil)
 	c.Assert(p3, qt.Not(qt.Equals), p1)
 
 	c.Assert(func() { New(Options{}) }, qt.PanicMatches, ".*nil Log.*")

--- a/cache/filecache/filecache_config_test.go
+++ b/cache/filecache/filecache_config_test.go
@@ -57,7 +57,7 @@ dir = "/path/to/c4"
 	c.Assert(err, qt.IsNil)
 	fs := afero.NewMemMapFs()
 	decoded := testconfig.GetTestConfigs(fs, cfg).Base.Caches
-	c.Assert(len(decoded), qt.Equals, 7)
+	c.Assert(decoded, qt.HasLen, 7)
 
 	c2 := decoded["misc"]
 	c.Assert(c2.MaxAge.String(), qt.Equals, "10m0s")
@@ -101,7 +101,7 @@ dir = "/path/to/c4"
 	c.Assert(err, qt.IsNil)
 	fs := afero.NewMemMapFs()
 	decoded := testconfig.GetTestConfigs(fs, cfg).Base.Caches
-	c.Assert(len(decoded), qt.Equals, 7)
+	c.Assert(decoded, qt.HasLen, 7)
 
 	for _, v := range decoded {
 		c.Assert(v.MaxAge, qt.Equals, time.Duration(0))
@@ -124,7 +124,7 @@ func TestDecodeConfigDefault(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	decoded := testconfig.GetTestConfigs(fs, cfg).Base.Caches
-	c.Assert(len(decoded), qt.Equals, 7)
+	c.Assert(decoded, qt.HasLen, 7)
 
 	imgConfig := decoded[filecache.CacheKeyImages]
 	miscConfig := decoded[filecache.CacheKeyMisc]

--- a/cache/filecache/filecache_test.go
+++ b/cache/filecache/filecache_test.go
@@ -87,10 +87,10 @@ dir = ":cacheDir/c"
 		caches.SetResourceFs(p.SourceFs)
 
 		cache := caches.Get("Misc")
-		c.Assert(cache, qt.Not(qt.IsNil))
+		c.Assert(cache, qt.IsNotNil)
 
 		cache = caches.Get("Images")
-		c.Assert(cache, qt.Not(qt.IsNil))
+		c.Assert(cache, qt.IsNotNil)
 
 		rf := func(s string) func() (io.ReadCloser, error) {
 			return func() (io.ReadCloser, error) {
@@ -112,7 +112,7 @@ dir = ":cacheDir/c"
 			for range 2 {
 				info, r, err := ca.GetOrCreate("a", rf("abc"))
 				c.Assert(err, qt.IsNil)
-				c.Assert(r, qt.Not(qt.IsNil))
+				c.Assert(r, qt.IsNotNil)
 				c.Assert(info.Name, qt.Equals, "a")
 				b, _ := io.ReadAll(r)
 				r.Close()
@@ -120,7 +120,7 @@ dir = ":cacheDir/c"
 
 				info, b, err = ca.GetOrCreateBytes("b", bf)
 				c.Assert(err, qt.IsNil)
-				c.Assert(r, qt.Not(qt.IsNil))
+				c.Assert(r, qt.IsNotNil)
 				c.Assert(info.Name, qt.Equals, "b")
 				c.Assert(string(b), qt.Equals, "bcd")
 
@@ -145,7 +145,7 @@ dir = ":cacheDir/c"
 
 		info, r, err := caches.ImageCache().Get("mykey")
 		c.Assert(err, qt.IsNil)
-		c.Assert(r, qt.Not(qt.IsNil))
+		c.Assert(r, qt.IsNotNil)
 		c.Assert(info.Name, qt.Equals, "mykey")
 		b, _ := io.ReadAll(r)
 		r.Close()
@@ -203,7 +203,7 @@ dir = "/cache/c"
 			defer wg.Done()
 			for range 20 {
 				ca := caches.Get(cacheName)
-				c.Assert(ca, qt.Not(qt.IsNil))
+				c.Assert(ca, qt.IsNotNil)
 				filename, data := filenameData(i)
 				_, r, err := ca.GetOrCreate(filename, func() (io.ReadCloser, error) {
 					return hugio.ToReadCloser(strings.NewReader(data)), nil

--- a/common/collections/append_test.go
+++ b/common/collections/append_test.go
@@ -84,7 +84,7 @@ func TestAppend(t *testing.T) {
 
 		if b, ok := test.expected.(bool); ok && !b {
 
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -128,7 +128,7 @@ func TestAppendToMultiDimensionalSlice(t *testing.T) {
 	} {
 		result, err := Append(test.to, test.from...)
 		if b, ok := test.expected.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 		} else {
 			c.Assert(err, qt.IsNil)
 			c.Assert(result, qt.DeepEquals, test.expected)

--- a/common/herrors/error_locator_test.go
+++ b/common/herrors/error_locator_test.go
@@ -87,7 +87,7 @@ This THEONE
 	pos = location.Position
 	c.Assert(pos.LineNumber, qt.Equals, 0)
 	c.Assert(location.LinesPos, qt.Equals, -1)
-	c.Assert(len(location.Lines), qt.Equals, 0)
+	c.Assert(location.Lines, qt.HasLen, 0)
 
 	lineMatcher = func(m LineMatcher) int {
 		if m.LineNumber == 6 {

--- a/common/herrors/file_error_test.go
+++ b/common/herrors/file_error_test.go
@@ -75,6 +75,6 @@ func TestNewFileErrorExtractFromMessage(t *testing.T) {
 		pos := got.Position()
 		c.Assert(pos.LineNumber, qt.Equals, test.lineNumber, errMsg)
 		c.Assert(pos.ColumnNumber, qt.Equals, test.columnNumber, errMsg)
-		c.Assert(errors.Unwrap(got), qt.Not(qt.IsNil))
+		c.Assert(errors.Unwrap(got), qt.IsNotNil)
 	}
 }

--- a/common/hmaps/cache_test.go
+++ b/common/hmaps/cache_test.go
@@ -28,7 +28,7 @@ func TestCacheSize(t *testing.T) {
 		cache.Set(string(rune('a'+i)), "value")
 	}
 
-	c.Assert(len(cache.m), qt.Equals, 10)
+	c.Assert(cache.m, qt.HasLen, 10)
 
 	for i := 20; i < 50; i++ {
 		cache.GetOrCreate(string(rune('a'+i)), func() (string, error) {
@@ -36,13 +36,13 @@ func TestCacheSize(t *testing.T) {
 		})
 	}
 
-	c.Assert(len(cache.m), qt.Equals, 10)
+	c.Assert(cache.m, qt.HasLen, 10)
 
 	for i := 100; i < 200; i++ {
 		cache.SetIfAbsent(string(rune('a'+i)), "value")
 	}
 
-	c.Assert(len(cache.m), qt.Equals, 10)
+	c.Assert(cache.m, qt.HasLen, 10)
 
 	cache.InitAndGet("foo", func(
 		get func(key string) (string, bool), set func(key string, value string),
@@ -53,5 +53,5 @@ func TestCacheSize(t *testing.T) {
 		return nil
 	})
 
-	c.Assert(len(cache.m), qt.Equals, 10)
+	c.Assert(cache.m, qt.HasLen, 10)
 }

--- a/common/math/math_test.go
+++ b/common/math/math_test.go
@@ -101,7 +101,7 @@ func TestDoArithmetic(t *testing.T) {
 		result, err := DoArithmetic(test.a, test.b, test.op)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 

--- a/common/types/evictingqueue_test.go
+++ b/common/types/evictingqueue_test.go
@@ -45,7 +45,7 @@ func TestEvictingStringQueue(t *testing.T) {
 	queue.Add("d")
 	// Overflowed, a should now be removed.
 	c.Assert(queue.PeekAll(), qt.DeepEquals, []string{"d", "c", "b"})
-	c.Assert(len(queue.PeekAllSet()), qt.Equals, 3)
+	c.Assert(queue.PeekAllSet(), qt.HasLen, 3)
 	c.Assert(queue.PeekAllSet()["c"], qt.Equals, true)
 }
 

--- a/common/urls/baseURL_test.go
+++ b/common/urls/baseURL_test.go
@@ -41,7 +41,7 @@ func TestBaseURL(t *testing.T) {
 	c.Assert(p.String(), qt.Equals, "webcal://example.com/")
 
 	_, err = b.WithProtocol("mailto:")
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 
 	b, err = NewBaseURLFromString("mailto:hugo@rules.com")
 	c.Assert(err, qt.IsNil)

--- a/config/defaultConfigProvider_test.go
+++ b/config/defaultConfigProvider_test.go
@@ -386,7 +386,7 @@ func TestDefaultConfigProvider(t *testing.T) {
 		cfg.Set(k, hmaps.Params{k: struct{}{}})
 		cfg.Set(k2, hmaps.Params{k2: struct{}{}})
 
-		c.Assert(len(cfg.Keys()), qt.Equals, 2)
+		c.Assert(cfg.Keys(), qt.HasLen, 2)
 
 		got := cfg.Keys()
 		slices.Sort(got)

--- a/config/namespace_test.go
+++ b/config/namespace_test.go
@@ -41,7 +41,7 @@ func TestNamespace(t *testing.T) {
 	)
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(ns, qt.Not(qt.IsNil))
+	c.Assert(ns, qt.IsNotNil)
 	c.Assert(ns.SourceStructure, qt.DeepEquals, map[string]any{"foo": "bar"})
 	c.Assert(ns.SourceHash, qt.Equals, "1420f6c7782f7459")
 	c.Assert(ns.Config, qt.DeepEquals, &tstNsExt{Foo: "bar"})

--- a/config/privacy/privacyConfig_test.go
+++ b/config/privacy/privacyConfig_test.go
@@ -54,7 +54,7 @@ simple = true
 
 	pc, err := DecodeConfig(cfg)
 	c.Assert(err, qt.IsNil)
-	c.Assert(pc, qt.Not(qt.IsNil))
+	c.Assert(pc, qt.IsNotNil)
 
 	got := []bool{
 		pc.Disqus.Disable, pc.GoogleAnalytics.Disable,
@@ -84,7 +84,7 @@ PrivacyENhanced = true
 
 	pc, err := DecodeConfig(cfg)
 	c.Assert(err, qt.IsNil)
-	c.Assert(pc, qt.Not(qt.IsNil))
+	c.Assert(pc, qt.IsNotNil)
 	c.Assert(pc.YouTube.PrivacyEnhanced, qt.Equals, true)
 }
 
@@ -93,6 +93,6 @@ func TestDecodeConfigDefault(t *testing.T) {
 
 	pc, err := DecodeConfig(config.New())
 	c.Assert(err, qt.IsNil)
-	c.Assert(pc, qt.Not(qt.IsNil))
+	c.Assert(pc, qt.IsNotNil)
 	c.Assert(pc.YouTube.PrivacyEnhanced, qt.Equals, false)
 }

--- a/config/security/securityConfig_test.go
+++ b/config/security/securityConfig_test.go
@@ -45,7 +45,7 @@ getEnv=["a", "b"]
 
 		pc, err := DecodeConfig(cfg)
 		c.Assert(err, qt.IsNil)
-		c.Assert(pc, qt.Not(qt.IsNil))
+		c.Assert(pc, qt.IsNotNil)
 		c.Assert(pc.EnableInlineShortcodes, qt.IsTrue)
 		c.Assert(pc.Exec.Allow.Accept("a"), qt.IsTrue)
 		c.Assert(pc.Exec.Allow.Accept("d"), qt.IsFalse)
@@ -74,7 +74,7 @@ osEnv="b"
 
 		pc, err := DecodeConfig(cfg)
 		c.Assert(err, qt.IsNil)
-		c.Assert(pc, qt.Not(qt.IsNil))
+		c.Assert(pc, qt.IsNotNil)
 		c.Assert(pc.Exec.Allow.Accept("a"), qt.IsTrue)
 		c.Assert(pc.Exec.Allow.Accept("d"), qt.IsFalse)
 		c.Assert(pc.Exec.OsEnv.Accept("b"), qt.IsTrue)
@@ -99,7 +99,7 @@ allow="a"
 
 		pc, err := DecodeConfig(cfg)
 		c.Assert(err, qt.IsNil)
-		c.Assert(pc, qt.Not(qt.IsNil))
+		c.Assert(pc, qt.IsNotNil)
 		c.Assert(pc.Exec.Allow.Accept("a"), qt.IsTrue)
 		c.Assert(pc.Exec.OsEnv.Accept("PATH"), qt.IsTrue)
 		c.Assert(pc.Exec.OsEnv.Accept("e"), qt.IsFalse)
@@ -145,7 +145,7 @@ func TestDecodeConfigDefault(t *testing.T) {
 
 	pc, err := DecodeConfig(config.New())
 	c.Assert(err, qt.IsNil)
-	c.Assert(pc, qt.Not(qt.IsNil))
+	c.Assert(pc, qt.IsNotNil)
 	c.Assert(pc.Exec.Allow.Accept("a"), qt.IsFalse)
 	c.Assert(pc.Exec.Allow.Accept("npx"), qt.IsTrue)
 	c.Assert(pc.Exec.Allow.Accept("Npx"), qt.IsFalse)

--- a/config/services/servicesConfig_test.go
+++ b/config/services/servicesConfig_test.go
@@ -44,7 +44,7 @@ disableInlineCSS = true
 
 	config, err := DecodeConfig(cfg)
 	c.Assert(err, qt.IsNil)
-	c.Assert(config, qt.Not(qt.IsNil))
+	c.Assert(config, qt.IsNotNil)
 
 	c.Assert(config.Disqus.Shortname, qt.Equals, "DS")
 	c.Assert(config.GoogleAnalytics.ID, qt.Equals, "ga_id")
@@ -62,7 +62,7 @@ func TestUseSettingsFromRootIfSet(t *testing.T) {
 
 	config, err := DecodeConfig(cfg)
 	c.Assert(err, qt.IsNil)
-	c.Assert(config, qt.Not(qt.IsNil))
+	c.Assert(config, qt.IsNotNil)
 
 	c.Assert(config.Disqus.Shortname, qt.Equals, "root_short")
 	c.Assert(config.GoogleAnalytics.ID, qt.Equals, "ga_root")

--- a/create/content_test.go
+++ b/create/content_test.go
@@ -88,7 +88,7 @@ func TestNewContentFromFile(t *testing.T) {
 
 			if b, ok := cas.expected.(bool); ok && !b {
 				if !b {
-					c.Assert(err, qt.Not(qt.IsNil))
+					c.Assert(err, qt.IsNotNil)
 				}
 				return
 			}
@@ -139,7 +139,7 @@ site RegularPages: {{ len site.RegularPages  }}
 	h := func() *hugolib.HugoSites {
 		h, err := hugolib.NewHugoSites(deps.DepsCfg{Configs: conf, Fs: fs})
 		c.Assert(err, qt.IsNil)
-		c.Assert(len(h.Sites), qt.Equals, 2)
+		c.Assert(h.Sites, qt.HasLen, 2)
 		return h
 	}
 

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -370,7 +370,7 @@ func TestExtractAndGroupRootPaths(t *testing.T) {
 
 		result := helpers.ExtractAndGroupRootPaths(in)
 		// Should have 10 paths + 1 "... and X more" message
-		c.Assert(len(result), qt.Equals, 11)
+		c.Assert(result, qt.HasLen, 11)
 		c.Assert(result[10], qt.Matches, `\.\.\. and \d+ more`)
 	})
 }

--- a/hugofs/filename_filter_fs_test.go
+++ b/hugofs/filename_filter_fs_test.go
@@ -58,7 +58,7 @@ func TestFilenameFilterFs(t *testing.T) {
 
 		} else {
 			for _, err := range []error{err1, err2} {
-				c.Assert(err, qt.Not(qt.IsNil))
+				c.Assert(err, qt.IsNotNil)
 				c.Assert(errors.Is(err, os.ErrNotExist), qt.IsTrue)
 			}
 		}

--- a/hugofs/files/classifier_test.go
+++ b/hugofs/files/classifier_test.go
@@ -23,7 +23,7 @@ func TestComponentFolders(t *testing.T) {
 	c := qt.New(t)
 
 	// It's important that these are absolutely right and not changed.
-	c.Assert(len(componentFoldersSet), qt.Equals, len(ComponentFolders))
+	c.Assert(componentFoldersSet, qt.HasLen, len(ComponentFolders))
 	c.Assert(IsComponentFolder("archetypes"), qt.Equals, true)
 	c.Assert(IsComponentFolder("layouts"), qt.Equals, true)
 	c.Assert(IsComponentFolder("data"), qt.Equals, true)

--- a/hugofs/rootmapping_fs_test.go
+++ b/hugofs/rootmapping_fs_test.go
@@ -100,7 +100,7 @@ func TestLanguageRootMapping(t *testing.T) {
 
 	dirs, err := rfs.Mounts(filepath.FromSlash("content/blog"))
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(dirs), qt.Equals, 4)
+	c.Assert(dirs, qt.HasLen, 4)
 	for _, dir := range dirs {
 		f, err := dir.Meta().Open()
 		c.Assert(err, qt.IsNil)
@@ -275,7 +275,7 @@ func TestRootMappingFsMount(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	files, err := d.(iofs.ReadDirFile).ReadDir(-1)
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(files), qt.Equals, 4)
+	c.Assert(files, qt.HasLen, 4)
 
 	singlesDir, err := rfs.Open(filepath.FromSlash("content/singles"))
 	c.Assert(err, qt.IsNil)
@@ -531,8 +531,8 @@ func TestRootMappingFileFilter(t *testing.T) {
 			c.Assert(err2, qt.IsNil)
 			c.Assert(f.Close(), qt.IsNil)
 		} else {
-			c.Assert(err1, qt.Not(qt.IsNil))
-			c.Assert(err2, qt.Not(qt.IsNil))
+			c.Assert(err1, qt.IsNotNil)
+			c.Assert(err2, qt.IsNotNil)
 		}
 	}
 
@@ -542,7 +542,7 @@ func TestRootMappingFileFilter(t *testing.T) {
 
 	dirEntriesSub, err := afero.ReadDir(rfs, filepath.Join("content", "sub"))
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(dirEntriesSub), qt.Equals, 3)
+	c.Assert(dirEntriesSub, qt.HasLen, 3)
 
 	f, err := rfs.Open("content")
 	c.Assert(err, qt.IsNil)
@@ -550,7 +550,7 @@ func TestRootMappingFileFilter(t *testing.T) {
 	dirEntries, err := f.(iofs.ReadDirFile).ReadDir(-1)
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(dirEntries), qt.Equals, 4)
+	c.Assert(dirEntries, qt.HasLen, 4)
 }
 
 var testDims = sitesmatrix.NewTestingDimensions([]string{"en", "no"}, []string{"v1", "v2", "v3"}, []string{"admin", "editor", "viewer", "guest"})

--- a/hugolib/content_map_test.go
+++ b/hugolib/content_map_test.go
@@ -428,7 +428,7 @@ func TestContentTreeReverseIndex(t *testing.T) {
 	for i := range 10 {
 		key := fmt.Sprint(i)
 		v := pageReverseIndex.Get(key)
-		c.Assert(v, qt.Not(qt.IsNil))
+		c.Assert(v, qt.IsNotNil)
 		c.Assert(v.Path(), qt.Equals, key)
 	}
 }

--- a/hugolib/filesystems/basefs_test.go
+++ b/hugolib/filesystems/basefs_test.go
@@ -91,7 +91,7 @@ theme = ["atheme"]
 
 	bfs, err := filesystems.NewBase(p, nil)
 	c.Assert(err, qt.IsNil)
-	c.Assert(bfs, qt.Not(qt.IsNil))
+	c.Assert(bfs, qt.IsNotNil)
 
 	root, err := bfs.I18n.Fs.Open("")
 	c.Assert(err, qt.IsNil)
@@ -145,14 +145,14 @@ func TestNewBaseFsEmpty(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	bfs, err := filesystems.NewBase(p, nil)
 	c.Assert(err, qt.IsNil)
-	c.Assert(bfs, qt.Not(qt.IsNil))
-	c.Assert(bfs.Archetypes.Fs, qt.Not(qt.IsNil))
-	c.Assert(bfs.Layouts.Fs, qt.Not(qt.IsNil))
-	c.Assert(bfs.Data.Fs, qt.Not(qt.IsNil))
-	c.Assert(bfs.I18n.Fs, qt.Not(qt.IsNil))
-	c.Assert(bfs.Work, qt.Not(qt.IsNil))
-	c.Assert(bfs.Content.Fs, qt.Not(qt.IsNil))
-	c.Assert(bfs.Static, qt.Not(qt.IsNil))
+	c.Assert(bfs, qt.IsNotNil)
+	c.Assert(bfs.Archetypes.Fs, qt.IsNotNil)
+	c.Assert(bfs.Layouts.Fs, qt.IsNotNil)
+	c.Assert(bfs.Data.Fs, qt.IsNotNil)
+	c.Assert(bfs.I18n.Fs, qt.IsNotNil)
+	c.Assert(bfs.Work, qt.IsNotNil)
+	c.Assert(bfs.Content.Fs, qt.IsNotNil)
+	c.Assert(bfs.Static, qt.IsNotNil)
 }
 
 func TestRealDirs(t *testing.T) {
@@ -194,17 +194,17 @@ func TestRealDirs(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	bfs, err := filesystems.NewBase(p, nil)
 	c.Assert(err, qt.IsNil)
-	c.Assert(bfs, qt.Not(qt.IsNil))
+	c.Assert(bfs, qt.IsNotNil)
 
 	checkFileCount(bfs.Assets.Fs, "", c, 6)
 
 	realDirs := bfs.Assets.RealDirs("scss")
-	c.Assert(len(realDirs), qt.Equals, 2)
+	c.Assert(realDirs, qt.HasLen, 2)
 	c.Assert(realDirs[0], qt.Equals, filepath.Join(root, "myassets/scss"))
 	c.Assert(realDirs[len(realDirs)-1], qt.Equals, filepath.Join(themesDir, "mytheme/assets/scss"))
 
 	realDirs = bfs.Assets.RealDirs("foo")
-	c.Assert(len(realDirs), qt.Equals, 0)
+	c.Assert(realDirs, qt.HasLen, 0)
 
 	c.Assert(afs.OpenFiles(), qt.HasLen, 0)
 }

--- a/hugolib/hugo_sites_build_errors_test.go
+++ b/hugolib/hugo_sites_build_errors_test.go
@@ -16,9 +16,9 @@ type testSiteBuildErrorAsserter struct {
 }
 
 func (t testSiteBuildErrorAsserter) getFileError(err error) herrors.FileError {
-	t.c.Assert(err, qt.Not(qt.IsNil), qt.Commentf(t.name))
+	t.c.Assert(err, qt.IsNotNil, qt.Commentf(t.name))
 	fe := herrors.UnwrapFileError(err)
-	t.c.Assert(fe, qt.Not(qt.IsNil))
+	t.c.Assert(fe, qt.IsNotNil)
 	return fe
 }
 
@@ -266,7 +266,7 @@ foo bar
 			},
 
 			assertErr: func(a testSiteBuildErrorAsserter, err error) {
-				a.c.Assert(err, qt.Not(qt.IsNil))
+				a.c.Assert(err, qt.IsNotNil)
 				fe := a.getFileError(err)
 				a.c.Assert(fe.Position().LineNumber, qt.Equals, 5)
 				a.c.Assert(fe.Position().ColumnNumber, qt.Equals, 21)
@@ -583,7 +583,7 @@ title: "A page"
 
 	_, err := TestE(t, filesBuilder.String())
 
-	qt.Assert(t, err, qt.Not(qt.IsNil))
+	qt.Assert(t, err, qt.IsNotNil)
 	qt.Assert(t, err.Error(), qt.Contains, "timed out rendering the page content")
 }
 

--- a/hugolib/hugo_sites_build_test.go
+++ b/hugolib/hugo_sites_build_test.go
@@ -68,12 +68,12 @@ p1 = "p1en"
 	sites := b.H.Sites
 
 	c := qt.New(t)
-	c.Assert(len(sites), qt.Equals, 2)
+	c.Assert(sites, qt.HasLen, 2)
 
 	nnSite := sites[0]
 	nnHome := nnSite.getPageOldVersion(kinds.KindHome)
-	c.Assert(len(nnHome.AllTranslations()), qt.Equals, 2)
-	c.Assert(len(nnHome.Translations()), qt.Equals, 1)
+	c.Assert(nnHome.AllTranslations(), qt.HasLen, 2)
+	c.Assert(nnHome.Translations(), qt.HasLen, 1)
 	c.Assert(nnHome.IsTranslated(), qt.Equals, true)
 
 	enHome := sites[1].getPageOldVersion(kinds.KindHome)

--- a/hugolib/page_permalink_test.go
+++ b/hugolib/page_permalink_test.go
@@ -82,7 +82,7 @@ output: ["HTML"]
 
 			b := Test(t, files)
 			s := b.H.Sites[0]
-			c.Assert(len(s.RegularPages()), qt.Equals, 1)
+			c.Assert(s.RegularPages(), qt.HasLen, 1)
 			p := s.RegularPages()[0]
 			u := p.Permalink()
 

--- a/hugolib/pagecollections_test.go
+++ b/hugolib/pagecollections_test.go
@@ -36,14 +36,14 @@ func (t *getPageTest) check(p page.Page, err error, errorMsg string, c *qt.C) {
 	errorComment := qt.Commentf(errorMsg)
 	switch t.kind {
 	case "Ambiguous":
-		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(err, qt.IsNotNil)
 		c.Assert(p, qt.IsNil, errorComment)
 	case "NoPage":
 		c.Assert(err, qt.IsNil)
 		c.Assert(p, qt.IsNil, errorComment)
 	default:
 		c.Assert(err, qt.IsNil, errorComment)
-		c.Assert(p, qt.Not(qt.IsNil), errorComment)
+		c.Assert(p, qt.IsNotNil, errorComment)
 		c.Assert(p.Kind(), qt.Equals, t.kind, errorComment)
 		c.Assert(p.Title(), qt.Equals, t.expectedTitle, errorComment)
 	}

--- a/hugolib/pages_language_merge_test.go
+++ b/hugolib/pages_language_merge_test.go
@@ -38,13 +38,13 @@ func TestMergeLanguages(t *testing.T) {
 	frSite := h.Sites[1]
 	nnSite := h.Sites[2]
 
-	c.Assert(len(enSite.RegularPages()), qt.Equals, 31)
-	c.Assert(len(frSite.RegularPages()), qt.Equals, 6)
-	c.Assert(len(nnSite.RegularPages()), qt.Equals, 12)
+	c.Assert(enSite.RegularPages(), qt.HasLen, 31)
+	c.Assert(frSite.RegularPages(), qt.HasLen, 6)
+	c.Assert(nnSite.RegularPages(), qt.HasLen, 12)
 
 	for range 2 {
 		mergedNN := nnSite.RegularPages().MergeByLanguage(enSite.RegularPages())
-		c.Assert(len(mergedNN), qt.Equals, 31)
+		c.Assert(mergedNN, qt.HasLen, 31)
 		for i := 1; i <= 31; i++ {
 			expectedLang := "en"
 			if i == 2 || i%3 == 0 || i == 31 {
@@ -56,7 +56,7 @@ func TestMergeLanguages(t *testing.T) {
 	}
 
 	mergedFR := frSite.RegularPages().MergeByLanguage(enSite.RegularPages())
-	c.Assert(len(mergedFR), qt.Equals, 31)
+	c.Assert(mergedFR, qt.HasLen, 31)
 	for i := 1; i <= 31; i++ {
 		expectedLang := "en"
 		if i%5 == 0 {
@@ -67,20 +67,20 @@ func TestMergeLanguages(t *testing.T) {
 	}
 
 	firstNN := nnSite.RegularPages()[0]
-	c.Assert(len(firstNN.Sites()), qt.Equals, 4)
+	c.Assert(firstNN.Sites(), qt.HasLen, 4)
 	c.Assert(firstNN.Sites().Default().Language().Lang, qt.Equals, "en")
 
 	nnBundle := nnSite.getPageOldVersion("page", "bundle")
 	enBundle := enSite.getPageOldVersion("page", "bundle")
 
-	c.Assert(len(enBundle.Resources()), qt.Equals, 6)
-	c.Assert(len(nnBundle.Resources()), qt.Equals, 2)
+	c.Assert(enBundle.Resources(), qt.HasLen, 6)
+	c.Assert(nnBundle.Resources(), qt.HasLen, 2)
 
 	var ri any = nnBundle.Resources()
 
 	// This looks less ugly in the templates ...
 	mergedNNResources := ri.(resource.ResourcesLanguageMerger).MergeByLanguage(enBundle.Resources())
-	c.Assert(len(mergedNNResources), qt.Equals, 6)
+	c.Assert(mergedNNResources, qt.HasLen, 6)
 
 	unchanged, err := nnSite.RegularPages().MergeByLanguageInterface(nil)
 	c.Assert(err, qt.IsNil)

--- a/markup/asciidocext/convert_test.go
+++ b/markup/asciidocext/convert_test.go
@@ -72,7 +72,7 @@ func TestAsciidoctorDefaultArgs(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	ac := conv.(*internal.AsciiDocConverter)
-	c.Assert(ac, qt.Not(qt.IsNil))
+	c.Assert(ac, qt.IsNotNil)
 
 	args, err := ac.ParseArgs(converter.DocumentContext{})
 	c.Assert(err, qt.IsNil)
@@ -110,7 +110,7 @@ func TestAsciidoctorNonDefaultArgs(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	ac := conv.(*internal.AsciiDocConverter)
-	c.Assert(ac, qt.Not(qt.IsNil))
+	c.Assert(ac, qt.IsNotNil)
 
 	args, err := ac.ParseArgs(converter.DocumentContext{})
 	c.Assert(err, qt.IsNil)
@@ -146,7 +146,7 @@ func TestAsciidoctorDisallowedArgs(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	ac := conv.(*internal.AsciiDocConverter)
-	c.Assert(ac, qt.Not(qt.IsNil))
+	c.Assert(ac, qt.IsNotNil)
 
 	args, err := ac.ParseArgs(converter.DocumentContext{})
 	c.Assert(err, qt.IsNil)
@@ -176,7 +176,7 @@ func TestAsciidoctorArbitraryExtension(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	ac := conv.(*internal.AsciiDocConverter)
-	c.Assert(ac, qt.Not(qt.IsNil))
+	c.Assert(ac, qt.IsNotNil)
 
 	args, err := ac.ParseArgs(converter.DocumentContext{})
 	c.Assert(err, qt.IsNil)
@@ -215,7 +215,7 @@ func TestAsciidoctorDisallowedExtension(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		ac := conv.(*internal.AsciiDocConverter)
-		c.Assert(ac, qt.Not(qt.IsNil))
+		c.Assert(ac, qt.IsNotNil)
 
 		args, err := ac.ParseArgs(converter.DocumentContext{})
 		c.Assert(err, qt.IsNil)
@@ -254,7 +254,7 @@ my-attribute-false = false
 	c.Assert(err, qt.IsNil)
 
 	ac := conv.(*internal.AsciiDocConverter)
-	c.Assert(ac, qt.Not(qt.IsNil))
+	c.Assert(ac, qt.IsNotNil)
 
 	expectedValues := map[string]bool{
 		"my-base-url=https://gohugo.io/": true,
@@ -265,7 +265,7 @@ my-attribute-false = false
 
 	args, err := ac.ParseArgs(converter.DocumentContext{})
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(args), qt.Equals, 9)
+	c.Assert(args, qt.HasLen, 9)
 	c.Assert(args[0], qt.Equals, "-a")
 	c.Assert(expectedValues[args[1]], qt.Equals, true)
 	c.Assert(args[2], qt.Equals, "-a")

--- a/markup/markup_test.go
+++ b/markup/markup_test.go
@@ -32,7 +32,7 @@ func TestConverterRegistry(t *testing.T) {
 
 	checkName := func(name string) {
 		p := r.Get(name)
-		c.Assert(p, qt.Not(qt.IsNil))
+		c.Assert(p, qt.IsNotNil)
 		c.Assert(p.Name(), qt.Equals, name)
 	}
 

--- a/media/config_test.go
+++ b/media/config_test.go
@@ -45,7 +45,7 @@ func TestDecodeTypes(t *testing.T) {
 					}
 				}
 
-				c.Assert(len(tt), qt.Equals, len(DefaultTypes))
+				c.Assert(tt, qt.HasLen, len(DefaultTypes))
 				json, si, found := tt.GetBySuffix("jasn")
 				c.Assert(found, qt.Equals, true)
 				c.Assert(json.String(), qt.Equals, "application/json")
@@ -62,7 +62,7 @@ func TestDecodeTypes(t *testing.T) {
 			},
 			false,
 			func(t *testing.T, name string, tt Types) {
-				c.Assert(len(tt), qt.Equals, len(DefaultTypes)+1)
+				c.Assert(tt, qt.HasLen, len(DefaultTypes)+1)
 				hg, si, found := tt.GetBySuffix("hg2")
 				c.Assert(found, qt.Equals, true)
 				c.Assert(hg.FirstSuffix.Suffix, qt.Equals, "hg1")
@@ -84,7 +84,7 @@ func TestDecodeTypes(t *testing.T) {
 			},
 			false,
 			func(t *testing.T, name string, tp Types) {
-				c.Assert(len(tp), qt.Equals, len(DefaultTypes)+1)
+				c.Assert(tp, qt.HasLen, len(DefaultTypes)+1)
 				// Make sure we have not broken the default config.
 
 				_, _, found := tp.GetBySuffix("json")
@@ -100,7 +100,7 @@ func TestDecodeTypes(t *testing.T) {
 	for _, test := range tests {
 		result, err := DecodeTypes(test.m)
 		if test.shouldError {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 		} else {
 			c.Assert(err, qt.IsNil)
 			test.assert(t, test.name, result.Config)
@@ -151,5 +151,5 @@ func TestDefaultTypes(t *testing.T) {
 
 	}
 
-	c.Assert(len(DefaultTypes), qt.Equals, 44)
+	c.Assert(DefaultTypes, qt.HasLen, 44)
 }

--- a/media/mediaType_test.go
+++ b/media/mediaType_test.go
@@ -58,7 +58,7 @@ func TestGetByMainSubType(t *testing.T) {
 func TestBySuffix(t *testing.T) {
 	c := qt.New(t)
 	formats := DefaultTypes.BySuffix("xml")
-	c.Assert(len(formats), qt.Equals, 2)
+	c.Assert(formats, qt.HasLen, 2)
 	c.Assert(formats[0].SubType, qt.Equals, "rss")
 	c.Assert(formats[1].SubType, qt.Equals, "xml")
 }
@@ -105,7 +105,7 @@ func TestFromTypeString(t *testing.T) {
 	c.Assert(f, qt.Equals, Type{Type: "application/custom+sfx", MainType: "application", SubType: "custom", mimeSuffix: "sfx"})
 
 	_, err = FromString("noslash")
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 
 	f, err = FromString("text/xml; charset=utf-8")
 	c.Assert(err, qt.IsNil)

--- a/modules/client_test.go
+++ b/modules/client_test.go
@@ -85,9 +85,9 @@ github.com/gohugoio/hugoTestModules1_darwin/modh2_2@v1.4.0 github.com/gohugoio/h
 		// Test Collect
 		mc, err := client.Collect()
 		c.Assert(err, qt.IsNil)
-		c.Assert(len(mc.AllModules), qt.Equals, 4)
+		c.Assert(mc.AllModules, qt.HasLen, 4)
 		for _, m := range mc.AllModules {
-			c.Assert(m, qt.Not(qt.IsNil))
+			c.Assert(m, qt.IsNotNil)
 		}
 
 		// Test Graph
@@ -191,7 +191,7 @@ project github.com/gohugoio/hugoTestModules1_darwin/modh2_2_2@v1.3.0+vendor
 		c.Assert(dirname, qt.Equals, filepath.Join(client.ccfg.ThemesDir, "../../foo"))
 
 		_, err = client.createThemeDirname("../../foo", false)
-		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(err, qt.IsNotNil)
 
 		absDir := filepath.Join(client.ccfg.WorkingDir, "..", "..")
 		dirname, err = client.createThemeDirname(absDir, true)
@@ -199,7 +199,7 @@ project github.com/gohugoio/hugoTestModules1_darwin/modh2_2_2@v1.3.0+vendor
 		c.Assert(dirname, qt.Equals, absDir)
 		dirname, err = client.createThemeDirname(absDir, false)
 		fmt.Println(dirname)
-		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(err, qt.IsNotNil)
 	})
 }
 

--- a/modules/collect_test.go
+++ b/modules/collect_test.go
@@ -46,6 +46,6 @@ func TestFilterUnwantedMounts(t *testing.T) {
 	filtered := filterDuplicateMounts(mounts)
 
 	c := qt.New(t)
-	c.Assert(len(filtered), qt.Equals, 2)
+	c.Assert(filtered, qt.HasLen, 2)
 	c.Assert(filtered, qt.DeepEquals, []Mount{{Source: "a", Target: "b", Lang: "en"}, {Source: "b", Target: "c", Lang: "en"}})
 }

--- a/modules/config_test.go
+++ b/modules/config_test.go
@@ -95,8 +95,8 @@ lang="en"
 
 		c.Assert(mcfg.Workspace, qt.Equals, hugoWorkFilename)
 
-		c.Assert(len(mcfg.Mounts), qt.Equals, 1)
-		c.Assert(len(mcfg.Imports), qt.Equals, 1)
+		c.Assert(mcfg.Mounts, qt.HasLen, 1)
+		c.Assert(mcfg.Imports, qt.HasLen, 1)
 		imp := mcfg.Imports[0]
 		imp.Path = "github.com/bep/mycomponent"
 		c.Assert(imp.Mounts[1].Source, qt.Equals, "src/markdown/blog")
@@ -150,7 +150,7 @@ path="a"
 
 	modCfg, err := DecodeConfig(loggers.NewDefault().Logger(), cfg)
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(modCfg.Imports), qt.Equals, 3)
+	c.Assert(modCfg.Imports, qt.HasLen, 3)
 	c.Assert(modCfg.Imports[0].Path, qt.Equals, "a")
 }
 
@@ -167,7 +167,7 @@ theme = ["a", "b"]
 	mcfg, err := DecodeConfig(loggers.NewDefault().Logger(), cfg)
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(len(mcfg.Imports), qt.Equals, 2)
+	c.Assert(mcfg.Imports, qt.HasLen, 2)
 	c.Assert(mcfg.Imports[0].Path, qt.Equals, "a")
 	c.Assert(mcfg.Imports[1].Path, qt.Equals, "b")
 }

--- a/navigation/menu_cache_test.go
+++ b/navigation/menu_cache_test.go
@@ -65,13 +65,13 @@ func TestMenuCache(t *testing.T) {
 				c.Assert(c2, qt.Equals, true)
 				c.Assert(slices.Equal(m, m2), qt.Equals, true)
 				c.Assert(slices.Equal(m, menu), qt.Equals, true)
-				c.Assert(m, qt.Not(qt.IsNil))
+				c.Assert(m, qt.IsNotNil)
 
 				l2.Lock()
 				m3, c3 := c1.get("k2", changeFirst, menu)
 				c.Assert(c3, qt.Equals, !atomic.CompareAndSwapUint64(&o2, uint64(k), uint64(k+1)))
 				l2.Unlock()
-				c.Assert(m3, qt.Not(qt.IsNil))
+				c.Assert(m3, qt.IsNotNil)
 				c.Assert("changed", qt.Equals, m3[0].Title)
 			}
 		})

--- a/output/config_test.go
+++ b/output/config_test.go
@@ -42,7 +42,7 @@ func TestDecodeConfig(t *testing.T) {
 			false,
 			func(t *testing.T, name string, f Formats) {
 				msg := qt.Commentf(name)
-				c.Assert(len(f), qt.Equals, len(DefaultFormats), msg)
+				c.Assert(f, qt.HasLen, len(DefaultFormats), msg)
 				json, _ := f.GetByName("JSON")
 				c.Assert(json.BaseName, qt.Equals, "myindex")
 				c.Assert(json.MediaType, qt.Equals, media.Builtin.JSONType)
@@ -59,7 +59,7 @@ func TestDecodeConfig(t *testing.T) {
 			},
 			false,
 			func(t *testing.T, name string, f Formats) {
-				c.Assert(len(f), qt.Equals, len(DefaultFormats)+1)
+				c.Assert(f, qt.HasLen, len(DefaultFormats)+1)
 				xml, found := f.GetByName("MYXMLFORMAT")
 				c.Assert(found, qt.Equals, true)
 				c.Assert(xml.BaseName, qt.Equals, "myxml")
@@ -89,7 +89,7 @@ func TestDecodeConfig(t *testing.T) {
 		msg := qt.Commentf(test.name)
 
 		if test.shouldError {
-			c.Assert(err, qt.Not(qt.IsNil), msg)
+			c.Assert(err, qt.IsNotNil, msg)
 		} else {
 			c.Assert(err, qt.IsNil, msg)
 			test.assert(t, test.name, result.Config)

--- a/output/outputFormat_test.go
+++ b/output/outputFormat_test.go
@@ -68,7 +68,7 @@ func TestDefaultTypes(t *testing.T) {
 	c.Assert(RSSFormat.NoUgly, qt.Equals, true)
 	c.Assert(CalendarFormat.IsHTML, qt.Equals, false)
 
-	c.Assert(len(DefaultFormats), qt.Equals, 15)
+	c.Assert(DefaultFormats, qt.HasLen, 15)
 }
 
 func TestGetFormatByName(t *testing.T) {

--- a/parser/metadecoders/decoder_test.go
+++ b/parser/metadecoders/decoder_test.go
@@ -103,7 +103,7 @@ func TestUnmarshalToMap(t *testing.T) {
 		msg := qt.Commentf("%d: %s", i, test.format)
 		m, err := d.UnmarshalToMap([]byte(test.data), test.format)
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), msg)
+			c.Assert(err, qt.IsNotNil, msg)
 		} else {
 			c.Assert(err, qt.IsNil, msg)
 			c.Assert(m, qt.DeepEquals, test.expect, msg)
@@ -146,7 +146,7 @@ func TestUnmarshalToInterface(t *testing.T) {
 		msg := qt.Commentf("%d: %s", i, test.format)
 		m, err := d.Unmarshal(test.data, test.format)
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), msg)
+			c.Assert(err, qt.IsNotNil, msg)
 		} else {
 			c.Assert(err, qt.IsNil, msg)
 			c.Assert(m, qt.DeepEquals, test.expect, msg)
@@ -178,7 +178,7 @@ func TestUnmarshalStringTo(t *testing.T) {
 		msg := qt.Commentf("%d: %T", i, test.to)
 		m, err := d.UnmarshalStringTo(test.data, test.to)
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), msg)
+			c.Assert(err, qt.IsNotNil, msg)
 		} else {
 			c.Assert(err, qt.IsNil, msg)
 			c.Assert(m, qt.DeepEquals, test.expect, msg)

--- a/related/inverted_index_test.go
+++ b/related/inverted_index_test.go
@@ -147,15 +147,15 @@ func TestSearch(t *testing.T) {
 
 	t.Run("count", func(t *testing.T) {
 		c := qt.New(t)
-		c.Assert(len(idx.index), qt.Equals, 2)
+		c.Assert(idx.index, qt.HasLen, 2)
 		set1, found := idx.index["tags"]
 		c.Assert(found, qt.Equals, true)
 		// 6 tags
-		c.Assert(len(set1), qt.Equals, 6)
+		c.Assert(set1, qt.HasLen, 6)
 
 		set2, found := idx.index["keywords"]
 		c.Assert(found, qt.Equals, true)
-		c.Assert(len(set2), qt.Equals, 2)
+		c.Assert(set2, qt.HasLen, 2)
 	})
 
 	t.Run("search-tags", func(t *testing.T) {
@@ -163,7 +163,7 @@ func TestSearch(t *testing.T) {
 		var cfg IndexConfig
 		m, err := idx.search(context.Background(), newQueryElement("tags", cfg.StringsToKeywords("a", "b", "d", "z")...))
 		c.Assert(err, qt.IsNil)
-		c.Assert(len(m), qt.Equals, 2)
+		c.Assert(m, qt.HasLen, 2)
 		c.Assert(m[0], qt.Equals, docs[0])
 		c.Assert(m[1], qt.Equals, docs[1])
 	})
@@ -175,7 +175,7 @@ func TestSearch(t *testing.T) {
 			newQueryElement("tags", cfg.StringsToKeywords("a", "b", "z")...),
 			newQueryElement("keywords", cfg.StringsToKeywords("a", "b")...))
 		c.Assert(err, qt.IsNil)
-		c.Assert(len(m), qt.Equals, 3)
+		c.Assert(m, qt.HasLen, 3)
 		c.Assert(m[0], qt.Equals, docs[3])
 		c.Assert(m[1], qt.Equals, docs[2])
 		c.Assert(m[2], qt.Equals, docs[0])
@@ -186,7 +186,7 @@ func TestSearch(t *testing.T) {
 		doc := newTestDoc("tags", "a").addKeywords("keywords", "a")
 		m, err := idx.Search(context.Background(), SearchOpts{Document: doc})
 		c.Assert(err, qt.IsNil)
-		c.Assert(len(m), qt.Equals, 2)
+		c.Assert(m, qt.HasLen, 2)
 		c.Assert(m[0], qt.Equals, docs[3])
 		c.Assert(m[1], qt.Equals, docs[2])
 	})
@@ -196,7 +196,7 @@ func TestSearch(t *testing.T) {
 		doc := newTestDoc("tags", "a", "b", "d", "z").addKeywords("keywords", "a", "b")
 		m, err := idx.Search(context.Background(), SearchOpts{Document: doc, Indices: []string{"tags"}})
 		c.Assert(err, qt.IsNil)
-		c.Assert(len(m), qt.Equals, 2)
+		c.Assert(m, qt.HasLen, 2)
 		c.Assert(m[0], qt.Equals, docs[0])
 		c.Assert(m[1], qt.Equals, docs[1])
 	})
@@ -210,7 +210,7 @@ func TestSearch(t *testing.T) {
 
 		m, err := idx.Search(context.Background(), SearchOpts{Document: doc, Indices: []string{"keywords"}})
 		c.Assert(err, qt.IsNil)
-		c.Assert(len(m), qt.Equals, 2)
+		c.Assert(m, qt.HasLen, 2)
 		c.Assert(m[0], qt.Equals, docs[3])
 	})
 
@@ -231,7 +231,7 @@ func TestSearch(t *testing.T) {
 
 		m, err := idx.Search(context.Background(), SearchOpts{Document: doc, Indices: []string{"keywords"}})
 		c.Assert(err, qt.IsNil)
-		c.Assert(len(m), qt.Equals, 10)
+		c.Assert(m, qt.HasLen, 10)
 		for i := range 10 {
 			c.Assert(m[i].Name(), qt.Equals, fmt.Sprintf("doc%d", i))
 		}

--- a/resources/image_test.go
+++ b/resources/image_test.go
@@ -82,7 +82,7 @@ func TestImageTransformBasic(t *testing.T) {
 	gotColors, err := image.Colors()
 	c.Assert(err, qt.IsNil)
 	expectedColors := images.HexStringsToColors("#2d2f33", "#a49e93", "#d39e59", "#a76936", "#737a84", "#7c838b")
-	c.Assert(len(gotColors), qt.Equals, len(expectedColors))
+	c.Assert(gotColors, qt.HasLen, len(expectedColors))
 	for i := range gotColors {
 		c1, c2 := gotColors[i], expectedColors[i]
 		c.Assert(c1.ColorHex(), qt.Equals, c2.ColorHex())
@@ -204,7 +204,7 @@ func TestImageTransformFormat(t *testing.T) {
 
 	assertExtWidthHeight := func(img images.ImageResource, ext string, w, h int) {
 		c.Helper()
-		c.Assert(img, qt.Not(qt.IsNil))
+		c.Assert(img, qt.IsNotNil)
 		c.Assert(paths.Ext(img.RelPermalink()), qt.Equals, ext)
 		c.Assert(img.Width(), qt.Equals, w)
 		c.Assert(img.Height(), qt.Equals, h)
@@ -258,7 +258,7 @@ func TestImagePermalinkPublishOrder(t *testing.T) {
 			}
 
 			original := fetchImageForSpec(spec, c, "sunset.jpg")
-			c.Assert(original, qt.Not(qt.IsNil))
+			c.Assert(original, qt.IsNotNil)
 
 			if checkOriginalFirst {
 				check2(original)
@@ -282,16 +282,16 @@ func TestImageBugs(t *testing.T) {
 	// Issue #4261
 	c.Run("Transform long filename", func(c *qt.C) {
 		_, image := fetchImage(c, "1234567890qwertyuiopasdfghjklzxcvbnm5to6eeeeee7via8eleph.jpg")
-		c.Assert(image, qt.Not(qt.IsNil))
+		c.Assert(image, qt.IsNotNil)
 
 		resized, err := image.Resize("200x")
 		c.Assert(err, qt.IsNil)
-		c.Assert(resized, qt.Not(qt.IsNil))
+		c.Assert(resized, qt.IsNotNil)
 		c.Assert(resized.Width(), qt.Equals, 200)
 		c.Assert(resized.RelPermalink(), qt.Equals, "/a/1234567890qwertyuiopasdfghjklzxcvbnm5to6eeeeee7via8eleph_hu_a6f31c42e1afef07.jpg")
 		resized, err = resized.Resize("100x")
 		c.Assert(err, qt.IsNil)
-		c.Assert(resized, qt.Not(qt.IsNil))
+		c.Assert(resized, qt.IsNotNil)
 		c.Assert(resized.Width(), qt.Equals, 100)
 		c.Assert(resized.RelPermalink(), qt.Equals, "/a/1234567890qwertyuiopasdfghjklzxcvbnm5to6eeeeee7via8eleph_hu_14e106419fe28039.jpg")
 	})
@@ -302,7 +302,7 @@ func TestImageBugs(t *testing.T) {
 
 		resized, err := image.Resize("200x")
 		c.Assert(err, qt.IsNil)
-		c.Assert(resized, qt.Not(qt.IsNil))
+		c.Assert(resized, qt.IsNotNil)
 		c.Assert(resized.Width(), qt.Equals, 200)
 	})
 
@@ -328,7 +328,7 @@ func TestImageBugs(t *testing.T) {
 				c.Assert(err, qt.IsNil)
 				resized, err := image.Fill(fmt.Sprintf("%dx%d smart", test.targetWH, test.targetWH))
 				c.Assert(err, qt.IsNil)
-				c.Assert(resized, qt.Not(qt.IsNil))
+				c.Assert(resized, qt.IsNotNil)
 				c.Assert(resized.Width(), qt.Equals, test.targetWH)
 				c.Assert(resized.Height(), qt.Equals, test.targetWH)
 			})
@@ -399,14 +399,14 @@ func TestSVGImage(t *testing.T) {
 	c := qt.New(t)
 	spec := newTestResourceSpec(specDescriptor{c: c})
 	svg := fetchResourceForSpec(spec, c, "circle.svg")
-	c.Assert(svg, qt.Not(qt.IsNil))
+	c.Assert(svg, qt.IsNotNil)
 }
 
 func TestSVGImageContent(t *testing.T) {
 	c := qt.New(t)
 	spec := newTestResourceSpec(specDescriptor{c: c})
 	svg := fetchResourceForSpec(spec, c, "circle.svg")
-	c.Assert(svg, qt.Not(qt.IsNil))
+	c.Assert(svg, qt.IsNotNil)
 
 	content, err := svg.Content(context.Background())
 	c.Assert(err, qt.IsNil)
@@ -425,7 +425,7 @@ func TestImageMeta(t *testing.T) {
 
 	getAndCheckMeta := func(c *qt.C, image images.ImageResource) {
 		x := image.Meta()
-		c.Assert(x, qt.Not(qt.IsNil))
+		c.Assert(x, qt.IsNotNil)
 
 		c.Assert(x.Date.Format("2006-01-02"), qt.Equals, "2017-10-27")
 
@@ -454,10 +454,10 @@ func TestImageColorsLuminance(t *testing.T) {
 	c := qt.New(t)
 
 	_, image := fetchSunset(c)
-	c.Assert(image, qt.Not(qt.IsNil))
+	c.Assert(image, qt.IsNotNil)
 	colors, err := image.Colors()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(colors), qt.Equals, 6)
+	c.Assert(colors, qt.HasLen, 6)
 	var prevLuminance float64
 	for i, color := range colors {
 		luminance := color.Luminance()
@@ -479,7 +479,7 @@ func BenchmarkImageMeta(b *testing.B) {
 
 	getAndCheckMeta := func(c *qt.C, image images.ImageResource) {
 		x := image.Meta()
-		c.Assert(x, qt.Not(qt.IsNil))
+		c.Assert(x, qt.IsNotNil)
 		c.Assert(x.Long, qt.Equals, float64(-4.50846))
 	}
 
@@ -548,7 +548,7 @@ func BenchmarkResizeParallel(b *testing.B) {
 
 func assertWidthHeight(c *qt.C, img images.ImageResource, w, h int) {
 	c.Helper()
-	c.Assert(img, qt.Not(qt.IsNil))
+	c.Assert(img, qt.IsNotNil)
 	c.Assert(img.Width(), qt.Equals, w)
 	c.Assert(img.Height(), qt.Equals, h)
 }

--- a/resources/images/color_test.go
+++ b/resources/images/color_test.go
@@ -49,7 +49,7 @@ func TestHexStringToColor(t *testing.T) {
 			result, err := hexStringToColorGo(test.arg)
 
 			if b, ok := test.expect.(bool); ok && !b {
-				c.Assert(err, qt.Not(qt.IsNil))
+				c.Assert(err, qt.IsNotNil)
 				return
 			}
 

--- a/resources/images/config_test.go
+++ b/resources/images/config_test.go
@@ -48,17 +48,17 @@ func TestDecodeConfig(t *testing.T) {
 	_, err = DecodeConfig(map[string]any{
 		"quality": 123,
 	})
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 
 	_, err = DecodeConfig(map[string]any{
 		"resampleFilter": "asdf",
 	})
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 
 	_, err = DecodeConfig(map[string]any{
 		"anchor": "asdf",
 	})
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 
 	imagingConfig, err = DecodeConfig(map[string]any{
 		"anchor": "Smart",

--- a/resources/page/page_matcher_test.go
+++ b/resources/page/page_matcher_test.go
@@ -77,8 +77,8 @@ func TestPageMatcher(t *testing.T) {
 
 	c.Run("Decode", func(c *qt.C) {
 		var v PageMatcher
-		c.Assert(dec.decodePageMatcher(map[string]any{"kind": "foo"}, &v), qt.Not(qt.IsNil))
-		c.Assert(dec.decodePageMatcher(map[string]any{"kind": "{foo,bar}"}, &v), qt.Not(qt.IsNil))
+		c.Assert(dec.decodePageMatcher(map[string]any{"kind": "foo"}, &v), qt.IsNotNil)
+		c.Assert(dec.decodePageMatcher(map[string]any{"kind": "{foo,bar}"}, &v), qt.IsNotNil)
 		c.Assert(dec.decodePageMatcher(map[string]any{"kind": "taxonomy"}, &v), qt.IsNil)
 		c.Assert(dec.decodePageMatcher(map[string]any{"kind": "{taxonomy,foo}"}, &v), qt.IsNil)
 		c.Assert(dec.decodePageMatcher(map[string]any{"kind": "{taxonomy,term}"}, &v), qt.IsNil)

--- a/resources/page/pages_cache_test.go
+++ b/resources/page/pages_cache_test.go
@@ -56,13 +56,13 @@ func TestPageCache(t *testing.T) {
 				c.Assert(c2, qt.Equals, true)
 				c.Assert(pagesEqual(p, p2), qt.Equals, true)
 				c.Assert(pagesEqual(p, pages), qt.Equals, true)
-				c.Assert(p, qt.Not(qt.IsNil))
+				c.Assert(p, qt.IsNotNil)
 
 				l2.Lock()
 				p3, c3 := c1.get("k2", changeFirst, pages)
 				c.Assert(c3, qt.Equals, !atomic.CompareAndSwapUint64(&o2, uint64(k), uint64(k+1)))
 				l2.Unlock()
-				c.Assert(p3, qt.Not(qt.IsNil))
+				c.Assert(p3, qt.IsNotNil)
 				c.Assert("changed", qt.Equals, p3[0].(*testPage).description)
 			}
 		})

--- a/resources/page/pages_related_test.go
+++ b/resources/page/pages_related_test.go
@@ -59,13 +59,13 @@ func TestRelated(t *testing.T) {
 	result, err := pages.Related(ctx, opts)
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(result), qt.Equals, 2)
+	c.Assert(result, qt.HasLen, 2)
 	c.Assert(result[0].Title(), qt.Equals, "Page 2")
 	c.Assert(result[1].Title(), qt.Equals, "Page 1")
 
 	result, err = pages.Related(ctx, pages[0])
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(result), qt.Equals, 2)
+	c.Assert(result, qt.HasLen, 2)
 	c.Assert(result[0].Title(), qt.Equals, "Page 2")
 	c.Assert(result[1].Title(), qt.Equals, "Page 3")
 
@@ -75,7 +75,7 @@ func TestRelated(t *testing.T) {
 	}
 	result, err = pages.Related(ctx, opts)
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(result), qt.Equals, 2)
+	c.Assert(result, qt.HasLen, 2)
 	c.Assert(result[0].Title(), qt.Equals, "Page 2")
 	c.Assert(result[1].Title(), qt.Equals, "Page 3")
 
@@ -89,7 +89,7 @@ func TestRelated(t *testing.T) {
 	}
 	result, err = pages.Related(context.Background(), opts)
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(result), qt.Equals, 2)
+	c.Assert(result, qt.HasLen, 2)
 	c.Assert(result[0].Title(), qt.Equals, "Page 2")
 	c.Assert(result[1].Title(), qt.Equals, "Page 3")
 }

--- a/resources/page/pages_sort_search_test.go
+++ b/resources/page/pages_sort_search_test.go
@@ -32,7 +32,7 @@ func TestSearchPage(t *testing.T) {
 
 	for _, pages := range []Pages{pages.ByTitle(), pages.ByTitle().Reverse()} {
 		less := isPagesProbablySorted(pages, lessPageTitle)
-		c.Assert(less, qt.Not(qt.IsNil))
+		c.Assert(less, qt.IsNotNil)
 		for i, p := range pages {
 			idx := searchPageBinary(p, pages, less)
 			c.Assert(idx, qt.Equals, i)
@@ -115,8 +115,8 @@ func TestIsPagesProbablySorted(t *testing.T) {
 	t.Parallel()
 	c := qt.New(t)
 
-	c.Assert(isPagesProbablySorted(createSortTestPages(6).ByWeight(), DefaultPageSort), qt.Not(qt.IsNil))
-	c.Assert(isPagesProbablySorted(createSortTestPages(300).ByWeight(), DefaultPageSort), qt.Not(qt.IsNil))
+	c.Assert(isPagesProbablySorted(createSortTestPages(6).ByWeight(), DefaultPageSort), qt.IsNotNil)
+	c.Assert(isPagesProbablySorted(createSortTestPages(300).ByWeight(), DefaultPageSort), qt.IsNotNil)
 	c.Assert(isPagesProbablySorted(createSortTestPages(6), DefaultPageSort), qt.IsNil)
-	c.Assert(isPagesProbablySorted(createSortTestPages(300).ByTitle(), pageLessFunctions...), qt.Not(qt.IsNil))
+	c.Assert(isPagesProbablySorted(createSortTestPages(300).ByTitle(), pageLessFunctions...), qt.IsNotNil)
 }

--- a/resources/page/pages_sort_test.go
+++ b/resources/page/pages_sort_test.go
@@ -138,7 +138,7 @@ func TestLimit(t *testing.T) {
 	c := qt.New(t)
 	p := createSortTestPages(10)
 	firstFive := p.Limit(5)
-	c.Assert(len(firstFive), qt.Equals, 5)
+	c.Assert(firstFive, qt.HasLen, 5)
 	for i := range 5 {
 		c.Assert(firstFive[i], qt.Equals, p[i])
 	}

--- a/resources/page/pages_test.go
+++ b/resources/page/pages_test.go
@@ -68,5 +68,5 @@ func TestToPages(t *testing.T) {
 	c.Assert(mustToPages([]any{p1, p2}), eq, pages12)
 
 	_, err := ToPages("not a page")
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 }

--- a/resources/page/pagination_test.go
+++ b/resources/page/pagination_test.go
@@ -26,7 +26,7 @@ func TestSplitPages(t *testing.T) {
 	c := qt.New(t)
 	pages := createTestPages(21)
 	chunks := splitPages(pages, 5)
-	c.Assert(len(chunks), qt.Equals, 5)
+	c.Assert(chunks, qt.HasLen, 5)
 
 	for i := range 4 {
 		c.Assert(chunks[i].Len(), qt.Equals, 5)
@@ -42,7 +42,7 @@ func TestSplitPageGroups(t *testing.T) {
 	pages := createTestPages(21)
 	groups, _ := pages.GroupBy(context.Background(), "Weight", "desc")
 	chunks := splitPageGroups(groups, 5)
-	c.Assert(len(chunks), qt.Equals, 5)
+	c.Assert(chunks, qt.HasLen, 5)
 
 	firstChunk := chunks[0]
 
@@ -87,10 +87,10 @@ func TestPager(t *testing.T) {
 	}
 
 	_, err := newPaginatorFromPages(pages, -1, urlFactory)
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 
 	_, err = newPaginatorFromPageGroups(groups, -1, urlFactory)
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 
 	pag, err := newPaginatorFromPages(pages, 5, urlFactory)
 	c.Assert(err, qt.IsNil)
@@ -112,7 +112,7 @@ func doTestPages(t *testing.T, paginator *Paginator) {
 	c := qt.New(t)
 	paginatorPages := paginator.Pagers()
 
-	c.Assert(len(paginatorPages), qt.Equals, 5)
+	c.Assert(paginatorPages, qt.HasLen, 5)
 	c.Assert(paginator.TotalNumberOfElements(), qt.Equals, 21)
 	c.Assert(paginator.PagerSize(), qt.Equals, 5)
 	c.Assert(paginator.TotalPages(), qt.Equals, 5)
@@ -170,18 +170,18 @@ func TestPagerNoPages(t *testing.T) {
 func doTestPagerNoPages(t *testing.T, paginator *Paginator) {
 	paginatorPages := paginator.Pagers()
 	c := qt.New(t)
-	c.Assert(len(paginatorPages), qt.Equals, 1)
+	c.Assert(paginatorPages, qt.HasLen, 1)
 	c.Assert(paginator.TotalNumberOfElements(), qt.Equals, 0)
 	c.Assert(paginator.PagerSize(), qt.Equals, 5)
 	c.Assert(paginator.TotalPages(), qt.Equals, 0)
 
 	// pageOne should be nothing but the first
 	pageOne := paginatorPages[0]
-	c.Assert(pageOne.First(), qt.Not(qt.IsNil))
+	c.Assert(pageOne.First(), qt.IsNotNil)
 	c.Assert(pageOne.HasNext(), qt.Equals, false)
 	c.Assert(pageOne.HasPrev(), qt.Equals, false)
 	c.Assert(pageOne.Next(), qt.IsNil)
-	c.Assert(len(pageOne.Pagers()), qt.Equals, 1)
+	c.Assert(pageOne.Pagers(), qt.HasLen, 1)
 	c.Assert(pageOne.Pages().Len(), qt.Equals, 0)
 	c.Assert(pageOne.NumberOfElements(), qt.Equals, 0)
 	c.Assert(pageOne.TotalNumberOfElements(), qt.Equals, 0)
@@ -249,7 +249,7 @@ func TestPaginationPage(t *testing.T) {
 	c.Assert(page11.FuzzyWordCount(context.Background()), qt.Equals, 3)
 	c.Assert(page1Nil, qt.IsNil)
 
-	c.Assert(page21, qt.Not(qt.IsNil))
+	c.Assert(page21, qt.IsNotNil)
 	c.Assert(page21.FuzzyWordCount(context.Background()), qt.Equals, 3)
 	c.Assert(page2Nil, qt.IsNil)
 }

--- a/resources/resource/resources_test.go
+++ b/resources/resource/resources_test.go
@@ -29,7 +29,7 @@ func TestResourcesMount(t *testing.T) {
 	check := func(in, expect string) {
 		c.Helper()
 		r := m.Get(in)
-		c.Assert(r, qt.Not(qt.IsNil))
+		c.Assert(r, qt.IsNotNil)
 		c.Assert(r.Name(), qt.Equals, expect)
 	}
 

--- a/resources/resource_spec_test.go
+++ b/resources/resource_spec_test.go
@@ -39,7 +39,7 @@ func TestNewResource(t *testing.T) {
 
 	r, err := spec.NewResource(rd)
 	c.Assert(err, qt.IsNil)
-	c.Assert(r, qt.Not(qt.IsNil))
+	c.Assert(r, qt.IsNotNil)
 	c.Assert(r.RelPermalink(), qt.Equals, "/c/d/a/b.txt")
 
 	info := resources.GetTestInfoForResource(r)

--- a/resources/resource_transformers/cssjs/postcss_integration_test.go
+++ b/resources/resource_transformers/cssjs/postcss_integration_test.go
@@ -183,7 +183,7 @@ func TestTransformPostCSSNotInstalledError(t *testing.T) {
 		}).BuildE()
 
 	ferrs := herrors.UnwrapFileErrors(err)
-	c.Assert(len(ferrs), qt.Equals, 1)
+	c.Assert(ferrs, qt.HasLen, 1)
 	c.Assert(err.Error(), qt.Contains, `binary with name "postcss" not found using npx`)
 }
 
@@ -204,7 +204,7 @@ func TestTransformPostCSSImportError(t *testing.T) {
 			TxtarString:     strings.ReplaceAll(postCSSIntegrationTestFiles, `@import "components/all.css";`, `@import "components/doesnotexist.css";`),
 		}).BuildE()
 	ferrs := herrors.UnwrapFileErrors(err)
-	c.Assert(len(ferrs), qt.Equals, 2)
+	c.Assert(ferrs, qt.HasLen, 2)
 	c.Assert(err.Error(), qt.Contains, "styles.css:4:3")
 	c.Assert(err.Error(), qt.Contains, filepath.FromSlash(`failed to resolve CSS @import "/css/components/doesnotexist.css"`))
 }

--- a/resources/resource_transformers/integrity/integrity_test.go
+++ b/resources/resource_transformers/integrity/integrity_test.go
@@ -42,7 +42,7 @@ func TestHashFromAlgo(t *testing.T) {
 				c.Assert(err, qt.IsNil)
 				c.Assert(h.Size(), qt.Equals, algo.bits/8)
 			} else {
-				c.Assert(err, qt.Not(qt.IsNil))
+				c.Assert(err, qt.IsNotNil)
 				c.Assert(err.Error(), qt.Contains, "use either md5, sha256, sha384 or sha512")
 			}
 		})

--- a/resources/resource_transformers/tocss/scss/scss_integration_test.go
+++ b/resources/resource_transformers/tocss/scss/scss_integration_test.go
@@ -227,7 +227,7 @@ T1: {{ $r.Content }}
 		b.Assert(err, qt.IsNotNil)
 		b.Assert(err.Error(), qt.Contains, filepath.FromSlash(`themes/mytheme/assets/scss/main.scss:6:1": expected ':' after $maincolor in assignment statement`))
 		ferrs := herrors.UnwrapFileErrors(err)
-		c.Assert(len(ferrs), qt.Equals, 2)
+		c.Assert(ferrs, qt.HasLen, 2)
 		fe := ferrs[1]
 		b.Assert(fe.ErrorContext(), qt.IsNotNil)
 		b.Assert(fe.ErrorContext().Lines, qt.DeepEquals, []string{"/* comment line 4 */", "", "$maincolor #eee;", "", "body {"})
@@ -245,7 +245,7 @@ T1: {{ $r.Content }}
 		b.Assert(err, qt.IsNotNil)
 		b.Assert(err.Error(), qt.Contains, `assets/scss/components/_foo.scss:2:1": expected ':' after $foocolor in assignment statement`)
 		ferrs := herrors.UnwrapFileErrors(err)
-		c.Assert(len(ferrs), qt.Equals, 2)
+		c.Assert(ferrs, qt.HasLen, 2)
 		fe := ferrs[1]
 		b.Assert(fe.ErrorContext(), qt.IsNotNil)
 		b.Assert(fe.ErrorContext().Lines, qt.DeepEquals, []string{"/* comment line 1 */", "$foocolor #ccc;", "", "foo {"})

--- a/resources/testhelpers_test.go
+++ b/resources/testhelpers_test.go
@@ -111,7 +111,7 @@ func fetchImage(c *qt.C, name string) (*resources.Spec, images.ImageResource) {
 func fetchImageForSpec(spec *resources.Spec, c *qt.C, name string) images.ImageResource {
 	r := fetchResourceForSpec(spec, c, name)
 	img := r.(images.ImageResource)
-	c.Assert(img, qt.Not(qt.IsNil))
+	c.Assert(img, qt.IsNotNil)
 	return img
 }
 
@@ -131,7 +131,7 @@ func fetchResourceForSpec(spec *resources.Spec, c *qt.C, name string, targetPath
 		GroupIdentity: identity.Anonymous,
 	})
 	c.Assert(err, qt.IsNil)
-	c.Assert(r, qt.Not(qt.IsNil))
+	c.Assert(r, qt.IsNotNil)
 
 	return r.(resource.ContentResource)
 }

--- a/resources/transform_test.go
+++ b/resources/transform_test.go
@@ -57,7 +57,7 @@ func TestTransform(t *testing.T) {
 			GroupIdentity:      identity.StringIdentity(targetPath),
 		})
 		c.Assert(err, qt.IsNil)
-		c.Assert(r, qt.Not(qt.IsNil), qt.Commentf(filename))
+		c.Assert(r, qt.IsNotNil, qt.Commentf(filename))
 		return r.(resources.Transformer)
 	}
 

--- a/tpl/cast/cast_test.go
+++ b/tpl/cast/cast_test.go
@@ -46,7 +46,7 @@ func TestToInt(t *testing.T) {
 		result, err := ns.ToInt(test.v)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -74,7 +74,7 @@ func TestToString(t *testing.T) {
 		result, err := ns.ToString(test.v)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -113,7 +113,7 @@ func TestToFloat(t *testing.T) {
 		result, err := ns.ToFloat(test.v)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 

--- a/tpl/collections/append_test.go
+++ b/tpl/collections/append_test.go
@@ -52,7 +52,7 @@ func TestAppend(t *testing.T) {
 		result, err := ns.Append(args...)
 
 		if b, ok := test.expected.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -62,7 +62,7 @@ func TestAfter(t *testing.T) {
 		result, err := ns.After(test.index, test.seq)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -113,7 +113,7 @@ func TestGroup(t *testing.T) {
 		result, err := ns.Group(test.key, test.items)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -202,7 +202,7 @@ func TestDictionary(t *testing.T) {
 			result, err := ns.Dictionary(test.values...)
 
 			if b, ok := test.expect.(bool); ok && !b {
-				c.Assert(err, qt.Not(qt.IsNil), errMsg)
+				c.Assert(err, qt.IsNotNil, errMsg)
 				return
 			}
 
@@ -227,7 +227,7 @@ func TestReverse(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(reversed, qt.IsNil)
 	_, err = ns.Reverse(43)
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 }
 
 func TestFirst(t *testing.T) {
@@ -259,7 +259,7 @@ func TestFirst(t *testing.T) {
 		result, err := ns.First(test.limit, test.seq)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -423,7 +423,7 @@ func TestIntersect(t *testing.T) {
 		result, err := ns.Intersect(test.l1, test.l2)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -501,7 +501,7 @@ func TestLast(t *testing.T) {
 		result, err := ns.Last(test.limit, test.seq)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -545,7 +545,7 @@ func TestSeq(t *testing.T) {
 		result, err := ns.Seq(test.args...)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -581,7 +581,7 @@ func TestShuffle(t *testing.T) {
 		result, err := ns.Shuffle(test.seq)
 
 		if !test.success {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -726,7 +726,7 @@ func TestUnion(t *testing.T) {
 
 		result, err := ns.Union(test.l1, test.l2)
 		if test.isErr {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -777,7 +777,7 @@ func TestUniq(t *testing.T) {
 
 		result, err := ns.Uniq(test.l)
 		if test.isErr {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 

--- a/tpl/collections/complement_test.go
+++ b/tpl/collections/complement_test.go
@@ -77,7 +77,7 @@ func TestComplement(t *testing.T) {
 		result, err := ns.Complement(args...)
 
 		if b, ok := test.expected.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -89,7 +89,7 @@ func TestComplement(t *testing.T) {
 	}
 
 	_, err := ns.Complement()
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 	_, err = ns.Complement([]string{"a", "b"})
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 }

--- a/tpl/collections/index_test.go
+++ b/tpl/collections/index_test.go
@@ -68,7 +68,7 @@ func TestIndex(t *testing.T) {
 			result, err := ns.Index(test.item, test.indices...)
 
 			if test.isErr {
-				c.Assert(err, qt.Not(qt.IsNil), errMsg)
+				c.Assert(err, qt.IsNotNil, errMsg)
 				return
 			}
 			c.Assert(err, qt.IsNil, errMsg)
@@ -81,7 +81,7 @@ func TestIndex(t *testing.T) {
 			result, err := ns.Index(test.item, test.indices)
 
 			if test.isErr {
-				c.Assert(err, qt.Not(qt.IsNil), errMsg)
+				c.Assert(err, qt.IsNotNil, errMsg)
 				return
 			}
 			c.Assert(err, qt.IsNil, errMsg)

--- a/tpl/collections/merge_test.go
+++ b/tpl/collections/merge_test.go
@@ -145,7 +145,7 @@ func TestMerge(t *testing.T) {
 			result, err := ns.Merge(test.params...)
 
 			if test.isErr {
-				c.Assert(err, qt.Not(qt.IsNil), errMsg)
+				c.Assert(err, qt.IsNotNil, errMsg)
 				return
 			}
 

--- a/tpl/collections/querify_test.go
+++ b/tpl/collections/querify_test.go
@@ -72,7 +72,7 @@ func TestQuerify(t *testing.T) {
 		result, err := ns.Querify(test.params...)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 

--- a/tpl/collections/symdiff_test.go
+++ b/tpl/collections/symdiff_test.go
@@ -57,7 +57,7 @@ func TestSymDiff(t *testing.T) {
 		result, err := ns.SymDiff(test.s2, test.s1)
 
 		if b, ok := test.expected.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -69,7 +69,7 @@ func TestSymDiff(t *testing.T) {
 	}
 
 	_, err := ns.Complement()
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 	_, err = ns.Complement([]string{"a", "b"})
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 }

--- a/tpl/crypto/crypto_test.go
+++ b/tpl/crypto/crypto_test.go
@@ -38,7 +38,7 @@ func TestMD5(t *testing.T) {
 		result, err := ns.MD5(test.in)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -65,7 +65,7 @@ func TestSHA1(t *testing.T) {
 		result, err := ns.SHA1(test.in)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -92,7 +92,7 @@ func TestSHA256(t *testing.T) {
 		result, err := ns.SHA256(test.in)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 
@@ -128,7 +128,7 @@ func TestHMAC(t *testing.T) {
 		result, err := ns.HMAC(test.hash, test.key, test.msg, test.encoding)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), errMsg)
+			c.Assert(err, qt.IsNotNil, errMsg)
 			continue
 		}
 

--- a/tpl/encoding/encoding_test.go
+++ b/tpl/encoding/encoding_test.go
@@ -41,7 +41,7 @@ func TestBase64Decode(t *testing.T) {
 		result, err := ns.Base64Decode(test.v)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -68,7 +68,7 @@ func TestBase64Encode(t *testing.T) {
 		result, err := ns.Base64Encode(test.v)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -111,7 +111,7 @@ func TestJsonify(t *testing.T) {
 		result, err := ns.Jsonify(args...)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil), qt.Commentf("#%d", i))
+			c.Assert(err, qt.IsNotNil, qt.Commentf("#%d", i))
 			continue
 		}
 

--- a/tpl/images/images_test.go
+++ b/tpl/images/images_test.go
@@ -99,7 +99,7 @@ func TestNSConfig(t *testing.T) {
 		// check for expected errors early to avoid writing files
 		if b, ok := test.expect.(bool); ok && !b {
 			_, err := ns.Config(test.path)
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 

--- a/tpl/inflect/inflect_test.go
+++ b/tpl/inflect/inflect_test.go
@@ -39,7 +39,7 @@ func TestInflect(t *testing.T) {
 		result, err := test.fn(test.in)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 

--- a/tpl/math/math_test.go
+++ b/tpl/math/math_test.go
@@ -54,7 +54,7 @@ func TestBasicNSArithmetic(t *testing.T) {
 		result, err := test.fn(test.values...)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -81,7 +81,7 @@ func TestAbs(t *testing.T) {
 		result, err := ns.Abs(test.x)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -113,7 +113,7 @@ func TestCeil(t *testing.T) {
 		result, err := ns.Ceil(test.x)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -146,7 +146,7 @@ func TestFloor(t *testing.T) {
 		result, err := ns.Floor(test.x)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -176,7 +176,7 @@ func TestLog(t *testing.T) {
 		result, err := ns.Log(test.a)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -215,7 +215,7 @@ func TestSqrt(t *testing.T) {
 		result, err := ns.Sqrt(test.a)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -266,7 +266,7 @@ func TestMod(t *testing.T) {
 		result, err := ns.Mod(test.a, test.b)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -312,7 +312,7 @@ func TestModBool(t *testing.T) {
 		result, err := ns.ModBool(test.a, test.b)
 
 		if test.expect == nil {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -345,7 +345,7 @@ func TestRound(t *testing.T) {
 		result, err := ns.Round(test.x)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -381,7 +381,7 @@ func TestPow(t *testing.T) {
 		result, err := ns.Pow(test.a, test.b)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -438,7 +438,7 @@ func TestMax(t *testing.T) {
 		result, err := ns.Max(test.values...)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -494,7 +494,7 @@ func TestMin(t *testing.T) {
 		result, err := ns.Min(test.values...)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -523,7 +523,7 @@ func TestSum(t *testing.T) {
 	c.Assert(mustSum([]any{}), qt.Equals, 0.0)
 
 	_, err := ns.Sum()
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 }
 
 func TestProduct(t *testing.T) {
@@ -545,7 +545,7 @@ func TestProduct(t *testing.T) {
 	c.Assert(mustProduct([]string{}), qt.Equals, 0.0)
 
 	_, err := ns.Product()
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 }
 
 // Test trigonometric functions
@@ -587,7 +587,7 @@ func TestSin(t *testing.T) {
 		result, err := ns.Sin(test.a)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -621,7 +621,7 @@ func TestCos(t *testing.T) {
 		result, err := ns.Cos(test.a)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -655,7 +655,7 @@ func TestTan(t *testing.T) {
 		result, err := ns.Tan(test.a)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -695,7 +695,7 @@ func TestAsin(t *testing.T) {
 		result, err := ns.Asin(test.x)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 		// we compare only 4 digits behind point if its a real float
@@ -730,7 +730,7 @@ func TestAcos(t *testing.T) {
 		result, err := ns.Acos(test.x)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -766,7 +766,7 @@ func TestAtan(t *testing.T) {
 		result, err := ns.Atan(test.x)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -803,7 +803,7 @@ func TestAtan2(t *testing.T) {
 		result, err := ns.Atan2(test.x, test.y)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -836,7 +836,7 @@ func TestToDegrees(t *testing.T) {
 		result, err := ns.ToDegrees(test.x)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -867,7 +867,7 @@ func TestToRadians(t *testing.T) {
 		result, err := ns.ToRadians(test.x)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 

--- a/tpl/os/os_test.go
+++ b/tpl/os/os_test.go
@@ -75,7 +75,7 @@ func TestFileExists(t *testing.T) {
 		result, err := ns.FileExists(test.filename)
 
 		if test.expect == nil {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 

--- a/tpl/path/path_test.go
+++ b/tpl/path/path_test.go
@@ -50,7 +50,7 @@ func TestBase(t *testing.T) {
 		result, err := ns.Base(test.path)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -81,7 +81,7 @@ func TestBaseName(t *testing.T) {
 		result, err := ns.BaseName(test.path)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -112,7 +112,7 @@ func TestDir(t *testing.T) {
 		result, err := ns.Dir(test.path)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -141,7 +141,7 @@ func TestExt(t *testing.T) {
 		result, err := ns.Ext(test.path)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -176,7 +176,7 @@ func TestJoin(t *testing.T) {
 		result, err := ns.Join(test.elements)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -205,7 +205,7 @@ func TestSplit(t *testing.T) {
 		result, err := ns.Split(test.path)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -235,7 +235,7 @@ func TestClean(t *testing.T) {
 		result, err := ns.Clean(test.path)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 

--- a/tpl/safe/safe_test.go
+++ b/tpl/safe/safe_test.go
@@ -40,7 +40,7 @@ func TestCSS(t *testing.T) {
 		result, err := ns.CSS(test.a)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -67,7 +67,7 @@ func TestHTML(t *testing.T) {
 		result, err := ns.HTML(test.a)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -93,7 +93,7 @@ func TestHTMLAttr(t *testing.T) {
 		result, err := ns.HTMLAttr(test.a)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -120,7 +120,7 @@ func TestJS(t *testing.T) {
 		result, err := ns.JS(test.a)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -147,7 +147,7 @@ func TestJSStr(t *testing.T) {
 		result, err := ns.JSStr(test.a)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -174,7 +174,7 @@ func TestURL(t *testing.T) {
 		result, err := ns.URL(test.a)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 

--- a/tpl/strings/regexp_test.go
+++ b/tpl/strings/regexp_test.go
@@ -41,7 +41,7 @@ func TestFindRE(t *testing.T) {
 		result, err := ns.FindRE(test.expr, test.content, test.limit)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -75,7 +75,7 @@ func TestFindRESubmatch(t *testing.T) {
 		result, err := ns.FindRESubmatch(test.expr, test.content, test.limit)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -117,7 +117,7 @@ func TestReplaceRE(t *testing.T) {
 		}
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 

--- a/tpl/strings/strings_test.go
+++ b/tpl/strings/strings_test.go
@@ -51,7 +51,7 @@ func TestChomp(t *testing.T) {
 		result, err := ns.Chomp(test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -94,7 +94,7 @@ func TestContains(t *testing.T) {
 		result, err := ns.Contains(test.s, test.substr)
 
 		if test.isErr {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -138,7 +138,7 @@ func TestContainsAny(t *testing.T) {
 		result, err := ns.ContainsAny(test.s, test.substr)
 
 		if test.isErr {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -199,7 +199,7 @@ func TestCountRunes(t *testing.T) {
 		result, err := ns.CountRunes(test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -226,7 +226,7 @@ func TestRuneCount(t *testing.T) {
 		result, err := ns.RuneCount(test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -256,7 +256,7 @@ func TestCountWords(t *testing.T) {
 		result, err := ns.CountWords(test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -290,7 +290,7 @@ func TestHasPrefix(t *testing.T) {
 		result, err := ns.HasPrefix(test.s, test.prefix)
 
 		if test.isErr {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -324,7 +324,7 @@ func TestHasSuffix(t *testing.T) {
 		result, err := ns.HasSuffix(test.s, test.suffix)
 
 		if test.isErr {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -367,7 +367,7 @@ func TestReplace(t *testing.T) {
 		}
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -509,7 +509,7 @@ func TestSliceString(t *testing.T) {
 		}
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -543,7 +543,7 @@ func TestSplit(t *testing.T) {
 		result, err := ns.Split(test.v1, test.v2)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -612,7 +612,7 @@ func TestSubstr(t *testing.T) {
 		}
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Check(err, qt.Not(qt.IsNil), qt.Commentf("%v", test))
+			c.Check(err, qt.IsNotNil, qt.Commentf("%v", test))
 			continue
 		}
 
@@ -621,10 +621,10 @@ func TestSubstr(t *testing.T) {
 	}
 
 	_, err = ns.Substr("abcdef")
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 
 	_, err = ns.Substr("abcdef", 1, 2, 3)
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 }
 
 func TestTitle(t *testing.T) {
@@ -645,7 +645,7 @@ func TestTitle(t *testing.T) {
 		result, err := ns.Title(test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -672,7 +672,7 @@ func TestToLower(t *testing.T) {
 		result, err := ns.ToLower(test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -699,7 +699,7 @@ func TestToUpper(t *testing.T) {
 		result, err := ns.ToUpper(test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -733,7 +733,7 @@ func TestTrim(t *testing.T) {
 		result, err := ns.Trim(test.s, test.cutset)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -768,7 +768,7 @@ func TestTrimLeft(t *testing.T) {
 		result, err := ns.TrimLeft(test.cutset, test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -798,7 +798,7 @@ func TestTrimPrefix(t *testing.T) {
 		result, err := ns.TrimPrefix(test.prefix, test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -833,7 +833,7 @@ func TestTrimRight(t *testing.T) {
 		result, err := ns.TrimRight(test.cutset, test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -863,7 +863,7 @@ func TestTrimSuffix(t *testing.T) {
 		result, err := ns.TrimSuffix(test.suffix, test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -898,7 +898,7 @@ func TestRepeat(t *testing.T) {
 		result, err := ns.Repeat(test.n, test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -931,7 +931,7 @@ func TestDiff(t *testing.T) {
 		result, err := ns.Diff(test.oldname, test.old, test.newname, test.new)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -959,7 +959,7 @@ func TestTrimSpace(t *testing.T) {
 		result, err := ns.TrimSpace(test.s)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 

--- a/tpl/transform/remarshal_test.go
+++ b/tpl/transform/remarshal_test.go
@@ -195,10 +195,10 @@ a = "b"
 
 	c.Run("Error", func(c *qt.C) {
 		_, err := ns.Remarshal("asdf", "asdf")
-		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(err, qt.IsNotNil)
 
 		_, err = ns.Remarshal("json", "asdf")
-		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(err, qt.IsNotNil)
 	})
 }
 
@@ -259,7 +259,7 @@ c: &c [*b, *b, *b, *b, *b, *b, *b, *b, *b, *b]
 			t.Parallel()
 			c := qt.New(t)
 			_, err := ns.Remarshal("json", test.data)
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 		})
 	}
 

--- a/tpl/urls/urls_test.go
+++ b/tpl/urls/urls_test.go
@@ -61,7 +61,7 @@ func TestParse(t *testing.T) {
 		result, err := ns.Parse(test.rawurl)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -98,7 +98,7 @@ func TestJoinPath(t *testing.T) {
 		result, err := ns.JoinPath(test.elements)
 
 		if b, ok := test.expect.(bool); ok && !b {
-			c.Assert(err, qt.Not(qt.IsNil))
+			c.Assert(err, qt.IsNotNil)
 			continue
 		}
 
@@ -174,7 +174,7 @@ func TestPathUnescape(t *testing.T) {
 		c.Run(tt.name, func(c *qt.C) {
 			got, err := ns.PathUnescape(tt.input)
 			if tt.wantErr {
-				c.Assert(err, qt.Not(qt.IsNil), qt.Commentf("PathUnescape(%v) should have failed", tt.input))
+				c.Assert(err, qt.IsNotNil, qt.Commentf("PathUnescape(%v) should have failed", tt.input))
 				if tt.errCheck != "" {
 					c.Assert(err, qt.ErrorMatches, ".*"+regexp.QuoteMeta(tt.errCheck)+".*")
 				}

--- a/watcher/filenotify/poller_test.go
+++ b/watcher/filenotify/poller_test.go
@@ -28,8 +28,8 @@ func TestPollerAddRemove(t *testing.T) {
 	c := qt.New(t)
 	w := NewPollingWatcher(watchWaitTime)
 
-	c.Assert(w.Add("foo"), qt.Not(qt.IsNil))
-	c.Assert(w.Remove("foo"), qt.Not(qt.IsNil))
+	c.Assert(w.Add("foo"), qt.IsNotNil)
+	c.Assert(w.Remove("foo"), qt.IsNotNil)
 
 	f, err := os.CreateTemp("", "asdf")
 	if err != nil {
@@ -149,7 +149,7 @@ func TestPollerClose(t *testing.T) {
 
 	defer os.Remove(f2.Name())
 
-	c.Assert(w.Add(f2.Name()), qt.Not(qt.IsNil))
+	c.Assert(w.Add(f2.Name()), qt.IsNotNil)
 }
 
 func TestCheckChange(t *testing.T) {


### PR DESCRIPTION
- Replace qt.Not(qt.IsNil) with qt.IsNotNil
- Replace manual len() comparisons with qt.HasLen