### PR TITLE
Fix duplicated 'in in' in Pages.Group godoc

### DIFF
--- a/resources/page/pages.go
+++ b/resources/page/pages.go
@@ -87,7 +87,7 @@ func ToPages(seq any) (Pages, error) {
 	return nil, fmt.Errorf("cannot convert type %T to Pages", seq)
 }
 
-// Group groups the pages in in by key.
+// Group groups the pages in by key.
 // This implements collections.Grouper.
 func (p Pages) Group(key any, in any) (any, error) {
 	pages, err := ToPages(in)


### PR DESCRIPTION
### WHY

The godoc comment for `Pages.Group` reads `groups the pages in in by key` — a duplicated `in`. Trivial doc fix.

### WHAT

Remove the duplicated `in`:

```go
// Group groups the pages in by key.
```

No code or behavior change.