### PR TITLE
markup/converter/hooks: Allow overriding Type in code block context

### DIFF
--- a/markup/converter/hooks/hooks.go
+++ b/markup/converter/hooks/hooks.go
@@ -70,6 +70,9 @@ type CodeblockContext interface {
 	// The type of code block. This will be the programming language, e.g. bash, when doing code highlighting.
 	Type() string
 
+	// WithType returns a copy of the context with Type overridden.
+	WithType(lang string) CodeblockContext
+
 	// The text between the code fences.
 	Inner() string
 }

--- a/markup/goldmark/codeblocks/codeblocks_integration_test.go
+++ b/markup/goldmark/codeblocks/codeblocks_integration_test.go
@@ -165,6 +165,50 @@ plain <code> & text
 	)
 }
 
+// Issue 11872
+func TestCodeblockWithType11872(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+[markup.highlight]
+noClasses = false # to reduce size of assertion string
+-- content/p1.md --
+---
+title: p1
+---
+§§§go {style=monokai class=my-class tabWidth=8}
+i = 42
+§§§
+-- content/p2.md --
+---
+title: p2
+---
+§§§{style=monokai class=my-class tabWidth=8}
+i = 42
+§§§
+-- layouts/page.html --
+{{ .Content }}
+-- layouts/_markup/render-codeblock.html --
+{{- $type := "text" }}
+{{- if transform.CanHighlight .Type }}
+	{{- $type = .Type }}
+{{- end }}
+{{- $result := transform.HighlightCodeBlock (.WithType $type) }}
+{{- $result.Wrapped -}}
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/p1/index.html",
+		`<div class="highlight my-class"><pre tabindex="0" class="chroma"><code class="language-go" data-lang="go"><span class="line"><span class="cl"><span class="nx">i</span><span class="w"> </span><span class="p">=</span><span class="w"> </span><span class="mi">42</span></span></span></code></pre></div>`,
+	)
+	b.AssertFileContent("public/p2/index.html",
+		`<div class="highlight my-class"><pre tabindex="0" class="chroma"><code class="language-text" data-lang="text"><span class="line"><span class="cl">i = 42</span></span></code></pre></div>`,
+	)
+}
+
 func TestCodeblocksBugs(t *testing.T) {
 	t.Parallel()
 

--- a/markup/goldmark/codeblocks/render.go
+++ b/markup/goldmark/codeblocks/render.go
@@ -126,6 +126,11 @@ func (c codeBlockContext) Type() string {
 	return c.lang
 }
 
+func (c codeBlockContext) WithType(lang string) hooks.CodeblockContext {
+	c.lang = lang
+	return c
+}
+
 func (c codeBlockContext) Inner() string {
 	return c.code
 }


### PR DESCRIPTION
Closes #11872

---

The purpose of this draft PR is to help evaluate the proposal described in this [comment](https://github.com/gohugoio/hugo/issues/11872#issuecomment-4472928140). No immediate code review expected; just sharing as a proof of concept for whenever we triage the issue.

Note that the intended use case was not possible prior to the recently merged fix in https://github.com/gohugoio/hugo/pull/14911.