### PR TITLE
create: Keep new content placeholders buildable

### DIFF
--- a/create/content_test.go
+++ b/create/content_test.go
@@ -159,6 +159,37 @@ site RegularPages: {{ len site.RegularPages  }}
 	cContains(c, readFileFromFs(t, fs.Source, filepath.Join("content", "mypage.md")), `draft: true`)
 }
 
+// See issue 15078.
+func TestNewContentWithBuildCascade(t *testing.T) {
+	t.Parallel()
+
+	mm := afero.NewMemMapFs()
+	c := qt.New(t)
+
+	c.Assert(initFs(mm), qt.IsNil)
+	c.Assert(mm.MkdirAll(filepath.Join("content", "posts", "drafts"), 0o755), qt.IsNil)
+	c.Assert(afero.WriteFile(mm, filepath.Join("content", "posts", "drafts", "_index.md"), []byte(`---
+title: Drafts
+build:
+  render: never
+cascade:
+  draft: true
+  build:
+    render: link
+draft: true
+---
+`), 0o755), qt.IsNil)
+
+	cfg, fs := newTestCfg(c, mm)
+	conf := testconfig.GetTestConfigs(fs.Source, cfg)
+	h, err := hugolib.NewHugoSites(deps.DepsCfg{Configs: conf, Fs: fs})
+	c.Assert(err, qt.IsNil)
+
+	const target = "posts/drafts/trip-to-puebla/index.md"
+	c.Assert(create.NewContent(h, "", target, false), qt.IsNil)
+	c.Assert(readFileFromFs(c, fs.Source, filepath.Join("content", target)), qt.Contains, `title: "Trip to Puebla"`)
+}
+
 func initFs(fs afero.Fs) error {
 	perm := os.FileMode(0o755)
 	var err error

--- a/hugolib/content_factory.go
+++ b/hugolib/content_factory.go
@@ -114,6 +114,7 @@ func (f ContentFactory) CreateContentPlaceHolder(filename string, force bool) (s
 	// the paths correct.
 	placeholder := `---
 title: "Content Placeholder"
+draft: false
 build:
   render: never
   list: never


### PR DESCRIPTION
## Summary

Fixes #15078.

`hugo new content` writes a temporary placeholder and builds it before applying the archetype. If an ancestor cascade sets `draft: true`, that placeholder can be dropped from the temporary build and `NewContent` returns a false path-conflict error while leaving the placeholder behind. This makes the placeholder explicitly non-draft so it remains available for archetype application; the generated file still comes from the selected archetype afterward.

## Changes

- Add `draft: false` to the temporary content placeholder front matter.
- Add a regression test for a branch bundle cascade that marks descendants as drafts.

## Testing

- `go test ./create -run TestNewContentWithBuildCascade -count=1`
- `go test ./create`
- `PATH="$(go env GOPATH)/bin:$PATH" ./check.sh ./create/...`

Note: I used Codex while preparing this narrow bug fix. I reviewed the final diff and ran the listed checks locally.
