### PR TITLE
resources/jsconfig: Remove deprecated baseUrl setting

### DIFF
--- a/resources/jsconfig/jsconfig.go
+++ b/resources/jsconfig/jsconfig.go
@@ -61,8 +61,7 @@ func (b *Builder) AddSourceRoot(root string) {
 
 // CompilerOptions holds compilerOptions for jsonconfig.json.
 type CompilerOptions struct {
-	BaseURL string              `json:"baseUrl"`
-	Paths   map[string][]string `json:"paths"`
+	Paths map[string][]string `json:"paths"`
 }
 
 // Config holds the data for jsconfig.json.
@@ -73,8 +72,7 @@ type Config struct {
 func newJSConfig() *Config {
 	return &Config{
 		CompilerOptions: CompilerOptions{
-			BaseURL: ".",
-			Paths:   make(map[string][]string),
+			Paths: make(map[string][]string),
 		},
 	}
 }

--- a/resources/jsconfig/jsconfig_test.go
+++ b/resources/jsconfig/jsconfig_test.go
@@ -14,6 +14,7 @@
 package jsconfig
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -28,8 +29,12 @@ func TestJsConfigBuilder(t *testing.T) {
 	b.AddSourceRoot("/d/assets")
 
 	conf := b.Build("/a/b")
-	c.Assert(conf.CompilerOptions.BaseURL, qt.Equals, ".")
 	c.Assert(conf.CompilerOptions.Paths["*"], qt.DeepEquals, []string{filepath.FromSlash("../../c/assets/*"), filepath.FromSlash("../../d/assets/*")})
+
+	// baseUrl is deprecated in TypeScript and not needed when paths is set; see issue 14991.
+	data, err := json.Marshal(conf)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(data), qt.Not(qt.Contains), "baseUrl")
 
 	c.Assert(NewBuilder().Build("/a/b"), qt.IsNil)
 }


### PR DESCRIPTION
baseUrl is deprecated in TypeScript and is no longer required when
paths is set (TypeScript 4.1+).

Fixes #14991
Closes #14996
