### PR TITLE
markup/highlight: fix HighlightCodeBlock.Inner for code blocks without language

### DIFF
--- a/markup/highlight/highlight.go
+++ b/markup/highlight/highlight.go
@@ -179,13 +179,17 @@ func highlight(fw hugio.FlexiWriter, code, lang string, attributes []attributes.
 	w := &byteCountFlexiWriter{delegate: fw}
 
 	if lexer == nil {
+		var pw *preWrapper
 		if cfg.Hl_inline {
 			fmt.Fprintf(w, "<code%s>%s</code>", inlineCodeAttrs(lang), gohtml.EscapeString(code))
 		} else {
-			preWrapper := getPreWrapper(lang, w)
-			fmt.Fprint(w, preWrapper.Start(true, ""))
+			pw = getPreWrapper(lang, w)
+			fmt.Fprint(w, pw.Start(true, ""))
 			fmt.Fprint(w, gohtml.EscapeString(code))
-			fmt.Fprint(w, preWrapper.End(true))
+			fmt.Fprint(w, pw.End(true))
+		}
+		if pw != nil {
+			return pw.low, pw.high, nil
 		}
 		return 0, 0, nil
 	}


### PR DESCRIPTION
When a code block has no language specified and no lexer can be found, the preWrapper was being created and used to write content, but its low/high positions were not being returned. This caused .Inner() to return the full highlighted output including wrapping tags.

Now when lexer is nil, we track the preWrapper and return its low/high positions so that .Inner() correctly extracts just the code content.

Fixes #14820