### PR TITLE
fix(inflect): do not insert space after opening quotes in humanize

### DIFF
--- a/tpl/inflect/inflect.go
+++ b/tpl/inflect/inflect.go
@@ -51,7 +51,46 @@ func (ns *Namespace) Humanize(v any) (string, error) {
 	}
 
 	str := _inflect.Humanize(word)
-	return _inflect.Humanize(strings.ToLower(str)), nil
+	// flect.Humanize inserts a space after some opening quotation marks
+	// (e.g. U+201E) before a capital letter. Collapse that so humanize of
+	// `Painting „Title“` does not become `Painting „ title“` (see #15126).
+	str = collapseSpaceAfterOpeningQuotes(str)
+	str = _inflect.Humanize(strings.ToLower(str))
+	str = collapseSpaceAfterOpeningQuotes(str)
+	return str, nil
+}
+
+// openingQuoteRunes are common opening quotation marks that flect may treat
+// as a word boundary, inserting a following space before the next word.
+var openingQuoteRunes = map[rune]struct{}{
+	'\u201e': {}, // double low-9 quotation mark
+	'\u201c': {}, // left double quotation mark
+	'\u2018': {}, // left single quotation mark
+	'\u00ab': {}, // left-pointing double angle quotation mark
+	'\u2039': {}, // single left-pointing angle quotation mark
+	'\u300c': {}, // left corner bracket
+	'\u300e': {}, // left white corner bracket
+	'"':      {},
+	'\'':     {},
+}
+
+func collapseSpaceAfterOpeningQuotes(s string) string {
+	if s == "" || !strings.Contains(s, " ") {
+		return s
+	}
+	runes := []rune(s)
+	out := make([]rune, 0, len(runes))
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		out = append(out, r)
+		if _, ok := openingQuoteRunes[r]; ok {
+			// Skip a single ASCII space immediately after the quote.
+			if i+1 < len(runes) && runes[i+1] == ' ' {
+				i++
+			}
+		}
+	}
+	return string(out)
 }
 
 // Pluralize returns the plural form of the single word in v.

--- a/tpl/inflect/inflect_test.go
+++ b/tpl/inflect/inflect_test.go
@@ -28,6 +28,8 @@ func TestInflect(t *testing.T) {
 		{ns.Humanize, t, false},
 		{ns.Humanize, "this is a TEST", "This is a test"},
 		{ns.Humanize, "my-first-Post", "My first post"},
+		// Opening low-9 quote must not gain a space before the next word (#15126).
+		{ns.Humanize, "Painting „Title“", "Painting „title“"},
 		{ns.Pluralize, "cat", "cats"},
 		{ns.Pluralize, "", ""},
 		{ns.Pluralize, t, false},


### PR DESCRIPTION
## Summary
Fixes #15126.

humanize of strings like Painting with low-9 quotes produced a spurious space after the opening quote because gobuffalo/flect treats some opening quotation marks as word boundaries, and Hugo then lowercases and re-humanizes.

Collapse a single ASCII space immediately after common opening quote runes after each humanize step.

## Test plan
- [x] go test ./tpl/inflect/
- [x] Case for low-9 opening quote
