### PR TITLE
js: Return error for missing batch imports

### DIFF
--- a/internal/js/esbuild/batch.go
+++ b/internal/js/esbuild/batch.go
@@ -45,7 +45,6 @@ import (
 	"github.com/gohugoio/hugo/resources/resource_factories/create"
 	"github.com/gohugoio/hugo/tpl/tplimpl"
 	"github.com/mitchellh/mapstructure"
-	"github.com/spf13/cast"
 )
 
 var _ js.Batcher = (*batcher)(nil)
@@ -567,17 +566,17 @@ func (b *batcher) doBuild(ctx context.Context) (*Package, error) {
 				}
 				return ""
 			},
-			ImportOnLoadFunc: func(args api.OnLoadArgs) string {
+			ImportOnLoadFunc: func(args api.OnLoadArgs) (string, error) {
 				imp := args.Path
 
 				if r, found := state.importResource.Get(imp); found {
-					content, err := r.(resource.ContentProvider).Content(ctx)
+					content, err := resources.InternalResourceSourceContent(ctx, r)
 					if err != nil {
-						panic(err)
+						return "", fmt.Errorf("failed to read import %q: %w", resources.InternalResourceSourcePathBestEffort(r), err)
 					}
-					return cast.ToString(content)
+					return content, nil
 				}
-				return ""
+				return "", nil
 			},
 			ImportParamsOnLoadFunc: func(args api.OnLoadArgs) json.RawMessage {
 				if importContext, found := state.importerImportContext.Get(args.Path); found {

--- a/internal/js/esbuild/batch_integration_test.go
+++ b/internal/js/esbuild/batch_integration_test.go
@@ -261,6 +261,26 @@ func TestBatchRenameBundledScript(t *testing.T) {
 	b.Build()
 }
 
+func TestBatchMissingImportedAssetIssue13737(t *testing.T) {
+	files := jsBatchFilesTemplate
+	b := hugolib.TestRunning(t, files, hugolib.TestOptWithOSFs())
+	b.AssertFileContent("public/mybatch/mygroup.js", "Hello, Main")
+
+	filename := filepath.Join(b.Cfg.WorkingDir, "assets/js/main.js")
+	content, err := os.ReadFile(filename)
+	b.Assert(err, qt.IsNil)
+	b.Assert(os.Remove(filename), qt.IsNil)
+
+	_, err = b.BuildE()
+	b.Assert(err, qt.IsNotNil)
+	b.Assert(err.Error(), qt.Contains, "failed to read import")
+	b.Assert(err.Error(), qt.Contains, "main.js")
+
+	b.Assert(os.WriteFile(filename, content, 0o666), qt.IsNil)
+	b.Build()
+	b.AssertFileContent("public/mybatch/mygroup.js", "Hello, Main")
+}
+
 func TestBatchErrorScriptResourceNotSet(t *testing.T) {
 	files := strings.Replace(jsBatchFilesTemplate, `(resources.Get "js/main.js")`, `(resources.Get "js/doesnotexist.js")`, 1)
 	b, err := hugolib.TestE(t, files, hugolib.TestOptWithOSFs())

--- a/internal/js/esbuild/options.go
+++ b/internal/js/esbuild/options.go
@@ -248,7 +248,7 @@ type InternalOptions struct {
 	TsConfig                string
 	EntryPoints             []string
 	ImportOnResolveFunc     func(string, api.OnResolveArgs) string
-	ImportOnLoadFunc        func(api.OnLoadArgs) string
+	ImportOnLoadFunc        func(api.OnLoadArgs) (string, error)
 	ImportParamsOnLoadFunc  func(args api.OnLoadArgs) json.RawMessage
 	ErrorMessageResolveFunc func(api.Message) *ErrorMessageResolved
 	ResolveSourceMapSource  func(string) string // Used to resolve paths in error source maps.

--- a/internal/js/esbuild/resolve.go
+++ b/internal/js/esbuild/resolve.go
@@ -314,7 +314,10 @@ func createBuildPlugins(rs *resources.Spec, assetsResolver *fsResolver, depsMana
 				})
 			build.OnLoad(api.OnLoadOptions{Filter: `.*`, Namespace: NsHugoImportResolveFunc},
 				func(args api.OnLoadArgs) (api.OnLoadResult, error) {
-					c := opts.ImportOnLoadFunc(args)
+					c, err := opts.ImportOnLoadFunc(args)
+					if err != nil {
+						return api.OnLoadResult{}, err
+					}
 					if c == "" {
 						return api.OnLoadResult{}, fmt.Errorf("ImportOnLoadFunc failed to resolve %q", args.Path)
 					}


### PR DESCRIPTION
## Summary

- Return errors from the js.Batch import loader instead of panicking when a previously registered resource cannot be read during a rebuild.
- Propagate those errors through esbuild so hugo server reports a build error and can recover on a later rebuild.
- Keep this scoped to the concrete missing batch import panic in #13737; the issue also mentions other live reload/deferred execution symptoms, so this intentionally uses See rather than Fixes.

See #13737

## Tests

- ./check.sh ./internal/js/esbuild/...
- ./check.sh

## AI Assistance

I used AI assistance to help investigate the issue, implement the change, and prepare tests. I reviewed the final diff, scope, and test coverage before publishing.