### PR TITLE
hugolib: Fix Page.GitInfo for modules with go.mod in a repo subdirectory

### DIFF
--- a/hugolib/gitinfo.go
+++ b/hugolib/gitinfo.go
@@ -80,6 +80,13 @@ func (g *gitInfo) gitInfoFromModuleRepo(p page.Page, mod modules.Module, repo *g
 	filePath := strings.TrimPrefix(filename, modDir)
 	filePath = strings.TrimPrefix(filePath, "/")
 
+	// If the module's go.mod lives in a subdirectory of the git repo,
+	// the blobless clone keys files by their path relative to the repo root,
+	// so we need to prepend the subdir.
+	if subdir := strings.Trim(mod.Origin().Subdir, "/"); subdir != "" {
+		filePath = subdir + "/" + filePath
+	}
+
 	gi, found := repo.Files[filePath]
 	if !found {
 		return nil

--- a/hugolib/gitinfo_github_test.go
+++ b/hugolib/gitinfo_github_test.go
@@ -95,3 +95,36 @@ module hugotest
 		"AuthorName: Bjørn Erik Pedersen|",
 	)
 }
+
+// See issue 14942.
+func TestGitInfoFromGitModuleWithGoModInSubdir(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com/"
+enableGitInfo = true
+
+[module]
+[[module.imports]]
+path = "github.com/bep/hugo-mod-misc/dummy-content"
+version = "v0.3.0"
+[[module.imports.mounts]]
+source = "content"
+target = "content"
+-- layouts/page.html --
+Title: {{ .Title }}|
+GitInfo: {{ with .GitInfo }}Hash: {{ .Hash }}|Subject: {{ .Subject }}|AuthorName: {{ .AuthorName }}{{ end }}|
+-- layouts/_default/list.html --
+List: {{ .Title }}
+-- go.mod --
+module hugotest
+`
+
+	b := Test(t, files, TestOptOsFs())
+
+	b.AssertFileContent("public/blog/music/satin-doll/index.html",
+		"Hash: 522ee6c486ff24b2e3d45e9b90061564e9427030|",
+		"AuthorName: Bjørn Erik Pedersen|",
+	)
+}

--- a/modules/client.go
+++ b/modules/client.go
@@ -991,6 +991,7 @@ type goModule struct {
 type goModuleOrigin struct {
 	VCS    string // version control system, e.g. "git"
 	URL    string // repository URL, e.g. "https://github.com/bep/hugo-testing-git-versions"
+	Subdir string // subdirectory within the repo where the module lives, e.g. "site"
 	Hash   string // commit hash
 	TagSum string
 	Ref    string // e.g. "refs/tags/v3.0.1"

--- a/modules/module.go
+++ b/modules/module.go
@@ -86,10 +86,11 @@ type Module interface {
 
 // ModuleOrigin contains origin info for a Go module.
 type ModuleOrigin struct {
-	VCS  string // version control system, e.g. "git"
-	URL  string // repository URL, e.g. "https://github.com/bep/hugo-testing-git-versions"
-	Hash string // commit hash
-	Ref  string // e.g. "refs/tags/v3.0.1"
+	VCS    string // version control system, e.g. "git"
+	URL    string // repository URL, e.g. "https://github.com/bep/hugo-testing-git-versions"
+	Subdir string // subdirectory within the repo where the module lives, e.g. "site"
+	Hash   string // commit hash
+	Ref    string // e.g. "refs/tags/v3.0.1"
 }
 
 func (o ModuleOrigin) IsZero() bool {
@@ -240,9 +241,10 @@ func (m *moduleAdapter) Origin() ModuleOrigin {
 		return ModuleOrigin{}
 	}
 	return ModuleOrigin{
-		VCS:  m.gomod.Origin.VCS,
-		URL:  m.gomod.Origin.URL,
-		Hash: m.gomod.Origin.Hash,
-		Ref:  m.gomod.Origin.Ref,
+		VCS:    m.gomod.Origin.VCS,
+		URL:    m.gomod.Origin.URL,
+		Subdir: m.gomod.Origin.Subdir,
+		Hash:   m.gomod.Origin.Hash,
+		Ref:    m.gomod.Origin.Ref,
 	}
 }


### PR DESCRIPTION
Map content files using their path relative to the git repo root by
prepending the module's Origin.Subdir to the lookup key.

Fixes #14942
