### PR TITLE
tpl: Error on duplicate inline partials across files

### DIFF
--- a/tpl/tplimpl/templatestore.go
+++ b/tpl/tplimpl/templatestore.go
@@ -149,6 +149,9 @@ func NewStore(opts StoreOptions, siteOpts SiteOptions) (*TemplateStore, error) {
 	if err := s.insertEmbedded(); err != nil {
 		return nil, err
 	}
+	if err := s.checkDuplicateInlinePartials(); err != nil {
+		return nil, err
+	}
 	if err := s.parseTemplates(); err != nil {
 		return nil, err
 	}
@@ -745,6 +748,9 @@ func (s *TemplateStore) RefreshFiles(include func(fi hugofs.FileMetaInfo) bool) 
 	if err := s.insertTemplates(include, true); err != nil {
 		return err
 	}
+	if err := s.checkDuplicateInlinePartials(); err != nil {
+		return err
+	}
 	if err := s.createTemplatesSnapshot(); err != nil {
 		return err
 	}
@@ -1017,11 +1023,99 @@ func (s *TemplateStore) extractIdentifiers(line string) []string {
 	return identifiers
 }
 
-func (s *TemplateStore) extractInlinePartials(rebuild bool) error {
-	isPartialName := func(s string) bool {
-		return strings.HasPrefix(s, "partials/") || strings.HasPrefix(s, "_partials/")
+func isPartialName(name string) bool {
+	return strings.HasPrefix(name, "partials/") || strings.HasPrefix(name, "_partials/")
+}
+
+// inlinePartialDefineNames returns {{define}}/{{block}} names that are inline partials.
+func inlinePartialDefineNames(content string) []string {
+	t := parse.New("")
+	t.Mode = parse.SkipFuncCheck
+	treeSet := make(map[string]*parse.Tree)
+	if _, err := t.Parse(content, "{{", "}}", treeSet); err != nil {
+		return nil
+	}
+	var names []string
+	for name := range treeSet {
+		if name != "" && isPartialName(name) {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func templSourcePath(ti *TemplInfo) string {
+	if ti != nil && ti.PathInfo != nil {
+		return ti.PathInfo.Path()
+	}
+	if ti != nil {
+		return ti.Name()
+	}
+	return ""
+}
+
+func sameInlinePartialSource(a, b *TemplInfo) bool {
+	if a == b {
+		return true
+	}
+	if a.PathInfo != nil && b.PathInfo != nil {
+		return a.PathInfo.Path() == b.PathInfo.Path()
+	}
+	return false
+}
+
+func (s *TemplateStore) normalizeInlinePartialName(name string) string {
+	if !paths.HasExt(name) {
+		name += s.htmlFormat.MediaType.FirstSuffix.FullSuffix
+	}
+	if !strings.HasPrefix(name, "_") {
+		name = "_" + name
+	}
+	return s.opts.PathParser.Parse(files.ComponentFolderLayouts, name).Path()
+}
+
+func (s *TemplateStore) checkDuplicateInlinePartials() error {
+	defined := make(map[string]*TemplInfo)
+	check := func(ti *TemplInfo) error {
+		if ti == nil || ti.content == "" {
+			return nil
+		}
+		for _, name := range inlinePartialDefineNames(ti.content) {
+			key := s.normalizeInlinePartialName(name)
+			prev, found := defined[key]
+			if !found {
+				defined[key] = ti
+				continue
+			}
+			if sameInlinePartialSource(prev, ti) {
+				continue
+			}
+			return s.addFileContext(ti, "parse of template failed",
+				fmt.Errorf("template: multiple definition of template %q (also defined in %q)", key, templSourcePath(prev)))
+		}
+		return nil
 	}
 
+	for _, v := range s.treeMain.All() {
+		for _, ti := range v {
+			if err := check(ti); err != nil {
+				return err
+			}
+		}
+	}
+	for _, v := range s.treeShortcodes.All() {
+		for _, m := range v {
+			for _, ti := range m {
+				if err := check(ti); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (s *TemplateStore) extractInlinePartials(rebuild bool) error {
 	// We may find both inline and external partials in the current template namespaces,
 	// so only add the ones we have not seen before.
 	for templ := range s.allRawTemplates() {

--- a/tpl/tplimpl/templatestore_integration_test.go
+++ b/tpl/tplimpl/templatestore_integration_test.go
@@ -1569,3 +1569,48 @@ layouts/p1/page.html
 
 	b.AssertFileContent("public/p1/index.html", "layouts/p1/page.html")
 }
+
+// See issue 14561.
+func TestDuplicateInlinePartialAcrossFiles(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['page','section','taxonomy','term','rss','sitemap']
+-- layouts/home.html --
+{{ partial "a.html" . }}
+-- layouts/_partials/a.html --
+A:{{ partial "inline/shared.html" . }}
+{{ define "_partials/inline/shared.html" }}from-a{{ end }}
+-- layouts/_partials/b.html --
+B:{{ partial "inline/shared.html" . }}
+{{ define "_partials/inline/shared.html" }}from-b{{ end }}
+`
+
+	b, err := hugolib.TestE(t, files)
+	b.Assert(err, qt.IsNotNil)
+	b.Assert(err.Error(), qt.Contains, "multiple definition of template")
+	b.Assert(err.Error(), qt.Contains, "/_partials/inline/shared.html")
+	b.Assert(err.Error(), qt.Contains, "/_partials/a.html")
+	b.Assert(err.Error(), qt.Contains, "/_partials/b.html")
+
+	// The same inline partial under the historical "partials/" prefix and
+	// without an extension must also be treated as a duplicate.
+	files = `
+-- hugo.toml --
+disableKinds = ['page','section','taxonomy','term','rss','sitemap']
+-- layouts/home.html --
+{{ partial "a.html" . }}
+-- layouts/_partials/a.html --
+A:{{ partial "inline/shared.html" . }}
+{{ define "partials/inline/shared" }}from-a{{ end }}
+-- layouts/_partials/b.html --
+B:{{ partial "inline/shared.html" . }}
+{{ define "_partials/inline/shared.html" }}from-b{{ end }}
+`
+
+	b, err = hugolib.TestE(t, files)
+	b.Assert(err, qt.IsNotNil)
+	b.Assert(err.Error(), qt.Contains, "multiple definition of template")
+	b.Assert(err.Error(), qt.Contains, "/_partials/inline/shared.html")
+}


### PR DESCRIPTION
Inline partials live in the global Go template namespace. Defining the same name twice in one file already fails at parse time, but a second file silently overwrote the first, so the wrong partial could run (and rebuilds could flip which one won).

Scan layout files for `{{ define }}` / `{{ block }}` of `_partials/` names and fail the build when two different files define the same normalized name.

Fixes #14561

This PR was written with AI assistance.