### PR TITLE
tpl/tplimpl: support inline partials in content adapters

### DIFF
--- a/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
+++ b/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
@@ -961,3 +961,36 @@ templateMetrics = true
 	b.Assert(got, qt.Contains, "/docs/_content.gotmpl")
 	b.Assert(got, qt.Not(qt.Contains), "content/docs/_content.gotmpl")
 }
+
+// See issue 14480.
+func TestContentAdapterInlinePartial(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ["taxonomy", "term", "sitemap", "robotsTXT"]
+-- content/test/_content.gotmpl --
+{{ define "_partials/inline/foo.html" }}
+The answer is {{ .answer }}.
+{{ end }}
+
+{{ $content := dict
+  "mediaType" "text/markdown"
+  "value" (partial "inline/foo.html" (dict "answer" 1831))
+}}
+
+{{ $page := dict
+  "content" $content
+  "kind" "page"
+  "path" "my-page"
+  "title" "The Title"
+}}
+
+{{ .AddPage $page }}
+-- layouts/page.html --
+Title: {{ .Title }}|Content: {{ .Content }}
+`
+
+	b := hugolib.Test(t, files)
+	b.AssertFileContent("public/test/my-page/index.html", "The answer is 1831.")
+}

--- a/tpl/tplimpl/templatestore.go
+++ b/tpl/tplimpl/templatestore.go
@@ -788,6 +788,9 @@ func (t *TemplateStore) TextParse(name, tpl string) (*TemplInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := t.extractInlinePartials(false); err != nil {
+		return nil, err
+	}
 	return &TemplInfo{
 		Template: templ,
 	}, nil
@@ -1066,6 +1069,11 @@ func (s *TemplateStore) allRawTemplates() iter.Seq[tpl.Template] {
 			}
 		}
 		for t := range p.templatesIn(p.parseText) {
+			if !yield(t) {
+				return
+			}
+		}
+		for t := range p.templatesIn(p.standaloneText) {
 			if !yield(t) {
 				return
 			}


### PR DESCRIPTION
Fixes #14480

Extract inline partials parsed in `_content.gotmpl` into the template store so calls to `partial "inline/..."` inside content adapters resolve and execute properly.