### PR TITLE
resources: Publish copies of page resources

### DIFF
--- a/resources/transform.go
+++ b/resources/transform.go
@@ -238,16 +238,15 @@ func (r *resourceAdapter) GetDependencyManager() identity.Manager {
 func (r resourceAdapter) cloneTo(targetPath string) resource.Resource {
 	newtTarget := r.target.cloneTo(targetPath)
 	r.sourceTarget = newtTarget.(transformableResource)
-	newInner := &resourceAdapterInner{
-		ctx:    r.ctx,
-		spec:   r.spec,
-		Staler: r.Staler,
-		target: newtTarget.(transformableResource),
+	// The copy has its own target path and is never part of an eager publish set
+	// (e.g. a page's own resources), so it must always publish lazily.
+	r.resourceAdapterInner = &resourceAdapterInner{
+		ctx:         r.ctx,
+		spec:        r.spec,
+		publishOnce: &publishOnce{},
+		target:      newtTarget.(transformableResource),
+		Staler:      r.Staler,
 	}
-	if r.resourceAdapterInner.publishOnce != nil {
-		newInner.publishOnce = &publishOnce{}
-	}
-	r.resourceAdapterInner = newInner
 	return &r
 }
 

--- a/tpl/resources/resources_integration_test.go
+++ b/tpl/resources/resources_integration_test.go
@@ -74,6 +74,34 @@ Copy3: /blog/js/copies/moo.a677329fc6c4ad947e0c7116d91f37a2.min.js|text/javascri
 	b.AssertFileExists("public/images/copy3.png", false)
 }
 
+// See issue 10584.
+func TestCopyPageResource(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+disableKinds = ['home','rss','section','sitemap','taxonomy','term']
+-- content/p1/index.md --
+---
+title: p1
+---
+-- content/p1/pixel.png --
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==
+-- layouts/page.html --
+{{ with .Resources.Get "pixel.png" }}
+Orig: {{ .RelPermalink }}|
+{{ with . | resources.Copy "p1/copy.png" }}
+Copy: {{ .RelPermalink }}|{{ .Width }}|{{ .Height }}|
+{{ end }}
+{{ end }}
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/p1/index.html", "Orig: /p1/pixel.png|", "Copy: /p1/copy.png|1|1|")
+	b.AssertFileContent("public/p1/copy.png", "PNG")
+}
+
 func TestCopyPageShouldFail(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`resources.Copy` inherits the publish mode of its source, and two kinds of source never carry `publishOnce`: a page's own resources, which the build publishes eagerly, and transformed resources, which write to their destination on init. Copies of either got none, so the file never got written even though `.RelPermalink` returned a link to it.

A copy has its own target path and nothing else writes it, so it now always publishes lazily.

Fixes #10584

This PR was written primarily by Claude Code. The change has been reviewed manually; the new test fails on master with the reported symptom.
