### PR TITLE
parser: Drop empty sub maps from hugo config output

### DIFF
--- a/parser/lowercase_camel_json.go
+++ b/parser/lowercase_camel_json.go
@@ -116,6 +116,9 @@ func (c ReplacingJSONMarshaller) MarshalJSON() ([]byte, error) {
 					switch vv := v.(type) {
 					case map[string]any:
 						removeZeroVAlues(vv)
+						if len(vv) == 0 {
+							delete(m, k)
+						}
 					case []any:
 						for _, vvv := range vv {
 							if m, ok := vvv.(map[string]any); ok {

--- a/parser/lowercase_camel_json_test.go
+++ b/parser/lowercase_camel_json_test.go
@@ -31,3 +31,60 @@ func TestReplacingJSONMarshaller(t *testing.T) {
 
 	c.Assert(string(b), qt.Equals, `{"baz":42,"foo":"bar"}`)
 }
+
+// See issue 14855.
+func TestReplacingJSONMarshallerOmitEmptySubMaps(t *testing.T) {
+	c := qt.New(t)
+
+	m := map[string]any{
+		"keep": "yes",
+		"target": map[string]any{
+			"path": "/x",
+			"sites": map[string]any{
+				"matrix": map[string]any{
+					"languages": []any{},
+					"versions":  []any{},
+				},
+				"complements": map[string]any{
+					"languages": []any{},
+				},
+			},
+		},
+		"all_zero_branch": map[string]any{
+			"inner": map[string]any{
+				"empty": "",
+				"deep": map[string]any{
+					"zero": 0,
+				},
+			},
+		},
+		"keep_slice_of_maps": []any{
+			map[string]any{
+				"name":  "a",
+				"empty": "",
+				"sub":   map[string]any{"x": 0},
+			},
+		},
+	}
+
+	marshaller := ReplacingJSONMarshaller{
+		Value:       m,
+		KeysToLower: true,
+		OmitEmpty:   true,
+	}
+
+	b, err := marshaller.MarshalJSON()
+	c.Assert(err, qt.IsNil)
+
+	s := string(b)
+	c.Assert(s, qt.Contains, `"keep":"yes"`)
+	c.Assert(s, qt.Contains, `"path":"/x"`)
+	c.Assert(s, qt.Not(qt.Contains), `"sites"`)
+	c.Assert(s, qt.Not(qt.Contains), `"matrix"`)
+	c.Assert(s, qt.Not(qt.Contains), `"complements"`)
+	c.Assert(s, qt.Not(qt.Contains), `"all_zero_branch"`)
+	c.Assert(s, qt.Not(qt.Contains), `"inner"`)
+	c.Assert(s, qt.Not(qt.Contains), `"deep"`)
+	c.Assert(s, qt.Contains, `"name":"a"`)
+	c.Assert(s, qt.Not(qt.Contains), `"sub"`)
+}


### PR DESCRIPTION
Fixes #14855
