### PR TITLE
fix(check): resolve staticcheck after go install

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -38,13 +38,20 @@ run_gofmt() {
 
 # Run staticcheck
 run_staticcheck() {
-    # Check if staticcheck is installed, install if not
-    if ! command -v staticcheck &> /dev/null; then
+    local staticcheck_bin
+    if command -v staticcheck &> /dev/null; then
+        staticcheck_bin=$(command -v staticcheck)
+    else
         echo "==> Installing staticcheck..."
         go install honnef.co/go/tools/cmd/staticcheck@latest
+        staticcheck_bin="$(go env GOBIN)"
+        if [ -z "$staticcheck_bin" ]; then
+            staticcheck_bin="$(go env GOPATH)/bin"
+        fi
+        staticcheck_bin="$staticcheck_bin/staticcheck"
     fi
     echo "==> Running staticcheck..."
-    staticcheck $PACKAGES
+    "$staticcheck_bin" $PACKAGES
     echo "    OK"
 }
 


### PR DESCRIPTION
Fixes #15142.

## Problem

`check.sh` installs `staticcheck` when it is missing, but then immediately invokes `staticcheck` by bare name. If Go installs the binary into `$(go env GOBIN)` or `$(go env GOPATH)/bin` and that directory is not on `PATH`, the install succeeds and the script still fails with `staticcheck: command not found`.

## Change

After installation, resolve the binary path from `go env GOBIN` or `$(go env GOPATH)/bin` and run that path directly. If `staticcheck` is already on `PATH`, keep using the discovered executable.

## Validation

Reproduced the failure with a `PATH` that includes `go` but excludes `~/go/bin`, then verified that this command passes after the fix:

- `PATH="$go_bin_dir:/usr/bin:/bin" ./check.sh ./cache/filecache/...`
