### PR TITLE
tpl/collections: Include template path in IsSet unsupported type warning

### DIFF
--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -20,6 +20,7 @@ const (
 	WarnGoldmarkRawHTML          = "warning-goldmark-raw-html"
 	WarnPartialSuperfluousPrefix = "warning-partial-superfluous-prefix"
 	WarnHomePageIsLeafBundle     = "warning-home-page-is-leaf-bundle"
+	WarnIsSetUnsupportedType     = "warning-isset-unsupported-type"
 )
 
 // Field/method names with special meaning.

--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -2376,6 +2376,7 @@ tpl:
         - isSet
         - isset
         Args:
+        - ctx
         - c
         - key
         Description: |-

--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -20,17 +20,20 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
 
 	"github.com/gohugoio/hugo/common/collections"
+	"github.com/gohugoio/hugo/common/constants"
 	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hreflect"
 	"github.com/gohugoio/hugo/common/hstore"
 	"github.com/gohugoio/hugo/common/types"
 	"github.com/gohugoio/hugo/deps"
 	"github.com/gohugoio/hugo/langs"
+	"github.com/gohugoio/hugo/tpl"
 	"github.com/gohugoio/hugo/tpl/compare"
 	"github.com/spf13/cast"
 )
@@ -329,7 +332,7 @@ func (ns *Namespace) Group(key any, items any) (any, error) {
 
 // IsSet returns whether a given array, channel, slice, or map in c has the given key
 // defined.
-func (ns *Namespace) IsSet(c any, key any) (bool, error) {
+func (ns *Namespace) IsSet(ctx context.Context, c any, key any) (bool, error) {
 	av := reflect.ValueOf(c)
 	kv := reflect.ValueOf(key)
 
@@ -347,7 +350,15 @@ func (ns *Namespace) IsSet(c any, key any) (bool, error) {
 			return av.MapIndex(kv).IsValid(), nil
 		}
 	default:
-		ns.deps.Log.Warnf("calling IsSet with unsupported type %q (%T) will always return false.\n", av.Kind(), c)
+		var where string
+		if currentTpl := tpl.Context.CurrentTemplate.Get(ctx); currentTpl != nil {
+			if f := currentTpl.Filename(); f != "" {
+				where = fmt.Sprintf(" in %q", filepath.ToSlash(f))
+			} else if n := currentTpl.Name(); n != "" {
+				where = fmt.Sprintf(" in template %q", n)
+			}
+		}
+		ns.deps.Log.Warnidf(constants.WarnIsSetUnsupportedType, "calling IsSet with unsupported type %q (%T)%s will always return false.", av.Kind(), c, where)
 	}
 
 	return false, nil

--- a/tpl/collections/collections_integration_test.go
+++ b/tpl/collections/collections_integration_test.go
@@ -653,3 +653,20 @@ All.
 		}
 	})
 }
+
+// Issue 11794
+func TestIsSetUnsupportedTypeWarningIncludesTemplatePath(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+-- layouts/home.html --
+{{ $s := "hello" }}
+{{ if isset $s "anyKey" }}A{{ else }}B{{ end }}
+`
+
+	b := hugolib.Test(t, files, hugolib.TestOptWarn())
+
+	b.AssertLogContains(`WARN  calling IsSet with unsupported type "string" (string) in "/layouts/home.html" will always return false.`)
+}

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -460,7 +460,7 @@ func TestIsSet(t *testing.T) {
 	} {
 		errMsg := qt.Commentf("[%d] %v", i, test)
 
-		result, err := ns.IsSet(test.a, test.key)
+		result, err := ns.IsSet(context.Background(), test.a, test.key)
 		if test.isErr {
 			continue
 		}


### PR DESCRIPTION
Fixes #11794

## Summary

When `isset` is called on a value that is not an array, channel, slice, or map, Hugo logs:

```
WARN  calling IsSet with unsupported type "string" (string) will always return false.
```

On any site with more than one template there's no way to find the offending call site. The warning is also emitted via `Log.Warnf`, so it has no ID and can't be silenced via `ignoreLogs`.

This PR threads `context.Context` through `IsSet`, looks up the executing template via `tpl.Context.CurrentTemplate.Get`, and surfaces the filename in the warning. It also switches `Log.Warnf` to `Log.Warnidf` with a new constant `WarnIsSetUnsupportedType` so the warning is groupable and suppressible.

After the change:

```
WARN  calling IsSet with unsupported type "string" (string) in "/layouts/home.html" will always return false.
You can suppress this message by adding the following to your site configuration:
ignoreLogs = ['warning-isset-unsupported-type']
```

## Changes

- `tpl/collections/collections.go` — `IsSet` accepts `ctx context.Context` as its first arg, matching the pattern used by `Delimit` and other ctx-aware namespace functions. The default branch resolves the current template and appends `in "<path>"` to the warning, then routes through `Log.Warnidf`.
- `common/constants/constants.go` — adds `WarnIsSetUnsupportedType`.
- `tpl/collections/collections_test.go` — passes `context.Background()` to the existing `TestIsSet` cases.
- `tpl/collections/collections_integration_test.go` — adds a regression test asserting the template path appears in the warning.
- `docs/data/docs.yaml` — adds `ctx` to `IsSet`'s `Args` list, matching the documented shape for other ctx-aware namespace functions.

## Tests

- `go test ./tpl/collections/... -run TestIsSet -v` — unit and integration tests pass.
- `go test ./tpl/collections/...` — full package green.
- `go vet ./tpl/collections/...` — clean.
- `gofmt -l` on touched paths — clean.
- `go build ./...` — full tree builds.

## AI Assistance

I used AI assistance to investigate the issue, design the fix, and prepare tests. I reviewed the final diff, kept the scope narrow per CONTRIBUTING.md, and ran the checks listed above before opening.
