### PR TITLE
tpl: prevent falsy with partial rendering quotes in script context

### DIFF
--- a/tpl/templates/templates.go
+++ b/tpl/templates/templates.go
@@ -17,6 +17,7 @@ package templates
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"strconv"
 	"sync/atomic"
 
@@ -113,7 +114,7 @@ func (ns *Namespace) _PopPartialDecorator(ctx context.Context, id string) any {
 	}
 	if !top.Bool {
 		// Prevents anything being rendered if inner was not called.
-		return ""
+		return template.JS("")
 	}
 	return top.Bool // return whether inner exists in the wrapped partial.
 }

--- a/tpl/tplimpl/tplimpl_integration_test.go
+++ b/tpl/tplimpl/tplimpl_integration_test.go
@@ -162,6 +162,33 @@ func TestGoTemplateBugs(t *testing.T) {
 
 		b.AssertFileContent("public/index.html", `key = value`)
 	})
+	t.Run("Issue 14711 with partial empty JS string injection", func(t *testing.T) {
+		t.Parallel()
+
+		files := `
+-- hugo.toml --
+-- layouts/partials/empty.html --
+{{ return "" }}
+-- layouts/home.html --
+<div id="html-ctx">
+{{- with partial "empty.html" . -}}FAIL{{- end -}}
+</div>
+<script id="js-ctx">
+{{- with partial "empty.html" . -}}FAIL{{- end -}}
+</script>
+`
+
+		b := hugolib.NewIntegrationTestBuilder(
+			hugolib.IntegrationTestConfig{
+				T:           t,
+				TxtarString: files,
+			},
+		)
+		b.Build()
+
+		b.AssertFileContent("public/index.html", `<div id="html-ctx"></div>`)
+		b.AssertFileContent("public/index.html", `<script id="js-ctx"></script>`)
+	})
 }
 
 func TestSecurityAllowActionJSTmpl(t *testing.T) {


### PR DESCRIPTION
This commit was assisted by Google Gemini. [Conversation link](https://gemini.google.com/share/cd34cb3959d6).

More details in #14711

I do know that the test looks right and the fix works with the test. I'm not sure about whether there are effects farther in the codebase by switching this to a template.JS string