### PR TITLE
common/hstore: keep read lock while sorting map values

### DIFF
--- a/common/hstore/scratch.go
+++ b/common/hstore/scratch.go
@@ -131,14 +131,13 @@ func (c *Scratch) DeleteInMap(key string, mapKey string) string {
 // GetSortedMapValues returns a sorted map previously filled with SetInMap.
 func (c *Scratch) GetSortedMapValues(key string) any {
 	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	if c.values[key] == nil {
-		c.mu.RUnlock()
 		return nil
 	}
 
 	unsortedMap := c.values[key].(map[string]any)
-	c.mu.RUnlock()
 	var keys []string
 	for mapKey := range unsortedMap {
 		keys = append(keys, mapKey)

--- a/common/hstore/scratch_test.go
+++ b/common/hstore/scratch_test.go
@@ -207,6 +207,30 @@ func TestScratchGetSortedMapValues(t *testing.T) {
 	}
 }
 
+func TestScratchGetSortedMapValuesConcurrentWithSetInMap(t *testing.T) {
+	t.Parallel()
+	scratch := NewScratch()
+	scratch.SetInMap("key", "initial", "initial")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := range 1000 {
+			scratch.SetInMap("key", "value", i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			scratch.GetSortedMapValues("key")
+		}
+	}()
+
+	wg.Wait()
+}
+
 func BenchmarkScratchGet(b *testing.B) {
 	scratch := NewScratch()
 	scratch.Add("A", 1)


### PR DESCRIPTION
Fixes #15237.

`GetSortedMapValues` released the read lock before iterating and indexing the map returned by `SetInMap`, allowing concurrent map access to abort the process. Keep the read lock for the full read operation and add a concurrent regression test.

Validation: `go test -race ./common/hstore/...`