### PR TITLE
docs: fix broken links in top README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [bugs]: https://github.com/gohugoio/hugo/issues?q=is%3Aopen+is%3Aissue+label%3ABug
 [contributing]: CONTRIBUTING.md
 [create a proposal]: https://github.com/gohugoio/hugo/issues/new?labels=Proposal%2C+NeedsTriage&template=feature_request.md
-[dart sass]: hhttps://gohugo.io/functions/css/sass/#dart-sass
+[dart sass]: https://gohugo.io/functions/css/sass/#dart-sass
 [details]: https://gohugo.io/host-and-deploy/deploy-with-hugo-deploy/
 [documentation repository]: https://github.com/gohugoio/hugoDocs
 [documentation]: https://gohugo.io/documentation


### PR DESCRIPTION
# Context

Trying to read the documentation at <https://github.com/gohugoio/hugo> several links go nowhere.

# Actions

Switched links to full URLs that are working

# Verifies

Preview in this PR looks right.