### PR TITLE
pagesfromdata: use relative path for content adapter template metrics

### DIFF
--- a/hugolib/pagesfromdata/pagesfromgotmpl.go
+++ b/hugolib/pagesfromdata/pagesfromgotmpl.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"path/filepath"
 
 	"github.com/gohugoio/hugo/common/hashing"
 	"github.com/gohugoio/hugo/common/hmaps"
@@ -346,7 +345,7 @@ func (p *PagesFromTemplate) Execute(ctx context.Context) (BuildInfo, error) {
 	}
 	defer f.Close()
 
-	tmpl, err := p.TemplateStore.TextParse(filepath.ToSlash(p.GoTmplFi.Meta().Filename), helpers.ReaderToString(f))
+	tmpl, err := p.TemplateStore.TextParse(p.GoTmplFi.Meta().PathInfo.Path(), helpers.ReaderToString(f))
 	if err != nil {
 		return BuildInfo{}, err
 	}

--- a/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
+++ b/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
@@ -14,6 +14,7 @@
 package pagesfromdata_test
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"testing"
@@ -922,4 +923,26 @@ iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAA
 	b := hugolib.Test(t, files)
 
 	b.AssertFileContent("public/p1/index.html", "Resized: 1x1|")
+}
+
+// See https://github.com/gohugoio/hugo/issues/14999
+func TestContentAdapterTemplateMetricsRelativePath(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+templateMetrics = true
+-- layouts/all.html --
+{{ .Title }}
+-- content/docs/_content.gotmpl --
+{{ .AddPage (dict "path" "/docs/p1" "title" "P1") }}
+`
+	b := hugolib.Test(t, files)
+
+	var buf bytes.Buffer
+	b.H.Metrics.WriteMetrics(&buf)
+	got := buf.String()
+
+	b.Assert(got, qt.Contains, "/docs/_content.gotmpl")
+	b.Assert(got, qt.Not(qt.Contains), "content/docs/_content.gotmpl")
 }


### PR DESCRIPTION
Content adapter templates (`_content.gotmpl`) were showing their absolute filesystem path in `--templateMetrics` output instead of a short relative path like regular layout templates.

**Before:**
```
/Users/you/mysite/content/docs/_content.gotmpl
```

**After:**
```
/docs/_content.gotmpl
```

The fix uses `PathInfo.Path()` (already available on the file's metadata) instead of `Filename` when naming the template passed to `TextParse`. `PathInfo` holds the path relative to the content root, which is consistent with how layout templates appear in metrics.

Fixes #14999

---

> This PR was written primarily with Claude Code (AI assistance). I have reviewed the code and understand the changes.