### PR TITLE
resources/page: Add JSON omitzero tag to PageMatcher.Sites

### DIFF
--- a/resources/page/page_matcher.go
+++ b/resources/page/page_matcher.go
@@ -51,7 +51,7 @@ type PageMatcher struct {
 
 	// The sites to apply this to.
 	// Note that we currently only use the Matrix field for cascade matching.
-	Sites sitesmatrix.Sites
+	Sites sitesmatrix.Sites `json:"sites,omitzero"`
 
 	// A Glob pattern matching the Page's Environment, e.g. "{production,development}".
 	Environment string


### PR DESCRIPTION
## Summary

Fixes #14855

Running `hugo config` with legacy `[permalinks]` configuration prints empty sites sub-maps because `PageMatcher.Sites` has no JSON struct tag.

## Root Cause

In `resources/page/page_matcher.go:54`, the `Sites sitesmatrix.Sites` field has no JSON struct tag. When the field is zero-valued during config output, `json.Marshal` emits `{"matrix":{},"complements":{}}`, and the downstream zero-value cleanup pass never calls `IsZero()` or removes these empty sub-maps.

## Fix

Add `json:"sites,omitzero"` to line 54. Go 1.24+ `omitzero` calls the `IsZero()` method during marshal, dropping the field entirely when empty. This matches how the same `sitesmatrix.Sites` type is already tagged in `commands/config.go`.

## Changes

- `resources/page/page_matcher.go`: 1 line changed (`+1 -1`)

## Testing

- **`hugo config` with legacy `[permalinks]` config**: No empty sites sub-maps in output ✅
- **`hugo config` without permalinks**: No regression ✅
- **Existing cascade/PageMatcher behavior**: Unaffected (only affects JSON marshaling output) ✅