### PR TITLE
commands: Close trace profile file when trace.Start fails

### DIFF
--- a/commands/hugobuilder.go
+++ b/commands/hugobuilder.go
@@ -301,6 +301,7 @@ func (c *hugoBuilder) initTraceProfile() (func(), error) {
 	}
 
 	if err := trace.Start(f); err != nil {
+		f.Close()
 		return nil, fmt.Errorf("failed to start trace: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes a resource leak in the `initTraceProfile` function where the trace file was not being closed when `trace.Start(f)` failed.

This is the same issue that was fixed for CPU profile in commit 9dd9c7602 (`commands: Close cpu profile file when StartCPUProfile fails`).

## Changes

- Added `f.Close()` before returning error when `trace.Start(f)` fails

## Before

```go
if err := trace.Start(f); err != nil {
    return nil, fmt.Errorf("failed to start trace: %w", err)
}
```

## After

```go
if err := trace.Start(f); err != nil {
    f.Close()
    return nil, fmt.Errorf("failed to start trace: %w", err)
}
```

This ensures the file handle is properly closed on error, preventing resource leaks.