### PR TITLE
tpl/inflect: fix Humanize inserting space after opening quotation marks

### DIFF
--- a/tpl/inflect/inflect.go
+++ b/tpl/inflect/inflect.go
@@ -15,6 +15,7 @@
 package inflect
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -29,6 +30,11 @@ func New() *Namespace {
 
 // Namespace provides template functions for the "inflect" namespace.
 type Namespace struct{}
+
+// quoteSpaceRe matches a spurious space that flect.Humanize inserts after an
+// opening quotation mark when the quoted text begins with an uppercase letter.
+// flect incorrectly treats quote+uppercase as a camelCase word boundary.
+var quoteSpaceRe = regexp.MustCompile("([\u201e\u201a\u201c\u2018\u00ab\u2039\"']) ")
 
 // Humanize returns the humanized form of v.
 //
@@ -51,7 +57,8 @@ func (ns *Namespace) Humanize(v any) (string, error) {
 	}
 
 	str := _inflect.Humanize(word)
-	return _inflect.Humanize(strings.ToLower(str)), nil
+	result := _inflect.Humanize(strings.ToLower(str))
+	return quoteSpaceRe.ReplaceAllString(result, "$1"), nil
 }
 
 // Pluralize returns the plural form of the single word in v.

--- a/tpl/inflect/inflect_test.go
+++ b/tpl/inflect/inflect_test.go
@@ -18,7 +18,7 @@ func TestInflect(t *testing.T) {
 		expect any
 	}{
 		{ns.Humanize, "MyCamel", "My camel"},
-		{ns.Humanize, "óbito", "Óbito"},
+		{ns.Humanize, "\u00f3bito", "\u00d3bito"},
 		{ns.Humanize, "", ""},
 		{ns.Humanize, "103", "103rd"},
 		{ns.Humanize, "41", "41st"},
@@ -28,6 +28,14 @@ func TestInflect(t *testing.T) {
 		{ns.Humanize, t, false},
 		{ns.Humanize, "this is a TEST", "This is a test"},
 		{ns.Humanize, "my-first-Post", "My first post"},
+		// Issue #15126: flect incorrectly treats quote+uppercase as a camelCase
+		// boundary, inserting a spurious space after the opening quote.
+		{ns.Humanize, "Painting \u201eTitle\u201c", "Painting \u201etitle\u201c"}, // German „Title" (from issue)
+		{ns.Humanize, "a \u201eB\u201c", "A \u201eb\u201c"},                       // German „B" uppercase
+		{ns.Humanize, "a \u201eb\u201c", "A \u201eb\u201c"},                       // German „b" lowercase (baseline, no split)
+		{ns.Humanize, "a \"B\"", "A \"b\""},                                       // ASCII " uppercase
+		{ns.Humanize, "A \"B\"", "A \"b\""},                                       // ASCII " uppercase, capital-initial first word
+		{ns.Humanize, "a \"b\"", "A \"b\""},                                       // ASCII " lowercase (baseline, no split)
 		{ns.Pluralize, "cat", "cats"},
 		{ns.Pluralize, "", ""},
 		{ns.Pluralize, t, false},


### PR DESCRIPTION
## Problem

Closes #15126

`{{ humanize "Painting „Title"" }}` produces `Painting „ title"` — a spurious space is inserted immediately after the opening German low quotation mark `„`.

The same bug affects ASCII double quotes when followed by an uppercase letter:
`{{ humanize "a \"B\"" }}` → `A " b"` (want `A "b"`).

## Root Cause

`flect.Humanize` (from `github.com/gobuffalo/flect`) incorrectly treats a **quote character followed by an uppercase letter** as a camelCase word boundary, splitting the token and inserting a word-separator space. This is a known upstream bug ([gobuffalo/flect#83](https://github.com/gobuffalo/flect/issues/83), [gobuffalo/flect#84](https://github.com/gobuffalo/flect/pull/84)). The upstream repository has been effectively unmaintained for ~2 years, so the fix needs to live in Hugo's wrapper.

## Fix

After the two `flect.Humanize` calls in `tpl/inflect/inflect.go`, apply a single regex substitution that removes any space that was inserted directly after an opening quotation mark:

```go
var quoteSpaceRe = regexp.MustCompile("([\u201e\u201a\u201c\u2018\u00ab\u2039\"']) ")

result := _inflect.Humanize(strings.ToLower(str))
return quoteSpaceRe.ReplaceAllString(result, "$1"), nil
```

The character class covers the most common opening quotes:
| Character | Unicode | Name |
|---|---|---|
| `„` | U+201E | German low double (opening) |
| `‚` | U+201A | German low single (opening) |
| `"` | U+201C | Left double quotation mark |
| `'` | U+2018 | Left single quotation mark |
| `«` | U+00AB | Left-pointing angle (French) |
| `‹` | U+2039 | Single left-pointing angle (French) |
| `"` | U+0022 | ASCII double quote |
| `'` | U+0027 | ASCII single quote |

## Tests

Six new cases added to `TestInflect` covering all confirmed-failing inputs from the issue thread, plus lowercase-initial baselines to verify no regression:

| Input | Before | After |
|---|---|---|
| `Painting „Title"` | `Painting „ title"` ❌ | `Painting „title"` ✅ |
| `a „B"` | `A „ b"` ❌ | `A „b"` ✅ |
| `a „b"` | `A „b"` ✅ | `A „b"` ✅ |
| `a "B"` | `A " b"` ❌ | `A "b"` ✅ |
| `A "B"` | `A " b"` ❌ | `A "b"` ✅ |
| `a "b"` | `A "b"` ✅ | `A "b"` ✅ |

## Integrity Note

The Go toolchain is not available in this sandbox environment. The tests cannot be executed locally and have been validated by manual logic trace only. A CI run on this PR will serve as the authoritative test gate.