### PR TITLE
hugolib: Print correct content file path in template render errors

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1752,8 +1752,15 @@ func (s *Site) renderForTemplate(ctx context.Context, name, outputFormat string,
 
 	if err = s.GetTemplateStore().ExecuteWithContext(ctx, templ, w, d); err != nil {
 		filename := name
-		if p, ok := d.(*pageState); ok {
-			filename = p.String()
+		if p, err := unwrapPage(d); err == nil && p != nil {
+			if ps, ok := p.(*pageState); ok {
+				filename = ps.pathOrTitle()
+			} else {
+				filename = p.Path()
+				if filename == "" {
+					filename = p.Title()
+				}
+			}
 		}
 		return fmt.Errorf("render of %q failed: %w", filename, err)
 	}


### PR DESCRIPTION
Previously, when a template execution failed, the resulting error message would often say `render of "page" failed`, obscuring the actual content file that triggered the error. This occurred because the data context passed to the template was sometimes an interface or wrapper, causing the direct type assertion to fail and default to the page Kind.

This commit updates the error formatting in `renderForTemplate` to use `unwrapPage()` to reliably extract the underlying `*pageState`. It then retrieves the appropriate file path or title via `pathOrTitle()`, ensuring that developers can easily identify the offending content file.

Fixes #14607