### PR TITLE
tpl: key deferred templates by owner so escaping follows the output format

### DIFF
--- a/tpl/templates/defer_integration_test.go
+++ b/tpl/templates/defer_integration_test.go
@@ -367,3 +367,35 @@ Home.
 	b.Assert(err, qt.Not(qt.IsNil))
 	b.Assert(err.Error(), qt.Contains, "templates.Defer cannot be used inside a partialCached partial")
 }
+
+// Issue #15234: byte-identical deferred blocks in templates of different
+// output formats collided on one deferred-template registration, and which
+// escaping (html vs text) survived followed the transform loop's random map
+// iteration order. Each output format must keep its own escaping.
+func TestDeferIdenticalBodiesAcrossOutputFormats(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ["page", "section", "taxonomy", "term", "rss", "sitemap", "robots", "404"]
+[outputFormats.probe]
+mediaType = "text/plain"
+baseName = "index"
+isPlainText = true
+[outputs]
+home = ["html", "probe"]
+-- layouts/home.html --
+{{ $v := "<b>&" }}OUT[{{ $v }}]{{ with (templates.Defer (dict "key" "K" "data" (dict "v" $v))) }}IN[{{ .v }}]{{ end }}
+-- layouts/home.probe.txt --
+{{ $v := "<b>&" }}OUT[{{ $v }}]{{ with (templates.Defer (dict "key" "K" "data" (dict "v" $v))) }}IN[{{ .v }}]{{ end }}
+`
+
+	b := hugolib.Test(t, files)
+
+	// The HTML output must html-escape the deferred interpolation.
+	b.AssertFileContent("public/index.html",
+		"OUT[&lt;b&gt;&amp;]IN[&lt;b&gt;&amp;]")
+	// The plain-text output must keep the raw bytes.
+	b.AssertFileContent("public/index.txt",
+		"OUT[<b>&]IN[<b>&]")
+}

--- a/tpl/tplimpl/templatetransform.go
+++ b/tpl/tplimpl/templatetransform.go
@@ -408,7 +408,15 @@ func (c *templateTransformContext) handleWith(withNode *parse.WithNode) {
 		c.err = errors.New("resources.PostProcess cannot be used in a deferred template")
 		return
 	}
-	innerHash := hashing.XxHashFromStringHexEncoded(s)
+	// The deferred template is registered under this ID and takes its
+	// escaping (text vs html) from the first owner that registers it.
+	// Hashing only the body made byte-identical blocks in templates of
+	// different output formats collide on one registration, and which
+	// escaping survived followed the (random) map iteration order of the
+	// surrounding transform loop. Include the owning template's name so
+	// each output format gets its own, correctly escaped registration —
+	// the same convention the partial-decorator hash below uses (#15234).
+	innerHash := hashing.XxHashFromStringHexEncoded(c.t.Name() + s)
 	deferredID := tpl.HugoDeferredTemplatePrefix + innerHash
 
 	c.deferNodes[deferredID] = inner


### PR DESCRIPTION
Fixes #15234.

## Root cause

The deferred-template ID is `__hdeferred/<hash of the deferred block's body>`, and `addDeferredTemplate` takes its escaping (text vs html) from **whichever owner registers that ID first**:

```go
innerHash := hashing.XxHashFromStringHexEncoded(s)          // body only
deferredID := tpl.HugoDeferredTemplatePrefix + innerHash
```

Byte-identical deferred blocks in templates of different output formats therefore collide on a single registration, and which escaping survives follows the random map iteration order of the transform loop — matching the report's measurement (28 of 40 unchanged builds wrong in `public/index.html`, 12 wrong in `public/index.txt`, all exit 0, no warning).

## Fix

Hash the owning template's name together with the body, so each output format registers its own, correctly escaped deferred template:

```go
innerHash := hashing.XxHashFromStringHexEncoded(c.t.Name() + s)
```

This is the same convention the partial-decorator transform a few lines below already uses (`c.t.Name() + withNodeInnerString`). The `Key` option of `templates.Defer` still deduplicates *executions* per key exactly as before — only the internal template registration is disambiguated.

## Testing

Added `TestDeferIdenticalBodiesAcrossOutputFormats`: a site with `home.html` and `home.probe.txt` carrying byte-identical defer bodies that interpolate `<b>&`, asserting the HTML output escapes (`&lt;b&gt;&amp;`) and the plain-text output keeps the raw bytes.

- With the fix: `go test ./tpl/templates/ ./tpl/tplimpl/` pass (network-dependent shortcode tests like `TestVimeoShortcode` skipped — they fail identically on `main` in this sandbox, no network).
- Differential (fix reverted, test kept): fails 3/3 runs here — the collision breaks at least one of the two assertions on every iteration order this build produced.
- `gofmt` clean.
