### PR TITLE
transform: Fix invalid YAML anchors for repeated empty arrays

### DIFF
--- a/tpl/transform/remarshal.go
+++ b/tpl/transform/remarshal.go
@@ -69,6 +69,18 @@ func applyMarshalTypes(m map[string]any) {
 		switch t := v.(type) {
 		case map[string]any:
 			applyMarshalTypes(t)
+		case []any:
+			if len(t) == 0 {
+				// The YAML decoder returns the same shared instance for
+				// every empty array literal, which makes the smart-anchor
+				// encoder treat them as one value referenced many times
+				// and emit an invalid self-referencing anchor. Give each
+				// one its own backing array (len 0 alone shares a pointer)
+				// to break the false sharing without touching real
+				// (non-empty) anchors, which still need dedup to guard
+				// against billion-laughs-style expansion.
+				m[k] = make([]any, 0, 1)
+			}
 		case float64:
 			i := int64(t)
 			if t == float64(i) {

--- a/tpl/transform/remarshal_test.go
+++ b/tpl/transform/remarshal_test.go
@@ -14,6 +14,7 @@
 package transform_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/gohugoio/hugo/htesting"
@@ -197,6 +198,36 @@ a = "b"
 
 		_, err = ns.Remarshal("json", "asdf")
 		c.Assert(err, qt.Not(qt.IsNil))
+	})
+
+	// Issue 14596
+	c.Run("Repeated empty arrays do not produce invalid YAML anchors", func(c *qt.C) {
+		input := `
+field1:
+  options: []
+  pattern: x1
+field2:
+  options: []
+  pattern: x2
+field3:
+  options: []
+  pattern: x3
+`
+
+		converted, err := ns.Remarshal("yaml", input)
+		c.Assert(err, qt.IsNil)
+
+		// The output must be valid YAML, in particular it must not contain
+		// a node that both defines and dereferences an anchor on the same
+		// line (e.g. "&options *options").
+		roundtripped, err := ns.Remarshal("json", converted)
+		c.Assert(err, qt.IsNil)
+		c.Assert(roundtripped, qt.Contains, `"field1"`)
+		c.Assert(roundtripped, qt.Contains, `"field2"`)
+		c.Assert(roundtripped, qt.Contains, `"field3"`)
+
+		// A node must never both define and dereference an anchor at once.
+		c.Assert(regexp.MustCompile(`&\S+\s+\*\S+`).MatchString(converted), qt.IsFalse)
 	})
 }
 


### PR DESCRIPTION
This PR was written primarily by Claude Code; I reviewed the change and verified it against the existing tests before submitting.

## Problem

`transform.Remarshal "yaml"` emits invalid, self-referencing YAML anchors when the input contains more than one empty array, e.g.:

```yaml
field1:
  options: &options []
field2:
  options: &options *options    # invalid: defines and dereferences the same anchor at once
```

Root cause: the YAML decoder (`goccy/go-yaml`) returns the exact same shared slice instance for every empty array literal in the source document. The smart-anchor-aware encoder option (`yaml.WithSmartAnchor()`, used to guard against billion-laughs-style expansion attacks) then treats these as one value referenced multiple times, and its anchor handling for empty sequences produces invalid output.

## Fix

In `applyMarshalTypes` (`tpl/transform/remarshal.go`), give each empty array its own backing allocation before marshaling, so the encoder no longer sees them as the same shared value. Non-empty arrays are left untouched, so genuinely shared/anchored structures still get smart-anchor deduplication.

## Testing

- Added a regression test reproducing the exact issue scenario (three sibling keys each holding an independent empty array), asserting the output round-trips and never contains an anchor-define-and-dereference-in-one-node pattern.
- Ran the full `tpl/transform` package test suite, including `TestRemarshaBillionLaughs`, to confirm the existing DoS-expansion protection is unaffected by this change.
- Ran `gofmt` and `go vet` on the changed files; both clean. I was unable to run `staticcheck` in my environment due to a local Go toolchain version mismatch unrelated to this change, so that check should be verified by CI.

Fixes #14596