### PR TITLE
hugolib: Fix home redirect overwriting content page with uglyURLs

### DIFF
--- a/hugolib/alias_test.go
+++ b/hugolib/alias_test.go
@@ -749,3 +749,24 @@ Output format: foo|Title: {{ .Title }}
 </head>
 	`)
 }
+
+// Issue 14576
+func TestHomeRedirectWithUglyURLs(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+defaultContentLanguageInSubdir = true
+uglyURLs = true
+-- layouts/home.html --
+HOME
+-- layouts/alias.html --
+ALIAS
+`
+
+	b := Test(t, files)
+
+	b.AssertFileContent("public/index.html", "ALIAS")
+	b.AssertFileContent("public/en/index.html", "HOME")
+}

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -364,7 +364,16 @@ func (s *Site) renderDefaultSiteRedirect(home *pageState) error {
 		//    /,/guest/,/guest/v1.0.0  = /guest/v1.0.0/en/
 		// /guest/v1.0.0/
 		//    /,/guest/ =  /guest/v1.0.0/
-		parts := strings.Split(strings.Trim(homeLink, "/"), "/")
+		//
+		// With uglyURLs enabled homeLink points to a file (e.g. /en/index.html)
+		// rather than a directory. Use the directory it lives in so the file
+		// name isn't treated as an extra path segment, which would add a
+		// redirect that overwrites the home page itself (#14576).
+		homeDir := homeLink
+		if !strings.HasSuffix(homeDir, "/") {
+			homeDir = path.Dir(homeDir)
+		}
+		parts := strings.Split(strings.Trim(homeDir, "/"), "/")
 
 		for i := 0; i < len(parts)-1; i++ {
 			ps = append(ps, paths.AddLeadingAndTrailingSlash(strings.Join(parts[0:i+1], "/")))


### PR DESCRIPTION
## Summary

Fixes #14576 (a regression introduced in v0.154.4 by commit 2d80b8a7).

When `defaultContentLanguageInSubdir` (or the `defaultContentVersionInSubdir` / `defaultContentRoleInSubdir` equivalents) is enabled together with `uglyURLs`, the default site home was published as a redirect at **both** `/` and `/<lang>/`. As a result `public/<lang>/index.html` contained the alias redirect instead of the rendered home page, while non-default languages rendered correctly.

## Root cause

`renderDefaultSiteRedirect` builds the ancestor-directory redirects (needed for multi-dimension setups such as `/guest/v1.0.0/en/`) by splitting the home page link into path segments:

```go
parts := strings.Split(strings.Trim(homeLink, "/"), "/")
```

With pretty URLs `homeLink` is a directory (`/en/`), but with `uglyURLs` it points to a file (`/en/index.html`). The trailing `index.html` became an extra path segment, so the loop emitted a redirect for `/en/` that overwrote the home page itself.

## Fix

Reduce `homeLink` to the directory it lives in (via `path.Dir`) before splitting. This is filename-agnostic, so it also holds for custom home output filenames, and leaves the pretty-URL and multi-dimension directory cases unchanged.

## Test

Adds `TestHomeRedirectWithUglyURLs` (the reproduction the maintainer posted on the issue): asserts `public/index.html` is the redirect and `public/en/index.html` is the rendered home page.

## Note

The issue thread also mentions a separate redirect problem for multihost projects; that is out of scope here and would be tracked/fixed separately.

## Test plan

- [ ] `go test ./hugolib/ -run TestHomeRedirectWithUglyURLs`
- [ ] Existing alias/redirect tests still pass (`go test ./hugolib/ -run 'Alias|Redirect'`)