### PR TITLE
hugolib: Preserve explicit file extensions in aliases

### DIFF
--- a/hugolib/alias.go
+++ b/hugolib/alias.go
@@ -180,7 +180,7 @@ func (a aliasHandler) targetPathAlias(src string) (string, error) {
 	alias = strings.TrimPrefix(alias, "/")
 	if strings.HasSuffix(alias, "/") {
 		alias = alias + "index.html"
-	} else if !strings.HasSuffix(alias, ".html") {
+	} else if ext := path.Ext(alias); ext == "" || ext == "." {
 		alias = alias + "/" + "index.html"
 	}
 

--- a/hugolib/alias_test.go
+++ b/hugolib/alias_test.go
@@ -789,3 +789,29 @@ build:
 	b.AssertFileExists("public/p2-alias/index.html", false)
 	b.AssertFileExists("public/p3-alias/index.html", false)
 }
+
+// Aliases with an explicit file extension should be published verbatim,
+// even with uglyURLs enabled, rather than having ".html" appended.
+// See issue 14402.
+func TestAliasWithExplicitExtension(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+uglyURLs = true
+-- content/tutorials.md --
+---
+title: tut
+url: /tutorials.htm
+aliases: ["/tutorials/index.html", "/tutorials/index.htm"]
+---
+-- layouts/page.html --
+page
+`
+	b := Test(t, files)
+
+	b.AssertFileContent("public/tutorials/index.html", "refresh")
+	b.AssertFileContent("public/tutorials/index.htm", "refresh")
+	b.AssertFileExists("public/tutorials/index.htm.html", false)
+}

--- a/hugolib/page__output.go
+++ b/hugolib/page__output.go
@@ -140,7 +140,7 @@ func (po *pageOutput) Aliases() []string {
 
 		a = path.Join(baseDir, a)
 
-		if conf.C.IsUglyURLSection(p.Section()) && !strings.HasSuffix(a, ".html") {
+		if ext := path.Ext(a); conf.C.IsUglyURLSection(p.Section()) && (ext == "" || ext == ".") {
 			a += ".html"
 		}
 


### PR DESCRIPTION
Aliases ending in an extension other than ".html" (e.g. ".htm") were
treated as extensionless: uglyURLs appended ".html" (index.htm.html) and
targetPathAlias appended "/index.html". Both now leave aliases with a
file extension untouched, so they're published verbatim.

Fixes #15066