### PR TITLE
tpl: Add embedded templates for llms.txt and llms-full.txt

### DIFF
--- a/docs/content/en/templates/llms.md
+++ b/docs/content/en/templates/llms.md
@@ -1,0 +1,105 @@
+---
+title: llms.txt template
+linkTitle: llms.txt templates
+description: Hugo provides embedded templates for generating llms.txt and llms-full.txt files for AI agents and language models.
+categories: []
+keywords: []
+weight: 200
+---
+
+Hugo provides embedded templates for generating [llms.txt] files. These files list the pages on your site in a markdown format that AI agents and language models can consume directly, without needing to parse HTML.
+
+The `llms.txt` file provides a curated listing of pages with descriptions, organized by section. The `llms-full.txt` file contains the full plain text content of every page on your site.
+
+## Configuration
+
+To enable the llms.txt output formats, add them to your project configuration:
+
+{{< code-toggle file=hugo >}}
+outputFormats:
+  LLMS:
+    baseName: llms
+    mediaType: text/plain
+    isPlainText: true
+    root: true
+    rel: alternate
+  LLMSFull:
+    baseName: llms-full
+    mediaType: text/plain
+    isPlainText: true
+    root: true
+    rel: alternate
+outputs:
+  home:
+    - HTML
+    - RSS
+    - LLMS
+    - LLMSFull
+{{< /code-toggle >}}
+
+This configuration instructs Hugo to generate both `llms.txt` and `llms-full.txt` at the root of your site when building the home page.
+
+## llms.txt
+
+The [embedded template] generates a markdown file listing all regular pages on your site, grouped by section, with each page's title, permalink, and description.
+
+```text
+# Site Title
+
+Site description from your site configuration.
+
+## Posts
+- [First Post](https://example.com/posts/first/): A description of the first post.
+- [Second Post](https://example.com/posts/second/): A description of the second post.
+
+## Projects
+- [Project Alpha](https://example.com/projects/alpha/): What Project Alpha is about.
+```
+
+Pages with `draft: true` in front matter are excluded. To set a site-wide description, use the `description` key in your site configuration.
+
+## llms-full.txt
+
+The [embedded template] generates a plain text file containing the full content of every regular page, concatenated and separated with horizontal rules:
+
+```text
+# Site Title
+
+---
+
+# First Post
+
+Full plain text content of the first post...
+
+---
+
+# Second Post
+
+Full plain text content of the second post...
+```
+
+## Template lookup order
+
+You may overwrite the internal templates with custom templates. Hugo selects the template using this lookup order:
+
+For `llms.txt`:
+1. `/layouts/llms.txt`
+1. `/themes/<THEME>/layouts/llms.txt`
+
+For `llms-full.txt`:
+1. `/layouts/llms-full.txt`
+1. `/themes/<THEME>/layouts/llms-full.txt`
+
+## Custom template example
+
+This template generates a simple llms.txt with only pages that have the `llms` tag:
+
+```text {file="layouts/llms.txt"}
+# {{ .Site.Title }}
+{{ range where .Site.RegularPages "Params.tags" "intersect" (slice "llms") }}
+- [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+{{ end }}
+```
+
+[embedded template]: <{{% eturl llms %}}>
+[llms.txt]: https://llmstxt.org/

--- a/docs/content/en/templates/types.md
+++ b/docs/content/en/templates/types.md
@@ -385,6 +385,7 @@ Use other specialized templates to create:
 - [RSS feeds](/templates/rss/)
 - [404 error pages](/templates/404/)
 - [robots.txt files](/templates/robots/)
+- [llms.txt files](/templates/llms/)
 
 [`Alphabetical`]: /methods/taxonomy/alphabetical/
 [`block`]: /functions/go-template/block/

--- a/docs/data/embedded_template_urls.toml
+++ b/docs/data/embedded_template_urls.toml
@@ -36,6 +36,8 @@
 
 # Other
 'alias' = 'alias.html'
+'llms' = 'llms.txt'
+'llms-full' = 'llms-full.txt'
 'robots' = 'robots.txt'
 'rss' = 'rss.xml'
 'sitemap' = 'sitemap.xml'

--- a/tpl/tplimpl/embedded/templates/llms-full.txt
+++ b/tpl/tplimpl/embedded/templates/llms-full.txt
@@ -1,0 +1,15 @@
+{{- with .Site }}
+# {{ .Title }}
+
+{{- with .Params.description }}
+{{ . }}
+{{- end }}
+{{- $pages := where .RegularPages "Draft" "!=" true }}
+{{- range $pages }}
+{{ "---" }}
+
+# {{ .Title }}
+
+{{ .Plain }}
+{{- end }}
+{{- end }}

--- a/tpl/tplimpl/embedded/templates/llms.txt
+++ b/tpl/tplimpl/embedded/templates/llms.txt
@@ -1,0 +1,16 @@
+{{- with .Site }}
+# {{ .Title }}
+
+{{- with .Params.description }}
+{{ . }}
+{{- end }}
+{{- $pages := where .RegularPages "Draft" "!=" true }}
+{{- range ($pages.GroupBy "Section") }}
+{{- if ne .Key "" }}
+## {{ .Key | title }}
+{{- end }}
+{{- range .Pages }}
+- [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This PR adds two new embedded templates that allow Hugo sites to generate `llms.txt` and `llms-full.txt` files for AI agents and language models, following the [llms.txt convention](https://llmstxt.org/).

## Changes

- **New embedded template** `tpl/tplimpl/embedded/templates/llms.txt` — generates a markdown listing of all regular pages, grouped by section, with titles, permalinks, and descriptions
- **New embedded template** `tpl/tplimpl/embedded/templates/llms-full.txt` — generates a plain text concatenation of all page content
- **New documentation** `docs/content/en/templates/llms.md` — explains how to enable and customize the output formats
- **Updated** `docs/content/en/templates/types.md` — added link to the new template docs
- **Updated** `docs/data/embedded_template_urls.toml` — added URL references for the embedded templates

## Usage

Users enable these by adding custom output formats to their project configuration:

```yaml
outputFormats:
  LLMS:
    baseName: llms
    mediaType: text/plain
    isPlainText: true
    root: true
    rel: alternate
  LLMSFull:
    baseName: llms-full
    mediaType: text/plain
    isPlainText: true
    root: true
    rel: alternate
outputs:
  home:
    - HTML
    - RSS
    - LLMS
    - LLMSFull
```

Both templates exclude draft pages. The `llms.txt` template respects `Site.Params.description` for a site-level description.

## Design decisions

- The templates are deliberately kept simple and general-purpose, matching the approach of other embedded templates (robots.txt, sitemap.xml)
- Not added to `DefaultFormats` to avoid conflicts with existing `.txt` suffix resolution — users opt in via configuration
- Section grouping follows Hugo's natural page organization by content directory
- `Root: true` places the files at the site root (e.g., `https://example.com/llms.txt`) which is the standard location

## AI Assistance Notice

This PR was written primarily by Jasper (AI agent) on behalf of Magnus Hedemark. The contributor understands the code and can answer questions about it.

See #14121