### PR TITLE
hugolib: Make .Render take an optional context argument

### DIFF
--- a/hugolib/page__per_output.go
+++ b/hugolib/page__per_output.go
@@ -104,21 +104,34 @@ func (pco *pageContentOutput) Reset() {
 	pco.renderHooks = &renderHooks{}
 }
 
-func (pco *pageContentOutput) Render(ctx context.Context, layout ...string) (template.HTML, error) {
-	if len(layout) == 0 {
-		return "", errors.New("no layout given")
+func (pco *pageContentOutput) Render(ctx context.Context, args ...any) (template.HTML, error) {
+	if len(args) == 0 {
+		return "", errors.New("no view given")
 	}
-	templ, found, err := pco.po.p.resolveTemplate(layout...)
+	if len(args) > 2 {
+		return "", errors.New("too many arguments, expected VIEW [CONTEXT]")
+	}
+	view, err := cast.ToStringE(args[0])
+	if err != nil {
+		return "", fmt.Errorf("failed to convert view argument to string: %w", err)
+	}
+
+	// Make sure to send the *pageState and not the *pageContentOutput to the template.
+	var data any = pco.po.p
+	if len(args) == 2 {
+		data = args[1]
+	}
+
+	templ, found, err := pco.po.p.resolveTemplate(view)
 	if err != nil {
 		return "", pco.po.p.wrapError(err)
 	}
 
 	if !found {
-		return "", fmt.Errorf("template %q not found", layout[0])
+		return "", fmt.Errorf("template %q not found", view)
 	}
 
-	// Make sure to send the *pageState and not the *pageContentOutput to the template.
-	res, err := executeToString(ctx, pco.po.p.s.GetTemplateStore(), templ, pco.po.p)
+	res, err := executeToString(ctx, pco.po.p.s.GetTemplateStore(), templ, data)
 	if err != nil {
 		return "", pco.po.p.wrapError(fmt.Errorf("failed to execute template %s: %w", templ.Name(), err))
 	}

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1913,6 +1913,56 @@ func TestRenderWithoutArgument(t *testing.T) {
 	b.Assert(err, qt.IsNotNil)
 }
 
+// See issue 15077.
+func TestRenderWithContext(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+-- content/p1.md --
+---
+title: "P1"
+---
+-- layouts/page.html --
+{{ .Render "li" }}|{{ .Render "li" (dict "Title" "Custom") }}
+-- layouts/li.html --
+Title: {{ .Title }}{{- /**/ -}}
+`
+
+	b := Test(t, files)
+
+	b.AssertFileContent("public/p1/index.html", "Title: P1|Title: Custom")
+}
+
+// See issue 15077.
+func TestRenderWithContextErrors(t *testing.T) {
+	t.Parallel()
+
+	filesTemplate := `
+-- hugo.toml --
+-- content/p1.md --
+---
+title: "P1"
+---
+-- layouts/li.html --
+li
+-- layouts/page.html --
+RENDER
+`
+
+	for _, test := range []struct {
+		render  string
+		message string
+	}{
+		{`{{ .Render "li" "foo" "bar" }}`, `(?s).*too many arguments, expected VIEW \[CONTEXT\].*`},
+		{`{{ .Render (slice "li") }}`, `(?s).*failed to convert view argument to string: unable to cast \[\]string{"li"} of type \[\]string to string.*`},
+	} {
+		files := strings.ReplaceAll(filesTemplate, "RENDER", test.render)
+		b, err := TestE(t, files)
+		b.Assert(err, qt.ErrorMatches, test.message)
+	}
+}
+
 // Issue #13021
 func TestAllStores(t *testing.T) {
 	t.Parallel()

--- a/resources/page/page.go
+++ b/resources/page/page.go
@@ -327,8 +327,9 @@ type PageMetaInternalProvider interface {
 
 // PageRenderProvider provides a way for a Page to render content.
 type PageRenderProvider interface {
-	// Render renders the given layout with this Page as context.
-	Render(ctx context.Context, layout ...string) (template.HTML, error)
+	// Render renders the given view (a layout template) with this Page as
+	// the data context, or, if given, the second argument CONTEXT.
+	Render(ctx context.Context, args ...any) (template.HTML, error)
 	// RenderString renders the first value in args with the content renderer defined
 	// for this Page.
 	// It takes an optional map as a second argument:

--- a/resources/page/page_lazy_contentprovider.go
+++ b/resources/page/page_lazy_contentprovider.go
@@ -117,8 +117,8 @@ func (lcp *LazyContentProvider) Len(ctx context.Context) int {
 	return lcp.init.Value(ctx).Len(ctx)
 }
 
-func (lcp *LazyContentProvider) Render(ctx context.Context, layout ...string) (template.HTML, error) {
-	return lcp.init.Value(ctx).Render(ctx, layout...)
+func (lcp *LazyContentProvider) Render(ctx context.Context, args ...any) (template.HTML, error) {
+	return lcp.init.Value(ctx).Render(ctx, args...)
 }
 
 func (lcp *LazyContentProvider) RenderString(ctx context.Context, args ...any) (template.HTML, error) {

--- a/resources/page/page_nop.go
+++ b/resources/page/page_nop.go
@@ -399,7 +399,7 @@ func (p *nopPage) RelRef(argsm map[string]any) (string, error) {
 	return "", nil
 }
 
-func (p *nopPage) Render(ctx context.Context, layout ...string) (template.HTML, error) {
+func (p *nopPage) Render(ctx context.Context, args ...any) (template.HTML, error) {
 	return "", nil
 }
 

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -483,7 +483,7 @@ func (p *testPage) RelRefFrom(argsm map[string]any, source any) (string, error) 
 	return "", nil
 }
 
-func (p *testPage) Render(ctx context.Context, layout ...string) (template.HTML, error) {
+func (p *testPage) Render(ctx context.Context, args ...any) (template.HTML, error) {
 	panic("testpage: not implemented")
 }
 


### PR DESCRIPTION
The signature is now PAGE.Render VIEW [CONTEXT], mirroring the partial API:
The first argument is always the view name, and if CONTEXT is given, it
replaces the Page as the template's data context.

Closes #15077

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
