### PR TITLE
cssjs: Fix Tailwind @import resolution with disableInlineImports

### DIFF
--- a/resources/resource_transformers/cssjs/inline_imports_test.go
+++ b/resources/resource_transformers/cssjs/inline_imports_test.go
@@ -15,6 +15,9 @@ package cssjs
 
 import (
 	"context"
+	"io"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -78,6 +81,27 @@ func TestShouldImportExcludes(t *testing.T) {
 	c.Assert(imp.shouldImport(`@import "tailwindcss";`), qt.Equals, false)
 	c.Assert(imp.shouldImport(`@import "tailwindcss.css";`), qt.Equals, true)
 	c.Assert(imp.shouldImport(`@import "tailwindcss/preflight";`), qt.Equals, false)
+}
+
+func TestRewriteImportsRelativeTo(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "red.css"), []byte(".red{}"), 0o644), qt.IsNil)
+
+	in := strings.NewReader(`@import "tailwindcss";
+@import "./red.css";
+@import "./missing.css";
+@source "hugo_stats.json";
+`)
+	out, err := rewriteImportsRelativeTo(in, dir)
+	c.Assert(err, qt.IsNil)
+	b, err := io.ReadAll(out)
+	c.Assert(err, qt.IsNil)
+	s := string(b)
+	c.Assert(s, qt.Contains, `@import "tailwindcss";`)
+	c.Assert(s, qt.Contains, filepath.ToSlash(filepath.Join(dir, "red.css")))
+	c.Assert(s, qt.Contains, `@import "./missing.css";`)
+	c.Assert(s, qt.Contains, `@source "hugo_stats.json";`)
 }
 
 func TestImportResolver(t *testing.T) {

--- a/resources/resource_transformers/cssjs/tailwindcss.go
+++ b/resources/resource_transformers/cssjs/tailwindcss.go
@@ -16,6 +16,8 @@ package cssjs
 import (
 	"bytes"
 	"io"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -136,6 +138,17 @@ func (t *tailwindcssTransformation) Transform(ctx *resources.ResourceTransformat
 		if err != nil {
 			return err
 		}
+	} else if ctx.SourcePath != "" {
+		// Tailwind resolves @import from process.cwd() when reading stdin
+		// (tailwindlabs/tailwindcss#14522). Keep cwd at the project root so
+		// @source "hugo_stats.json" still works; rewrite entry-relative imports
+		// to absolute paths so Tailwind can resolve them.
+		if rf := t.rs.Assets.RealFilename(ctx.SourcePath); filepath.IsAbs(rf) {
+			src, err = rewriteImportsRelativeTo(src, filepath.Dir(rf))
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	go func() {
@@ -166,4 +179,42 @@ func decodeTailwindCSSOptions(m map[string]any) (opts TailwindCSSOptions, err er
 	}
 	err = mapstructure.WeakDecode(m, &opts)
 	return
+}
+
+// rewriteImportsRelativeTo rewrites top-level relative @import paths so they
+// resolve against baseDir. Nested imports are resolved by Tailwind relative to
+// each loaded file.
+func rewriteImportsRelativeTo(r io.Reader, baseDir string) (io.Reader, error) {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(b), "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, "url(") {
+			continue
+		}
+		m := shouldImportRe.FindStringSubmatch(trimmed)
+		if m == nil {
+			continue
+		}
+		impPath := m[1]
+		if tailwindImportExclude(impPath) {
+			continue
+		}
+		if filepath.IsAbs(impPath) || strings.Contains(impPath, "://") {
+			continue
+		}
+
+		abs := filepath.Join(baseDir, filepath.FromSlash(impPath))
+		if _, err := os.Stat(abs); err != nil {
+			// Leave package imports / mount-only paths for Tailwind (or its error).
+			continue
+		}
+		lines[i] = strings.Replace(line, impPath, filepath.ToSlash(abs), 1)
+	}
+
+	return strings.NewReader(strings.Join(lines, "\n")), nil
 }

--- a/resources/resource_transformers/cssjs/tailwindcss_integration_test.go
+++ b/resources/resource_transformers/cssjs/tailwindcss_integration_test.go
@@ -14,8 +14,10 @@
 package cssjs_test
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/bep/logg"
 	qt "github.com/frankban/quicktest"
 	"github.com/gohugoio/hugo/htesting"
 	"github.com/gohugoio/hugo/hugolib"
@@ -103,10 +105,12 @@ CSS: {{ $css.Content | safeCSS }}|
 	)
 }
 
+// See issue 13719.
 func TestTailwindCSSNoInlineImportsIssue13719(t *testing.T) {
 	t.Parallel()
 	htesting.SkipSlowTestUnlessCI(t)
 
+	// Imports only available via Hugo mounts/theme (not on the real FS next to main.css).
 	files := `
 -- hugo.toml --
 disableKinds = ['page','rss','section','sitemap','taxonomy','term']
@@ -122,15 +126,8 @@ target = 'assets/css'
 -- assets/css/main.css --
 @import "tailwindcss";
 
-@import "colors/red.css";
 @import "colors/blue.css";
 @import "colors/purple.css";
--- assets/css/colors/red.css --
-@import "green.css";
-
-.red {color: red;}
--- assets/css/colors/green.css --
-.green {color: green;}
 -- themes/my-theme/assets/css/colors/blue.css --
 .blue {color: blue;}
 -- other/colors/purple.css --
@@ -156,6 +153,92 @@ target = 'assets/css'
 	b, err := hugolib.TestE(t, files, hugolib.TestOptOsFs(), hugolib.TestOptWithNpmInstall(), hugolib.TestOptInfo())
 
 	b.Assert(err, qt.IsNotNil)
-	b.Assert(err.Error(), qt.Contains, "Can't resolve 'colors/red.css'")
+	b.Assert(err.Error(), qt.Contains, "Can't resolve")
 	b.Assert(err.Error(), qt.Contains, "You may want to set the 'disableInlineImports' option to false")
+}
+
+// See issue 13738.
+func TestTailwindCSSNativeImportResolve(t *testing.T) {
+	t.Parallel()
+	htesting.SkipSlowTestUnlessCI(t)
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','rss','section','sitemap','taxonomy','term']
+theme = 'my-theme'
+
+[[module.mounts]]
+source = 'assets'
+target = 'assets'
+
+[[module.mounts]]
+source = 'other'
+target = 'assets/css'
+-- assets/css/main.css --
+@import "tailwindcss";
+
+@import "./colors/red.css";
+@import "./colors/blue.css";
+@import "./colors/purple.css";
+-- assets/css/colors/red.css --
+@import "./green.css";
+
+.red {color: red;}
+-- assets/css/colors/green.css --
+.green {color: green;}
+-- themes/my-theme/assets/css/colors/blue.css --
+.blue {color: blue;}
+-- other/colors/purple.css --
+.purple {color: purple;}
+-- layouts/home.html --
+{{ with (templates.Defer (dict "key" "global")) }}
+  {{ with resources.Get "css/main.css" }}
+    {{ $opts := dict "disableInlineImports" false }}
+    {{ with . | css.TailwindCSS $opts }}
+      <link rel="stylesheet" href="{{ .RelPermalink }}">
+    {{ end }}
+  {{ end }}
+{{ end }}
+-- package.json --
+{
+  "devDependencies": {
+    "@tailwindcss/cli": "^4.1.7",
+    "tailwindcss": "^4.1.7"
+  }
+}
+`
+
+	// disableInlineImports: false — Hugo inlines imports (including mounts/theme).
+	b := hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:               t,
+			TxtarString:     files,
+			NeedsOsFS:       true,
+			NeedsNpmInstall: true,
+			LogLevel:        logg.LevelInfo,
+		}).Build()
+
+	b.AssertFileContent("public/css/main.css", "color: red;")
+	b.AssertFileContent("public/css/main.css", "color: green;")
+	b.AssertFileContent("public/css/main.css", "color: blue;")
+	b.AssertFileContent("public/css/main.css", "color: purple;")
+
+	// disableInlineImports: true — Tailwind resolves FS-local imports only.
+	files = strings.ReplaceAll(files, `"disableInlineImports" false`, `"disableInlineImports" true`)
+	files = strings.ReplaceAll(files, `@import "./colors/blue.css";`, ``)
+	files = strings.ReplaceAll(files, `@import "./colors/purple.css";`, ``)
+
+	b = hugolib.NewIntegrationTestBuilder(
+		hugolib.IntegrationTestConfig{
+			T:               t,
+			TxtarString:     files,
+			NeedsOsFS:       true,
+			NeedsNpmInstall: true,
+			LogLevel:        logg.LevelInfo,
+		}).Build()
+
+	b.AssertFileContent("public/css/main.css", "color: red;")
+	b.AssertFileContent("public/css/main.css", "color: green;")
+	b.AssertFileContent("public/css/main.css", "! color: blue;")
+	b.AssertFileContent("public/css/main.css", "! color: purple;")
 }


### PR DESCRIPTION
## Summary

When `disableInlineImports` is `true`, Hugo feeds CSS to the Tailwind CLI via stdin. Tailwind then resolves `@import` relative to `process.cwd()` (the project root), not the entry stylesheet — so relative imports such as `@import "./colors/red.css"` fail (see [tailwindlabs/tailwindcss#14522](https://github.com/tailwindlabs/tailwindcss/pull/14522)).

This PR rewrites top-level relative `@import` paths to absolute filesystem paths based on the entry file's real directory before piping to Tailwind. Nested imports continue to resolve relative to each loaded file. Project-root cwd is preserved so `@source "hugo_stats.json"` still works.

Changing the process working directory to the CSS folder (as explored in #13739) would fix imports but risk breaking `@source` paths rooted at the project.

Fixes #13738

## Test plan

- [x] `CI=true go test ./resources/resource_transformers/cssjs/ -run 'TestTailwind|TestRewrite' -count=1`
  - `TestTailwindCSSNativeImportResolve` — issue repro: Hugo inline imports resolve all colors; with `disableInlineImports: true`, FS-local red/green resolve and theme/mount blue/purple do not
  - `TestTailwindCSSNoInlineImportsMissingHint` — still surfaces the helpful error when Tailwind cannot resolve mount-only imports
  - `TestRewriteImportsRelativeTo` — unit coverage for path rewrite
  - `TestTailwindV4Basic` — existing smoke test still passes

## AI Assistance Notice

This PR was written with substantial assistance from Grok (xAI) in the Cursor harness. Scope is limited to this bug fix and tests. I reviewed and verified the change, including running the tests above.