### PR TITLE
hugolib: Fix server no watch

### DIFF
--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -61,7 +61,7 @@ import (
 // Build builds all sites. If filesystem events are provided,
 // this is considered to be a potential partial rebuild.
 func (h *HugoSites) Build(config BuildCfg, events ...fsnotify.Event) error {
-	if h.isRebuild() && !h.Conf.Watching() {
+	if h.isRebuild() && !h.Conf.Watching() && !h.Conf.Running() {
 		return errors.New("Build called multiple times when not in watch or server mode (typically with hugolib.Test(t, files).Build(); Build() is already called once by Test)")
 	}
 	if !h.isRebuild() && terminal.PrintANSIColors(os.Stdout) {

--- a/testscripts/server/server__watch_false.txt
+++ b/testscripts/server/server__watch_false.txt
@@ -1,0 +1,17 @@
+# Test the hugo server command with watch disabled.
+
+hugo server --watch=false &
+
+waitServer
+
+httpget $HUGOTEST_BASEURL_0 'HOME'
+httpget $HUGOTEST_BASEURL_0 'HOME'
+
+stopServer
+! stderr .
+
+-- hugo.toml --
+baseURL = 'https://example.org/'
+disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+-- layouts/home.html --
+HOME


### PR DESCRIPTION
Closes #14615

This was just a missed condition check. The error message is "Build called multiple times when not in watch or server mode" but we were not checking for server mode.