### PR TITLE
tpl/debug: add List function

### DIFF
--- a/tpl/debug/debug.go
+++ b/tpl/debug/debug.go
@@ -16,6 +16,7 @@ package debug
 
 import (
 	"encoding/json"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -118,6 +119,43 @@ func (ns *Namespace) Dump(val any) string {
 func (ns *Namespace) VisualizeSpaces(val any) string {
 	s := cast.ToString(val)
 	return string(util.VisualizeSpaces([]byte(s)))
+}
+
+// List returns a sorted list of field names and method names for structs/pointers,
+// or a sorted list of keys for maps. Non-recursive.
+func (ns *Namespace) List(val any) []string {
+	if val == nil {
+		return nil
+	}
+
+	v := reflect.ValueOf(val)
+	for v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+
+	var names []string
+
+	switch v.Kind() {
+	case reflect.Struct:
+		t := v.Type()
+		for i := range t.NumField() {
+			if f := t.Field(i); f.IsExported() {
+				names = append(names, f.Name)
+			}
+		}
+		// Include methods on the original (possibly pointer) value.
+		pt := reflect.TypeOf(val)
+		for i := range pt.NumMethod() {
+			names = append(names, pt.Method(i).Name)
+		}
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			names = append(names, cast.ToString(k.Interface()))
+		}
+	}
+
+	sort.Strings(names)
+	return names
 }
 
 func (ns *Namespace) Timer(name string) Timer {

--- a/tpl/debug/debug_integration_test.go
+++ b/tpl/debug/debug_integration_test.go
@@ -73,3 +73,25 @@ Dump: {{ debug.Dump . | safeHTML }}
 	b := hugolib.TestRunning(t, files)
 	b.AssertFileContent("public/index.html", "Dump: {\n  \"Date\": \"2012-03-15T00:00:00Z\"")
 }
+
+func TestDebugList(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+disableKinds = ["taxonomy", "term"]
+-- content/p1.md --
+---
+title: "P1"
+---
+-- layouts/page.html --
+List: {{ debug.List . | jsonify }}
+-- layouts/home.html --
+{{ $m := dict "b" 1 "a" 2 "c" 3 }}
+Map: {{ debug.List $m | jsonify }}
+`
+	b := hugolib.Test(t, files)
+	// Page struct: should contain exported fields and methods like Title, Date, etc.
+	b.AssertFileContent("public/p1/index.html", `"Title"`)
+	// Map: should return sorted keys.
+	b.AssertFileContent("public/index.html", `["a","b","c"]`)
+}

--- a/tpl/debug/init.go
+++ b/tpl/debug/init.go
@@ -58,6 +58,11 @@ func init() {
 			[][2]string{},
 		)
 
+		ns.AddMethodMapping(ctx.List,
+			nil,
+			[][2]string{},
+		)
+
 		ns.AddMethodMapping(ctx.Timer,
 			nil,
 			[][2]string{},


### PR DESCRIPTION
Add `debug.List` that uses reflection to return a sorted string slice of:
- **Structs/pointers**: exported field names + method names
- **Maps**: keys (cast to string)

Non-recursive, one level deep.

```
{{ debug.List . }}       → ["BundleType","Content","Data","Date",...]
{{ debug.List $myMap }}  → ["key1","key2","key3"]
```

> This PR was written with assistance from Claude Code.

Fixes #9148