### PR TITLE
minifiers: Keep x-bind and blank namespace in SVG minification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,8 +66,8 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/fsync v0.10.1
 	github.com/spf13/pflag v1.0.10
-	github.com/tdewolff/minify/v2 v2.24.10
-	github.com/tdewolff/parse/v2 v2.8.10
+	github.com/tdewolff/minify/v2 v2.24.11
+	github.com/tdewolff/parse/v2 v2.8.11
 	github.com/tetratelabs/wazero v1.11.0
 	github.com/yuin/goldmark v1.7.17
 	github.com/yuin/goldmark-emoji v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -495,8 +495,12 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tdewolff/minify/v2 v2.24.10 h1:SjOOY2Y3Uv34WY4wtyUzJA2T1Xd1v1zQVSZvPP0A/h4=
 github.com/tdewolff/minify/v2 v2.24.10/go.mod h1:fXkGpJ4gel+z1nmeIjVtKmxGZ4ZXd7g1gA3dfTz5/j8=
+github.com/tdewolff/minify/v2 v2.24.11 h1:JlANsiWaRBXedoYtsiZgY3YFkdr42oF32vp2SLgQKi4=
+github.com/tdewolff/minify/v2 v2.24.11/go.mod h1:exq1pjdrh9uAICdfVKQwqz6MsJmWmQahZuTC6pTO6ro=
 github.com/tdewolff/parse/v2 v2.8.10 h1:5a8o388UmuiU3zlOBJ56PN0rxVi67LRNED/zzuHAfC0=
 github.com/tdewolff/parse/v2 v2.8.10/go.mod h1:Hwlni2tiVNKyzR1o6nUs4FOF07URA+JLBLd6dlIXYqo=
+github.com/tdewolff/parse/v2 v2.8.11 h1:SGyjEy3xEqd+W9WVzTlTQ5GkP/en4a1AZNZVJ1cvgm0=
+github.com/tdewolff/parse/v2 v2.8.11/go.mod h1:Hwlni2tiVNKyzR1o6nUs4FOF07URA+JLBLd6dlIXYqo=
 github.com/tdewolff/test v1.0.11 h1:FdLbwQVHxqG16SlkGveC0JVyrJN62COWTRyUFzfbtBE=
 github.com/tdewolff/test v1.0.11/go.mod h1:XPuWBzvdUzhCuxWO1ojpXsyzsA5bFoS3tO/Q3kFuTG8=
 github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=

--- a/minifiers/config.go
+++ b/minifiers/config.go
@@ -46,8 +46,9 @@ var defaultTdewolffConfig = TdewolffConfig{
 	},
 	JSON: json.Minifier{},
 	SVG: svg.Minifier{
-		KeepComments: false,
-		Precision:    0, // 0 means no trimming
+		KeepComments:   false,
+		Precision:      0, // 0 means no trimming
+		KeepNamespaces: []string{"", "x-bind"},
 	},
 	XML: xml.Minifier{
 		KeepWhitespace: false,

--- a/minifiers/minifiers_test.go
+++ b/minifiers/minifiers_test.go
@@ -158,6 +158,9 @@ func TestBugs(t *testing.T) {
 		{media.Builtin.HTMLType, "<i class='fas fa-tags fa-fw'></i> Tags", `<i class='fas fa-tags fa-fw'></i> Tags`},
 		// Issue #13082
 		{media.Builtin.HTMLType, "<gcse:searchresults-only></gcse:searchresults-only>", `<gcse:searchresults-only></gcse:searchresults-only>`},
+		// Issue #14669.
+		{media.Builtin.SVGType, `<use x-bind:href="myicon">`, `<use x-bind:href="myicon">`},
+		{media.Builtin.SVGType, `<use :href="myicon">`, `<use :href="myicon">`},
 	} {
 		var b bytes.Buffer
 


### PR DESCRIPTION
Update tdewolff/minify to v2.24.11 and add "" and "x-bind" to KeepNamespaces
to prevent Alpine.js directives from being stripped in SVGs.

This is a new option in tdewolff/minify v2.24.11, and it is needed to prevent breakage of Alpine.js, and possilby others, directives in SVGs.

Fixes #14669
