### PR TITLE
hugolib: Keep nested index.md as a resource on rebuild

### DIFF
--- a/hugolib/content_map.go
+++ b/hugolib/content_map.go
@@ -300,6 +300,15 @@ func (m *pageMap) AddFi(fi hugofs.FileMetaInfo, buildConfig *BuildCfg) (pageSour
 		}
 
 	default:
+		// Partial rebuilds may start below a leaf; keep those files as resources.
+		if m.leafBundleOwner(pi) != nil {
+			paths.ModifyPathBundleTypeResource(pi)
+			if err := insertResource(fi); err != nil {
+				addErr = err
+			}
+			return
+		}
+
 		m.s.Log.Trace(logg.StringFunc(
 			func() string {
 				return fmt.Sprintf("insert bundle: %q", fi.Meta().Filename)

--- a/hugolib/content_map_page.go
+++ b/hugolib/content_map_page.go
@@ -136,6 +136,40 @@ type pageTrees struct {
 	resourceTrees doctree.MutableTrees
 }
 
+// leafBundleOwner returns the closest ancestor leaf bundle for p, if any.
+func (t *pageTrees) leafBundleOwner(p *paths.Path) *paths.Path {
+	if p == nil || p.Component() != files.ComponentFolderContent || p.IsContentData() {
+		return nil
+	}
+
+	t.treePages.Lock(false)
+	defer t.treePages.Unlock(false)
+
+	for dir := path.Dir(p.Base()); ; dir = path.Dir(dir) {
+		key := dir
+		if dir == "/" {
+			// The home page is stored at "".
+			key = ""
+		}
+		if n, ok := t.treePages.GetRaw(key); ok {
+			var owner *paths.Path
+			n.forEeachContentNode(func(_ sitesmatrix.Vector, nn contentNode) bool {
+				if pi := cnh.PathInfo(nn); pi != nil && pi.IsLeafBundle() {
+					owner = pi
+					return false
+				}
+				return true
+			})
+			if owner != nil {
+				return owner
+			}
+		}
+		if dir == "/" || dir == "." || dir == "" {
+			return nil
+		}
+	}
+}
+
 // collectAndMarkStaleIdentities collects all identities from in all trees matching the given key.
 // We currently re-read all page/resources for all languages that share the same path,
 // so we mark all entries as stale (which will trigger cache invalidation), then

--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -933,6 +933,11 @@ func (h *HugoSites) processPartialFileEvents(ctx context.Context, l logg.LevelLo
 			}
 
 			pss[i] = h.Configs.ContentPathParser.Parse(cps.Component, p)
+			if pss[i].IsLeafBundle() || pss[i].IsBranchBundle() {
+				if h.pageTrees.leafBundleOwner(pss[i]) != nil {
+					paths.ModifyPathBundleTypeResource(pss[i])
+				}
+			}
 			if ev.added && !ev.isChangedDir && cps.Component == files.ComponentFolderContent {
 				addedContentPaths = append(addedContentPaths, pss[i])
 			}

--- a/hugolib/rebuild_test.go
+++ b/hugolib/rebuild_test.go
@@ -125,6 +125,80 @@ func TestRebuildEditTextFileInLeafBundle(t *testing.T) {
 	b.AssertRenderCountContent(0)
 }
 
+// See issue 13961.
+func TestRebuildEditNestedContentInLeafBundle(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.com"
+disableLiveReload = true
+disableKinds = ["taxonomy", "term", "sitemap", "robotsTXT", "404", "rss"]
+-- content/_index.md --
+---
+title: "Home"
+---
+-- content/a/index.md --
+---
+title: "A"
+---
+A.
+-- content/a/b/index.md --
+---
+title: "B"
+---
+B.
+-- content/a/b/c.md --
+---
+title: "C"
+---
+C.
+-- content/s/_index.md --
+---
+title: "S"
+---
+-- content/s/p/index.md --
+---
+title: "P"
+---
+P.
+-- layouts/home.html --
+Home.
+-- layouts/list.html --
+List: {{ .Title }}|
+-- layouts/page.html --
+Page: {{ .Title }}|{{ .Content }}|Resources: {{ range .Resources }}{{ .Name }}:{{ .Content }}{{ end }}|
+`
+
+	b := Test(t, files, TestOptRunning())
+	b.AssertFileContent("public/a/index.html", "Page: A", "index.md:<p>B.</p>", "c.md:<p>C.</p>")
+	b.AssertFileExists("public/a/b/index.html", false)
+	b.AssertFileExists("public/a/b/c/index.html", false)
+	b.AssertFileContent("public/s/p/index.html", "Page: P", "<p>P.</p>")
+
+	b.EditFileReplaceAll("content/a/b/index.md", "B.", "B edited.").Build()
+	b.AssertFileContent("public/a/index.html", "index.md:<p>B edited.</p>")
+	b.AssertFileExists("public/a/b/index.html", false)
+	b.AssertFileExists("public/a/b/c/index.html", false)
+
+	b.EditFileReplaceAll("content/a/b/c.md", "C.", "C edited.").Build()
+	b.AssertFileContent("public/a/index.html", "c.md:<p>C edited.</p>")
+	b.AssertFileExists("public/a/b/index.html", false)
+	b.AssertFileExists("public/a/b/c/index.html", false)
+
+	b.AddFiles("content/a/b/d/index.md", `---
+title: "D"
+---
+D.
+`).Build()
+	b.AssertFileContent("public/a/index.html", "index.md:<p>D.</p>")
+	b.AssertFileExists("public/a/b/d/index.html", false)
+
+	// A real leaf below a branch bundle must still rebuild as a page.
+	b.EditFileReplaceAll("content/s/p/index.md", "P.", "P edited.").Build()
+	b.AssertFileContent("public/s/p/index.html", "Page: P", "<p>P edited.</p>")
+}
+
 func TestRebuildAddingALeaffBundleIssue13925(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
A full content walk classifies files below a leaf bundle as resources. A server rebuild can start at the nested directory, so `content/a/b/index.md` was parsed as a new leaf from its filename and published as `/a/b/`.

Look up the owning leaf in the page tree and keep those nested bundle files as resources on rebuild, including when they are inserted.

Fixes #13961

This PR was written with AI assistance; I reviewed the rebuild classification and the regression test.