### PR TITLE
all: Adjust tests for deprecated link and image render hook settings

### DIFF
--- a/config/allconfig/allconfig_integration_test.go
+++ b/config/allconfig/allconfig_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/config/allconfig"
 	"github.com/gohugoio/hugo/hugolib"
-	gc "github.com/gohugoio/hugo/markup/goldmark/goldmark_config"
 	"github.com/gohugoio/hugo/media"
 )
 
@@ -360,25 +359,46 @@ weight = 3
 
 // Issue 13535
 // We changed enablement of the embedded link and image render hooks from
-// booleans to enums in v0.148.0.
+// booleans to enums in v0.148.0. This should throw error with v0.163.0 and later.
 func TestLegacyEmbeddedRenderHookEnablement(t *testing.T) {
 	files := `
 -- hugo.toml --
 [markup.goldmark.renderHooks.image]
-#KEY_VALUE
+#KEY_VALUE_IMAGE
 
 [markup.goldmark.renderHooks.link]
-#KEY_VALUE
+#KEY_VALUE_LINK
 `
-	f := strings.ReplaceAll(files, "#KEY_VALUE", "enableDefault = false")
-	b := hugolib.Test(t, f)
-	c := b.H.Configs.Base.Markup.Goldmark.RenderHooks
-	b.Assert(c.Link.UseEmbedded, qt.Equals, gc.RenderHookUseEmbeddedNever)
-	b.Assert(c.Image.UseEmbedded, qt.Equals, gc.RenderHookUseEmbeddedNever)
 
-	f = strings.ReplaceAll(files, "#KEY_VALUE", "enableDefault = true")
-	b = hugolib.Test(t, f)
-	c = b.H.Configs.Base.Markup.Goldmark.RenderHooks
-	b.Assert(c.Link.UseEmbedded, qt.Equals, gc.RenderHookUseEmbeddedFallback)
-	b.Assert(c.Image.UseEmbedded, qt.Equals, gc.RenderHookUseEmbeddedFallback)
+	replacer := strings.NewReplacer(
+		"#KEY_VALUE_IMAGE", "enableDefault = false",
+		"#KEY_VALUE_LINK", "",
+	)
+	f := replacer.Replace(files)
+	b, _ := hugolib.TestE(t, f)
+	b.AssertLogContains("ERROR deprecated")
+
+	replacer = strings.NewReplacer(
+		"#KEY_VALUE_IMAGE", "enableDefault = true",
+		"#KEY_VALUE_LINK", "",
+	)
+	f = replacer.Replace(files)
+	b, _ = hugolib.TestE(t, f)
+	b.AssertLogContains("ERROR deprecated")
+
+	replacer = strings.NewReplacer(
+		"#KEY_VALUE_IMAGE", "",
+		"#KEY_VALUE_LINK", "enableDefault = false",
+	)
+	f = replacer.Replace(files)
+	b, _ = hugolib.TestE(t, f)
+	b.AssertLogContains("ERROR deprecated")
+
+	replacer = strings.NewReplacer(
+		"#KEY_VALUE_IMAGE", "",
+		"#KEY_VALUE_LINK", "enableDefault = true",
+	)
+	f = replacer.Replace(files)
+	b, _ = hugolib.TestE(t, f)
+	b.AssertLogContains("ERROR deprecated")
 }

--- a/hugolib/content_render_hooks_test.go
+++ b/hugolib/content_render_hooks_test.go
@@ -239,9 +239,9 @@ defaultContentLanguageInSubdir = true
 duplicateResourceFiles = false
 [markup.goldmark.renderhooks]
 [markup.goldmark.renderhooks.link]
-#enableDefault = false
+#useEmbedded = 'never'
 [markup.goldmark.renderhooks.image]
-#enableDefault = false
+#useEmbedded = 'never'
 [languages]
 [languages.en]
 weight = 1
@@ -291,7 +291,7 @@ iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAA
 	})
 
 	t.Run("Disabled", func(t *testing.T) {
-		b := Test(t, strings.ReplaceAll(files, "#enableDefault = false", "enableDefault = false"))
+		b := Test(t, strings.ReplaceAll(files, "#useEmbedded = 'never'", "useEmbedded = 'never'"))
 
 		b.AssertFileContent("public/nn/p1/index.html",
 			"p1|<p><a href=\"p2\">P2</a>", "<img src=\"pixel.png\" alt=\"Pixel\">")
@@ -304,9 +304,9 @@ func TestRenderHooksDefaultEscape(t *testing.T) {
 [markup.goldmark.extensions.typographer]
 disable = true
 [markup.goldmark.renderHooks.image]
-enableDefault = ENABLE
+useEmbedded = 'WHEN'
 [markup.goldmark.renderHooks.link]
-enableDefault = ENABLE
+useEmbedded = 'WHEN'
 [markup.goldmark.parser]
 wrapStandAloneImageWithinParagraph = false
 [markup.goldmark.parser.attribute]
@@ -326,13 +326,13 @@ Image: ![alt-"<>&](/destination-"<> 'title-"<>&')
 {{ .Content }}
 `
 
-	for _, enabled := range []bool{true, false} {
-		t.Run(fmt.Sprint(enabled), func(t *testing.T) {
+	for _, when := range []string{"auto", "never", "always", "fallback"} {
+		t.Run(fmt.Sprint(when), func(t *testing.T) {
 			t.Parallel()
-			b := Test(t, strings.ReplaceAll(files, "ENABLE", fmt.Sprint(enabled)))
+			b := Test(t, strings.ReplaceAll(files, "WHEN", fmt.Sprint(when)))
 
 			// The escaping is slightly different between the two.
-			if enabled {
+			if when == "always" || when == "fallback" {
 				b.AssertFileContent("public/index.html",
 					"Link: <a href=\"/destination-%22%3C%3E\" title=\"title-&#34;&lt;&gt;&amp;\">text-&quot;&lt;&gt;&amp;</a>",
 					"img src=\"/destination-%22%3C%3E\" alt=\"alt-&#34;&lt;&gt;&amp;\" title=\"title-&#34;&lt;&gt;&amp;\">",

--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -69,9 +69,9 @@ func TestRSSCanonifyURLsSubDir(t *testing.T) {
 baseURL = 'https://example.org/subdir'
 disableKinds = ['section','sitemap','taxonomy','term']
 [markup.goldmark.renderHooks.image]
-enableDefault = true
+useEmbedded = 'fallback'
 [markup.goldmark.renderHooks.link]
-enableDefault = true
+useEmbedded = 'fallback'
 -- layouts/_markup/render-image.html --
 {{- $u := urls.Parse .Destination -}}
 {{- $src := $u.String | relURL -}}

--- a/markup/goldmark/goldmark_integration_test.go
+++ b/markup/goldmark/goldmark_integration_test.go
@@ -519,8 +519,8 @@ func TestImageAltApostrophesWithTypographer(t *testing.T) {
 -- hugo.toml --
 [markup.goldmark.extensions.typographer]
 disable = false
- [markup.goldmark.renderHooks.image]
- enableDefault = true
+[markup.goldmark.renderHooks.image]
+useEmbedded = 'always'
 -- content/p1.md --
 ---
 title: "p1"

--- a/tpl/tplimpl/render_hook_integration_test.go
+++ b/tpl/tplimpl/render_hook_integration_test.go
@@ -27,7 +27,7 @@ func TestEmbeddedLinkRenderHook(t *testing.T) {
 -- hugo.toml --
 disableKinds = ['rss','sitemap','taxonomy','term']
 [markup.goldmark.renderHooks.link]
-enableDefault = true
+useEmbedded = 'always'
 -- layouts/list.html --
 {{ .Content }}
 -- layouts/single.html --
@@ -153,7 +153,7 @@ wrapStandAloneImageWithinParagraph = false
 [markup.goldmark.parser.attribute]
 block = false
 [markup.goldmark.renderHooks.image]
-enableDefault = true
+useEmbedded = 'always'
 -- content/p1/index.md --
 ![]()
 
@@ -253,37 +253,29 @@ custom image render hook: {{ .Text }}|{{ .Destination }}
 		id             string // the test id
 		isMultilingual bool   // whether the site is multilingual single-host
 		hasCustomHooks bool   // whether the site has custom link and image render hooks
-		keyValuePair   string // the enableDefault (deprecated in v0.148.0) or useEmbedded key-value pair
+		keyValuePair   string // the useEmbedded key-value pair
 		want           string // the expected content of public/s1/p1/index.html
 	}{
 		{"01", false, false, "", wantGoldmark},                         // monolingual
-		{"02", false, false, "enableDefault = false", wantGoldmark},    // monolingual, enableDefault = false
-		{"03", false, false, "enableDefault = true", wantEmbedded},     // monolingual, enableDefault = true
-		{"04", false, false, "useEmbedded = 'always'", wantEmbedded},   // monolingual, useEmbedded = 'always'
-		{"05", false, false, "useEmbedded = 'auto'", wantGoldmark},     // monolingual, useEmbedded = 'auto'
-		{"06", false, false, "useEmbedded = 'fallback'", wantEmbedded}, // monolingual, useEmbedded = 'fallback'
-		{"07", false, false, "useEmbedded = 'never'", wantGoldmark},    // monolingual, useEmbedded = 'never'
-		{"08", false, true, "", wantCustom},                            // monolingual, with custom hooks
-		{"09", false, true, "enableDefault = false", wantCustom},       // monolingual, with custom hooks, enableDefault = false
-		{"10", false, true, "enableDefault = true", wantCustom},        // monolingual, with custom hooks, enableDefault = true
-		{"11", false, true, "useEmbedded = 'always'", wantEmbedded},    // monolingual, with custom hooks, useEmbedded = 'always'
-		{"12", false, true, "useEmbedded = 'auto'", wantCustom},        // monolingual, with custom hooks, useEmbedded = 'auto'
-		{"13", false, true, "useEmbedded = 'fallback'", wantCustom},    // monolingual, with custom hooks, useEmbedded = 'fallback'
-		{"14", false, true, "useEmbedded = 'never'", wantCustom},       // monolingual, with custom hooks, useEmbedded = 'never'
-		{"15", true, false, "", wantEmbedded},                          // multilingual
-		{"16", true, false, "enableDefault = false", wantGoldmark},     // multilingual, enableDefault = false
-		{"17", true, false, "enableDefault = true", wantEmbedded},      // multilingual, enableDefault = true
-		{"18", true, false, "useEmbedded = 'always'", wantEmbedded},    // multilingual, useEmbedded = 'always'
-		{"19", true, false, "useEmbedded = 'auto'", wantEmbedded},      // multilingual, useEmbedded = 'auto'
-		{"20", true, false, "useEmbedded = 'fallback'", wantEmbedded},  // multilingual, useEmbedded = 'fallback'
-		{"21", true, false, "useEmbedded = 'never'", wantGoldmark},     // multilingual, useEmbedded = 'never'
-		{"22", true, true, "", wantCustom},                             // multilingual, with custom hooks
-		{"23", true, true, "enableDefault = false", wantCustom},        // multilingual, with custom hooks, enableDefault = false
-		{"24", true, true, "enableDefault = true", wantCustom},         // multilingual, with custom hooks, enableDefault = true
-		{"25", true, true, "useEmbedded = 'always'", wantEmbedded},     // multilingual, with custom hooks, useEmbedded = 'always'
-		{"26", true, true, "useEmbedded = 'auto'", wantCustom},         // multilingual, with custom hooks, useEmbedded = 'auto'
-		{"27", true, true, "useEmbedded = 'fallback'", wantCustom},     // multilingual, with custom hooks, useEmbedded = 'fallback'
-		{"28", true, true, "useEmbedded = 'never'", wantCustom},        // multilingual, with custom hooks, useEmbedded = 'never'
+		{"02", false, false, "useEmbedded = 'always'", wantEmbedded},   // monolingual, useEmbedded = 'always'
+		{"03", false, false, "useEmbedded = 'auto'", wantGoldmark},     // monolingual, useEmbedded = 'auto'
+		{"04", false, false, "useEmbedded = 'fallback'", wantEmbedded}, // monolingual, useEmbedded = 'fallback'
+		{"05", false, false, "useEmbedded = 'never'", wantGoldmark},    // monolingual, useEmbedded = 'never'
+		{"06", false, true, "", wantCustom},                            // monolingual, with custom hooks
+		{"07", false, true, "useEmbedded = 'always'", wantEmbedded},    // monolingual, with custom hooks, useEmbedded = 'always'
+		{"08", false, true, "useEmbedded = 'auto'", wantCustom},        // monolingual, with custom hooks, useEmbedded = 'auto'
+		{"09", false, true, "useEmbedded = 'fallback'", wantCustom},    // monolingual, with custom hooks, useEmbedded = 'fallback'
+		{"10", false, true, "useEmbedded = 'never'", wantCustom},       // monolingual, with custom hooks, useEmbedded = 'never'
+		{"11", true, false, "", wantEmbedded},                          // multilingual
+		{"12", true, false, "useEmbedded = 'always'", wantEmbedded},    // multilingual, useEmbedded = 'always'
+		{"13", true, false, "useEmbedded = 'auto'", wantEmbedded},      // multilingual, useEmbedded = 'auto'
+		{"14", true, false, "useEmbedded = 'fallback'", wantEmbedded},  // multilingual, useEmbedded = 'fallback'
+		{"15", true, false, "useEmbedded = 'never'", wantGoldmark},     // multilingual, useEmbedded = 'never'
+		{"16", true, true, "", wantCustom},                             // multilingual, with custom hooks
+		{"17", true, true, "useEmbedded = 'always'", wantEmbedded},     // multilingual, with custom hooks, useEmbedded = 'always'
+		{"18", true, true, "useEmbedded = 'auto'", wantCustom},         // multilingual, with custom hooks, useEmbedded = 'auto'
+		{"19", true, true, "useEmbedded = 'fallback'", wantCustom},     // multilingual, with custom hooks, useEmbedded = 'fallback'
+		{"20", true, true, "useEmbedded = 'never'", wantCustom},        // multilingual, with custom hooks, useEmbedded = 'never'
 	}
 
 	for _, tt := range tests {
@@ -313,7 +305,7 @@ func TestRenderHookMultilingual(t *testing.T) {
 baseURL = 'https://example.org/'
 defaultContentLanguage = 'en'
 [markup.goldmark.renderHooks.image]
-enableDefault = false
+useEmbedded = 'never'
 [languages.en]
 weight = 1
 [languages.tr]


### PR DESCRIPTION
With v0.163.0 and later the presence of these config settings throws deprecation errors instead of warnings, as expected:

- markup.goldmark.renderHooks.image.enableDefault
- markup.goldmark.renderHooks.link.enableDefault

Adjust related tests accordingly.