### PR TITLE
tpl/collections: Fix shuffle panic on arrays and pointers to slices

### DIFF
--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -505,13 +505,21 @@ func (ns *Namespace) Shuffle(l any) (any, error) {
 	}
 
 	switch lv.Kind() {
-	case reflect.Array, reflect.Slice, reflect.String:
+	case reflect.Array, reflect.Slice:
 		// okay
 	default:
 		return nil, errors.New("can't iterate over " + reflect.ValueOf(l).Type().String())
 	}
 
-	shuffled := reflect.MakeSlice(reflect.TypeOf(l), lv.Len(), lv.Len())
+	// Use the type of the indirected value so a pointer to a slice is
+	// handled, and collect arrays into a slice of their element type as
+	// reflect.MakeSlice requires a slice type.
+	sliceType := lv.Type()
+	if sliceType.Kind() == reflect.Array {
+		sliceType = reflect.SliceOf(sliceType.Elem())
+	}
+
+	shuffled := reflect.MakeSlice(sliceType, lv.Len(), lv.Len())
 
 	randomIndices := rand.Perm(lv.Len())
 

--- a/tpl/collections/collections_integration_test.go
+++ b/tpl/collections/collections_integration_test.go
@@ -653,3 +653,29 @@ All.
 		}
 	})
 }
+
+// shuffle accepted arrays, strings and pointers to slices in its type switch,
+// but built the result with reflect.MakeSlice(reflect.TypeOf(l)), which panics
+// with "reflect.MakeSlice of non-slice type" for anything that is not a plain
+// slice. A template such as {{ shuffle "abc" }} therefore crashed the build.
+// A string now returns the regular iteration error, and a plain slice still
+// shuffles.
+func TestShuffleNonSlice(t *testing.T) {
+	t.Parallel()
+
+	_, err := hugolib.TestE(t, `
+-- hugo.toml --
+-- layouts/home.html --
+{{ shuffle "abc" }}
+`)
+	if err == nil || !strings.Contains(err.Error(), "can't iterate over string") {
+		t.Fatalf("expected a \"can't iterate over string\" error, got: %v", err)
+	}
+
+	b := hugolib.Test(t, `
+-- hugo.toml --
+-- layouts/home.html --
+{{ shuffle (slice "a" "b" "c") | sort }}
+`)
+	b.AssertFileContent("public/index.html", "[a b c]")
+}

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -571,10 +571,12 @@ func TestShuffle(t *testing.T) {
 		{[]int{100, 200, 300}, true},
 		{[]int{100, 200, 300}, true},
 		{[]int{100}, true},
+		{[3]int{100, 200, 300}, true},
 		// errors
 		{nil, false},
 		{t, false},
 		{(*string)(nil), false},
+		{"abc", false},
 	} {
 		errMsg := qt.Commentf("[%d] %v", i, test)
 
@@ -592,6 +594,11 @@ func TestShuffle(t *testing.T) {
 
 		c.Assert(seqv.Len(), qt.Equals, resultv.Len(), errMsg)
 	}
+
+	// A pointer to a slice should be shuffled after being dereferenced.
+	result, err := ns.Shuffle(&[]int{100, 200, 300})
+	c.Assert(err, qt.IsNil)
+	c.Assert(reflect.ValueOf(result).Len(), qt.Equals, 3)
 }
 
 func TestShuffleRandomising(t *testing.T) {


### PR DESCRIPTION
`shuffle`'s type switch accepts arrays, slices and strings (and pointers to those), but the result was built with `reflect.MakeSlice(reflect.TypeOf(l), ...)`, which panics with "reflect.MakeSlice of non-slice type" for anything but a plain slice value - so `{{ shuffle "abc" }}`, an array, or a pointer to a slice crash the build.

Build the result from the indirected value's type so a pointer to a slice works, collect arrays into a slice of their element type, and drop strings from the accepted kinds so they return the regular "can't iterate over" error instead of panicking. Behavior for a plain slice (including named slice types) is unchanged.
