### PR TITLE
common/paths: Avoid panic in PathEscape on invalid URL input

### DIFF
--- a/common/paths/path.go
+++ b/common/paths/path.go
@@ -388,7 +388,11 @@ func (df DirFile) String() string {
 func PathEscape(pth string) string {
 	u, err := url.Parse(pth)
 	if err != nil {
-		panic(err)
+		// pth is not a valid URL, e.g. it contains a bare '%' that is not part
+		// of a valid percent-encoding (a filename may legitimately contain one).
+		// Escape it as a path so we degrade gracefully instead of panicking.
+		// See https://github.com/gohugoio/hugo/issues/12447
+		return (&url.URL{Path: pth}).EscapedPath()
 	}
 	return u.EscapedPath()
 }

--- a/common/paths/path_test.go
+++ b/common/paths/path_test.go
@@ -360,6 +360,7 @@ func TestPathEscape(t *testing.T) {
 		{"/simple-path", "/simple-path"},
 		{"/path/with/slash", "/path/with/slash"},
 		{"/path/with special&chars", "/path/with%20special&chars"},
+		{"/about/index.md%", "/about/index.md%25"},
 	} {
 		in := this.input
 		for range 2 {


### PR DESCRIPTION
Fixes #12447

### Problem
`common/paths.PathEscape` parses its input with `url.Parse` and `panic(err)` on failure. A path can legitimately contain a bare `%` that is not a valid percent-encoding (e.g. a content filename), so `url.Parse` returns `invalid URL escape "%"` and the whole build/server crashes:

```
panic: parse "/about/index.md%": invalid URL escape "%"
```

`PathEscape` is on the hot path for resource `Permalink`/`RelPermalink`, page links and the dev-server request URI, so a single odd character takes the process down.

### Fix
On `url.Parse` error, fall back to escaping the value as a URL path via `(&url.URL{Path: pth}).EscapedPath()`, which turns a bare `%` into `%25` and never errors. This keeps `/` unescaped, matching the function's documented contract.

Valid input is unchanged: it still goes through `url.Parse`, so this only affects inputs that previously panicked — zero blast radius on working sites.

### Test
Extended the existing table-driven `TestPathEscape` with `{"/about/index.md%", "/about/index.md%25"}`. The test also asserts idempotency (escaping the result again is stable), which holds here because `%25` is a valid encoding and round-trips through `url.Parse` unchanged.

I don't have a Go toolchain in this environment, so I relied on the project's CI to run the tests.