### PR TITLE
hugolib: Do not render aliases if the page is not rendered

### DIFF
--- a/hugolib/alias_test.go
+++ b/hugolib/alias_test.go
@@ -749,3 +749,43 @@ Output format: foo|Title: {{ .Title }}
 </head>
 	`)
 }
+
+// Issue 14807
+func TestDoNotRenderAliasesIfPageNotRendered14807(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+-- content/p1.md --
+---
+title: p1
+aliases: [p1-alias]
+---
+-- content/p2.md --
+---
+title: p2
+aliases: [p2-alias]
+build:
+  render: never
+---
+-- content/p3.md --
+---
+title: p3
+aliases: [p3-alias]
+build:
+  render: link
+---
+-- layouts/page.html --
+{{ .Title }}
+`
+
+	b := Test(t, files)
+
+	b.AssertFileExists("public/p1/index.html", true)
+	b.AssertFileExists("public/p2/index.html", false)
+	b.AssertFileExists("public/p3/index.html", false)
+	b.AssertFileExists("public/p1-alias/index.html", true)
+	b.AssertFileExists("public/p2-alias/index.html", false)
+	b.AssertFileExists("public/p3-alias/index.html", false)
+}

--- a/hugolib/disableKinds_test.go
+++ b/hugolib/disableKinds_test.go
@@ -191,7 +191,7 @@ DATA
 		files := filesForDisabledKind("")
 		b := Test(t, files)
 		b.AssertFileExists("public/sect/no-render-link/index.html", false)
-		b.AssertFileContent("public/link-alias/index.html", "refresh")
+		b.AssertFileExists("public/link-alias/index.html", false)
 	})
 
 	t.Run("Build config, no publish resources", func(t *testing.T) {

--- a/hugolib/page__output.go
+++ b/hugolib/page__output.go
@@ -86,7 +86,7 @@ func newPageOutput(
 type pageOutput struct {
 	p *pageState
 
-	// Set if this page isn't configured to be rendered to this format.
+	// Set if this page is configured to be rendered to this format.
 	render bool
 
 	f output.Format

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -154,7 +154,7 @@ func pageRenderer(
 			}
 		}
 
-		if !s.conf.DisableAliases && !s.h.BuildState.IsRebuild() {
+		if !s.conf.DisableAliases && !s.h.BuildState.IsRebuild() && p.render {
 			of := p.outputFormat()
 			if of.IsHTML && of.Permalinkable {
 				// Render any aliases for this page.


### PR DESCRIPTION
Closes #14807

Note: this changes an existing assertion in `hugolib/disableKinds_test.go`. I'm pretty sure the existing assertion was incorrect, but it needs another set of eyes.