### PR TITLE
js: Resolve bare package imports to module.esm.js in assets

### DIFF
--- a/internal/js/esbuild/resolve.go
+++ b/internal/js/esbuild/resolve.go
@@ -133,6 +133,13 @@ func ResolveComponent[T any](impPath string, resolve func(string) (v T, found, i
 		if !found {
 			v, found, _ = findFirst(filepath.Join(impPath, "index.esm"))
 		}
+		if !found && isBarePackage(impPath) {
+			// A bare package import, e.g. "alpinejs" or "@alpinejs/persist". Try
+			// the conventional ESM entry, e.g. alpinejs/module.esm.js (AlpineJS'
+			// package.json "module" field), so it can be imported without
+			// spelling out the filename.
+			v, found, _ = findFirst(filepath.Join(impPath, "module.esm"))
+		}
 	}
 
 	if !found && strings.HasSuffix(base, ".js") {
@@ -140,6 +147,16 @@ func ResolveComponent[T any](impPath string, resolve func(string) (v T, found, i
 	}
 
 	return
+}
+
+// isBarePackage reports whether p is a bare package specifier, i.e. a package
+// name without a subpath: "alpinejs" or the scoped "@alpinejs/persist", but not
+// "foo/bar".
+func isBarePackage(p string) bool {
+	if strings.HasPrefix(p, "@") {
+		return strings.Count(p, "/") == 1
+	}
+	return !strings.Contains(p, "/")
 }
 
 // ResolveResource resolves a resource using the given resourceGetter.

--- a/internal/js/esbuild/resolve_test.go
+++ b/internal/js/esbuild/resolve_test.go
@@ -53,6 +53,13 @@ func TestResolveComponentInAssets(t *testing.T) {
 
 		// Issue #8949
 		{"Check file before directory", []string{"foo.js", "foo/index.js"}, "foo", "foo.js"},
+
+		// Issue #14973: resolve bare package imports to their module.esm.js entry.
+		{"Package module.esm", []string{"alpinejs/module.esm.js", "bar.js"}, "alpinejs", "alpinejs/module.esm.js"},
+		{"Package index before module.esm", []string{"alpinejs/index.js", "alpinejs/module.esm.js"}, "alpinejs", "alpinejs/index.js"},
+		{"Package module.esm not for subpaths", []string{"foo/bar/module.esm.js"}, "foo/bar", ""},
+		{"Scoped package module.esm", []string{"@alpinejs/persist/module.esm.js", "bar.js"}, "@alpinejs/persist", "@alpinejs/persist/module.esm.js"},
+		{"Scoped package module.esm not for subpaths", []string{"@alpinejs/persist/dist/module.esm.js"}, "@alpinejs/persist/dist", ""},
 	} {
 		c.Run(test.name, func(c *qt.C) {
 			baseDir := "assets"


### PR DESCRIPTION
Resolve a bare package name (e.g. "alpinejs") to its conventional ESM
entry module.esm.js when neither index.js nor index.esm.js exists, so it
can be imported without spelling out the filename.

Fixes #14973
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
