### PR TITLE
herrors: standardize feature not available error message

### DIFF
--- a/common/herrors/errors.go
+++ b/common/herrors/errors.go
@@ -84,7 +84,7 @@ func IsFeatureNotAvailableError(err error) bool {
 //
 // We will, at least to begin with, make some Hugo features (SCSS with libsass) optional,
 // and this error is used to signal those situations.
-var ErrFeatureNotAvailable = &FeatureNotAvailableError{Cause: errors.New("this feature is not available in your current Hugo version, see https://goo.gl/YMrWcn for more information")}
+var ErrFeatureNotAvailable = &FeatureNotAvailableError{Cause: errors.New("this feature is not available in this edition of Hugo")}
 
 // FeatureNotAvailableError is an error type used to signal that a feature is not available.
 type FeatureNotAvailableError struct {


### PR DESCRIPTION
Fixes #13003

Standardizes the error message thrown when a feature is not available
in the current Hugo edition.

The previous message referenced "your current Hugo version" which was
inaccurate — the issue is edition-specific (standard vs extended), not
version-specific. The message also included a goo.gl shortlink whose
anchor has become stale since the FAQ was updated.

The new message aligns with what the documentation already displays:

    this feature is not available in this edition of Hugo