### PR TITLE
hugolib: Merge existing hugo_stats.json when renderSegments is set

### DIFF
--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -779,6 +779,23 @@ func (h *HugoSites) writeBuildStats() error {
 		htmlElements.Merge(stats.HTMLElements)
 	}
 
+	filename := filepath.Join(h.Configs.LoadingInfo.BaseConfig.WorkingDir, files.FilenameHugoStatsJSON)
+
+	existingContent, _ := afero.ReadFile(hugofs.Os, filename)
+
+	// When rendering only a subset of the site, merge with any existing
+	// hugo_stats.json so that elements from pages not rendered in this build
+	// are preserved (e.g. so Tailwind doesn't strip their classes).
+	// See issue 14939.
+	if len(h.Configs.Base.RenderSegments) > 0 && len(existingContent) > 0 {
+		var existing publisher.PublishStats
+		if err := json.Unmarshal(existingContent, &existing); err == nil {
+			htmlElements.Merge(existing.HTMLElements)
+		} else {
+			h.Log.Warnf("Failed to unmarshal existing hugo_stats.json: %s", err)
+		}
+	}
+
 	htmlElements.Sort()
 
 	stats := publisher.PublishStats{
@@ -795,13 +812,8 @@ func (h *HugoSites) writeBuildStats() error {
 	}
 	js := buf.Bytes()
 
-	filename := filepath.Join(h.Configs.LoadingInfo.BaseConfig.WorkingDir, files.FilenameHugoStatsJSON)
-
-	if existingContent, err := afero.ReadFile(hugofs.Os, filename); err == nil {
-		// Check if the content has changed.
-		if bytes.Equal(existingContent, js) {
-			return nil
-		}
+	if bytes.Equal(existingContent, js) {
+		return nil
 	}
 
 	// Make sure it's always written to the OS fs.

--- a/hugolib/segments/segments_integration_test.go
+++ b/hugolib/segments/segments_integration_test.go
@@ -75,3 +75,56 @@ tags: ["tag1", "tag2"]
 	b.AssertFileExists("public/no/index.html", true)
 	b.AssertFileExists("public/no/index.xml", false)
 }
+
+// See issue 14939.
+func TestRenderSegmentsMergesHugoStatsJSON(t *testing.T) {
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+renderSegments = ["docs"]
+[build.buildStats]
+enable = true
+[segments]
+[segments.docs]
+[[segments.docs.includes]]
+path = "{/docs,/docs/**}"
+-- hugo_stats.json --
+{
+  "htmlElements": {
+    "tags": [
+      "section"
+    ],
+    "classes": [
+      "from-previous-build"
+    ],
+    "ids": [
+      "previous-id"
+    ]
+  }
+}
+-- layouts/single.html --
+<div id="docs-id" class="docs-class">{{ .Title }}</div>
+-- layouts/list.html --
+<div id="list-id" class="list-class">{{ .Title }}</div>
+-- content/docs/section1/page1.md --
+---
+title: "Docs Page 1"
+---
+-- content/blog/section1/page1.md --
+---
+title: "Blog Page 1"
+---
+`
+
+	b := hugolib.Test(t, files, hugolib.TestOptOsFs())
+
+	b.AssertFileContent("public/docs/section1/page1/index.html", "Docs Page 1")
+	b.AssertFileExists("public/blog/section1/page1/index.html", false)
+
+	b.AssertFileContent("hugo_stats.json",
+		"from-previous-build",
+		"previous-id",
+		"section",
+		"docs-class",
+	)
+}


### PR DESCRIPTION
With renderSegments only a subset of pages is rendered, so the resulting
hugo_stats.json would no longer contain elements from the excluded pages,
causing tools like Tailwind to strip classes that are actually in use.

Fixes #14939
