### PR TITLE
fix(filecache): preserve mixed-case entries during prune

### DIFF
--- a/cache/filecache/filecache.go
+++ b/cache/filecache/filecache.go
@@ -66,6 +66,7 @@ type lockTracker struct {
 // after a Hugo build.
 func (l *lockTracker) Lock(id string) {
 	l.seen.AddIfAbsent(id)
+	l.seen.AddIfAbsent(strings.ToLower(id))
 	l.Locker.Lock(id)
 }
 

--- a/cache/filecache/filecache_pruner.go
+++ b/cache/filecache/filecache_pruner.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/gohugoio/hugo/common/herrors"
 	"github.com/gohugoio/hugo/hugofs"
@@ -95,7 +96,7 @@ func (c *Cache) Prune(force bool) (int, error) {
 
 		if !shouldRemove && c.entryLocker.seen.Len() > 0 {
 			// Remove it if it's not been touched/used in the last build.
-			shouldRemove = !c.entryLocker.seen.Has(name)
+			shouldRemove = !c.entryLocker.seen.Has(name) && !c.entryLocker.seen.Has(strings.ToLower(name))
 		}
 
 		if shouldRemove {

--- a/cache/filecache/filecache_pruner_test.go
+++ b/cache/filecache/filecache_pruner_test.go
@@ -15,6 +15,7 @@ package filecache_test
 
 import (
 	"fmt"
+	"io"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -24,6 +25,24 @@ import (
 
 	qt "github.com/frankban/quicktest"
 )
+
+func TestPrunePreservesCaseInsensitiveCacheEntry(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	cache := filecache.NewCache(afero.NewMemMapFs(), filecache.FileCacheConfig{Dir: "cache", MaxAge: time.Hour})
+
+	_, w, err := cache.WriteCloser("MyBundle/image")
+	c.Assert(err, qt.IsNil)
+	_, err = io.WriteString(w, "content")
+	c.Assert(err, qt.IsNil)
+	c.Assert(w.Close(), qt.IsNil)
+
+	cache.NamedLock("mybundle/image")()
+	count, err := cache.Prune(false)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+	c.Assert(cache.GetString("MyBundle/image"), qt.Equals, "content")
+}
 
 func TestPrune(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #15101.

## Problem

On case-insensitive filesystems, an existing cache entry may have a mixed-case on-disk path while the current cache key is lowercase. The file-cache pruner compared names case-sensitively and could delete an entry used during the same build.

## Change

Record a lowercase alias for each active cache key and use it during pruning. This preserves actively used legacy entries without changing cache reads or writes.

## Tests

- Added a regression test covering a mixed-case cache entry and lowercase active key.
- `go test ./cache/filecache`
- `go test ./cache/filecache/...`
- staticcheck passed for the package.