### PR TITLE
all: Fix typos in comments and unexported identifiers

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -1250,10 +1250,10 @@ func canRedirect(requestURIWithoutQuery string, r *http.Request) bool {
 // Fall back to the file extension if not set.
 // The main take here is that we don't want to have CSS/JS files etc. partake in this logic.
 func isNavigation(requestURIWithoutQuery string, r *http.Request) bool {
-	return r.Header.Get("Sec-Fetch-Mode") == "navigate" || isPropablyHTMLRequest(requestURIWithoutQuery)
+	return r.Header.Get("Sec-Fetch-Mode") == "navigate" || isProbablyHTMLRequest(requestURIWithoutQuery)
 }
 
-func isPropablyHTMLRequest(requestURIWithoutQuery string) bool {
+func isProbablyHTMLRequest(requestURIWithoutQuery string) bool {
 	if strings.HasSuffix(requestURIWithoutQuery, "/") || strings.HasSuffix(requestURIWithoutQuery, "html") || strings.HasSuffix(requestURIWithoutQuery, "htm") {
 		return true
 	}

--- a/markup/converter/hooks/hooks.go
+++ b/markup/converter/hooks/hooks.go
@@ -112,12 +112,12 @@ type BlockquoteContext interface {
 
 	// The alert title.
 	// Currently only relevant for Obsidian alerts.
-	// GitHub does not suport alert titles and will not render alerts with titles.
+	// GitHub does not support alert titles and will not render alerts with titles.
 	AlertTitle() hstring.HTML
 
 	// The alert sign,  "+" or "-" or "" used to indicate folding.
 	// Currently only relevant for Obsidian alerts.
-	// GitHub does not suport alert signs and will not render alerts with signs.
+	// GitHub does not support alert signs and will not render alerts with signs.
 	AlertSign() string
 }
 

--- a/markup/goldmark/convert.go
+++ b/markup/goldmark/convert.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	// Don't change this. This pattern is lso used in the image render hooks.
+	// Don't change this. This pattern is also used in the image render hooks.
 	internalAttrPrefix = "_h__"
 )
 

--- a/resources/page/page_markup.go
+++ b/resources/page/page_markup.go
@@ -164,11 +164,11 @@ func (s *HtmlSummary) resolveParagraphTagAndSetWrapper(mt media.Type) tagReStart
 // Avoid counting words that are most likely HTML tokens.
 var (
 	isProbablyHTMLTag      = regexp.MustCompile(`^<\/?[A-Za-z]+>?$`)
-	isProablyHTMLAttribute = regexp.MustCompile(`^[A-Za-z]+=["']`)
+	isProbablyHTMLAttribute = regexp.MustCompile(`^[A-Za-z]+=["']`)
 )
 
 func isProbablyHTMLToken(s string) bool {
-	return s == ">" || isProbablyHTMLTag.MatchString(s) || isProablyHTMLAttribute.MatchString(s)
+	return s == ">" || isProbablyHTMLTag.MatchString(s) || isProbablyHTMLAttribute.MatchString(s)
 }
 
 // ExtractSummaryFromHTML extracts a summary from the given HTML content.

--- a/resources/resource_transformers/cssjs/postcss.go
+++ b/resources/resource_transformers/cssjs/postcss.go
@@ -79,7 +79,7 @@ type InlineImports struct {
 
 	// See issue https://github.com/gohugoio/hugo/issues/13719
 	// Disable inlining of @import statements
-	// This is currenty only used for css.TailwindCSS.
+	// This is currently only used for css.TailwindCSS.
 	DisableInlineImports bool
 
 	// When InlineImports is enabled, we fail the build if an import cannot be resolved.


### PR DESCRIPTION
Spelling fixes only:

- `suport` -> `support` in the `AlertTitle`/`AlertSign` doc comments (`markup/converter/hooks/hooks.go`)
- `currenty` -> `currently` (`resources/resource_transformers/cssjs/postcss.go`)
- `lso` -> `also` (`markup/goldmark/convert.go`)
- `isPropablyHTMLRequest` -> `isProbablyHTMLRequest` (`commands/server.go`)
- `isProablyHTMLAttribute` -> `isProbablyHTMLAttribute` (`resources/page/page_markup.go`)

The two renamed identifiers are unexported with all references in their own file. `go build ./...` and `go vet` on the touched packages pass.