### PR TITLE
markup/goldmark/codeblocks: Always split Chroma options into .Options

### DIFF
--- a/markup/goldmark/codeblocks/codeblocks_integration_test.go
+++ b/markup/goldmark/codeblocks/codeblocks_integration_test.go
@@ -276,6 +276,7 @@ Attributes: {{ .Attributes }}|Type: {{ .Type }}|
 }
 
 // Issue 9571
+// Issue 14909
 func TestAttributesChroma(t *testing.T) {
 	t.Parallel()
 
@@ -288,7 +289,7 @@ title: "p1"
 
 ##   Code
 
-§§§LANGUAGE {style=monokai}
+§§§LANGUAGE {style=monokai class=my-class tabWidth=8}
 echo "p1";
 §§§
 -- layouts/single.html --
@@ -304,8 +305,9 @@ Attributes: {{ .Attributes }}|Options: {{ .Options }}|
 		b.AssertFileContent("public/p1/index.html", expect)
 	}
 
-	testLanguage("bash", "Attributes: map[]|Options: map[style:monokai]|")
-	testLanguage("hugo", "Attributes: map[style:monokai]|Options: map[]|")
+	testLanguage("bash", "Attributes: map[class:my-class]|Options: map[style:monokai tabWidth:8]|")
+	testLanguage("hugo", "Attributes: map[class:my-class]|Options: map[style:monokai tabWidth:8]|")
+	testLanguage("", "Attributes: map[class:my-class]|Options: map[style:monokai tabWidth:8]|")
 }
 
 func TestPanics(t *testing.T) {

--- a/markup/goldmark/codeblocks/render.go
+++ b/markup/goldmark/codeblocks/render.go
@@ -23,7 +23,6 @@ import (
 	htext "github.com/gohugoio/hugo/common/text"
 	"github.com/gohugoio/hugo/markup/converter/hooks"
 	"github.com/gohugoio/hugo/markup/goldmark/internal/render"
-	"github.com/gohugoio/hugo/markup/highlight/chromalexers"
 	"github.com/gohugoio/hugo/markup/internal/attributes"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
@@ -89,13 +88,6 @@ func (r *htmlRenderer) renderCodeBlock(w util.BufWriter, src []byte, node ast.No
 		info = n.Info.Segment.Value(src)
 	}
 
-	attrtp := attributes.AttributesOwnerCodeBlockCustom
-	if isd, ok := renderer.(hooks.IsDefaultCodeBlockRendererProvider); (ok && isd.IsDefaultCodeBlockRenderer()) || chromalexers.Get(lang) != nil {
-		// We say that this is a Chroma code block if it's the default code block renderer
-		// or if the language is supported by Chroma.
-		attrtp = attributes.AttributesOwnerCodeBlockChroma
-	}
-
 	attrs, attrStr, err := getAttributes(n, info)
 	if err != nil {
 		return ast.WalkStop, &herrors.TextSegmentError{Err: err, Segment: attrStr}
@@ -105,7 +97,7 @@ func (r *htmlRenderer) renderCodeBlock(w util.BufWriter, src []byte, node ast.No
 		BaseContext:      render.NewBaseContext(ctx, renderer, node, src, ordinal),
 		lang:             lang,
 		code:             s,
-		AttributesHolder: attributes.New(attrs, attrtp),
+		AttributesHolder: attributes.New(attrs, attributes.AttributesOwnerCodeBlockChroma),
 	}
 
 	cr := renderer.(hooks.CodeBlockRenderer)


### PR DESCRIPTION
Closes #14909