### PR TITLE
hugolib: Support subdirectory paths in .Render

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -631,7 +631,41 @@ func (ps *pageState) resolveTemplate(layouts ...string) (*tplimpl.TemplInfo, boo
 	dir, d := ps.GetInternalTemplateBasePathAndDescriptor()
 
 	if len(layouts) > 0 {
-		d.LayoutFromUser = layouts[0]
+		layout := layouts[0]
+		if i := strings.LastIndex(layout, "/"); i != -1 {
+			if i == len(layout)-1 {
+				return nil, false, nil
+			}
+			subdir := layout[:i]
+			d.LayoutFromUser = layout[i+1:]
+			d.LayoutFromUserMustMatch = true
+
+			// Try the subdir relative to each ancestor of the page's path,
+			// from most specific to least: {page-path}/subdir, {parent}/subdir, ..., /subdir.
+			var parts []string
+			if trimmed := strings.Trim(dir, "/"); trimmed != "" {
+				parts = strings.Split(trimmed, "/")
+			}
+			for depth := len(parts); depth >= 0; depth-- {
+				var searchPath string
+				if depth > 0 {
+					searchPath = "/" + strings.Join(parts[:depth], "/") + "/" + subdir
+				} else {
+					searchPath = "/" + subdir
+				}
+				q := tplimpl.TemplateQuery{
+					Path:     searchPath,
+					Category: tplimpl.CategoryLayout,
+					Sites:    ps.s.siteVector,
+					Desc:     d,
+				}
+				if tinfo := ps.s.TemplateStore.LookupPagesLayoutAtPath(q); tinfo != nil {
+					return tinfo, true, nil
+				}
+			}
+			return nil, false, nil
+		}
+		d.LayoutFromUser = layout
 		d.LayoutFromUserMustMatch = true
 	}
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -2167,3 +2167,141 @@ EF
 	b.AssertFileContent("public/s4/p9/index.html", "EF")
 	b.AssertFileContent("public/s4/p10/index.html", "EF")
 }
+
+// See issue 15056.
+func TestRenderViewSubdir(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+-- content/s1/p1.md --
+---
+title: p1
+---
+-- layouts/s1/p1/page.html --
+{{ .Render "a" }}|{{ .Render "b" }}|{{ .Render "c" }}|{{ .Render "foo/d" }}|{{ .Render "foo/e" }}|{{ .Render "foo/f" }}|{{ .Render "sub/foo/g" }}
+-- layouts/s1/p1/a.html --
+a{{- /**/ -}}
+-- layouts/s1/b.html --
+b{{- /**/ -}}
+-- layouts/c.html --
+c{{- /**/ -}}
+-- layouts/s1/p1/foo/d.html --
+d{{- /**/ -}}
+-- layouts/s1/foo/e.html --
+e{{- /**/ -}}
+-- layouts/foo/f.html --
+f{{- /**/ -}}
+-- layouts/sub/foo/g.html --
+g{{- /**/ -}}
+`
+
+	b := Test(t, files)
+	b.AssertFileContent("public/s1/p1/index.html", "a|b|c|d|e|f|g")
+}
+
+// See issue 15056.
+func TestRenderViewSubdirRootPage(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+-- content/p1.md --
+---
+title: p1
+---
+-- layouts/page.html --
+{{ .Render "foo/a" }}
+-- layouts/foo/a.html --
+a{{- /**/ -}}
+`
+
+	b := Test(t, files)
+	b.AssertFileContent("public/p1/index.html", "a")
+}
+
+// See issue 15056.
+func TestRenderViewSubdirNotFound(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+-- content/s1/p1.md --
+---
+title: p1
+---
+-- layouts/s1/p1/page.html --
+{{ .Render "foo/missing" }}
+-- layouts/s1/p1/missing.html --
+should-not-match{{- /**/ -}}
+`
+
+	b, err := TestE(t, files)
+	b.Assert(err, qt.ErrorMatches, `.*template "foo/missing" not found.*`)
+}
+
+// See issue 15056.
+func TestRenderViewSubdirTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+-- content/s1/p1.md --
+---
+title: p1
+---
+-- layouts/s1/p1/page.html --
+{{ .Render "foo/" }}
+-- layouts/s1/p1/foo.html --
+should-not-match{{- /**/ -}}
+`
+
+	b, err := TestE(t, files)
+	b.Assert(err, qt.ErrorMatches, `.*template "foo/" not found.*`)
+}
+
+// See issue 15056.
+func TestRenderViewSubdirCaseInsensitiveArgument(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+-- content/s1/p1.md --
+---
+title: p1
+---
+-- layouts/s1/p1/page.html --
+{{ .Render "Foo/Bar" }}
+-- layouts/s1/p1/foo/bar.html --
+bar{{- /**/ -}}
+`
+
+	b := Test(t, files)
+	b.AssertFileContent("public/s1/p1/index.html", "bar")
+}
+
+// See issue 15056.
+func TestRenderViewSubdirCaseInsensitivePath(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+-- content/s1/p1.md --
+---
+title: p1
+---
+-- layouts/s1/p1/page.html --
+{{ .Render "foo/bar" }}
+-- layouts/s1/p1/Foo/Bar.html --
+bar{{- /**/ -}}
+`
+
+	b := Test(t, files)
+	b.AssertFileContent("public/s1/p1/index.html", "bar")
+}

--- a/tpl/tplimpl/templatestore.go
+++ b/tpl/tplimpl/templatestore.go
@@ -585,11 +585,25 @@ func (s *TemplateStore) putBest(b *bestMatch) {
 func (s *TemplateStore) LookupPagesLayout(q TemplateQuery) *TemplInfo {
 	q.init()
 	key := s.key(q.Path)
-
 	slashCountKey := strings.Count(key, "/")
 	best1 := s.getBest()
 	defer s.putBest(best1)
 	s.findBestMatchWalkPath(q, key, slashCountKey, best1)
+	return s.resolveBaseof(q, key, slashCountKey, best1)
+}
+
+// LookupPagesLayoutAtPath is like LookupPagesLayout but only checks the given
+// path for a layout match, without walking up to parent directories.
+func (s *TemplateStore) LookupPagesLayoutAtPath(q TemplateQuery) *TemplInfo {
+	q.init()
+	key := strings.ToLower(s.key(q.Path))
+	best1 := s.getBest()
+	defer s.putBest(best1)
+	s.findBestMatchGet(key, q.Category, q.Consider, q.Desc, q.Sites, best1)
+	return s.resolveBaseof(q, key, strings.Count(key, "/"), best1)
+}
+
+func (s *TemplateStore) resolveBaseof(q TemplateQuery, key string, slashCountKey int, best1 *bestMatch) *TemplInfo {
 	if best1.w.w1 <= 0 {
 		return nil
 	}
@@ -602,7 +616,6 @@ func (s *TemplateStore) LookupPagesLayout(q TemplateQuery) *TemplInfo {
 	if best1.w.w1 <= 0 {
 		return nil
 	}
-
 	return best1.templ
 }
 


### PR DESCRIPTION
A slash in the `.Render` argument scopes the lookup to a subdirectory. The subdirectory portion may itself contain multiple path segments. For example, `.Render "a/b/c"` resolves a template named `c` inside the directory path `a/b`:
    
    layouts/{page-path}/a/b/c.html
    layouts/{section}/a/b/c.html
    layouts/a/b/c.html
    
This walks up the page path, matching the subdirectory at each level, consistent with how subdirectory shortcodes are resolved.
    
    Closes #15056