### PR TITLE
magefile: Fix typo in test comments

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -181,7 +181,7 @@ func Test386() error {
 func Test() error {
 	env := map[string]string{"GOFLAGS": testGoFlags()}
 	if isCI() {
-		// We have space issues on GitHub Actions (lots tests, incresing usage of Go generics).
+		// We have space issues on GitHub Actions (lots tests, increasing usage of Go generics).
 		// Test each package separately and clean up in between.
 		pkgs, err := hugoPackages()
 		if err != nil {
@@ -205,7 +205,7 @@ func Test() error {
 func TestRace() error {
 	env := map[string]string{"GOFLAGS": testGoFlags()}
 	if isCI() {
-		// We have space issues on GitHub Actions (lots tests, incresing usage of Go generics).
+		// We have space issues on GitHub Actions (lots tests, increasing usage of Go generics).
 		// Test each package separately and clean up in between.
 		pkgs, err := hugoPackages()
 		if err != nil {


### PR DESCRIPTION
Fixes a small typo in the CI comments inside `Test()` and `TestRace()` in `magefile.go`: "incresing" → "increasing".

Comment-only change, no functional impact.

---

AI Assistance Notice: This patch was prepared with help from Claude. The change is a 2-line typo fix in code comments only.