### PR TITLE
hugolib: include content file path in error messages

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1728,11 +1728,10 @@ func (s *Site) renderForTemplate(ctx context.Context, name, outputFormat string,
 	}
 
 	if err = s.GetTemplateStore().ExecuteWithContext(ctx, templ, w, d); err != nil {
-		filename := name
 		if p, ok := d.(*pageState); ok {
-			filename = p.String()
+			return fmt.Errorf("render of %q failed for %q: %w", name, p.String(), err)
 		}
-		return fmt.Errorf("render of %q failed: %w", filename, err)
+		return fmt.Errorf("render of %q failed: %w", name, err)
 	}
 	return
 }


### PR DESCRIPTION
## Problem

When Hugo encounters an error during content file rendering, the error message does not include which content file caused the issue, making it difficult for users to identify the problematic file.

## Solution

Modified the renderForTemplate function in hugolib/site.go to include the page path in error messages when a template render fails for a page.

## Changes

- When a render error occurs and the data is a *pageState, the error message now includes the page path
- Error format: render of "template_name" failed for "page_path": original_error

## Example

Before:
render of "list" failed: template: ...

After:
render of "list" failed for "content/posts/my-post.md": template: ...

Closes #14607