### PR TITLE
hugolib: Throw error when Render cannot find template

### DIFF
--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -114,7 +114,7 @@ func (pco *pageContentOutput) Render(ctx context.Context, layout ...string) (tem
 	}
 
 	if !found {
-		return "", nil
+		return "", fmt.Errorf("template %q not found", layout)
 	}
 
 	// Make sure to send the *pageState and not the *pageContentOutput to the template.

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -2055,3 +2055,22 @@ disableKinds = ["taxonomy", "term"]
 		}
 	}
 }
+
+// See issue 15052.
+func TestRenderViewNotFound(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+-- layouts/home.html --
+{{ .Render "view_foo" }}
+{{ .Render "view_bar" }}
+-- layouts/view_foo.html --
+foo
+`
+
+	b, err := TestE(t, files)
+	b.Assert(err, qt.IsNotNil)
+	b.Assert(err.Error(), qt.Contains, "template [\"view_bar\"] not found")
+}


### PR DESCRIPTION
Previously, invoking `.Page.Render` with a non-existent template name would silently return an empty string. This behavior masks developer errors and makes debugging template failures difficult.

This commit updates the `Render` method to explicitly return a formatted error containing the name of the missing template when it cannot be resolved, adhering to Go's idiomatic error-handling patterns.

Fixes #15052