### PR TITLE
markup/highlight: Re-emit token colors dropped by Chroma's minifier

### DIFF
--- a/markup/highlight/chromastyles.go
+++ b/markup/highlight/chromastyles.go
@@ -91,11 +91,7 @@ func ChromaStylesCSS(opts ChromaStylesOptions) (string, error) {
 
 	options := []html.Option{
 		html.WithCSSComments(!opts.OmitClassComments),
-	}
-	if !opts.ModeSelector {
-		// Only needed for the shared-scope overlay; modeSelector
-		// gives each mode its own scope and makes this redundant.
-		options = append(options, html.WithCustomCSS(chromaCSSOverrides(style)))
+		html.WithCustomCSS(chromaCSSOverrides(style)),
 	}
 
 	var buf bytes.Buffer
@@ -129,10 +125,11 @@ func ChromaStylesCSS(opts ChromaStylesOptions) (string, error) {
 }
 
 // chromaCSSOverrides re-emits leaf token colors that Chroma's minifier drops
-// because they equal the style's default foreground (the .chroma color). Without
-// modeSelector scoping, a paired light/dark stylesheet shares the same .chroma
-// scope, and the light sheet's explicit rule (e.g. .chroma .nx) would otherwise
-// leak into dark mode, since an explicit declaration beats inheritance.
+// because they equal the style's default foreground (the .chroma color).
+// In a paired light/dark setup, the other sheet's explicit rule (e.g. .chroma .nx)
+// would otherwise leak into this mode, since an explicit declaration beats
+// inheritance from .chroma.
+// TODO(bep): replace with an upstream option, see issue 15161.
 func chromaCSSOverrides(style *chroma.Style) map[chroma.TokenType]string {
 	bg := style.Get(chroma.Background)
 	m := make(map[chroma.TokenType]string)

--- a/tpl/css/chromastyles_integration_test.go
+++ b/tpl/css/chromastyles_integration_test.go
@@ -47,6 +47,28 @@ Light: {{ $light.RelPermalink }}|Dark: {{ $dark.RelPermalink }}|Default: {{ $def
 	b.AssertFileContent("public/css/chroma.css", "/* Background */ .bg {", "background-color:#272822")
 }
 
+// Chroma's minifier drops token rules whose color equals the style's default
+// foreground (e.g. .nx in github-dark). In a paired light/dark setup the light
+// sheet's explicit rule would then leak into dark mode, so these must be re-emitted.
+// See issue 15161.
+func TestChromaStylesKeepDefaultForegroundTokens(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ["taxonomy", "term", "rss", "sitemap", "section", "page"]
+-- layouts/home.html --
+{{ $light := css.ChromaStyles (dict "targetPath" "css/chroma-light.css" "style" "github" "mode" "light") }}
+{{ $dark := css.ChromaStyles (dict "targetPath" "css/chroma-dark.css" "style" "github" "mode" "dark" "modeSelector" true) }}
+Light: {{ $light.RelPermalink }}|Dark: {{ $dark.RelPermalink }}|
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/css/chroma-light.css", "/* NameOther */ .chroma .nx { color:#1f2328 }")
+	b.AssertFileContent("public/css/chroma-dark.css", "/* NameOther */ .dark .chroma .nx { color:#e6edf3 }")
+}
+
 func TestChromaStylesErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Chroma drops token rules whose color equals the style's default foreground
(e.g. .nx in github-dark). In a paired light/dark setup the other sheet's
explicit rule then leaks in, since an explicit declaration beats inheritance
from .chroma. Apply the chromaCSSOverrides custom CSS unconditionally so
these rules survive in modeSelector sheets too.

Updates #15161
