### PR TITLE
tpl: Fix stray quotes from partial decorator in script context

### DIFF
--- a/tpl/templates/decorator_falsy_test.go
+++ b/tpl/templates/decorator_falsy_test.go
@@ -61,3 +61,30 @@ title: "Page 1"
 
 	b.AssertFileContent("public/index.html", "d:truthy", "$")
 }
+
+// Issue 14711
+// When using {{ with partial "name" . }} inside a <script> tag,
+// the injected else block's empty string return was being JS-escaped to "".
+func TestDecoratorPartialFalsyReturnInScript(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ["section", "taxonomy", "term", "sitemap", "RSS"]
+-- content/p1.md --
+---
+title: "Page 1"
+---
+-- layouts/_partials/empty.html --
+{{ return "" }}
+-- layouts/home.html --
+<script>
+  {{- with partial "empty" . }}
+  "this-should-be-skipped": "{{ . }}"
+  {{- end }}
+</script>
+`
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/index.html", "! \"\"")
+}

--- a/tpl/templates/templates.go
+++ b/tpl/templates/templates.go
@@ -17,6 +17,7 @@ package templates
 import (
 	"context"
 	"fmt"
+	htmltemplate "html/template"
 	"strconv"
 	"sync/atomic"
 
@@ -113,7 +114,10 @@ func (ns *Namespace) _PopPartialDecorator(ctx context.Context, id string) any {
 	}
 	if !top.Bool {
 		// Prevents anything being rendered if inner was not called.
-		return ""
+		// Use template.JS to avoid Go's html/template JS escaper
+		// wrapping an empty string in quotes inside <script> tags.
+		// See https://github.com/gohugoio/hugo/issues/14711
+		return htmltemplate.JS("")
 	}
 	return top.Bool // return whether inner exists in the wrapped partial.
 }


### PR DESCRIPTION
Use template.JS for the falsy return value of _PopPartialDecorator
so Go's html/template JS escaper doesn't wrap the empty string in
quotes inside <script> tags.

Fixes #14711

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
