### PR TITLE
fix: prevent panic in TOC generation with passthrough nodes

### DIFF
--- a/markup/goldmark/convert.go
+++ b/markup/goldmark/convert.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 
 	"github.com/gohugoio/hugo-goldmark-extensions/extras"
+	passthroughExt "github.com/gohugoio/hugo-goldmark-extensions/passthrough"
 	"github.com/gohugoio/hugo/markup/goldmark/blockquotes"
 	"github.com/gohugoio/hugo/markup/goldmark/codeblocks"
 	"github.com/gohugoio/hugo/markup/goldmark/goldmark_config"
@@ -121,6 +122,13 @@ func newMarkdown(pcfg converter.ProviderConfig) goldmark.Markdown {
 			renderer.WithNodeRenderers(util.Prioritized(extras.NewInlineTagHTMLRenderer(tag), tag.RenderPriority)),
 		)
 	}
+
+	// Add passthrough renderer for TOC to prevent panic when rendering headings
+	// that contain passthrough nodes (e.g., LaTeX like $a$) nested inside other
+	// inline elements like emphasis. Issue #14677.
+	tocRendererOptions = append(tocRendererOptions,
+		renderer.WithNodeRenderers(util.Prioritized(newTocPassthroughHTMLRenderer(), 90)),
+	)
 
 	var (
 		extensions = []goldmark.Extender{
@@ -352,4 +360,40 @@ func toTypographicPunctuationMap(t goldmark_config.Typographer) map[extension.Ty
 		extension.RightAngleQuote:  []byte(t.RightAngleQuote),
 		extension.Apostrophe:       []byte(t.Apostrophe),
 	}
+}
+
+// tocPassthroughHTMLRenderer is a simple renderer for passthrough nodes in TOC.
+// It renders the raw text content (including delimiters) without any special
+// processing, preventing panics when passthrough nodes appear in headings.
+// Issue #14677.
+type tocPassthroughHTMLRenderer struct{}
+
+func newTocPassthroughHTMLRenderer() renderer.NodeRenderer {
+	return &tocPassthroughHTMLRenderer{}
+}
+
+func (r *tocPassthroughHTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(passthroughExt.KindPassthroughInline, r.renderPassthrough)
+	reg.Register(passthroughExt.KindPassthroughBlock, r.renderPassthrough)
+}
+
+func (r *tocPassthroughHTMLRenderer) renderPassthrough(w util.BufWriter, src []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+
+	// For TOC, we want to render the raw content including delimiters.
+	// This is similar to what the passthrough extension does when no render hook is configured.
+	switch nn := node.(type) {
+	case *passthroughExt.PassthroughInline:
+		w.Write(nn.Text(src))
+	case *passthroughExt.PassthroughBlock:
+		l := nn.Lines().Len()
+		for i := range l {
+			line := nn.Lines().At(i)
+			w.Write(line.Value(src))
+		}
+	}
+
+	return ast.WalkContinue, nil
 }

--- a/markup/goldmark/toc_integration_test.go
+++ b/markup/goldmark/toc_integration_test.go
@@ -364,3 +364,40 @@ title: home
 		`<li><a href="#1st">1^st^</a></li>`,
 	)
 }
+
+// Issue 14677
+func TestTableOfContentsWithPassthrough(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+[markup.goldmark.extensions.passthrough]
+  enable = true
+[markup.goldmark.extensions.passthrough.delimiters]
+  inline = [['$', '$']]
+-- content/_index.md --
+---
+title: home
+---
+## Heading with **$a$**
+
+## Heading with $b$
+
+## Heading with *$x + y$*
+
+-- layouts/home.html --
+{{ .TableOfContents }}
+`
+
+	b := hugolib.Test(t, files)
+
+	// Should not panic and should render the passthrough content
+	// Note: Emphasis nodes are rendered with <em> tags, so passthrough inside
+	// emphasis will be wrapped in <em>.
+	b.AssertFileContent("public/index.html",
+		`<li><a href="#">Heading with <em>$a$</em></a></li>`,
+		`<li><a href="#">Heading with $b$</a></li>`,
+		`<li><a href="#">Heading with <em>$x + y$</em></a></li>`,
+	)
+}


### PR DESCRIPTION
## Summary

Fixes a runtime panic when generating Table of Contents (TOC) for headings that contain passthrough extension nodes (e.g., LaTeX `$a$`) nested within other inline elements (e.g., emphasis `**$a$**`).

## Problem

When using passthrough extensions like LaTeX math (`$a$`) nested in emphasis or other inline elements within a heading:

```markdown
**$a$** Heading
```

The TOC renderer would panic with:
```
runtime error: index out of range [0] with length 0
```

### Root Cause

1. The TOC renderer (`tocRendererOptions`) didn't register a renderer for passthrough nodes
2. When rendering Emphasis nodes, Goldmark recursively renders children
3. If a child is a Passthrough node without a registered renderer, it panics

## Solution

1. Added passthrough extension import to `convert.go`
2. Added passthrough renderer to `tocRendererOptions`
3. Implemented `tocPassthroughHTMLRenderer` to render passthrough node content as-is

## Changes

- `markup/goldmark/convert.go` (+44 lines)
- `markup/goldmark/toc_integration_test.go` (+37 lines) - Test case for nested passthrough in TOC

## Testing

Added integration test that reproduces the panic scenario with:
- LaTeX passthrough in emphasis within heading
- Verifies TOC renders without panic

Fixes #14677