### PR TITLE
cache/filecache: Clarify :resourceDir handling

### DIFF
--- a/cache/filecache/filecache_config_test.go
+++ b/cache/filecache/filecache_config_test.go
@@ -140,6 +140,38 @@ func TestDecodeConfigDefault(t *testing.T) {
 	c.Assert(miscConfig.IsResourceDir, qt.Equals, false)
 }
 
+// See issue 14165.
+func TestDecodeConfigResourceDirHandling(t *testing.T) {
+	t.Parallel()
+
+	t.Run("supported", func(t *testing.T) {
+		t.Parallel()
+
+		c := qt.New(t)
+		fs := afero.NewMemMapFs()
+		cfg := config.New()
+		cfg.Set("cacheDir", "/cache/thecache")
+		cfg.Set("workingDir", filepath.FromSlash("/my/cool/hugoproject"))
+		cfg.Set("resourceDir", "/cache/resources")
+		cfg.Set("caches", map[string]any{
+			"images": map[string]any{
+				"dir":    ":resourceDir/_gen",
+				"maxAge": "10m",
+			},
+		})
+
+		testCfg := testconfig.GetTestConfig(fs, cfg)
+		decoded, err := filecache.DecodeConfig(fs, testCfg.BaseConfig(), cfg.GetStringMap("caches"))
+		c.Assert(err, qt.IsNil)
+
+		imgConfig := decoded[filecache.CacheKeyImages]
+		c.Assert(imgConfig.DirCompiled, qt.Equals, filepath.FromSlash("_gen/images"))
+		c.Assert(imgConfig.MaxAge, qt.Equals, 10*time.Minute)
+		c.Assert(imgConfig.IsResourceDir, qt.Equals, true)
+	})
+
+}
+
 func TestFileCacheConfigMarshalJSON(t *testing.T) {
 	c := qt.New(t)
 

--- a/docs/content/en/configuration/caches.md
+++ b/docs/content/en/configuration/caches.md
@@ -38,7 +38,7 @@ modules
 ## Keys
 
 dir
-: (`string`) The absolute file system path where Hugo stores the cached files. You can begin the path with the `:cacheDir` or `:resourceDir` [tokens](#tokens) to anchor the cache to specific system or project locations.
+: (`string`) The absolute file system path where Hugo stores the cached files. You can begin the path with the `:cacheDir` [token](#tokens) to anchor the cache to a system location. The `:resourceDir` token is a special case for the layered resources cache, with limited support as described below.
 
 maxAge
 : (`string`) The duration a cached entry remains valid before being evicted, expressed as a [duration](g). A value of `0` disables the cache for that key, and a value of `-1` means the cache entry never expires. Default is `-1`.
@@ -52,7 +52,7 @@ maxAge
 : (`string`) The base directory name of the current Hugo project. This ensures isolated file caches for each project, preventing the `hugo build --gc` command from affecting other projects on the same machine.
 
 `:resourceDir`
-: (`string`) The designated directory for caching output from [asset pipelines](g). See [details](/configuration/all/#resourcedir).
+: (`string`) A special token for the layered resources cache used by asset pipelines. This token does not behave like a general path placeholder. The built-in `images` and `assets` caches use the `:resourceDir/_gen` form to target the resources cache filesystem. See [details](/configuration/all/#resourcedir).
 
 ## Garbage collection
 


### PR DESCRIPTION
Fixes part of #14165 by clarifying the special ":resourceDir" behavior in the cache docs and adding tests that pin the current filecache behavior.

## Summary
- document that :resourceDir is a special case for the layered resources cache, not a general path placeholder
- add a test that verifies caches.images.dir = ":resourceDir/_gen" keeps the special _gen/images compiled path behavior
- prove the override is applied by asserting a custom maxAge

## Validation
- go test ./cache/filecache/...
- ./check.sh ./cache/filecache/...
- ./check.sh

## AI disclosure
This PR was written with substantial assistance from Codex.