### PR TITLE
Fix the broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ CGO_ENABLED=1 go install -tags extended,withdeploy github.com/gohugoio/hugo@late
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=gohugoio/hugo&type=Timeline)](https://star-history.com/#gohugoio/hugo&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=gohugoio/hugo&type=Timeline)](https://star-history.dera.page/#gohugoio/hugo&Timeline)
 
 ## Documentation
 


### PR DESCRIPTION
The Star History chart in the README no longer renders because GitHub now restricts the stargazer API to repository owners, which broke the previously used service. This switches the chart to star-history.dera.page, a new instance that uses a different data source and requires no API token.