### PR TITLE
Drop duplicate words in two doc comments

### DIFF
--- a/config/allconfig/docshelper.go
+++ b/config/allconfig/docshelper.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gohugoio/hugo/docshelper"
 )
 
-// This is is just some helpers used to create some JSON used in the Hugo docs.
+// This is just some helpers used to create some JSON used in the Hugo docs.
 func init() {
 	docsProvider := func() docshelper.DocProvider {
 		cfg := config.New()

--- a/related/inverted_index.go
+++ b/related/inverted_index.go
@@ -331,7 +331,7 @@ type SearchOpts struct {
 	// The indices to search in.
 	Indices []string
 
-	// Fragments holds a a list of special keywords that is used
+	// Fragments holds a list of special keywords that is used
 	// for indices configured as type "fragments".
 	// This will match the fragment identifiers of the documents.
 	Fragments []string


### PR DESCRIPTION
Two small comment fixes:

- `config/allconfig/docshelper.go`: "This is is just some helpers" -> drop the stray `is`.
- `related/inverted_index.go`: "holds a a list of special keywords" -> drop the stray `a`.

AI assistance disclosure: spotted via a grep for duplicated short words during a doc cleanup pass.