### PR TITLE
transform: fix duplicate "to" in chain.go doc comment

### DIFF
--- a/transform/chain.go
+++ b/transform/chain.go
@@ -58,7 +58,7 @@ func NewEmpty() Chain {
 }
 
 // Implements contentTransformer
-// Content is read from the from-buffer and rewritten to to the to-buffer.
+// Content is read from the from-buffer and rewritten to the to-buffer.
 type fromToBuffer struct {
 	from *bytes.Buffer
 	to   *bytes.Buffer


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix a duplicate `to` in the doc comment for `fromToBuffer` in
`transform/chain.go` — `rewritten to to the to-buffer` →
`rewritten to the to-buffer`. Comment-only change.

## Why

Tiny in-file `//` comment cleanup. The corrected sentence reads
unambiguously, since the surrounding `from` / `to` buffers make the
intent obvious.

## How verified

Single-line edit in a `//` comment. No exported names, types, or runtime
behavior altered.

## Maintainer note

Feel free to close if not worth the review cycle. Commit is signed off.
