### PR TITLE
tpl/tplimpl: extend page image lookup to include global resources

### DIFF
--- a/tpl/tplimpl/embedded/templates/_partials/_funcs/get-page-images.html
+++ b/tpl/tplimpl/embedded/templates/_partials/_funcs/get-page-images.html
@@ -23,9 +23,8 @@
   {{- $img := . }}
   {{- $url := urls.Parse $img }}
   {{- if eq $url.Scheme "" }}
-    {{/* Internal image. */}}
-    {{- with $resources.GetMatch $img -}}
-      {{/* Image resource. */}}
+    {{/* Internal image: check page resources first, then global resources. */}}
+    {{- with or ($resources.GetMatch $img) (resources.Get $img) -}}
       {{- $imgs = $imgs | append (dict
         "Image" .
         "RelPermalink" .RelPermalink


### PR DESCRIPTION
Extend `_partials/_funcs/get-page-images.html` to fall back to global resources via `resources.Get` when page resources don't match for named images specified in the `images` front matter parameter.

This aligns its behavior with:
- `_markup/render-image.html` — uses `or (.PageInner.Resources.Get $path) (resources.Get $path)`
- `_markup/render-link.html` — same pattern
- `_shortcodes/figure.html` — same pattern

The featured image auto-detection (`*feature*`, `*cover*`, `*thumbnail*`) is left unchanged since those glob patterns are specific to page bundles.

> This PR was written with assistance from Claude Code.

Fixes #14062