### PR TITLE
feat: add ignoreUnusedTemplates config option

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -628,7 +628,7 @@ func applyLocalFlagsBuild(cmd *cobra.Command, r *rootCommand) {
 	cmd.Flags().BoolP("noChmod", "", false, "don't sync permission mode of files")
 	cmd.Flags().BoolP("printI18nWarnings", "", false, "print missing translations")
 	cmd.Flags().BoolP("printPathWarnings", "", false, "print warnings on duplicate target paths etc.")
-	cmd.Flags().BoolP("printUnusedTemplates", "", false, "print warnings on unused templates.")
+	cmd.Flags().BoolP("printUnusedTemplates", "", false, "print warnings on potentially unused templates.")
 	cmd.Flags().StringVarP(&r.cpuprofile, "profile-cpu", "", "", "write cpu profile to `file`")
 	cmd.Flags().StringVarP(&r.memprofile, "profile-mem", "", "", "write memory profile to `file`")
 	cmd.Flags().BoolVarP(&r.printm, "printMemoryUsage", "", false, "print memory usage to screen at intervals")

--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -247,6 +247,7 @@ func (c Config) cloneForLang() *Config {
 	x.MainSections = copyStringSlice(x.MainSections)
 	x.IgnoreLogs = copyStringSlice(x.IgnoreLogs)
 	x.IgnoreFiles = copyStringSlice(x.IgnoreFiles)
+	x.IgnoreUnusedTemplates = copyStringSlice(x.IgnoreUnusedTemplates)
 	x.Theme = copyStringSlice(x.Theme)
 
 	// Collapse all static dirs to one.
@@ -759,6 +760,10 @@ type RootConfig struct {
 
 	// Whether to track and print unused templates during the build.
 	PrintUnusedTemplates bool
+
+	// Glob patterns matched against a template's path to exclude it from the
+	// unused templates warnings printed when PrintUnusedTemplates is enabled.
+	IgnoreUnusedTemplates []string
 
 	// Enable to print warnings for missing translation strings.
 	PrintI18nWarnings bool

--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -635,15 +635,30 @@ func (h *HugoSites) printUnusedTemplatesOnce() error {
 		if conf.PrintUnusedTemplates {
 			unusedTemplates := h.GetTemplateStore().UnusedTemplates()
 			for _, unusedTemplate := range unusedTemplates {
+				p := unusedTemplate.PathInfo.Path()
+				if isIgnoredUnusedTemplate(conf.IgnoreUnusedTemplates, p) {
+					continue
+				}
 				if unusedTemplate.Fi != nil {
-					h.Log.Warnf("Template %s is unused, source %q", unusedTemplate.PathInfo.Path(), unusedTemplate.Fi.Meta().Filename)
+					h.Log.Warnf("Template %s is unused, source %q", p, unusedTemplate.Fi.Meta().Filename)
 				} else {
-					h.Log.Warnf("Template %s is unused", unusedTemplate.PathInfo.Path())
+					h.Log.Warnf("Template %s is unused", p)
 				}
 			}
 		}
 	})
 	return nil
+}
+
+// isIgnoredUnusedTemplate reports whether p matches any of the glob patterns.
+func isIgnoredUnusedTemplate(patterns []string, p string) bool {
+	p = strings.TrimPrefix(p, "/")
+	for _, pattern := range patterns {
+		if ok, _ := path.Match(strings.TrimPrefix(pattern, "/"), p); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // postProcess runs the post processors, e.g. writing the hugo_stats.json file.

--- a/hugolib/is_ignored_unused_template_test.go
+++ b/hugolib/is_ignored_unused_template_test.go
@@ -1,0 +1,30 @@
+package hugolib
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestIsIgnoredUnusedTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		path     string
+		want     bool
+	}{
+		{"exact match", []string{"/_partials/unusedpartial.html"}, "/_partials/unusedpartial.html", true},
+		{"no match", []string{"/_partials/unusedpartial.html"}, "/_shortcodes/unusedshortcode.html", false},
+		{"glob match", []string{"/_partials/*"}, "/_partials/unusedpartial.html", true},
+		{"glob no match", []string{"/_partials/*"}, "/_shortcodes/unused.html", false},
+		{"multiple patterns match", []string{"/_default/*", "/_partials/*"}, "/_partials/unused.html", true},
+		{"empty patterns", []string{}, "/_partials/unused.html", false},
+		{"path with leading slash, pattern without", []string{"_partials/unusedpartial.html"}, "/_partials/unusedpartial.html", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isIgnoredUnusedTemplate(tt.patterns, tt.path)
+			qt.Assert(t, got, qt.Equals, tt.want)
+		})
+	}
+}

--- a/tpl/tplimpl/templatestore_integration_test.go
+++ b/tpl/tplimpl/templatestore_integration_test.go
@@ -395,6 +395,46 @@ title: "P1"
 	b.Assert(len(unused), qt.Equals, 5, qt.Commentf("%#v", names))
 }
 
+func TestPrintUnusedTemplatesIgnore(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = 'http://example.com/'
+printUnusedTemplates=true
+ignoreUnusedTemplates=['/_partials/unusedpartial.html']
+-- content/p1.md --
+---
+title: "P1"
+---
+{{< usedshortcode >}}
+-- layouts/baseof.html --
+{{ block "main" . }}{{ end }}
+-- layouts/baseof.json --
+{{ block "main" . }}{{ end }}
+-- layouts/home.html --
+{{ define "main" }}FOO{{ end }}
+-- layouts/single.json --
+-- layouts/single.html --
+{{ define "main" }}MAIN /_default/single.html{{ end }}
+-- layouts/post/single.html --
+{{ define "main" }}MAIN{{ end }}
+-- layouts/_partials/usedpartial.html --
+-- layouts/_partials/unusedpartial.html --
+-- layouts/_shortcodes/usedshortcode.html --
+{{ partial "usedpartial.html" }}
+-- layouts/_shortcodes/unusedshortcode.html --
+
+`
+
+	b := hugolib.Test(t, files, hugolib.TestOptOsFs())
+
+	// The ignore list only affects logging, not template detection.
+	// All 5 unused templates should still be detected.
+	unused := b.H.GetTemplateStore().UnusedTemplates()
+	b.Assert(len(unused), qt.Equals, 5, qt.Commentf("unused templates should still be detected"))
+}
+
 func TestCreateManyTemplateStores(t *testing.T) {
 	t.Parallel()
 	htesting.SkipSlowTestUnlessCI(t)


### PR DESCRIPTION
## Summary

Adds a new `ignoreUnusedTemplates` config option that suppresses unused template warnings for templates that are intentionally retained but may not execute during a successful build.

## Problem

Hugo's `printUnusedTemplates` option reports templates whose execution count is zero during a build. Some templates are intentionally only used on error paths or rare conditional paths (e.g., shared fail-fast partials, debug-only templates, optional theme extension points). These templates are valid and intentional but appear as "unused" in the warnings.

## Solution

Add an `ignoreUnusedTemplates` config option that accepts a list of glob patterns. Templates matching any pattern are excluded from `printUnusedTemplates` warnings.

The matching uses Go's `path.Match` for glob support. Both the pattern and template path are normalized by trimming leading slashes for consistent matching.

Also updates the `printUnusedTemplates` CLI flag description from "print warnings on unused templates" to "print warnings on potentially unused templates".

## Changes

- `config/allconfig/allconfig.go`: Added `IgnoreUnusedTemplates` field to `RootConfig`, added to `cloneForLang`
- `hugolib/hugo_sites_build.go`: Added `isIgnoredUnusedTemplate` function, integrated into `printUnusedTemplatesOnce`
- `commands/commandeer.go`: Updated CLI flag description
- `hugolib/is_ignored_unused_template_test.go` (new): 7 unit tests for glob matching
- `tpl/tplimpl/templatestore_integration_test.go`: Integration test verifying ignore list doesn't affect detection

## Test Plan

- `go build ./...` compiles
- `go test ./hugolib/... -run TestIsIgnoredUnusedTemplate -v` passes (7 cases)
- `go test ./tpl/tplimpl/... -run TestPrintUnusedTemplatesIgnore -v` passes
- `go test ./tpl/tplimpl/... -run TestPrintUnusedTemplates -v` passes (no regression)

Fixes #15110
