### PR TITLE
resources/jsconfig: Drop source root mapping for the current source root

### DIFF
--- a/resources/jsconfig/jsconfig.go
+++ b/resources/jsconfig/jsconfig.go
@@ -39,6 +39,11 @@ func (b *Builder) Build(dir string) *Config {
 	}
 	var roots []string
 	for root := range b.sourceRoots.All() {
+		if root == dir {
+			// We need mappings for other source roots (e.g. mounted modules), but not for the current one.
+			// See issue 15169.
+			continue
+		}
 		rel, err := filepath.Rel(dir, filepath.Join(root, "*"))
 		if err == nil {
 			roots = append(roots, rel)

--- a/resources/jsconfig/jsconfig_test.go
+++ b/resources/jsconfig/jsconfig_test.go
@@ -37,4 +37,10 @@ func TestJsConfigBuilder(t *testing.T) {
 	c.Assert(string(data), qt.Not(qt.Contains), "baseUrl")
 
 	c.Assert(NewBuilder().Build("/a/b"), qt.IsNil)
+
+	// Issue 15169.
+	b = NewBuilder()
+	b.AddSourceRoot("/c/assets")
+	conf = b.Build("/c/assets")
+	c.Assert(conf, qt.IsNil)
 }


### PR DESCRIPTION
Fixes #15169
