### PR TITLE
resources/jsconfig: Remove deprecated baseUrl setting

### DIFF
--- a/resources/jsconfig/jsconfig.go
+++ b/resources/jsconfig/jsconfig.go
@@ -61,20 +61,18 @@ func (b *Builder) AddSourceRoot(root string) {
 
 // CompilerOptions holds compilerOptions for jsonconfig.json.
 type CompilerOptions struct {
-	BaseURL string              `json:"baseUrl"`
-	Paths   map[string][]string `json:"paths"`
+        Paths   map[string][]string `json:"paths"`
 }
 
 // Config holds the data for jsconfig.json.
 type Config struct {
-	CompilerOptions CompilerOptions `json:"compilerOptions"`
+        CompilerOptions CompilerOptions `json:"compilerOptions"`
 }
 
 func newJSConfig() *Config {
-	return &Config{
-		CompilerOptions: CompilerOptions{
-			BaseURL: ".",
-			Paths:   make(map[string][]string),
-		},
-	}
+        return &Config{
+                CompilerOptions: CompilerOptions{
+                        Paths:   make(map[string][]string),
+                },
+        }
 }

--- a/resources/jsconfig/jsconfig_test.go
+++ b/resources/jsconfig/jsconfig_test.go
@@ -28,7 +28,6 @@ func TestJsConfigBuilder(t *testing.T) {
 	b.AddSourceRoot("/d/assets")
 
 	conf := b.Build("/a/b")
-	c.Assert(conf.CompilerOptions.BaseURL, qt.Equals, ".")
 	c.Assert(conf.CompilerOptions.Paths["*"], qt.DeepEquals, []string{filepath.FromSlash("../../c/assets/*"), filepath.FromSlash("../../d/assets/*")})
 
 	c.Assert(NewBuilder().Build("/a/b"), qt.IsNil)


### PR DESCRIPTION
This PR removes the deprecated `baseUrl` setting from `resources/jsconfig` as requested in #14991. 

All tests passed locally.