### PR TITLE
metadecoders: Emit valid YAML for repeated empty slices

### DIFF
--- a/parser/metadecoders/encoder.go
+++ b/parser/metadecoders/encoder.go
@@ -21,7 +21,19 @@ var yamlEncodeOptions = []yaml.EncodeOption{
 	yaml.WithSmartAnchor(),
 }
 
+var yamlEncodeOptionsNoAnchor = []yaml.EncodeOption{
+	yaml.UseSingleQuote(true),
+}
+
 // MarshalYAML marshals the given value to YAML.
 var MarshalYAML = func(v any) ([]byte, error) {
-	return yaml.MarshalWithOptions(v, yamlEncodeOptions...)
+	b, err := yaml.MarshalWithOptions(v, yamlEncodeOptions...)
+	if err != nil {
+		return nil, err
+	}
+	// WithSmartAnchor can emit invalid YAML for empty slices (goccy/go-yaml#853).
+	if err := yaml.Unmarshal(b, new(any)); err != nil {
+		return yaml.MarshalWithOptions(v, yamlEncodeOptionsNoAnchor...)
+	}
+	return b, nil
 }

--- a/parser/metadecoders/encoder_test.go
+++ b/parser/metadecoders/encoder_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadecoders
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// See issue 14596.
+func TestMarshalYAMLRepeatedEmptySlices(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	in := map[string]any{
+		"alpha": map[string]any{"tags": []any{}},
+		"beta":  map[string]any{"tags": []any{}},
+		"gamma": map[string]any{"tags": []any{}},
+	}
+
+	out, err := MarshalYAML(in)
+	c.Assert(err, qt.IsNil)
+	got := string(out)
+	c.Assert(strings.Contains(got, "&"), qt.IsFalse)
+	c.Assert(strings.Contains(got, "*"), qt.IsFalse)
+
+	var decoded any
+	c.Assert(UnmarshalYaml(out, &decoded), qt.IsNil)
+}
+
+// See issue 14596.
+func TestMarshalYAMLRepeatedEmptyStringSlices(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	in := map[string]any{
+		"a": []string{},
+		"b": []string{},
+		"c": []string{"item"},
+	}
+
+	out, err := MarshalYAML(in)
+	c.Assert(err, qt.IsNil)
+
+	var decoded any
+	c.Assert(UnmarshalYaml(out, &decoded), qt.IsNil)
+}
+
+func TestMarshalYAMLKeepsAliasesCompact(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	in := []byte(`
+a: &a [_, _, _, _, _, _, _, _, _, _, _, _, _, _, _]
+b: &b [*a, *a, *a, *a, *a, *a, *a, *a, *a, *a]
+c: &c [*b, *b, *b, *b, *b, *b, *b, *b, *b, *b]
+`)
+	m, err := Default.Unmarshal(in, YAML)
+	c.Assert(err, qt.IsNil)
+
+	out, err := MarshalYAML(m)
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(out) < 512, qt.IsTrue)
+	c.Assert(strings.Contains(string(out), "*"), qt.IsTrue)
+
+	var decoded any
+	c.Assert(UnmarshalYaml(out, &decoded), qt.IsNil)
+}

--- a/tpl/transform/remarshal_test.go
+++ b/tpl/transform/remarshal_test.go
@@ -14,6 +14,7 @@
 package transform_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gohugoio/hugo/htesting"
@@ -198,6 +199,39 @@ a = "b"
 		_, err = ns.Remarshal("json", "asdf")
 		c.Assert(err, qt.Not(qt.IsNil))
 	})
+}
+
+// See issue 14596.
+func TestRemarshalYAMLRepeatedEmptySlices(t *testing.T) {
+	t.Parallel()
+
+	b := hugolib.Test(t, "")
+	ns := transform.New(b.H.Deps)
+	c := qt.New(t)
+
+	input := `
+alpha:
+  tags: []
+  kind: one
+beta:
+  tags: []
+  kind: two
+gamma:
+  tags: []
+  kind: three
+`
+
+	got, err := ns.Remarshal("yaml", input)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(got, "&"), qt.IsFalse)
+	c.Assert(strings.Contains(got, "*"), qt.IsFalse)
+	c.Assert(got, qt.Contains, "tags: []")
+
+	roundtrip, err := ns.Remarshal("json", got)
+	c.Assert(err, qt.IsNil)
+	c.Assert(roundtrip, qt.Contains, `"alpha"`)
+	c.Assert(roundtrip, qt.Contains, `"beta"`)
+	c.Assert(roundtrip, qt.Contains, `"gamma"`)
 }
 
 func TestRemarshaBillionLaughs(t *testing.T) {


### PR DESCRIPTION
`transform.Remarshal "yaml"` (and other `MarshalYAML` callers) can emit invalid self-referential anchors such as `options: &options *options` when the input contains more than one empty slice. That output cannot be parsed by go-yaml, yq, or PyYAML.

This comes from `goccy/go-yaml`'s `WithSmartAnchor` (goccy/go-yaml#853; upstream PR goccy/go-yaml#854 is still open). If the smart-anchor pass produces YAML that go-yaml itself cannot unmarshal, retry without smart anchors. Documents that already encode correctly keep anchors, so the existing billion-laughs protection is unchanged.

Fixes #14596

This PR was written with AI assistance.