### PR TITLE
fix: multilingual URL rendering with uglyURLs

### DIFF
--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -366,7 +366,19 @@ func (s *Site) renderDefaultSiteRedirect(home *pageState) error {
 		//    /,/guest/ =  /guest/v1.0.0/
 		parts := strings.Split(strings.Trim(homeLink, "/"), "/")
 
-		for i := 0; i < len(parts)-1; i++ {
+		// With uglyURLs enabled for home pages, homeLink ends with an index file
+		// (e.g., "/en/index.html"). We need to skip creating redirects for the
+		// directory that contains this index file, as the redirect path would
+		// resolve to the same file (via targetPathAlias), overwriting the home page.
+		// See https://github.com/gohugoio/hugo/issues/14576
+		lastPartIsIndex := len(parts) > 0 && strings.HasPrefix(parts[len(parts)-1], of.BaseName+".")
+
+		skipCount := 0
+		if lastPartIsIndex {
+			skipCount = 1
+		}
+
+		for i := 0; i < len(parts)-1-skipCount; i++ {
 			ps = append(ps, paths.AddLeadingAndTrailingSlash(strings.Join(parts[0:i+1], "/")))
 		}
 	}

--- a/hugolib/sitesmatrix/sitematrix_integration_test.go
+++ b/hugolib/sitesmatrix/sitematrix_integration_test.go
@@ -1746,3 +1746,44 @@ title: p1 de
 </ul>
 	`)
 }
+
+// Issue 14576
+// Test that uglyURLs with defaultContentLanguageInSubdir does not create
+// a redirect at the default language home page that would overwrite the actual content.
+func TestSitesMatrixUglyURLsDefaultContentLanguageInSubdir(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+disableKinds = ["sitemap", "taxonomy", "term"]
+defaultContentLanguage = "en"
+defaultContentLanguageInSubDir = true
+uglyURLs = true
+[languages]
+[languages.en]
+languageName = "English"
+weight = 1
+[languages.fr]
+languageName = "Français"
+weight = 2
+-- layouts/index.html --
+Home Content: {{ .Language.LanguageName }}
+-- content/_index.md --
+---
+title: "Home"
+---
+`
+
+	b := hugolib.Test(t, files)
+
+	// The root index.html should be a redirect to the default language home page
+	b.AssertFileContent("public/index.html", "url=https://example.org/en/index.html")
+
+	// The default language home page (/en/index.html) should have actual content,
+	// NOT a redirect. This is the bug fix - previously it would also be a redirect.
+	b.AssertFileContent("public/en/index.html", "Home Content: English", "! url=https://example.org/en/index.html")
+
+	// The non-default language home page should have actual content
+	b.AssertFileContent("public/fr/index.html", "Home Content: Français")
+}


### PR DESCRIPTION
This PR fixes multilingual URL rendering when uglyURLs is enabled.\n\n## Changes\n- Fixed URL rendering to properly handle multilingual sites with uglyURLs\n\nFixes #14576