### PR TITLE
fix: show content file path in render error messages

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1728,11 +1728,10 @@ func (s *Site) renderForTemplate(ctx context.Context, name, outputFormat string,
 	}
 
 	if err = s.GetTemplateStore().ExecuteWithContext(ctx, templ, w, d); err != nil {
-		filename := name
 		if p, ok := d.(*pageState); ok {
-			filename = p.String()
+			return fmt.Errorf("render of %q failed: %w", p.getPageInfoForError(), err)
 		}
-		return fmt.Errorf("render of %q failed: %w", filename, err)
+		return fmt.Errorf("render of %q failed: %w", name, err)
 	}
 	return
 }


### PR DESCRIPTION
## Summary

Improves error messages when template rendering fails by showing the content file path, making it easier for users to locate the problematic file.

## Problem

Previously, when a template render failed, the error message only showed:
```
render of "page" failed: execute of template failed...
```

This made it difficult for users to identify which content file caused the error.

## Solution

Modified `renderForTemplate()` in `site.go` to use `getPageInfoForError()` which provides detailed page information:
- `kind`: Page type (e.g., "page", "home", "section")
- `path`: Page path (e.g., "posts/my-post")
- `file`: Content file path (e.g., "/content/posts/my-post.md")

New error message format:
```
render of "kind: "page", path: "posts/my-post", file: "/content/posts/my-post.md"" failed: execute of template failed...
```

## Changes

- `hugolib/site.go` - Modified `renderForTemplate` to use `getPageInfoForError()` for better error context

## Testing

- `go build ./...` ✓
- `go test -v -run TestRender ./hugolib/...` ✓

Fixes #14607