### PR TITLE
tpl/collections: Include key in IsSet unsupported-type warning

### DIFF
--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -347,7 +347,7 @@ func (ns *Namespace) IsSet(c any, key any) (bool, error) {
 			return av.MapIndex(kv).IsValid(), nil
 		}
 	default:
-		ns.deps.Log.Warnf("calling IsSet with unsupported type %q (%T) will always return false.\n", av.Kind(), c)
+		ns.deps.Log.Warnf("calling IsSet with unsupported type %q (%T) for key %v will always return false.\n", av.Kind(), c, key)
 	}
 
 	return false, nil


### PR DESCRIPTION
## Summary

`collections.IsSet` logs a warning when called with an unsupported type, but the message only reports the type, not the key:

> calling IsSet with unsupported type "invalid" (...) will always return false.

As reported in #11794, this gives no clue which key/template triggered it, making the warning hard to act on. This includes the key in the message:

> calling IsSet with unsupported type "invalid" (...) for key "name" will always return false.

The return-value behaviour is unchanged; only the log message gains the key.

Fixes #11794