### PR TITLE
Fix automatic summary container balancing

### DIFF
--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -784,6 +784,36 @@ Content: {{ .Content }}|
 		"Content: <p>This is <strong>summary</strong>.")
 }
 
+// Issue 14044
+func TestSummaryAutoBalancesContainerTags(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+summaryLength = 1
+-- content/p1.md --
+---
+title: p1
+---
+> foo
+-- content/p2.md --
+---
+title: p2
+---
+- item 1 line 1
+
+  item 1 line 2
+-- layouts/single.html --
+|{{ .Summary }}|
+`
+
+	b := Test(t, files)
+
+	b.AssertFileContent("public/p1/index.html", "|<blockquote>\n<p>foo</p>\n</blockquote>|")
+	b.AssertFileContent("public/p2/index.html", "|<ul>\n<li>\n<p>item 1 line 1</p>\n<p>item 1 line 2</p>\n</li>\n</ul>|")
+}
+
 // #2973
 func TestSummaryWithHTMLTagsOnNextLine(t *testing.T) {
 	htesting.SkipSlowTestUnlessCI(t)

--- a/resources/page/page_markup.go
+++ b/resources/page/page_markup.go
@@ -16,6 +16,7 @@ package page
 import (
 	"context"
 	"html/template"
+	"io"
 	"regexp"
 	"strings"
 	"unicode"
@@ -25,6 +26,7 @@ import (
 	"github.com/gohugoio/hugo/markup/tableofcontents"
 	"github.com/gohugoio/hugo/media"
 	"github.com/gohugoio/hugo/tpl"
+	"golang.org/x/net/html"
 )
 
 type Content interface {
@@ -234,9 +236,11 @@ func ExtractSummaryFromHTML(mt media.Type, input string, numWords int, isCJK boo
 		}
 
 		if count >= numWords {
+			summaryHigh := j + closingIndex + len(ptag.tagName) + 3
+			summaryHigh = expandSummaryHighToBalancedHTML(input, result.WrapperStart.High, summaryHigh, high)
 			result.SummaryLowHigh = types.LowHigh[string]{
 				Low:  result.WrapperStart.High,
-				High: j + closingIndex + len(ptag.tagName) + 3,
+				High: summaryHigh,
 			}
 			return
 		}
@@ -251,6 +255,83 @@ func ExtractSummaryFromHTML(mt media.Type, input string, numWords int, isCJK boo
 	}
 
 	return
+}
+
+func expandSummaryHighToBalancedHTML(input string, low, high, maxHigh int) int {
+	if low >= high || high >= maxHigh {
+		return high
+	}
+
+	stack, ok := htmlElementStack(input[low:high])
+	if !ok || len(stack) == 0 {
+		return high
+	}
+
+	t := html.NewTokenizer(strings.NewReader(input[high:maxHigh]))
+	offset := high
+
+	for {
+		tt := t.Next()
+		if tt == html.ErrorToken {
+			return high
+		}
+
+		offset += len(t.Raw())
+
+		switch tt {
+		case html.StartTagToken:
+			token := t.Token()
+			if !isVoidHTMLElement(token.Data) {
+				stack = append(stack, strings.ToLower(token.Data))
+			}
+		case html.EndTagToken:
+			token := t.Token()
+			stack = popHTMLStack(stack, strings.ToLower(token.Data))
+			if len(stack) == 0 {
+				return offset
+			}
+		}
+	}
+}
+
+func htmlElementStack(input string) ([]string, bool) {
+	t := html.NewTokenizer(strings.NewReader(input))
+	var stack []string
+
+	for {
+		switch t.Next() {
+		case html.ErrorToken:
+			if t.Err() == io.EOF {
+				return stack, true
+			}
+			return nil, false
+		case html.StartTagToken:
+			token := t.Token()
+			if !isVoidHTMLElement(token.Data) {
+				stack = append(stack, strings.ToLower(token.Data))
+			}
+		case html.EndTagToken:
+			token := t.Token()
+			stack = popHTMLStack(stack, strings.ToLower(token.Data))
+		}
+	}
+}
+
+func popHTMLStack(stack []string, name string) []string {
+	for i := len(stack) - 1; i >= 0; i-- {
+		if stack[i] == name {
+			return stack[:i]
+		}
+	}
+	return stack
+}
+
+func isVoidHTMLElement(name string) bool {
+	switch strings.ToLower(name) {
+	case "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "source", "track", "wbr":
+		return true
+	}
+	return false
 }
 
 // ExtractSummaryFromHTMLWithDivider extracts a summary from the given HTML content with

--- a/resources/page/page_markup_test.go
+++ b/resources/page/page_markup_test.go
@@ -38,6 +38,9 @@ func TestExtractSummaryFromHTML(t *testing.T) {
 		{media.Builtin.MarkdownType, "<p>First paragraph</p>", false, 10, "<p>First paragraph</p>", ""},
 		{media.Builtin.MarkdownType, "<p>First paragraph</p><p>Second paragraph</p>", false, 2, "<p>First paragraph</p>", "<p>Second paragraph</p>"},
 		{media.Builtin.MarkdownType, "<p>First paragraph</p><p>Second paragraph</p><p>Third paragraph</p>", false, 3, "<p>First paragraph</p><p>Second paragraph</p>", "<p>Third paragraph</p>"},
+		{media.Builtin.MarkdownType, "<blockquote>\n<p>foo</p>\n</blockquote>\n<p>bar</p>", false, 1, "<blockquote>\n<p>foo</p>\n</blockquote>", "<p>bar</p>"},
+		{media.Builtin.MarkdownType, "<ul>\n<li>\n<p>item 1 line 1</p>\n<p>item 1 line 2</p>\n</li>\n</ul>\n<p>bar</p>", false, 1, "<ul>\n<li>\n<p>item 1 line 1</p>\n<p>item 1 line 2</p>\n</li>\n</ul>", "<p>bar</p>"},
+		{media.Builtin.HTMLType, "<div><p>foo</p></div><p>bar</p>", false, 1, "<div><p>foo</p></div>", "<p>bar</p>"},
 		{media.Builtin.AsciiDocType, "<div><p>First paragraph</p></div><div><p>Second paragraph</p></div>", false, 2, "<div><p>First paragraph</p></div>", "<div><p>Second paragraph</p></div>"},
 		{media.Builtin.MarkdownType, "<p>这是中文，全中文</p><p>a这是中文，全中文</p>", true, 5, "<p>这是中文，全中文</p>", "<p>a这是中文，全中文</p>"},
 	}


### PR DESCRIPTION
## Summary
- keep automatic summaries from splitting blockquote, list, and HTML container tags when the word cutoff lands inside them
- extend the automatic summary cutoff to the matching closing tag before `ContentWithoutSummary` starts
- add unit and integration coverage for blockquotes, lists, and HTML containers

Fixes #14044

## Tests
- `GOMODCACHE=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gomodcache GOCACHE=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gocache go test ./resources/page -run TestExtractSummaryFromHTML -count=1`
- `GOMODCACHE=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gomodcache GOCACHE=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gocache go test ./hugolib -run TestSummaryAutoBalancesContainerTags -count=1`
- `GOMODCACHE=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gomodcache GOCACHE=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gocache go test ./resources/page ./hugolib -count=1`
- `GOMODCACHE=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gomodcache GOCACHE=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gocache GOBIN=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gobin PATH=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gobin:$PATH ./check.sh ./resources/page`
- `GOMODCACHE=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gomodcache GOCACHE=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gocache GOBIN=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gobin PATH=/Users/deepakkudi23/ai-resume-contrib-100/hugo-cache/gobin:$PATH ./check.sh ./hugolib`
- `git diff --check`

## AI Assistance
I used AI assistance to help prepare this narrow bug fix. I reviewed the implementation and tests before submitting.
