### PR TITLE
hugolib: Preserve nested leaf bundle resources on rebuild

### DIFF
--- a/hugolib/pages_capture.go
+++ b/hugolib/pages_capture.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -152,7 +153,9 @@ func (c *pagesCollector) Collect() (collectErr error) {
 		}
 
 		for _, id := range c.ids {
-			if id.p.IsLeafBundle() {
+			if owner := c.leafBundleOwner(id.p); owner != nil {
+				collectErr = c.collectDirBelowLeafBundle(owner, id)
+			} else if id.p.IsLeafBundle() {
 				collectErr = c.collectDir(
 					id.p,
 					false,
@@ -220,6 +223,52 @@ func (c *pagesCollector) Collect() (collectErr error) {
 	}
 
 	return
+}
+
+func (c *pagesCollector) collectDirBelowLeafBundle(owner *paths.Path, id pathChange) error {
+	return c.collectDir(
+		owner,
+		false,
+		func(fim hugofs.FileMetaInfo) bool {
+			fimp := fim.Meta().PathInfo
+			if fimp == nil {
+				return false
+			}
+
+			if id.isStructuralChange() {
+				return strings.HasPrefix(fimp.Path(), paths.AddTrailingSlash(owner.Base()))
+			}
+
+			if fimp.IsLeafBundle() && fimp.Base() == owner.Base() {
+				return true
+			}
+
+			if fim.IsDir() {
+				return strings.HasPrefix(id.p.Path(), paths.AddTrailingSlash(fimp.Path()))
+			}
+
+			return fimp.Path() == id.p.Path()
+		},
+	)
+}
+
+func (c *pagesCollector) leafBundleOwner(p *paths.Path) *paths.Path {
+	for dir := path.Dir(p.Base()); dir != "." && dir != "/"; dir = path.Dir(dir) {
+		n, ok := c.h.pageTrees.treePages.GetRaw(dir)
+		if !ok {
+			continue
+		}
+
+		pi := cnh.PathInfo(n)
+		if pi != nil && pi.IsLeafBundle() {
+			if p.Dir() == pi.Base() {
+				return nil
+			}
+			return pi
+		}
+	}
+
+	return nil
 }
 
 func (c *pagesCollector) collectDir(dirPath *paths.Path, isDir bool, inFilter func(fim hugofs.FileMetaInfo) bool) error {

--- a/hugolib/rebuild_test.go
+++ b/hugolib/rebuild_test.go
@@ -125,6 +125,61 @@ func TestRebuildEditTextFileInLeafBundle(t *testing.T) {
 	b.AssertRenderCountContent(0)
 }
 
+func TestRebuildEditNestedContentInLeafBundleIssue13961(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com"
+disableLiveReload = true
+disableKinds = ["taxonomy", "term", "sitemap", "robotsTXT", "404", "rss", "section"]
+-- content/_index.md --
+---
+title: "Home"
+---
+-- content/a/index.md --
+---
+title: "A"
+---
+A.
+-- content/a/b/index.md --
+---
+title: "B"
+---
+B.
+-- content/a/b/c.md --
+---
+title: "C"
+---
+C.
+-- layouts/home.html --
+Home.
+-- layouts/page.html --
+Page: {{ .Title }}|{{ .Content }}|Resources: {{ range .Resources }}{{ .Content }}{{ end }}|
+`
+
+	b := Test(t, files, TestOptRunning())
+	b.AssertFileContent("public/a/index.html", "Page: A", "B.", "C.")
+	b.AssertFileExists("public/a/b/index.html", false)
+	b.AssertFileExists("public/a/b/c/index.html", false)
+
+	b.EditFileReplaceAll("content/a/b/index.md", "B.", "B edited.").Build()
+	b.AssertFileContent("public/a/index.html", "B edited.")
+	b.AssertFileExists("public/a/b/index.html", false)
+	b.AssertFileExists("public/a/b/c/index.html", false)
+
+	b.EditFileReplaceAll("content/a/b/c.md", "C.", "C edited.").Build()
+	b.AssertFileContent("public/a/index.html", "C edited.")
+	b.AssertFileExists("public/a/b/index.html", false)
+	b.AssertFileExists("public/a/b/c/index.html", false)
+
+	b.AddFiles("content/a/b/d/index.md", `---
+title: "D"
+---
+D.
+`).Build()
+	b.AssertFileContent("public/a/index.html", "D.")
+	b.AssertFileExists("public/a/b/d/index.html", false)
+}
+
 func TestRebuildAddingALeaffBundleIssue13925(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- keep server partial rebuilds rooted at the owning leaf bundle for nested changes
- preserve the full-build behavior where content below a leaf bundle is treated as bundled resources
- add a regression test for editing and adding nested content below a leaf bundle

## Details

The full content walk already has the directory context needed to classify files below a leaf bundle as resources. A server partial rebuild could start below that leaf bundle, so a changed `content/a/b/index.md` was parsed as a new leaf bundle and rendered as `/a/b/`.

This keeps the partial walk rooted at the existing leaf bundle owner for nested changes, letting the existing component filesystem resource classification apply consistently.

Fixes #13961

## Tests

- `go test ./hugolib -run TestRebuildEditNestedContentInLeafBundleIssue13961 -count=1`
- `./check.sh ./hugolib`
- `git diff --check`

I also attempted `./check.sh` locally, but repo-wide staticcheck compilation stopped with `no space left on device` before tests ran. CI should provide the full validation.

## AI Assistance

AI assistance was used to inspect the rebuild path, draft the patch, and run local validation. I reviewed the changes and test coverage before submitting.
