### PR TITLE
hugolib: Preserve inline manual summary formatting

### DIFF
--- a/hugolib/page__content.go
+++ b/hugolib/page__content.go
@@ -14,6 +14,7 @@
 package hugolib
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -55,8 +56,8 @@ const (
 )
 
 var (
-	internalSummaryDividerPreString = "\n\n" + internalSummaryDividerBase + "\n\n"
-	internalSummaryDividerPre       = []byte(internalSummaryDividerPreString)
+	internalSummaryDivider    = []byte(internalSummaryDividerBase)
+	internalSummaryDividerPre = []byte("\n\n" + internalSummaryDividerBase + "\n\n")
 )
 
 type pageContentReplacement struct {
@@ -326,7 +327,11 @@ Loop:
 
 			// The content may be rendered by Goldmark or similar,
 			// and we need to track the summary.
-			pi.AddReplacement(internalSummaryDividerPre, it)
+			divider := internalSummaryDividerPre
+			if !bytes.ContainsRune(it.Val(source), '\n') {
+				divider = internalSummaryDivider
+			}
+			pi.AddReplacement(divider, it)
 
 		// Handle shortcode
 		case it.IsLeftShortcodeDelim():

--- a/hugolib/page__content.go
+++ b/hugolib/page__content.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 	"sync/atomic"
+	"unicode"
 	"unicode/utf8"
 
 	maps0 "maps"
@@ -328,11 +329,16 @@ Loop:
 			// The content may be rendered by Goldmark or similar,
 			// and we need to track the summary.
 			divider := internalSummaryDividerPre
-			before := bytes.TrimSpace(source[:it.Pos()])
-			after := bytes.TrimSpace(source[it.Pos()+len(it.Val(source)):])
-			if !bytes.ContainsRune(it.Val(source), '\n') &&
-				!bytes.HasSuffix(before, []byte("}}")) &&
-				!bytes.HasPrefix(after, []byte("{{")) {
+			before := source[:it.Pos()]
+			after := source[it.Pos()+len(it.Val(source)):]
+			beforeRune, _ := utf8.DecodeLastRune(before)
+			afterRune, _ := utf8.DecodeRune(after)
+			if len(before) > 0 && len(after) > 0 &&
+				!bytes.ContainsRune(it.Val(source), '\n') &&
+				!unicode.IsSpace(beforeRune) &&
+				!unicode.IsSpace(afterRune) &&
+				!bytes.HasSuffix(bytes.TrimSpace(before), []byte("}}")) &&
+				!bytes.HasPrefix(bytes.TrimSpace(after), []byte("{{")) {
 				divider = internalSummaryDivider
 			}
 			pi.AddReplacement(divider, it)

--- a/hugolib/page__content.go
+++ b/hugolib/page__content.go
@@ -328,7 +328,11 @@ Loop:
 			// The content may be rendered by Goldmark or similar,
 			// and we need to track the summary.
 			divider := internalSummaryDividerPre
-			if !bytes.ContainsRune(it.Val(source), '\n') {
+			before := bytes.TrimSpace(source[:it.Pos()])
+			after := bytes.TrimSpace(source[it.Pos()+len(it.Val(source)):])
+			if !bytes.ContainsRune(it.Val(source), '\n') &&
+				!bytes.HasSuffix(before, []byte("}}")) &&
+				!bytes.HasPrefix(after, []byte("{{")) {
 				divider = internalSummaryDivider
 			}
 			pi.AddReplacement(divider, it)

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -737,6 +737,25 @@ Content: {{ .Content }}|
 	)
 }
 
+func TestSummaryManualSplitPreservesParagraph(t *testing.T) {
+	t.Parallel()
+	Test(t, `
+-- hugo.toml --
+-- content/simple.md --
+---
+title: Simple
+---
+This is **summary**.<!--more-->This is **content**.
+-- layouts/single.html --
+Summary: {{ .Summary }}|
+Content: {{ .Content }}|
+
+`).AssertFileContent("public/simple/index.html",
+		"Summary: <p>This is <strong>summary</strong>.</p>|",
+		"Content: <p>This is <strong>summary</strong>.This is <strong>content</strong>.</p>|",
+	)
+}
+
 func TestSummaryManualSplitHTML(t *testing.T) {
 	t.Parallel()
 	Test(t, `

--- a/resources/page/page_markup.go
+++ b/resources/page/page_markup.go
@@ -71,12 +71,13 @@ func (s Summary) PrintableValue() any {
 var _ types.PrintableValueProvider = (*Summary)(nil)
 
 type HtmlSummary struct {
-	source         string
-	SummaryLowHigh types.LowHigh[string]
-	SummaryEndTag  types.LowHigh[string]
-	WrapperStart   types.LowHigh[string]
-	WrapperEnd     types.LowHigh[string]
-	Divider        types.LowHigh[string]
+	source          string
+	SummaryLowHigh  types.LowHigh[string]
+	SummaryStartTag types.LowHigh[string]
+	SummaryEndTag   types.LowHigh[string]
+	WrapperStart    types.LowHigh[string]
+	WrapperEnd      types.LowHigh[string]
+	Divider         types.LowHigh[string]
 }
 
 func (s HtmlSummary) wrap(ss string) string {
@@ -134,6 +135,9 @@ func (s HtmlSummary) ContentWithoutSummary() string {
 	}
 	if s.SummaryEndTag.IsZero() {
 		return s.trimSpace(s.wrapLeft(s.source[s.Divider.High:]))
+	}
+	if !s.SummaryStartTag.IsZero() {
+		return s.trimSpace(s.wrapLeft(s.Value(s.SummaryStartTag) + s.source[s.Divider.High:]))
 	}
 	return s.trimSpace(s.wrapLeft(s.source[s.SummaryEndTag.High:]))
 }
@@ -268,7 +272,7 @@ func ExtractSummaryFromHTMLWithDivider(mt media.Type, input, divider string) (re
 	ptag := result.resolveParagraphTagAndSetWrapper(mt)
 
 	if !mt.IsHTML() {
-		result.Divider, result.SummaryEndTag = expandSummaryDivider(result.source, ptag, result.Divider)
+		result.Divider, result.SummaryStartTag, result.SummaryEndTag = expandSummaryDivider(result.source, ptag, result.Divider)
 	}
 
 	result.SummaryLowHigh = types.LowHigh[string]{
@@ -280,7 +284,8 @@ func ExtractSummaryFromHTMLWithDivider(mt media.Type, input, divider string) (re
 }
 
 var (
-	pOrDiv = regexp.MustCompile(`<p[^>]?>|<div[^>]?>$`)
+	pOrDiv           = regexp.MustCompile(`<p[^>]?>|<div[^>]?>$`)
+	closingTagsAtEnd = regexp.MustCompile(`(?:\s*</[^>]+>)+$`)
 
 	startEndDiv = tagReStartEnd{
 		startEndOfString: regexp.MustCompile(`<div[^>]*?>$`),
@@ -301,11 +306,12 @@ type tagReStartEnd struct {
 	tagName          string
 }
 
-func expandSummaryDivider(s string, re tagReStartEnd, divider types.LowHigh[string]) (types.LowHigh[string], types.LowHigh[string]) {
+func expandSummaryDivider(s string, re tagReStartEnd, divider types.LowHigh[string]) (types.LowHigh[string], types.LowHigh[string], types.LowHigh[string]) {
+	var startMarkup types.LowHigh[string]
 	var endMarkup types.LowHigh[string]
 
 	if divider.IsZero() {
-		return divider, endMarkup
+		return divider, startMarkup, endMarkup
 	}
 
 	lo, hi := divider.Low, divider.High
@@ -347,8 +353,39 @@ func expandSummaryDivider(s string, re tagReStartEnd, divider types.LowHigh[stri
 	}
 
 	if preserveEndMarkup {
-		endMarkup.Low = divider.High
-		endMarkup.High = hi
+		for i := divider.Low - 1; i >= 0; i-- {
+			if s[i] != '>' {
+				continue
+			}
+			if match := re.startEndOfString.FindString(s[:i+1]); match != "" {
+				startMarkup.Low = i - len(match) + 1
+				startMarkup.High = startMarkup.Low
+				for startMarkup.High < divider.Low {
+					if s[startMarkup.High] == '<' {
+						j := strings.IndexByte(s[startMarkup.High:], '>')
+						if j == -1 {
+							break
+						}
+						startMarkup.High += j + 1
+						continue
+					}
+					r, size := utf8.DecodeRuneInString(s[startMarkup.High:])
+					if !unicode.IsSpace(r) {
+						break
+					}
+					startMarkup.High += size
+				}
+				break
+			}
+		}
+
+		if match := closingTagsAtEnd.FindStringIndex(s[divider.High:hi]); match != nil {
+			endMarkup.Low = divider.High + match[0]
+			endMarkup.High = hi
+		}
+		if strings.TrimSpace(s[divider.High:endMarkup.Low]) == "" {
+			startMarkup = types.LowHigh[string]{}
+		}
 	} else {
 		divider.High = hi
 	}
@@ -358,5 +395,5 @@ func expandSummaryDivider(s string, re tagReStartEnd, divider types.LowHigh[stri
 		divider.High++
 	}
 
-	return divider, endMarkup
+	return divider, startMarkup, endMarkup
 }

--- a/resources/page/page_markup_test.go
+++ b/resources/page/page_markup_test.go
@@ -105,6 +105,7 @@ func TestExtractSummaryFromHTMLWithDivider(t *testing.T) {
 		{media.Builtin.MarkdownType, "<p>First paragraph</p>\n<p>FOOO</p>\n<p>Second paragraph</p>", "<p>First paragraph</p>", "<p>Second paragraph</p>", "<p>First paragraph</p>\n<p>Second paragraph</p>"},
 		{media.Builtin.MarkdownType, "<p>FOOO</p>\n<p>First paragraph</p>", "", "<p>First paragraph</p>", "<p>First paragraph</p>"},
 		{media.Builtin.MarkdownType, "<p>First paragraph</p><p>Second paragraphFOOO</p><p>Third paragraph</p>", "<p>First paragraph</p><p>Second paragraph</p>", "<p>Third paragraph</p>", "<p>First paragraph</p><p>Second paragraph</p><p>Third paragraph</p>"},
+		{media.Builtin.MarkdownType, "<p>First FOOOSecond</p>", "<p>First </p>", "<p>Second</p>", "<p>First Second</p>"},
 		{media.Builtin.MarkdownType, "<p>这是中文，全中文FOOO</p><p>a这是中文，全中文</p>", "<p>这是中文，全中文</p>", "<p>a这是中文，全中文</p>", "<p>这是中文，全中文</p><p>a这是中文，全中文</p>"},
 		{media.Builtin.MarkdownType, `<p>a <strong>b</strong>` + "\v" + ` c</p>` + "\n<p>FOOO</p>", "<p>a <strong>b</strong>\v c</p>", "", "<p>a <strong>b</strong>\v c</p>"},
 
@@ -131,25 +132,28 @@ func TestExpandDivider(t *testing.T) {
 	c := qt.New(t)
 
 	for i, test := range []struct {
-		input           string
-		divider         string
-		ptag            tagReStartEnd
-		expect          string
-		expectEndMarkup string
+		input             string
+		divider           string
+		ptag              tagReStartEnd
+		expect            string
+		expectStartMarkup string
+		expectEndMarkup   string
 	}{
-		{"<p>First paragraph</p>\n<p>FOOO</p>\n<p>Second paragraph</p>", "FOOO", startEndP, "<p>FOOO</p>\n", ""},
-		{"<div class=\"paragraph\">\n<p>FOOO</p>\n</div>", "FOOO", startEndDiv, "<div class=\"paragraph\">\n<p>FOOO</p>\n</div>", ""},
-		{"<div><p>FOOO</p></div><div><p>Second paragraph</p></div>", "FOOO", startEndDiv, "<div><p>FOOO</p></div>", ""},
-		{"<div><p>First paragraphFOOO</p></div><div><p>Second paragraph</p></div>", "FOOO", startEndDiv, "FOOO", "</p></div>"},
-		{"   <p> abc FOOO  </p>  ", "FOOO", startEndP, "FOOO", "  </p>"},
-		{"   <p>  FOOO  </p>  ", "FOOO", startEndP, "<p>  FOOO  </p>", ""},
-		{"   <p>\n  \nFOOO  </p>  ", "FOOO", startEndP, "<p>\n  \nFOOO  </p>", ""},
-		{"   <div>  FOOO  </div>  ", "FOOO", startEndDiv, "<div>  FOOO  </div>", ""},
+		{"<p>First paragraph</p>\n<p>FOOO</p>\n<p>Second paragraph</p>", "FOOO", startEndP, "<p>FOOO</p>\n", "", ""},
+		{"<div class=\"paragraph\">\n<p>FOOO</p>\n</div>", "FOOO", startEndDiv, "<div class=\"paragraph\">\n<p>FOOO</p>\n</div>", "", ""},
+		{"<div><p>FOOO</p></div><div><p>Second paragraph</p></div>", "FOOO", startEndDiv, "<div><p>FOOO</p></div>", "", ""},
+		{"<div><p>First paragraphFOOO</p></div><div><p>Second paragraph</p></div>", "FOOO", startEndDiv, "FOOO", "", "</p></div>"},
+		{"   <p> abc FOOO  </p>  ", "FOOO", startEndP, "FOOO", "", "  </p>"},
+		{"   <p> abc FOOO def</p>  ", "FOOO", startEndP, "FOOO", "<p> ", "</p>"},
+		{"   <p>  FOOO  </p>  ", "FOOO", startEndP, "<p>  FOOO  </p>", "", ""},
+		{"   <p>\n  \nFOOO  </p>  ", "FOOO", startEndP, "<p>\n  \nFOOO  </p>", "", ""},
+		{"   <div>  FOOO  </div>  ", "FOOO", startEndDiv, "<div>  FOOO  </div>", "", ""},
 	} {
 
 		l := types.LowHigh[string]{Low: strings.Index(test.input, test.divider), High: strings.Index(test.input, test.divider) + len(test.divider)}
-		e, t := expandSummaryDivider(test.input, test.ptag, l)
+		e, s, t := expandSummaryDivider(test.input, test.ptag, l)
 		c.Assert(test.input[e.Low:e.High], qt.Equals, test.expect, qt.Commentf("[%d] Test.expect %q", i, test.input))
+		c.Assert(test.input[s.Low:s.High], qt.Equals, test.expectStartMarkup, qt.Commentf("[%d] Test.expectStartMarkup %q", i, test.input))
 		c.Assert(test.input[t.Low:t.High], qt.Equals, test.expectEndMarkup, qt.Commentf("[%d] Test.expectEndMarkup %q", i, test.input))
 	}
 }


### PR DESCRIPTION
Inline `<!--more-->` dividers were always replaced with a blank-line-wrapped marker, which forced Markdown to split a paragraph at the summary boundary.

This keeps the existing behavior for standalone dividers while preserving inline dividers. The summary extractor now closes the summary markup and reopens it for the remaining content, so `.Summary`, `.ContentWithoutSummary`, and `.Content` all remain valid.

Tests:

- `go test ./resources/page -run 'TestExtractSummaryFromHTMLWithDivider|TestExpandDivider' -count=1`
- `go test ./hugolib -run 'TestSummaryManualSplit(PreservesParagraph)?$' -count=1`

Fixes #11440
