### PR TITLE
commands: fix github-dark chromastyles

### DIFF
--- a/commands/gen.go
+++ b/commands/gen.go
@@ -88,6 +88,7 @@ See https://gohugo.io/quick-reference/syntax-highlighting-styles/ for a preview 
 				}
 				options := []html.Option{
 					html.WithCSSComments(!omitClassComments),
+					html.WithCustomCSS(chromaCSSOverrides(style)),
 				}
 				formatter := html.New(options...)
 
@@ -273,6 +274,33 @@ url: %s
 			newDocsHelper(),
 		},
 	}
+}
+
+func chromaCSSOverrides(style *chroma.Style) map[chroma.TokenType]string {
+	bg := style.Get(chroma.Background)
+	m := make(map[chroma.TokenType]string)
+	for tt := range chroma.StandardTypes {
+		if tt == chroma.Background || !style.Has(tt) || !chromaLeafToken(tt) {
+			continue
+		}
+		entry := style.Get(tt)
+		if !entry.Sub(bg).IsZero() || !entry.Colour.IsSet() {
+			continue
+		}
+		if css := html.StyleEntryToCSS(chroma.StyleEntry{Colour: entry.Colour}); css != "" {
+			m[tt] = css
+		}
+	}
+	return m
+}
+
+func chromaLeafToken(tt chroma.TokenType) bool {
+	for other := range chroma.StandardTypes {
+		if other != tt && (other.Category() == tt || other.SubCategory() == tt) {
+			return false
+		}
+	}
+	return true
 }
 
 type genCommand struct {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gohugoio/hugo
 require (
 	github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0
-	github.com/alecthomas/chroma/v2 v2.23.1
+	github.com/alecthomas/chroma/v2 v2.23.2-0.20260408022300-8d04def94bbc
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.61.1
 	github.com/bep/clocks v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gohugoio/hugo
 require (
 	github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0
-	github.com/alecthomas/chroma/v2 v2.23.2-0.20260408022300-8d04def94bbc
+	github.com/alecthomas/chroma/v2 v2.24.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.61.1
 	github.com/bep/clocks v0.5.0
@@ -127,7 +127,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.6.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
-	github.com/dlclark/regexp2 v1.11.5 // indirect
+	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ
 github.com/alecthomas/chroma/v2 v2.23.1/go.mod h1:NqVhfBR0lte5Ouh3DcthuUCTUpDC9cxBOfyMbMQPs3o=
 github.com/alecthomas/chroma/v2 v2.23.2-0.20260408022300-8d04def94bbc h1:DeAUK41O6QGArswbgBhFnsCQ9cZr6F905IqvuSCQTBs=
 github.com/alecthomas/chroma/v2 v2.23.2-0.20260408022300-8d04def94bbc/go.mod h1:NqVhfBR0lte5Ouh3DcthuUCTUpDC9cxBOfyMbMQPs3o=
+github.com/alecthomas/chroma/v2 v2.24.0 h1:zrg+k0tAaVbM8whaT2hR5DOUqAdopsDaH998EGi6Llk=
+github.com/alecthomas/chroma/v2 v2.24.0/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
@@ -211,6 +213,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8v
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ/Vk/iY=
 github.com/alecthomas/chroma/v2 v2.23.1/go.mod h1:NqVhfBR0lte5Ouh3DcthuUCTUpDC9cxBOfyMbMQPs3o=
+github.com/alecthomas/chroma/v2 v2.23.2-0.20260408022300-8d04def94bbc h1:DeAUK41O6QGArswbgBhFnsCQ9cZr6F905IqvuSCQTBs=
+github.com/alecthomas/chroma/v2 v2.23.2-0.20260408022300-8d04def94bbc/go.mod h1:NqVhfBR0lte5Ouh3DcthuUCTUpDC9cxBOfyMbMQPs3o=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=

--- a/markup/highlight/highlight_test.go
+++ b/markup/highlight/highlight_test.go
@@ -17,6 +17,9 @@ package highlight
 import (
 	"testing"
 
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/styles"
+
 	qt "github.com/frankban/quicktest"
 )
 
@@ -144,4 +147,13 @@ User-Agent: foo
 		c.Assert(result, qt.Contains, "hello")
 		c.Assert(result, qt.Contains, "}")
 	})
+}
+
+func TestGitHubDarkStyleIncludesNameOther(t *testing.T) {
+	c := qt.New(t)
+
+	style := styles.Get("github-dark")
+	c.Assert(style, qt.Not(qt.IsNil))
+	c.Assert(style.Has(chroma.NameOther), qt.Equals, true)
+	c.Assert(style.Get(chroma.NameOther).Colour.String(), qt.Equals, "#e6edf3")
 }

--- a/testscripts/commands/gen.txt
+++ b/testscripts/commands/gen.txt
@@ -22,6 +22,11 @@ hugo gen chromastyles --style monokai
 hugo gen chromastyles --omitEmpty --style monokai --logLevel info
 stderr 'deprecated: --omitEmpty was deprecated'
 
+# Keep same-colour token classes in generated CSS. This is needed when pairing
+# styles such as github and github-dark in dual-theme sites.
+hugo gen chromastyles --style github-dark
+stdout 'NameOther.*\.chroma \.nx \{ color:#e6edf3 \}'
+
 # Disable class comments.
 hugo gen chromastyles --style monokai
 stdout 'GenericSubheading'


### PR DESCRIPTION
## Summary
- update Chroma to the commit that adds `NameOther` to `github-dark`
- make `hugo gen chromastyles` emit foreground overrides for explicit leaf tokens omitted by Chroma same-as-background optimization
- add regressions for `github-dark` / `.nx`

Closes #14730

## Tests
- `go test ./markup/highlight -run TestGitHubDarkStyleIncludesNameOther -count=1`
- `go test -run 'TestCommands/gen' .`
- `./check.sh ./markup/highlight/...`
- `./check.sh ./commands/...`
- `./check.sh`

AI assistance disclosure:
- Developed with AI assistance; changes and validation were reviewed before submission.