### PR TITLE
parser: Drop empty config maps recursively

### DIFF
--- a/parser/lowercase_camel_json.go
+++ b/parser/lowercase_camel_json.go
@@ -107,26 +107,33 @@ func (c ReplacingJSONMarshaller) MarshalJSON() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		var removeZeroVAlues func(m map[string]any)
-		removeZeroVAlues = func(m map[string]any) {
+		var removeZeroValues func(m map[string]any) bool
+		removeZeroValues = func(m map[string]any) bool {
 			for k, v := range m {
-				if !hreflect.IsMap(v) && !hreflect.IsTruthful(v) {
-					delete(m, k)
-				} else {
-					switch vv := v.(type) {
-					case map[string]any:
-						removeZeroVAlues(vv)
-					case []any:
-						for _, vvv := range vv {
-							if m, ok := vvv.(map[string]any); ok {
-								removeZeroVAlues(m)
-							}
+				switch vv := v.(type) {
+				case map[string]any:
+					if removeZeroValues(vv) {
+						delete(m, k)
+					}
+				case []any:
+					if !hreflect.IsTruthful(vv) {
+						delete(m, k)
+						continue
+					}
+					for _, vvv := range vv {
+						if m, ok := vvv.(map[string]any); ok {
+							removeZeroValues(m)
 						}
+					}
+				default:
+					if !hreflect.IsTruthful(v) {
+						delete(m, k)
 					}
 				}
 			}
+			return len(m) == 0
 		}
-		removeZeroVAlues(m)
+		removeZeroValues(m)
 		converted, err = json.Marshal(m)
 
 	}

--- a/parser/lowercase_camel_json_test.go
+++ b/parser/lowercase_camel_json_test.go
@@ -31,3 +31,57 @@ func TestReplacingJSONMarshaller(t *testing.T) {
 
 	c.Assert(string(b), qt.Equals, `{"baz":42,"foo":"bar"}`)
 }
+
+func TestReplacingJSONMarshallerOmitEmptyMapsIssue14855(t *testing.T) {
+	c := qt.New(t)
+
+	m := map[string]any{
+		"dropBranch": map[string]any{
+			"inner": map[string]any{
+				"emptyString": "",
+				"emptySlice":  []any{},
+				"nested": map[string]any{
+					"zero": 0,
+				},
+			},
+		},
+		"keep": "yes",
+		"slice": []any{
+			map[string]any{
+				"name": "a",
+				"sub": map[string]any{
+					"zero": 0,
+				},
+			},
+		},
+		"target": map[string]any{
+			"path": "/{photo,photo/**}",
+			"sites": map[string]any{
+				"complements": map[string]any{
+					"languages": []any{},
+				},
+				"matrix": map[string]any{
+					"languages": []any{},
+					"versions":  []any{},
+				},
+			},
+		},
+	}
+
+	marshaller := ReplacingJSONMarshaller{
+		Value:       m,
+		KeysToLower: true,
+		OmitEmpty:   true,
+	}
+
+	b, err := marshaller.MarshalJSON()
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(b), qt.Equals, `{"keep":"yes","slice":[{"name":"a"}],"target":{"path":"/{photo,photo/**}"}}`)
+
+	marshaller.OmitEmpty = false
+	b, err = marshaller.MarshalJSON()
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(b), qt.Contains, `"sites"`)
+	c.Assert(string(b), qt.Contains, `"matrix"`)
+	c.Assert(string(b), qt.Contains, `"dropbranch"`)
+}


### PR DESCRIPTION
Fixes #14855

## Summary

This fixes `hugo config` output when zero-valued nested maps are left behind after the existing `OmitEmpty` cleanup.

`ReplacingJSONMarshaller` already removes zero-valued leaves after marshaling config to a map. This change makes that cleanup recursive for parent maps too: when a child map becomes empty after its zero-valued fields are removed, the parent key is removed as well.

The cleanup still only runs when `OmitEmpty` is true, so `hugo config --printZero` is unchanged.

Related to #14861, which fixes the same issue with the same broad recursive cleanup approach. This version keeps the "did this map become empty?" decision inside the recursive helper, keeps slice entries in place while pruning empty maps inside them, and adds regression coverage for both the recursive empty-map pruning and the unchanged `OmitEmpty=false` path used by `hugo config --printZero`.

## Tests

- `./check.sh ./parser/...`
- `go test ./parser -run TestReplacingJSONMarshallerOmitEmptyMapsIssue14855 -count=10`
- `./check.sh` was attempted locally; it failed in existing `TestGitInfoFromGitModuleWithGoMod`, unrelated to this parser change and previously reproducible on `upstream/master` in this environment.

## AI assistance

I used AI assistance to investigate the issue, implement the narrow parser fix, and prepare the regression test. I reviewed the final diff, scope, and validation before publishing.
