### PR TITLE
parser: Drop empty sub maps from `hugo config` output

### DIFF
--- a/parser/lowercase_camel_json.go
+++ b/parser/lowercase_camel_json.go
@@ -116,6 +116,9 @@ func (c ReplacingJSONMarshaller) MarshalJSON() ([]byte, error) {
 					switch vv := v.(type) {
 					case map[string]any:
 						removeZeroVAlues(vv)
+						if len(vv) == 0 {
+							delete(m, k)
+						}
 					case []any:
 						for _, vvv := range vv {
 							if m, ok := vvv.(map[string]any); ok {

--- a/parser/lowercase_camel_json_test.go
+++ b/parser/lowercase_camel_json_test.go
@@ -31,3 +31,60 @@ func TestReplacingJSONMarshaller(t *testing.T) {
 
 	c.Assert(string(b), qt.Equals, `{"baz":42,"foo":"bar"}`)
 }
+
+// Issue 14855
+func TestReplacingJSONMarshallerOmitEmptySubMaps(t *testing.T) {
+	c := qt.New(t)
+
+	m := map[string]any{
+		"keep": "yes",
+		"target": map[string]any{
+			"path": "/x",
+			"sites": map[string]any{
+				"matrix": map[string]any{
+					"languages": []any{},
+					"versions":  []any{},
+				},
+				"complements": map[string]any{
+					"languages": []any{},
+				},
+			},
+		},
+		"all_zero_branch": map[string]any{
+			"inner": map[string]any{
+				"empty": "",
+				"deep": map[string]any{
+					"zero": 0,
+				},
+			},
+		},
+		"keep_slice_of_maps": []any{
+			map[string]any{
+				"name":  "a",
+				"empty": "",
+				"sub":   map[string]any{"x": 0},
+			},
+		},
+	}
+
+	marshaller := ReplacingJSONMarshaller{
+		Value:       m,
+		KeysToLower: true,
+		OmitEmpty:   true,
+	}
+
+	b, err := marshaller.MarshalJSON()
+	c.Assert(err, qt.IsNil)
+
+	s := string(b)
+	c.Assert(s, qt.Contains, `"keep":"yes"`)
+	c.Assert(s, qt.Contains, `"path":"/x"`)
+	c.Assert(s, qt.Not(qt.Contains), `"sites"`)
+	c.Assert(s, qt.Not(qt.Contains), `"matrix"`)
+	c.Assert(s, qt.Not(qt.Contains), `"complements"`)
+	c.Assert(s, qt.Not(qt.Contains), `"all_zero_branch"`)
+	c.Assert(s, qt.Not(qt.Contains), `"inner"`)
+	c.Assert(s, qt.Not(qt.Contains), `"deep"`)
+	c.Assert(s, qt.Contains, `"name":"a"`)
+	c.Assert(s, qt.Not(qt.Contains), `"sub"`)
+}


### PR DESCRIPTION
Took a stab at this. Happy to drop the PR if you've already got something underway.

`ReplacingJSONMarshaller.MarshalJSON` walks the unmarshalled map and deletes zero-valued leaves when `OmitEmpty` is true, but it skips the truthiness check for any value that is itself a map. So once recursion empties a child map, the now-empty parent map sticks around in the output. With the issue's input, that surfaces as:

```toml
[[permalinks]]
  pattern = '/:year/:month/:slug/'
  [permalinks.target]
    path = '/{photo,photo/**}'

    [permalinks.target.sites]
      [permalinks.target.sites.complements]

      [permalinks.target.sites.matrix]
```

`sitesmatrix.Sites.IsZero` is defined and would return true here, but at this point in the pipeline everything is already a `map[string]any`, so the struct-level `IsZero` is gone.

The change after recursing into a child map, drop the key if the child is now empty. Slices of maps are deliberately left alone since removing slice entries would shift indices and the existing behavior never did that.

Verified locally with the issue's `hugo.toml`. Output for `permalinks`, `privacy`, etc. is now collapsed to just the populated fields, in `--format toml`, `--format yaml`, and `--format json`. `--printZero` is unchanged (that path doesn't enter the `OmitEmpty` block).

Added a regression test in `parser/lowercase_camel_json_test.go` covering:
- a nested chain of maps that should fully prune away
- a `target.sites.{matrix,complements}` shape with empty slice fields
- a slice-of-maps where the entry has an empty sub map but a populated sibling key (verifies the slice path still strips the sub map but keeps the entry)

Fixes #14855