### PR TITLE
hugolib: Return error for missing deferred execution

### DIFF
--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -543,7 +543,7 @@ func (s *Site) executeDeferredTemplates(de *deps.DeferredExecutions) error {
 			if err := func() error {
 				deferred, found := de.Executions.Get(id)
 				if !found {
-					panic(fmt.Sprintf("deferred execution with id %q not found", id))
+					return fmt.Errorf("deferred execution with id %q not found in %q", id, filename)
 				}
 				deferred.Mu.Lock()
 				defer deferred.Mu.Unlock()
@@ -552,7 +552,7 @@ func (s *Site) executeDeferredTemplates(de *deps.DeferredExecutions) error {
 					tmpl := s.Deps.GetTemplateStore()
 					ti := s.TemplateStore.LookupByPath(deferred.TemplatePath)
 					if ti == nil {
-						panic(fmt.Sprintf("template %q not found", deferred.TemplatePath))
+						return fmt.Errorf("template %q for deferred execution %q not found in %q", deferred.TemplatePath, id, filename)
 					}
 
 					if err := func() error {

--- a/hugolib/hugo_sites_build_test.go
+++ b/hugolib/hugo_sites_build_test.go
@@ -9,6 +9,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/gohugoio/hugo/common/paths"
 	"github.com/gohugoio/hugo/resources/kinds"
+	"github.com/gohugoio/hugo/tpl"
 
 	"github.com/spf13/afero"
 )
@@ -40,6 +41,32 @@ Single: {{ .Title }}|{{ .Lang }}|{{ .RelPermalink }}|
 	b := Test(t, files)
 	b.AssertFileContent("public/sect/doc1-fr/index.html", "Single: doc1 fr|fr|/sect/doc1-fr/|")
 	b.AssertFileContent("public/en/sect/doc1/index.html", "Single: doc1 en|en|/en/sect/doc1/|")
+}
+
+func TestDeferredTemplateMissingExecutionReturnsErrorIssue13737(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org"
+disableKinds = ["home", "section", "taxonomy", "term", "rss", "sitemap"]
+-- content/p1.md --
+---
+title: p1
+---
+-- layouts/page.html --
+OK
+`
+	b := Test(t, files)
+	s := b.H.Sites[0]
+	filename := "p1/index.html"
+	id := tpl.HugoDeferredTemplatePrefix + "missing" + tpl.HugoDeferredTemplateSuffix
+
+	b.Assert(afero.WriteFile(s.BaseFs.PublishFs, filename, []byte(id), 0o666), qt.IsNil)
+	b.H.Deps.BuildState.DeferredExecutions.FilenamesWithPostPrefix.Set(filename, true)
+
+	err := s.executeDeferredTemplates(b.H.Deps.BuildState.DeferredExecutions)
+	b.Assert(err, qt.ErrorMatches, `deferred execution with id "__hdeferred/missing__d=" not found in "/?p1/index.html"`)
 }
 
 func TestMultiSitesWithTwoLanguages(t *testing.T) {


### PR DESCRIPTION
## Summary

- Return a render error instead of panicking when a published file contains a deferred template placeholder with no matching execution in the current build state.
- Include the output filename in the error to make stale placeholders easier to diagnose.
- Return an error instead of panicking if the deferred template path is missing.

This is a narrow follow-up hardening for one panic path mentioned in #13737. The issue is already closed by the js.Batch missing-import fix, so this intentionally uses See rather than Fixes.

See #13737

## Tests

- go test ./hugolib -run TestDeferredTemplateMissingExecutionReturnsErrorIssue13737 -count=20
- ./check.sh ./hugolib/...
- ./check.sh

## AI Assistance

I used AI assistance to help investigate the issue context, implement the change, and prepare tests. I reviewed the final diff, scope, and test coverage before publishing.