### PR TITLE
hugolib: Fix error position for nested shortcode extraction failures

### DIFF
--- a/hugolib/hugo_sites_build_errors_test.go
+++ b/hugolib/hugo_sites_build_errors_test.go
@@ -421,6 +421,39 @@ line 4
 	b.Assert(errors[3].ErrorContext().Lines, qt.DeepEquals, []string{"line 1", "line 2", "123{{ .ThisDoesNotExist }}", "line 4"})
 }
 
+// Issue #11302: "failed to extract" error should refer to inner shortcode, not outer.
+func TestErrorNestedShortcodeExtractInnerNotFound(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+-- content/_index.md --
+---
+title: "Home"
+---
+
+## Hello
+{{< outer >}}{{< inner >}}{{< /outer >}}
+
+-- layouts/home.html --
+{{ .Content }}
+-- layouts/_shortcodes/outer.html --
+<div>{{ .Inner }}</div>
+`
+
+	b, err := TestE(t, files)
+
+	b.Assert(err, qt.IsNotNil)
+	fe := herrors.UnwrapFileError(err)
+	b.Assert(fe, qt.Not(qt.IsNil))
+
+	// The error should point to the inner shortcode's position (line 6, column 12),
+	// not the outer shortcode's position (line 6, column 1).
+	b.Assert(fe.Position().LineNumber, qt.Equals, 6)
+	b.Assert(fe.Position().ColumnNumber, qt.Equals, 12)
+	b.Assert(fe.Error(), qt.Contains, `failed to extract shortcode: template for shortcode "inner" not found`)
+}
+
 func TestErrorRenderHookHeading(t *testing.T) {
 	t.Parallel()
 

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -612,6 +612,7 @@ Loop:
 			if cnt > 0 {
 				// nested shortcode; append it to inner content
 				pt.Backup()
+				nestedPos := currItem.Pos()
 				nested, err := s.extractShortcode(nestedOrdinal, nextLevel, source, pt)
 				nestedOrdinal++
 				if nested != nil && nested.name != "" {
@@ -621,7 +622,14 @@ Loop:
 				if err == nil {
 					sc.inner = append(sc.inner, nested)
 				} else {
-					return sc, err
+					// Wrap the error with the nested shortcode's position so that
+					// the error points to the correct shortcode (the inner one)
+					// rather than the outer shortcode.
+					if fe, ok := err.(herrors.FileError); ok {
+						return sc, fe
+					}
+					pos := posFromInput("", source, nestedPos)
+					return sc, herrors.NewFileErrorFromPos(err, pos)
 				}
 
 			} else {


### PR DESCRIPTION
Fixes #11302

## Problem
When nested shortcode extraction fails, the error position was not correctly reported, making debugging difficult.

## Solution
Fixed the error position reporting to correctly identify the location of the failing shortcode in nested scenarios.

## Testing
- Added tests for nested shortcode error position reporting
- Verified error messages now show correct line numbers