### PR TITLE
fix: prevent TOC rendering panics in Goldmark by adding recovery

### DIFF
--- a/hugolib/toc_panic_test.go
+++ b/hugolib/toc_panic_test.go
@@ -1,0 +1,31 @@
+package hugolib
+
+import (
+	"testing"
+)
+
+// TestTOCPanicMinimal reproduces the index out of range panic in the TOC transformer
+func TestTOCPanicMinimal(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "http://example.com/"
+[markup.goldmark.extensions.passthrough]
+enable = true
+[markup.goldmark.extensions.passthrough.delimiters]
+inline = [['$', '$']]
+-- content/p1.md --
+---
+title: p1
+---
+# **$a$**
+-- layouts/_default/single.html --
+{{ .Summary }}
+`
+
+	// This should not panic.
+	// Before the fix, this would panic with "index out of range [41] with length 41"
+	// (or a similar ID depending on the Goldmark version/build).
+	Test(t, files)
+}

--- a/markup/goldmark/toc.go
+++ b/markup/goldmark/toc.go
@@ -106,7 +106,14 @@ func (t *tocTransformer) Transform(n *ast.Document, reader text.Reader, pc parse
 			extras.KindMark,
 			extras.KindSubscript,
 			extras.KindSuperscript:
-			err := t.r.Render(&headingText, reader.Source(), n)
+			err := func() (err error) {
+				defer func() {
+					if r := recover(); r != nil {
+						headingText.Write(n.Text(reader.Source()))
+					}
+				}()
+				return t.r.Render(&headingText, reader.Source(), n)
+			}()
 			if err != nil {
 				return s, err
 			}
@@ -117,7 +124,14 @@ func (t *tocTransformer) Transform(n *ast.Document, reader text.Reader, pc parse
 			ast.KindRawHTML,
 			ast.KindText,
 			ast.KindString:
-			err := t.r.Render(&headingText, reader.Source(), n)
+			err := func() (err error) {
+				defer func() {
+					if r := recover(); r != nil {
+						headingText.Write(n.Text(reader.Source()))
+					}
+				}()
+				return t.r.Render(&headingText, reader.Source(), n)
+			}()
 			if err != nil {
 				return s, err
 			}


### PR DESCRIPTION
The original issue is in https://github.com/gohugoio/hugo/issues/14677. I added panic recovery blocks in tocTransformer.Transform around the t.r.Render call to catch these out-of-range errors and fall back to rendering the node's raw text. And added a minimum test case to reproduce the bug.