### PR TITLE
tpl: Refine error for return in non-partial templates

### DIFF
--- a/tpl/partials/partials_integration_test.go
+++ b/tpl/partials/partials_integration_test.go
@@ -335,3 +335,20 @@ BAR
 
 	b.AssertFileContent("public/index.html", "OO:BAR")
 }
+
+// See Issue #11708
+func TestReturnInNonPartialError(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = 'http://example.com/'
+-- layouts/home.html --
+{{ return "hugo" }}
+`
+
+	b, err := hugolib.TestE(t, files)
+
+	b.Assert(err, qt.Not(qt.IsNil))
+	b.Assert(err.Error(), qt.Contains, "\"return\" is only supported in partial templates")
+}

--- a/tpl/tplimpl/templatetransform.go
+++ b/tpl/tplimpl/templatetransform.go
@@ -567,16 +567,25 @@ func (c *templateTransformContext) collectInnerInPartial(n *parse.CommandNode) {
 }
 
 func (c *templateTransformContext) collectReturnNode(n *parse.CommandNode) bool {
-	if c.t.category != CategoryPartial || c.returnNode != nil {
-		return true
-	}
-
-	if len(n.Args) < 2 {
+	if len(n.Args) == 0 {
 		return true
 	}
 
 	ident, ok := n.Args[0].(*parse.IdentifierNode)
 	if !ok || ident.Ident != "return" {
+		return true
+	}
+
+	if c.t.category != CategoryPartial {
+		c.err = errors.New(`"return" is only supported in partial templates`)
+		return true
+	}
+
+	if c.returnNode != nil {
+		return true
+	}
+
+	if len(n.Args) < 2 {
 		return true
 	}
 


### PR DESCRIPTION
Fixes #11708.

When a user used the `return` function in a non-partial template (such as a standard layout), the Go `text/template` engine threw an unhelpful error. This intercepts the `return` node during AST transformation for non-partial templates and outputs a clear error instead. Added a unit test.