### PR TITLE
hugolib: Don't warn about lang/kind/path coming from cascade.params

### DIFF
--- a/hugolib/cascade_test.go
+++ b/hugolib/cascade_test.go
@@ -543,3 +543,31 @@ cascade:
 	b.AssertFileExists("public/s2/p2/index.html", false)
 	b.AssertFileExists("public/s2/p3/index.html", false)
 }
+
+// Issue 14848
+func TestCascadeParamsLangIssue14848(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org"
+disableKinds = ['rss','sitemap','taxonomy','term']
+-- content/_index.md --
+---
+title: Home
+cascade:
+  params:
+    lang: en
+---
+-- content/p1.md --
+---
+title: p1
+---
+-- layouts/all.html --
+{{ .Title }}|lang: {{ .Params.lang }}|
+`
+
+	b := Test(t, files)
+
+	b.AssertFileContent("public/p1/index.html", "p1|lang: en|")
+}

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -679,7 +679,12 @@ params:
 
 		if loki == "path" || loki == "kind" || loki == "lang" {
 			// See issue 12484.
-			hugo.DeprecateLevelMin(loki+" in front matter", "", "v0.144.0", logg.LevelWarn)
+			// Only warn when the key was set at the top level of the
+			// original front matter; cascade.params can legitimately carry
+			// these names as user params (issue 14848).
+			if _, ok := pm.pageConfigSource.Frontmatter[loki]; ok {
+				hugo.DeprecateLevelMin(loki+" in front matter", "", "v0.144.0", logg.LevelWarn)
+			}
 		}
 
 		switch loki {


### PR DESCRIPTION
These keys are reserved at the top level of front matter, but are
legitimate user params under cascade.params. Only fire the deprecation
when the key was actually set at the top level of the original front
matter.

Fixes #14848
