### PR TITLE
hugolib: Make IsNode false for 404 pages

### DIFF
--- a/hugolib/404_test.go
+++ b/hugolib/404_test.go
@@ -63,6 +63,29 @@ Data: 1|
 `)
 }
 
+// See issue 12162.
+func Test404IsNotNode(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "http://example.com/"
+disableKinds = ["rss", "sitemap", "taxonomy", "term"]
+-- layouts/404.html --
+Kind: {{ .Kind }}|
+IsNode: {{ .IsNode }}|
+IsPage: {{ .IsPage }}|
+`
+
+	b := Test(t, files)
+
+	b.AssertFileContent("public/404.html",
+		"Kind: 404|",
+		"IsNode: false|",
+		"IsPage: false|",
+	)
+}
+
 func Test404EditTemplate(t *testing.T) {
 	t.Parallel()
 

--- a/hugolib/page__meta.go
+++ b/hugolib/page__meta.go
@@ -469,7 +469,7 @@ func (m *pageMeta) Name() string {
 }
 
 func (m *pageMeta) IsNode() bool {
-	return !m.IsPage()
+	return kinds.IsBranch(m.Kind())
 }
 
 func (m *pageMeta) IsPage() bool {


### PR DESCRIPTION
## Summary
- make `.IsNode` return `false` for `kind=404`
- add an integration test covering the `404.html` template context

## Context
The public `IsNode` contract describes node pages as `home`, `section`, `taxonomy`, and `term`.
The 404 template was returning `true` because `pageMeta.IsNode` treated every non-`page` kind as a node.

## Root cause
`pageMeta.IsNode` used `!IsPage()` instead of checking the actual branch kinds.

## Testing
- `go test ./hugolib -run 'Test404$|Test404IsNotNode$|Test404EditTemplate$|Test404Panic14283$'
- `PATH="/Users/xndvaz/go/bin:$PATH" ./check.sh`

## Related
- Fixes #12162
- Related #12192
- Related #11574

## AI assistance
This PR was written with Codex assistance, then reviewed and validated locally.
