### PR TITLE
fix: duplicated words in docshelper init-comments and chain.go transformer doc

### DIFF
--- a/config/allconfig/docshelper.go
+++ b/config/allconfig/docshelper.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gohugoio/hugo/docshelper"
 )
 
-// This is is just some helpers used to create some JSON used in the Hugo docs.
+// This is just some helpers used to create some JSON used in the Hugo docs.
 func init() {
 	docsProvider := func() docshelper.DocProvider {
 		cfg := config.New()

--- a/helpers/docshelper.go
+++ b/helpers/docshelper.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gohugoio/hugo/docshelper"
 )
 
-// This is is just some helpers used to create some JSON used in the Hugo docs.
+// This is just some helpers used to create some JSON used in the Hugo docs.
 func init() {
 	docsProvider := func() docshelper.DocProvider {
 		var chromaLexers []any

--- a/transform/chain.go
+++ b/transform/chain.go
@@ -58,7 +58,7 @@ func NewEmpty() Chain {
 }
 
 // Implements contentTransformer
-// Content is read from the from-buffer and rewritten to to the to-buffer.
+// Content is read from the from-buffer and rewritten to the to-buffer.
 type fromToBuffer struct {
 	from *bytes.Buffer
 	to   *bytes.Buffer


### PR DESCRIPTION
Signed-off-by: Mira Sato <275437409+oab24413gmai@users.noreply.github.com>