### PR TITLE
tpl/tplimpl: Use AllTranslations in sitemap

### DIFF
--- a/hugolib/sitemap_test.go
+++ b/hugolib/sitemap_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	qt "github.com/frankban/quicktest"
 	"github.com/gohugoio/hugo/config"
 )
 
@@ -82,6 +83,55 @@ Doc2
 	b.AssertFileContent("public/sitemap.xml", "<loc>https://example.com/en/sitemap.xml</loc>", "<loc>https://example.com/nn/sitemap.xml</loc>")
 	b.AssertFileContent("public/en/sitemap.xml", " <loc>https://example.com/sect/doc1/</loc>", "doc2")
 	b.AssertFileContent("public/nn/sitemap.xml", " <loc>https://example.com/nn/sect/doc2/</loc>")
+}
+
+// See issue 14912.
+func TestSitemapMultilingualAlternateLinksUseAllTranslations(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com"
+disableKinds = ["term", "taxonomy"]
+defaultContentLanguage = "en"
+[languages]
+[languages.en]
+weight = 1
+languageName = "English"
+languageCode = "en-US"
+[languages.nn]
+weight = 2
+languageName = "Nynorsk"
+languageCode = "nn-NO"
+-- content/sect/doc1.md --
+---
+title: doc1
+---
+Doc1
+-- content/sect/doc1.nn.md --
+---
+title: doc1
+---
+Doc1 nn
+`
+
+	b := Test(t, files)
+
+	sitemap := b.FileContent("public/en/sitemap.xml")
+	enLink := `<xhtml:link
+                rel="alternate"
+                hreflang="en-US"
+                href="https://example.com/sect/doc1/"
+                />`
+	nnLink := `<xhtml:link
+                rel="alternate"
+                hreflang="nn-NO"
+                href="https://example.com/nn/sect/doc1/"
+                />`
+
+	b.Assert(sitemap, qt.Contains, enLink)
+	b.Assert(sitemap, qt.Contains, nnLink)
+	b.Assert(strings.Index(sitemap, enLink) < strings.Index(sitemap, nnLink), qt.IsTrue)
 }
 
 // https://github.com/gohugoio/hugo/issues/5910

--- a/tpl/tplimpl/embedded/templates/sitemap.xml
+++ b/tpl/tplimpl/embedded/templates/sitemap.xml
@@ -8,17 +8,12 @@
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
-    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .AllTranslations }}
     <xhtml:link
                 rel="alternate"
                 hreflang="{{ .Language.Locale }}"
                 href="{{ .Permalink }}"
-                />{{ end }}
-    <xhtml:link
-                rel="alternate"
-                hreflang="{{ .Language.Locale }}"
-                href="{{ .Permalink }}"
-                />{{ end }}
+                />{{ end }}{{ end }}
   </url>
     {{- end -}}
   {{ end }}


### PR DESCRIPTION
## Summary

Fixes the embedded sitemap template alternate-link block to use `.AllTranslations` for translated pages.

## What changed

- Updated the sitemap template to range `.AllTranslations` inside the existing `.IsTranslated` guard.
- Added a regression test covering a translated page where the current language link should be emitted before the translated language link.

## Why

The previous template ranged `.Translations` and then manually appended the current page. That produced the right set of links, but it duplicated the behavior that `.AllTranslations` already provides and made the current-language entry come from a separate code path. Keeping `.IsTranslated` preserves the existing behavior for single-language sites.

## Testing

- Before the template change, `go test ./hugolib -run TestSitemapMultilingualAlternateLinksUseAllTranslations -count=1` failed because the current language link was emitted after the translated language link.
- `go test ./hugolib -run TestSitemapMultilingualAlternateLinksUseAllTranslations -count=1`
- `go test ./hugolib -run 'TestSitemap' -count=1`
- `git diff --check`
- `PATH="$(go env GOPATH)/bin:$PATH" ./check.sh ./hugolib`
- `PATH="$(go env GOPATH)/bin:$PATH" ./check.sh ./tpl/tplimpl`

I also ran `PATH="$(go env GOPATH)/bin:$PATH" ./check.sh`; it passed gofmt and staticcheck, then failed in `hugolib/pagesfromdata` because local external converters were missing (`asciidoctor`; with warnings for missing `pandoc` and `rst2html`).

Fixes #14912

Note: I used Codex to help inspect the issue, prepare the narrow fix, and run local verification; I reviewed the final diff and the listed command results before opening this PR.
