### PR TITLE
cache/filecache: avoid pruning used entries on case-insensitive filesystems

### DIFF
--- a/cache/filecache/filecache.go
+++ b/cache/filecache/filecache.go
@@ -54,10 +54,14 @@ type Cache struct {
 	initOnce sync.Once
 	isInited bool
 	initErr  error
+
+	caseInsensitiveFilesystemInit sync.Once
+	caseInsensitiveFilesystem     bool
 }
 
 type lockTracker struct {
-	seen *maphelpers.ConcurrentSet[string]
+	seen                *maphelpers.ConcurrentSet[string]
+	seenCaseInsensitive *maphelpers.ConcurrentSet[string]
 
 	*locker.Locker
 }
@@ -66,6 +70,7 @@ type lockTracker struct {
 // after a Hugo build.
 func (l *lockTracker) Lock(id string) {
 	l.seen.AddIfAbsent(id)
+	l.seenCaseInsensitive.AddIfAbsent(foldID(id))
 	l.Locker.Lock(id)
 }
 
@@ -82,9 +87,13 @@ func NewCache(fs afero.Fs, cfg FileCacheConfig) *Cache {
 	}
 
 	return &Cache{
-		Fs:          fs,
-		entryLocker: &lockTracker{Locker: locker.NewLocker(), seen: maphelpers.NewConcurrentSet[string]()},
-		cfg:         cfg,
+		Fs: fs,
+		entryLocker: &lockTracker{
+			Locker:              locker.NewLocker(),
+			seen:                maphelpers.NewConcurrentSet[string](),
+			seenCaseInsensitive: maphelpers.NewConcurrentSet[string](),
+		},
+		cfg: cfg,
 	}
 }
 
@@ -471,6 +480,34 @@ func (c *Cache) isExpired(modTime time.Time) bool {
 	// Note the use of time.Since here.
 	// We cannot use Hugo's global Clock for this.
 	return c.cfg.MaxAge == 0 || time.Since(modTime) > c.cfg.MaxAge
+}
+
+func (c *Cache) isCaseInsensitiveFilesystem() bool {
+	c.caseInsensitiveFilesystemInit.Do(func() {
+		c.caseInsensitiveFilesystem = c.detectCaseInsensitiveFilesystem()
+	})
+	return c.caseInsensitiveFilesystem
+}
+
+func (c *Cache) detectCaseInsensitiveFilesystem() bool {
+	nameUpper := fmt.Sprintf(".hugo-case-check-%p-%d-A", c, time.Now().UnixNano())
+	nameLower := strings.TrimSuffix(nameUpper, "A") + "a"
+
+	f, err := c.Fs.Create(nameUpper)
+	if err != nil {
+		return false
+	}
+	f.Close()
+
+	defer c.Fs.Remove(nameUpper)
+	defer c.Fs.Remove(nameLower)
+
+	_, err = c.Fs.Stat(nameLower)
+	return err == nil
+}
+
+func foldID(name string) string {
+	return strings.ToLower(name)
 }
 
 // For testing

--- a/cache/filecache/filecache_pruner.go
+++ b/cache/filecache/filecache_pruner.go
@@ -58,6 +58,8 @@ func (c *Cache) Prune(force bool) (int, error) {
 	}
 
 	counter := 0
+	hasSeen := !force && c.entryLocker.seen.Len() > 0
+	caseInsensitiveFilesystem := hasSeen && c.isCaseInsensitiveFilesystem()
 
 	err := afero.Walk(c.Fs, "", func(name string, info os.FileInfo, err error) error {
 		if info == nil {
@@ -93,9 +95,12 @@ func (c *Cache) Prune(force bool) (int, error) {
 
 		shouldRemove := force || c.isExpired(info.ModTime())
 
-		if !shouldRemove && c.entryLocker.seen.Len() > 0 {
+		if !shouldRemove && hasSeen {
 			// Remove it if it's not been touched/used in the last build.
 			shouldRemove = !c.entryLocker.seen.Has(name)
+			if shouldRemove && caseInsensitiveFilesystem {
+				shouldRemove = !c.entryLocker.seenCaseInsensitive.Has(foldID(name))
+			}
 		}
 
 		if shouldRemove {

--- a/cache/filecache/filecache_pruner_internal_test.go
+++ b/cache/filecache/filecache_pruner_internal_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filecache
+
+import (
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/spf13/afero"
+)
+
+func TestPruneSeenFileCaseSensitiveFilesystem(t *testing.T) {
+	t.Parallel()
+
+	c := qt.New(t)
+	cache := newPruneSeenTestCache(false)
+	writePruneSeenTestFile(c, cache, "MyBundle/test.jpeg")
+	markPruneSeenTestFile(cache, "mybundle/test.jpeg")
+
+	count, err := cache.Prune(false)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 1)
+	c.Assert(cache.GetString(filepath.FromSlash("MyBundle/test.jpeg")), qt.Equals, "")
+}
+
+// See issue 15101.
+func TestPruneSeenFileCaseInsensitiveFilesystem(t *testing.T) {
+	t.Parallel()
+
+	c := qt.New(t)
+	cache := newPruneSeenTestCache(true)
+	writePruneSeenTestFile(c, cache, "MyBundle/test.jpeg")
+	markPruneSeenTestFile(cache, "mybundle/test.jpeg")
+
+	count, err := cache.Prune(false)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+	c.Assert(cache.GetString(filepath.FromSlash("MyBundle/test.jpeg")), qt.Equals, "abc")
+}
+
+func newPruneSeenTestCache(caseInsensitiveFilesystem bool) *Cache {
+	cache := NewCache(afero.NewMemMapFs(), FileCacheConfig{
+		MaxAge: -1,
+		Dir:    "cache/c",
+	})
+	cache.caseInsensitiveFilesystemInit.Do(func() {
+		cache.caseInsensitiveFilesystem = caseInsensitiveFilesystem
+	})
+	return cache
+}
+
+func writePruneSeenTestFile(c *qt.C, cache *Cache, name string) {
+	filename := filepath.FromSlash(name)
+	c.Assert(cache.Fs.MkdirAll(filepath.Dir(filename), 0o777), qt.IsNil)
+	c.Assert(afero.WriteFile(cache.Fs, filename, []byte("abc"), 0o666), qt.IsNil)
+}
+
+func markPruneSeenTestFile(cache *Cache, name string) {
+	id := cleanID(filepath.FromSlash(name))
+	cache.entryLocker.Lock(id)
+	cache.entryLocker.Unlock(id)
+}


### PR DESCRIPTION
## Summary

- detect whether the cache filesystem is case-insensitive before pruning
- keep a folded seen set for cache usage checks on case-insensitive filesystems
- preserve existing case-sensitive pruning behavior
- add regression coverage for mixed-case on-disk cache paths

Fixes #15101.

## Testing

- `go test ./cache/filecache`
- `git diff --check`