### PR TITLE
hugolib: Use AllTranslated in IsTranslated

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -475,7 +475,7 @@ func (ps *pageState) String() string {
 // IsTranslated returns whether this content file is translated to
 // other language(s).
 func (ps *pageState) IsTranslated() bool {
-	return len(ps.Translations()) > 0
+	return len(ps.AllTranslations()) > 1
 }
 
 // TranslationKey returns the key used to identify a translation of this content.

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1991,3 +1991,28 @@ func content(c resource.ContentProvider) string {
 	}
 	return ccs
 }
+
+func BenchmarkIsTranslatedOneLanguage(b *testing.B) {
+	// Set it reasonably high to get a balance between cached and uncached calls to IsTranslated.
+	const numPages = 3000
+
+	files := `
+-- hugo.toml --
+disableKinds = ["taxonomy", "term"]
+`
+	for i := range numPages {
+		files += fmt.Sprintf(`
+-- content/sect/p%d.md --`, i)
+	}
+
+	bb := Test(b, files, TestOptSkipRender())
+	p := bb.H.Sites[0].RegularPages()
+
+	b.ResetTimer()
+
+	for i := range b.N {
+		if p[i%numPages].IsTranslated() {
+			b.Fatalf("Page %d should not be translated", i)
+		}
+	}
+}


### PR DESCRIPTION
Which makes it faster:

```
                           │ benchcmp.bench │   feat-speedupistranslated.bench    │
                           │     sec/op     │    sec/op     vs base               │
IsTranslatedOneLanguage-10     996.2n ± ∞ ¹   685.6n ± ∞ ¹  -31.18% (p=0.029 n=4)
¹ need >= 6 samples for confidence interval at level 0.95

                           │ benchcmp.bench │   feat-speedupistranslated.bench   │
                           │      B/op      │    B/op      vs base               │
IsTranslatedOneLanguage-10      832.0 ± ∞ ¹   536.0 ± ∞ ¹  -35.58% (p=0.029 n=4)
¹ need >= 6 samples for confidence interval at level 0.95

                           │ benchcmp.bench │   feat-speedupistranslated.bench   │
                           │   allocs/op    │  allocs/op   vs base               │
IsTranslatedOneLanguage-10      18.00 ± ∞ ¹   13.00 ± ∞ ¹  -27.78% (p=0.029 n=4)
¹ need >= 6 samples for confidence interval at level 0.95
````
