### PR TITLE
fix(hstore): hold read lock for whole GetSortedMapValues

### DIFF
--- a/common/hstore/scratch.go
+++ b/common/hstore/scratch.go
@@ -129,16 +129,16 @@ func (c *Scratch) DeleteInMap(key string, mapKey string) string {
 }
 
 // GetSortedMapValues returns a sorted map previously filled with SetInMap.
+// It is safe to call concurrently with SetInMap.
 func (c *Scratch) GetSortedMapValues(key string) any {
 	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	if c.values[key] == nil {
-		c.mu.RUnlock()
 		return nil
 	}
 
 	unsortedMap := c.values[key].(map[string]any)
-	c.mu.RUnlock()
 	var keys []string
 	for mapKey := range unsortedMap {
 		keys = append(keys, mapKey)

--- a/common/hstore/scratch_test.go
+++ b/common/hstore/scratch_test.go
@@ -207,6 +207,33 @@ func TestScratchGetSortedMapValues(t *testing.T) {
 	}
 }
 
+// See issue 15237.
+func TestScratchGetSortedMapValuesInParallel(t *testing.T) {
+	var wg sync.WaitGroup
+	scratch := NewScratch()
+	scratch.SetInMap("key", "seed", "seed")
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range 100000 {
+			scratch.SetInMap("key", string(rune('a'+i%26)), i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 100000 {
+			_ = scratch.GetSortedMapValues("key")
+		}
+	}()
+	wg.Wait()
+
+	v := scratch.GetSortedMapValues("key")
+	if v == nil {
+		t.Fatal("expected values after concurrent writes")
+	}
+}
+
 func BenchmarkScratchGet(b *testing.B) {
 	scratch := NewScratch()
 	scratch.Add("A", 1)


### PR DESCRIPTION
Fixes #15237

Scratch.GetSortedMapValues released the read lock before iterating and indexing the map, while every other method holds the lock for the whole access. A concurrent SetInMap (both documented together on the build-shared hugo.Store) could then trigger Go's fatal concurrent map read and map write / concurrent map iteration and map write abort, killing the build with a non-Hugo panic.

This moves defer c.mu.RUnlock() to cover the whole function, per the suggested fix in the issue. The function already returns a freshly allocated slice, so no caller can observe the lock being held longer.

Also adds a regression test adapted from the issue's deterministic repro (TestScratchGetSortedMapValuesInParallel), co-authored with the reporter.