### PR TITLE
resources/page: Return empty :contentbasename for section pages

### DIFF
--- a/resources/page/permalinks.go
+++ b/resources/page/permalinks.go
@@ -335,7 +335,12 @@ func (l PermalinkExpander) pageToPermalinkSectionSlugs(p Page, attr string) (str
 }
 
 // pageToPermalinkContentBaseName returns the URL-safe form of the content base name.
+// For section pages it returns an empty string; :sections already carries the
+// section's own name, so emitting it again here would duplicate a path segment.
 func (l PermalinkExpander) pageToPermalinkContentBaseName(p Page, _ string) (string, error) {
+	if p.Kind() == kinds.KindSection {
+		return "", nil
+	}
 	return l.urlize(p.PathInfo().Unnormalized().BaseNameNoIdentifier()), nil
 }
 

--- a/resources/page/permalinks_integration_test.go
+++ b/resources/page/permalinks_integration_test.go
@@ -122,11 +122,11 @@ slug: "mytagslug"
 	b.AssertFileContent("public/sectionslug/section-root-slug/page1-slug/index.html", "Single|page|/sectionslug/section-root-slug/page1-slug/|")
 	b.AssertFileContent("public/sectionslugs/sections-root-slug/level1-slug/page1-slug/index.html", "Single|page|/sectionslugs/sections-root-slug/level1-slug/page1-slug/|")
 
-	b.AssertFileContent("public/sectionwithfilefilename/withfilefilename/index.html", "List|section|/sectionwithfilefilename/withfilefilename/|")
+	b.AssertFileContent("public/sectionwithfilefilename/index.html", "List|section|/sectionwithfilefilename/|")
 
 	b.AssertFileContent("public/sectionwithfileslug/withfileslugvalue/index.html", "List|section|/sectionwithfileslug/withfileslugvalue/|")
 
-	b.AssertFileContent("public/sectionnofilefilename/nofilefilename/index.html", "List|section|/sectionnofilefilename/nofilefilename/|")
+	b.AssertFileContent("public/sectionnofilefilename/index.html", "List|section|/sectionnofilefilename/|")
 	b.AssertFileContent("public/sectionnofileslug/nofileslugs/index.html", "List|section|/sectionnofileslug/nofileslugs/|")
 	b.AssertFileContent("public/sectionnofiletitle1/nofiletitle1s/index.html", "List|section|/sectionnofiletitle1/nofiletitle1s/|")
 	b.AssertFileContent("public/sectionnofiletitle2/index.html", "List|section|/sectionnofiletitle2/|")
@@ -401,7 +401,7 @@ slug: "c2slug"
 	b := hugolib.Test(t, files)
 
 	// Sections.
-	b.AssertFileContent("public/mya/a/index.html", "As|/mya/a/|section|")
+	b.AssertFileContent("public/mya/index.html", "As|/mya/|section|")
 
 	// Pages.
 	b.AssertFileContent("public/myapage/b/index.html", "My Title|/myapage/b/|page|")
@@ -409,6 +409,42 @@ slug: "c2slug"
 	// Taxonomies.
 	b.AssertFileContent("public/myc/c1/index.html", "C1|/myc/c1/|term|")
 	b.AssertFileContent("public/myc/c2slug/index.html", "C2|/myc/c2slug/|term|")
+}
+
+// Issue 14104
+func TestPermalinksContentBaseNameSectionIssue14104(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['rss','sitemap','taxonomy','term']
+
+[permalinks.page]
+s1 = "/:sections[1:]/:slugorcontentbasename/"
+
+[permalinks.section]
+s1 = "/:sections[1:]/:slugorcontentbasename/"
+
+-- content/s1/s2/_index.md --
+---
+title: s2
+---
+-- content/s1/s2/p1.md --
+---
+title: p1
+---
+-- layouts/all.html --
+{{ .Title }}|
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileExists("public/index.html", true)
+	b.AssertFileExists("public/s2/index.html", true)
+	b.AssertFileExists("public/s2/p1/index.html", true)
+
+	b.AssertFileExists("public/s1/index.html", false)
+	b.AssertFileExists("public/s2/s2/index.html", false)
 }
 
 func TestIssue13755(t *testing.T) {


### PR DESCRIPTION
:sections already carries a section's own name, so also emitting it via
:contentbasename duplicates a path segment (e.g. /:sections[1:]/:slugorcontentbasename/
producing /bar/bar/ for a section at content/foo/bar/_index.md).

The previous fix in #14126 keyed on IsBranchBundle && File != nil, which
also collapsed term pages whose container name is their identity, and had
to be reverted (#14325). Scoping the empty return to Kind == section
leaves term, taxonomy and page behavior unchanged.

Fixes #14104

Co-authored-by: Joe Mooring <joe@mooring.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
