### PR TITLE
resources/page: Avoid slice bounds panic on shortened CJK summary

### DIFF
--- a/resources/page/page_markup.go
+++ b/resources/page/page_markup.go
@@ -83,7 +83,7 @@ func (s HtmlSummary) wrap(ss string) string {
 	if s.WrapperStart.IsZero() {
 		return ss
 	}
-	return s.source[s.WrapperStart.Low:s.WrapperStart.High] + ss + s.source[s.WrapperEnd.Low:s.WrapperEnd.High]
+	return s.safeSlice(s.WrapperStart.Low, s.WrapperStart.High) + ss + s.safeSlice(s.WrapperEnd.Low, s.WrapperEnd.High)
 }
 
 func (s HtmlSummary) wrapLeft(ss string) string {
@@ -91,11 +91,11 @@ func (s HtmlSummary) wrapLeft(ss string) string {
 		return ss
 	}
 
-	return s.source[s.WrapperStart.Low:s.WrapperStart.High] + ss
+	return s.safeSlice(s.WrapperStart.Low, s.WrapperStart.High) + ss
 }
 
 func (s HtmlSummary) Value(l types.LowHigh[string]) string {
-	return s.source[l.Low:l.High]
+	return s.safeSlice(l.Low, l.High)
 }
 
 func (s HtmlSummary) trimSpace(ss string) string {
@@ -106,8 +106,8 @@ func (s HtmlSummary) Content() string {
 	if s.Divider.IsZero() {
 		return s.trimSpace(s.source)
 	}
-	ss := s.source[:s.Divider.Low]
-	ss += s.source[s.Divider.High:]
+	ss := s.safeSlice(0, s.Divider.Low)
+	ss += s.safeSliceFrom(s.Divider.High)
 	return s.trimSpace(ss)
 }
 
@@ -115,9 +115,9 @@ func (s HtmlSummary) Summary() string {
 	if s.Divider.IsZero() {
 		return s.trimSpace(s.wrap(s.Value(s.SummaryLowHigh)))
 	}
-	ss := s.source[s.SummaryLowHigh.Low:s.Divider.Low]
+	ss := s.safeSlice(s.SummaryLowHigh.Low, s.Divider.Low)
 	if s.SummaryLowHigh.High > s.Divider.High {
-		ss += s.source[s.Divider.High:s.SummaryLowHigh.High]
+		ss += s.safeSlice(s.Divider.High, s.SummaryLowHigh.High)
 	}
 	if !s.SummaryEndTag.IsZero() {
 		ss += s.Value(s.SummaryEndTag)
@@ -130,13 +130,64 @@ func (s HtmlSummary) ContentWithoutSummary() string {
 		if s.SummaryLowHigh.Low == s.WrapperStart.High && s.SummaryLowHigh.High == s.WrapperEnd.Low {
 			return ""
 		}
-		return s.trimSpace(s.wrapLeft(s.source[s.SummaryLowHigh.High:]))
+		return s.trimSpace(s.wrapLeft(s.safeSliceFrom(s.SummaryLowHigh.High)))
 	}
 	if s.SummaryEndTag.IsZero() {
-		return s.trimSpace(s.wrapLeft(s.source[s.Divider.High:]))
+		return s.trimSpace(s.wrapLeft(s.safeSliceFrom(s.Divider.High)))
 	}
-	return s.trimSpace(s.wrapLeft(s.source[s.SummaryEndTag.High:]))
+	return s.trimSpace(s.wrapLeft(s.safeSliceFrom(s.SummaryEndTag.High)))
 }
+
+func (s HtmlSummary) safeSlice(low, high int) string {
+	if low < 0 {
+		low = 0
+	}
+	if high < 0 {
+		high = 0
+	}
+	n := len(s.source)
+	if low > n {
+		low = n
+	}
+	if high > n {
+		high = n
+	}
+	if low > high {
+		low = high
+	}
+	low = s.safeRuneBoundary(low)
+	high = s.safeRuneBoundary(high)
+	if low > high {
+		low = high
+	}
+	return s.source[low:high]
+}
+
+func (s HtmlSummary) safeSliceFrom(low int) string {
+	if low < 0 {
+		low = 0
+	}
+	n := len(s.source)
+	if low > n {
+		low = n
+	}
+	low = s.safeRuneBoundary(low)
+	return s.source[low:]
+}
+
+func (s HtmlSummary) safeRuneBoundary(idx int) int {
+	if idx <= 0 {
+		return 0
+	}
+	if idx >= len(s.source) {
+		return len(s.source)
+	}
+	for idx > 0 && !utf8.RuneStart(s.source[idx]) {
+		idx--
+	}
+	return idx
+}
+
 
 func (s HtmlSummary) Truncated() bool {
 	return s.Summary() != s.Content()

--- a/resources/page/page_markup_test.go
+++ b/resources/page/page_markup_test.go
@@ -206,3 +206,28 @@ func BenchmarkSummaryFromHTMLWithDivider(b *testing.B) {
 		}
 	}
 }
+
+func TestExtractSummaryFromHTMLShortenedSource(t *testing.T) {
+	// Simulate a case where a previous run has a longer SummaryLowHigh.High.
+	// We want to verify that methods on HtmlSummary do not panic if the source string is shortened.
+	inputLong := "<p>这是一个非常长长的中文段落，用来生成一个长边界索引。</p>"
+	summaryLong := ExtractSummaryFromHTML(media.Builtin.MarkdownType, inputLong, 70, false)
+
+	// Create a shorter input
+	inputShort := "<p>短内容</p>"
+
+	// Reuse the SummaryLowHigh index from the long summary with the short input
+	summaryStale := HtmlSummary{
+		source:         inputShort,
+		SummaryLowHigh: summaryLong.SummaryLowHigh,
+		WrapperStart:   summaryLong.WrapperStart,
+		WrapperEnd:     summaryLong.WrapperEnd,
+		Divider:        summaryLong.Divider,
+	}
+
+	// This should not panic
+	_ = summaryStale.Summary()
+	_ = summaryStale.ContentWithoutSummary()
+}
+
+


### PR DESCRIPTION
### Description

This PR fixes a Go runtime panic `slice bounds out of range` that occurs during `hugo server` rebuilds when CJK page content is shortened.

### Cause of the Bug
When generating `.Summary` or `.ContentWithoutSummary`, Hugo slices the rendered HTML source using pre-computed boundary indices (such as `SummaryLowHigh` or `Divider`). When rebuilding a page after shortening its content under CJK environments (where `hasCJKLanguage = false` is default), the calculated or stale boundary indices from earlier parsing or layout evaluation can exceed the new shorter content's length, leading to a panic.

### Solution
- Introduced `safeSlice`, `safeSliceFrom` and `safeRuneBoundary` helper methods to `HtmlSummary` in `resources/page/page_markup.go`.
- These helper methods enforce boundary limits (`0 <= low <= high <= len(s.source)`) and automatically align indices back to valid UTF-8 rune boundaries (preventing half-rune CJK character truncation).
- Replaced all unsafe direct slicing operations in `HtmlSummary` with calls to these safe helpers.
- Added a unit test `TestExtractSummaryFromHTMLShortenedSource` to reproduce and verify the fix.
