### PR TITLE
page: Add IndexOf method to Pages

### DIFF
--- a/resources/page/pages.go
+++ b/resources/page/pages.go
@@ -130,6 +130,11 @@ func (pages Pages) ProbablyEq(other any) bool {
 	return true
 }
 
+// IndexOf returns the index of page in p, or -1 if not found.
+func (p Pages) IndexOf(page Page) int {
+	return searchPage(page, p)
+}
+
 // PagesFactory somehow creates some Pages.
 // We do a lot of lazy Pages initialization in Hugo, so we need a type.
 type PagesFactory func() Pages

--- a/resources/page/pages_test.go
+++ b/resources/page/pages_test.go
@@ -70,3 +70,15 @@ func TestToPages(t *testing.T) {
 	_, err := ToPages("not a page")
 	c.Assert(err, qt.Not(qt.IsNil))
 }
+
+func TestIndexOf(t *testing.T) {
+	c := qt.New(t)
+
+	p1, p2, p3, p4 := &testPage{title: "p1"}, &testPage{title: "p2"}, &testPage{title: "p3"}, &testPage{title: "p4"}
+
+	pages := Pages{p1, p2, p3}
+	c.Assert(pages.IndexOf(p1), qt.Equals, 0)
+	c.Assert(pages.IndexOf(p2), qt.Equals, 1)
+	c.Assert(pages.IndexOf(p3), qt.Equals, 2)
+	c.Assert(pages.IndexOf(p4), qt.Equals, -1)
+}


### PR DESCRIPTION
See #13589

Adds an IndexOf method to Pages that returns the index of a page, or -1 if the page is not found.

The implementation reuses the existing searchPage function.

AI assistance was used to help understand the existing codebase. 
The final implementation and changes were manually reviewed and verified.