### PR TITLE
common/hexec: Allow Tailwind child processes

### DIFF
--- a/common/hexec/exec.go
+++ b/common/hexec/exec.go
@@ -280,6 +280,11 @@ func (e *Exec) nodePermissionArgs(name, scriptPath string) []string {
 		args = append(args, "--allow-addons")
 	}
 
+	if slices.Contains(perms.AllowChildProcess, name) {
+		silenceSecurityWarnings = true
+		args = append(args, "--allow-child-process")
+	}
+
 	if slices.Contains(perms.AllowWorker, name) {
 		silenceSecurityWarnings = true
 		args = append(args, "--allow-worker")

--- a/common/hexec/exec_test.go
+++ b/common/hexec/exec_test.go
@@ -42,6 +42,7 @@ func TestNodePermissionArgs(t *testing.T) {
 			"--permission",
 			"--allow-fs-read=" + site,
 			"--allow-addons",
+			"--allow-child-process",
 			"--allow-worker",
 			"--disable-warning=SecurityWarning",
 		})
@@ -74,6 +75,7 @@ func TestNodePermissionArgs(t *testing.T) {
 			"--allow-fs-read=" + tmp,
 			"--allow-fs-write=" + site,
 			"--allow-addons",
+			"--allow-child-process",
 			"--allow-worker",
 			"--disable-warning=SecurityWarning",
 		})
@@ -93,6 +95,7 @@ func TestNodePermissionArgs(t *testing.T) {
 			"--allow-fs-read=*",
 			"--allow-fs-write=*",
 			"--allow-addons",
+			"--allow-child-process",
 			"--allow-worker",
 			"--disable-warning=SecurityWarning",
 		})
@@ -112,6 +115,7 @@ func TestNodePermissionArgs(t *testing.T) {
 	c.Run("No fs flags", func(c *qt.C) {
 		cfg := security.DefaultConfig
 		cfg.Node.Permissions.AllowRead = nil
+		cfg.Node.Permissions.AllowChildProcess = nil
 		cfg.Node.Permissions.AllowAddons = nil
 		cfg.Node.Permissions.AllowWorker = nil
 		e := &Exec{

--- a/config/security/securityConfig.go
+++ b/config/security/securityConfig.go
@@ -65,11 +65,12 @@ var DefaultConfig = Config{
 	},
 	Node: Node{
 		Permissions: NodePermissions{
-			Disable:     false,
-			AllowRead:   []string{"."},
-			AllowWrite:  []string{},              // No write access by default.
-			AllowAddons: []string{"tailwindcss"}, // tailwindcss does not work without addon permissions.
-			AllowWorker: []string{"tailwindcss"}, // tailwindcss needs worker access.
+			Disable:           false,
+			AllowRead:         []string{"."},
+			AllowWrite:        []string{},              // No write access by default.
+			AllowAddons:       []string{"tailwindcss"}, // tailwindcss does not work without addon permissions.
+			AllowChildProcess: []string{"tailwindcss"},
+			AllowWorker:       []string{"tailwindcss"}, // tailwindcss needs worker access.
 		},
 	},
 }
@@ -128,11 +129,12 @@ type Node struct {
 // Use "*" to allow all paths.
 type NodePermissions struct {
 	// Disable turns off the Node.js permission model entirely.
-	Disable     bool     `json:"disable"`
-	AllowRead   []string `json:"allowRead"`
-	AllowWrite  []string `json:"allowWrite"`
-	AllowAddons []string `json:"allowAddons"`
-	AllowWorker []string `json:"allowWorker"`
+	Disable           bool     `json:"disable"`
+	AllowRead         []string `json:"allowRead"`
+	AllowWrite        []string `json:"allowWrite"`
+	AllowAddons       []string `json:"allowAddons"`
+	AllowChildProcess []string `json:"allowChildProcess"`
+	AllowWorker       []string `json:"allowWorker"`
 }
 
 // IsEnabled reports whether the Node.js permission model is active.
@@ -219,6 +221,7 @@ func DecodeConfig(cfg config.Provider) (Config, error) {
 	sc.Node.Permissions.AllowRead = slices.Clone(sc.Node.Permissions.AllowRead)
 	sc.Node.Permissions.AllowWrite = slices.Clone(sc.Node.Permissions.AllowWrite)
 	sc.Node.Permissions.AllowAddons = slices.Clone(sc.Node.Permissions.AllowAddons)
+	sc.Node.Permissions.AllowChildProcess = slices.Clone(sc.Node.Permissions.AllowChildProcess)
 	sc.Node.Permissions.AllowWorker = slices.Clone(sc.Node.Permissions.AllowWorker)
 	if cfg.IsSet(securityConfigKey) {
 		m := cfg.GetStringMap(securityConfigKey)

--- a/config/security/securityConfig_test.go
+++ b/config/security/securityConfig_test.go
@@ -135,7 +135,7 @@ func TestToTOML(t *testing.T) {
 	got := DefaultConfig.ToTOML()
 
 	c.Assert(got, qt.Equals,
-		"[security]\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^(dart-)?sass(-embedded)?$', '^go$', '^git$', '^node$', '^postcss$', '^tailwindcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\\w+|(XDG_CONFIG_)?HOME|USERPROFILE|SSH_AUTH_SOCK|DISPLAY|LANG|SYSTEMDRIVE|PROGRAMDATA)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_', '^CI$']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['(?i)^https?://[a-z]', '! (?i)localhost', '! @']\n\n  [security.node]\n    [security.node.permissions]\n      allowAddons = ['tailwindcss']\n      allowRead = ['.']\n      allowWorker = ['tailwindcss']\n      allowWrite = []\n      disable = false",
+		"[security]\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^(dart-)?sass(-embedded)?$', '^go$', '^git$', '^node$', '^postcss$', '^tailwindcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\\w+|(XDG_CONFIG_)?HOME|USERPROFILE|SSH_AUTH_SOCK|DISPLAY|LANG|SYSTEMDRIVE|PROGRAMDATA)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_', '^CI$']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['(?i)^https?://[a-z]', '! (?i)localhost', '! @']\n\n  [security.node]\n    [security.node.permissions]\n      allowAddons = ['tailwindcss']\n      allowChildProcess = ['tailwindcss']\n      allowRead = ['.']\n      allowWorker = ['tailwindcss']\n      allowWrite = []\n      disable = false",
 	)
 }
 
@@ -168,6 +168,7 @@ func TestDecodeConfigDefault(t *testing.T) {
 	c.Assert(pc.Node.Permissions.IsEnabled(), qt.IsTrue)
 	c.Assert(pc.Node.Permissions.AllowRead, qt.DeepEquals, []string{"."})
 	c.Assert(pc.Node.Permissions.AllowWrite, qt.DeepEquals, []string{})
+	c.Assert(pc.Node.Permissions.AllowChildProcess, qt.DeepEquals, []string{"tailwindcss"})
 }
 
 func TestCheckAllowedHTTPURLHardenedDefaultsIssue14792(t *testing.T) {
@@ -256,6 +257,7 @@ func TestDecodeConfigNodePermissions(t *testing.T) {
 [security.node.permissions]
 allowRead = ["/tmp", "."]
 allowWrite = ["."]
+allowChildProcess = ["tailwindcss"]
 `
 		cfg, err := config.FromConfigString(tomlConfig, "toml")
 		c.Assert(err, qt.IsNil)
@@ -264,6 +266,7 @@ allowWrite = ["."]
 		c.Assert(pc.Node.Permissions.IsEnabled(), qt.IsTrue)
 		c.Assert(pc.Node.Permissions.AllowRead, qt.DeepEquals, []string{"/tmp", "."})
 		c.Assert(pc.Node.Permissions.AllowWrite, qt.DeepEquals, []string{"."})
+		c.Assert(pc.Node.Permissions.AllowChildProcess, qt.DeepEquals, []string{"tailwindcss"})
 	})
 
 	c.Run("Disabled", func(c *qt.C) {


### PR DESCRIPTION
## Summary

Allow `tailwindcss` to use Node's `--allow-child-process` permission by default, matching the existing default allowances for addons and workers. This keeps Tailwind plugins that probe the host environment from failing under Node's permission model.

Fixes #14824

AI assistance disclosure: This narrow bug fix was implemented with AI assistance; I reviewed the code and ran the checks below.

## Tests

- `go test ./common/hexec ./config/security`
- `./check.sh ./common/hexec/...`
- `./check.sh ./config/security/...`
- `git diff --check`
