### PR TITLE
fix(hstore): hold read lock for the full GetSortedMapValues operation

### DIFF
--- a/common/hstore/scratch.go
+++ b/common/hstore/scratch.go
@@ -131,14 +131,13 @@ func (c *Scratch) DeleteInMap(key string, mapKey string) string {
 // GetSortedMapValues returns a sorted map previously filled with SetInMap.
 func (c *Scratch) GetSortedMapValues(key string) any {
 	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	if c.values[key] == nil {
-		c.mu.RUnlock()
 		return nil
 	}
 
 	unsortedMap := c.values[key].(map[string]any)
-	c.mu.RUnlock()
 	var keys []string
 	for mapKey := range unsortedMap {
 		keys = append(keys, mapKey)

--- a/common/hstore/scratch_test.go
+++ b/common/hstore/scratch_test.go
@@ -14,6 +14,7 @@
 package hstore
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
@@ -214,4 +215,26 @@ func BenchmarkScratchGet(b *testing.B) {
 	for b.Loop() {
 		scratch.Get("A")
 	}
+}
+
+func TestScratchGetSortedMapValuesConcurrentWithSetInMap(t *testing.T) {
+	c := qt.New(t)
+
+	s := NewScratch()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			s.SetInMap("m", fmt.Sprintf("k%d", i), i)
+		}(i)
+		go func() {
+			defer wg.Done()
+			s.GetSortedMapValues("m")
+		}()
+	}
+	wg.Wait()
+
+	val := s.GetSortedMapValues("m").([]any)
+	c.Assert(val, qt.HasLen, 100)
 }


### PR DESCRIPTION
Fixes #15237

## Summary

`Scratch.GetSortedMapValues` in `common/hstore/scratch.go` released the `RWMutex` after extracting the map header, then iterated and indexed the map without holding the lock. A concurrent `SetInMap` writing into the same map caused a fatal Go runtime abort (unsynchronized map read against a write).

Every other method on this type holds the mutex during its full operation. This was the only outlier.

## Fix

Replace the early `c.mu.RUnlock()` calls with `defer c.mu.RUnlock()` so the read lock covers all map accesses:

```diff
 func (c *Scratch) GetSortedMapValues(key string) any {
 	c.mu.RLock()
+	defer c.mu.RUnlock()

 	if c.values[key] == nil {
-		c.mu.RUnlock()
 		return nil
 	}

 	unsortedMap := c.values[key].(map[string]any)
-	c.mu.RUnlock()
```

No behavior change for single-threaded callers.

## Test

Added `TestScratchGetSortedMapValuesConcurrentWithSetInMap`: 100 goroutines calling `SetInMap` and 100 calling `GetSortedMapValues` concurrently on the same Scratch.

**On the old code**, `go test -race -count=1` immediately reports:
```
WARNING: DATA RACE
Write at 0x... by goroutine ...
--- FAIL: TestScratchGetSortedMapValuesConcurrentWithSetInMap
    race detected during execution of test
FAIL
```

**On the fixed code**: `go test -race -count=5 ./common/hstore/` passes all 5 rounds. All existing tests also pass.