### PR TITLE
cache: Preserve case-insensitively accessed files

### DIFF
--- a/cache/filecache/filecache_pruner.go
+++ b/cache/filecache/filecache_pruner.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/gohugoio/hugo/common/herrors"
 	"github.com/gohugoio/hugo/hugofs"
@@ -58,6 +59,11 @@ func (c *Cache) Prune(force bool) (int, error) {
 	}
 
 	counter := 0
+	seen := make(map[string][]string, c.entryLocker.seen.Len())
+	for name := range c.entryLocker.seen.All() {
+		key := strings.ToLower(name)
+		seen[key] = append(seen[key], name)
+	}
 
 	err := afero.Walk(c.Fs, "", func(name string, info os.FileInfo, err error) error {
 		if info == nil {
@@ -95,7 +101,7 @@ func (c *Cache) Prune(force bool) (int, error) {
 
 		if !shouldRemove && c.entryLocker.seen.Len() > 0 {
 			// Remove it if it's not been touched/used in the last build.
-			shouldRemove = !c.entryLocker.seen.Has(name)
+			shouldRemove = !c.wasSeen(name, info, seen)
 		}
 
 		if shouldRemove {
@@ -114,6 +120,22 @@ func (c *Cache) Prune(force bool) (int, error) {
 	})
 
 	return counter, err
+}
+
+func (c *Cache) wasSeen(name string, info os.FileInfo, seen map[string][]string) bool {
+	for _, seenName := range seen[strings.ToLower(name)] {
+		if seenName == name {
+			return true
+		}
+		if !strings.EqualFold(seenName, name) {
+			continue
+		}
+		seenInfo, err := c.Fs.Stat(seenName)
+		if err == nil && os.SameFile(info, seenInfo) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Cache) pruneRootDirs(force bool) (int, error) {

--- a/cache/filecache/filecache_pruner_test.go
+++ b/cache/filecache/filecache_pruner_test.go
@@ -15,6 +15,8 @@ package filecache_test
 
 import (
 	"fmt"
+	"os"
+	"path"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -112,4 +114,32 @@ dir = ":resourceDir/_gen"
 
 		}
 	})
+}
+
+// See #15101.
+func TestPruneKeepsRecentlyUsedCaseInsensitiveFile(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	fsys := afero.NewBasePathFs(afero.NewOsFs(), t.TempDir())
+	const (
+		seenName = "images/mybundle/cover"
+		diskName = "images/MyBundle/cover"
+	)
+	c.Assert(fsys.MkdirAll(path.Dir(diskName), 0o755), qt.IsNil)
+	c.Assert(afero.WriteFile(fsys, diskName, []byte("cached"), 0o644), qt.IsNil)
+
+	seenInfo, err := fsys.Stat(seenName)
+	if err != nil {
+		t.Skip("filesystem is case-sensitive")
+	}
+	diskInfo, err := fsys.Stat(diskName)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.SameFile(seenInfo, diskInfo), qt.IsTrue)
+
+	cache := filecache.NewCache(fsys, filecache.FileCacheConfig{Dir: "cache", MaxAge: -1})
+	c.Assert(cache.GetString(seenName), qt.Equals, "cached")
+	count, err := cache.Prune(false)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+	c.Assert(cache.GetString(seenName), qt.Equals, "cached")
 }


### PR DESCRIPTION
Fixes #15101.

### Problem

`Cache.Prune` compares the cache key recorded during the build with the name returned by the filesystem walk. On case-insensitive filesystems, old cache directories can retain mixed-case names while current image cache keys are lowercase. The string comparison then treats a file read during the same build as unused and removes it.

### Fix

Group seen names by a case-folded key. When a folded match is found, confirm both paths identify the same file before retaining it. Exact matches stay on the existing fast path, and distinct paths on case-sensitive filesystems are still pruned independently.

### Test

Adds a real-filesystem regression that creates a mixed-case cache entry, accesses it through its lowercase key, and verifies pruning retains it. The test skips on case-sensitive filesystems.

### Validation

- `gofmt -l cache/filecache`
- `go vet ./cache/filecache`
- `staticcheck ./cache/filecache`
- `go test ./cache/filecache`
- `git diff --check`

### AI assistance

This narrow bug fix was produced with Codex. The implementation and validation output above are included for review.
