### PR TITLE
fix(paths): allow '=' character in path validation

### DIFF
--- a/common/paths/path.go
+++ b/common/paths/path.go
@@ -329,7 +329,7 @@ func isAllowedPathCharacter(s string, i int, r rune) bool {
 	}
 	// Check for the most likely first (faster).
 	isAllowed := unicode.IsLetter(r) || unicode.IsDigit(r)
-	isAllowed = isAllowed || r == '.' || r == '/' || r == '\\' || r == '_' || r == '#' || r == '+' || r == '~' || r == '-' || r == '@'
+	isAllowed = isAllowed || r == '.' || r == '/' || r == '\\' || r == '_' || r == '#' || r == '+' || r == '~' || r == '-' || r == '@' || r == '='
 	isAllowed = isAllowed || unicode.IsMark(r)
 	isAllowed = isAllowed || (r == '%' && i+2 < len(s) && ishex(s[i+1]) && ishex(s[i+2]))
 	return isAllowed

--- a/common/paths/path_test.go
+++ b/common/paths/path_test.go
@@ -209,6 +209,7 @@ func TestSanitize(t *testing.T) {
 		{"a%C3%B1ame", "a%C3%B1ame"},         // Issue #1292
 		{"this+is+a+test", "this+is+a+test"}, // Issue #1290
 		{"~foo", "~foo"},                     // Issue #2177
+		{"foo=bar", "foo=bar"},               // Issue #12993
 
 	}
 


### PR DESCRIPTION
# What

- Allow the `=` character in Hugo page paths and URLs.

# Why

- `=` is a valid URL path character per RFC 3986 (sub-delimiters set).
- Hugo was silently dropping `=` from content file names/slugs, causing path conflicts and broken URLs (e.g. `foo=bar.md` would produce `/foobar/` instead of `/foo=bar/`).

# References

- https://github.com/gohugoio/hugo/issues/12993
