### PR TITLE
resources/images: Parse hex colors as non-premultiplied NRGBA

### DIFF
--- a/resources/images/color.go
+++ b/resources/images/color.go
@@ -69,9 +69,13 @@ func (c Color) Key() string {
 }
 
 func (c *Color) init() error {
-	c.hex = ColorGoToHexString(c.color)
-	r, g, b, _ := c.color.RGBA()
-	c.luminance = 0.2126*c.toSRGB(uint8(r)) + 0.7152*c.toSRGB(uint8(g)) + 0.0722*c.toSRGB(uint8(b))
+	// Normalize to the canonical non-premultiplied form so that equal colors
+	// compare equal no matter where they came from (a hex string or the
+	// pixels of an image).
+	nrgba := color.NRGBAModel.Convert(c.color).(color.NRGBA)
+	c.color = nrgba
+	c.hex = ColorGoToHexString(nrgba)
+	c.luminance = 0.2126*c.toSRGB(nrgba.R) + 0.7152*c.toSRGB(nrgba.G) + 0.0722*c.toSRGB(nrgba.B)
 	return nil
 }
 
@@ -88,10 +92,13 @@ func (c Color) toSRGB(i uint8) float64 {
 // Note that it does no additional checks, so callers must make sure
 // that the palette is valid for the relevant format.
 func AddColorToPalette(c color.Color, p color.Palette) color.Palette {
-	var found bool
-	if slices.Contains(p, c) {
-		found = true
-	}
+	// Compare color values rather than the interface values, so that e.g. a
+	// color.NRGBA is found even if the palette holds it as a color.RGBA.
+	cr, cg, cb, ca := c.RGBA()
+	found := slices.ContainsFunc(p, func(v color.Color) bool {
+		vr, vg, vb, va := v.RGBA()
+		return cr == vr && cg == vg && cb == vb && ca == va
+	})
 
 	if !found {
 		p = append(color.Palette{c}, p...)
@@ -108,12 +115,13 @@ func ReplaceColorInPalette(c color.Color, p color.Palette) {
 
 // ColorGoToHexString converts a color.Color to a hex string.
 func ColorGoToHexString(c color.Color) string {
-	r, g, b, a := c.RGBA()
-	rgba := color.RGBA{uint8(r), uint8(g), uint8(b), uint8(a)}
-	if rgba.A == 0xff {
-		return fmt.Sprintf("#%.2x%.2x%.2x", rgba.R, rgba.G, rgba.B)
+	// Hex notation is not alpha-premultiplied, so convert via NRGBA to
+	// un-premultiply the color components of any transparent color.
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	if nrgba.A == 0xff {
+		return fmt.Sprintf("#%.2x%.2x%.2x", nrgba.R, nrgba.G, nrgba.B)
 	}
-	return fmt.Sprintf("#%.2x%.2x%.2x%.2x", rgba.R, rgba.G, rgba.B, rgba.A)
+	return fmt.Sprintf("#%.2x%.2x%.2x%.2x", nrgba.R, nrgba.G, nrgba.B, nrgba.A)
 }
 
 // ColorGoToColor converts a color.Color to a Color.
@@ -195,5 +203,10 @@ func hexStringToColorGo(s string) (color.Color, error) {
 		return nil, err
 	}
 
-	return color.RGBA{b[0], b[1], b[2], b[3]}, nil
+	// Hex notation is not alpha-premultiplied, so this must be a color.NRGBA.
+	// Returning the components as a color.RGBA (which is alpha-premultiplied
+	// by definition) produces an invalid color whenever the alpha component
+	// is less than the color components, and drawing it corrupts the color
+	// on the alpha-premultiplied code paths. See issue #12536.
+	return color.NRGBA{b[0], b[1], b[2], b[3]}, nil
 }

--- a/resources/images/color_test.go
+++ b/resources/images/color_test.go
@@ -39,8 +39,13 @@ func TestHexStringToColor(t *testing.T) {
 		{"#ffffff", color.White},
 		{"ffffff", color.White},
 		{"#000", color.Black},
-		{"#4287f5", color.RGBA{R: 0x42, G: 0x87, B: 0xf5, A: 0xff}},
-		{"777", color.RGBA{R: 0x77, G: 0x77, B: 0x77, A: 0xff}},
+		{"#4287f5", color.NRGBA{R: 0x42, G: 0x87, B: 0xf5, A: 0xff}},
+		{"777", color.NRGBA{R: 0x77, G: 0x77, B: 0x77, A: 0xff}},
+		// Hex notation is not alpha-premultiplied, so a transparent color must
+		// parse to a color.NRGBA; as a color.RGBA it would be an invalid
+		// premultiplied color that corrupts drawing. See issue #12536.
+		{"#00f7", color.NRGBA{R: 0x00, G: 0x00, B: 0xff, A: 0x77}},
+		{"4287f580", color.NRGBA{R: 0x42, G: 0x87, B: 0xf5, A: 0x80}},
 	} {
 
 		c.Run(test.arg, func(c *qt.C) {
@@ -71,10 +76,11 @@ func TestColorToHexString(t *testing.T) {
 		{color.Black, "#000000"},
 		{color.RGBA{R: 0x42, G: 0x87, B: 0xf5, A: 0xff}, "#4287f5"},
 
-		// 50% opacity.
+		// 50% opacity. Hex notation is not alpha-premultiplied, so the
+		// components of a transparent color are the non-premultiplied ones.
 		// Note that the .Colors (dominant colors) received from the Image resource
 		// will always have an alpha value of 0xff.
-		{color.RGBA{R: 0x42, G: 0x87, B: 0xf5, A: 0x80}, "#4287f580"},
+		{color.NRGBA{R: 0x42, G: 0x87, B: 0xf5, A: 0x80}, "#4287f580"},
 	} {
 
 		c.Run(test.expect, func(c *qt.C) {

--- a/resources/images/filters_test.go
+++ b/resources/images/filters_test.go
@@ -14,6 +14,10 @@
 package images
 
 import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -29,4 +33,45 @@ func TestFilterHash(t *testing.T) {
 	c.Assert(hashing.HashString(f.Grayscale()), qt.Not(qt.Equals), hashing.HashString(f.Invert()))
 	c.Assert(hashing.HashString(f.Gamma(32)), qt.Not(qt.Equals), hashing.HashString(f.Gamma(33)))
 	c.Assert(hashing.HashString(f.Gamma(32)), qt.Equals, hashing.HashString(f.Gamma(32)))
+}
+
+// Issue 12536. A transparent padding color must survive the trip through an
+// alpha-premultiplied destination image. The destination type is derived from
+// the source image type, so the padding color came out wrong whenever the
+// source decoded to an alpha-premultiplied *image.RGBA (e.g. an opaque PNG
+// written by a previous "resize x200 png" step), while the same filter applied
+// to a JPEG source looked correct.
+func TestPaddingTransparentColor(t *testing.T) {
+	c := qt.New(t)
+
+	ccolor, err := hexStringToColorGo("#00f7")
+	c.Assert(err, qt.IsNil)
+
+	pad := paddingFilter{
+		top: 2, right: 2, bottom: 2, left: 2,
+		ccolor: ccolor,
+	}
+
+	for _, test := range []struct {
+		name string
+		src  image.Image
+	}{
+		{"YCbCr source (e.g. JPEG)", image.NewYCbCr(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio420)},
+		{"RGBA source (e.g. opaque PNG)", image.NewRGBA(image.Rect(0, 0, 10, 10))},
+	} {
+		c.Run(test.name, func(c *qt.C) {
+			img, err := (&ImageProcessor{}).Filter(test.src, pad)
+			c.Assert(err, qt.IsNil)
+
+			// Encode and decode as PNG so the padding pixel is read back the
+			// same way a browser would see it.
+			var buf bytes.Buffer
+			c.Assert(png.Encode(&buf, img), qt.IsNil)
+			decoded, err := png.Decode(&buf)
+			c.Assert(err, qt.IsNil)
+
+			got := color.NRGBAModel.Convert(decoded.At(1, 1)).(color.NRGBA)
+			c.Assert(got, qt.Equals, color.NRGBA{R: 0x00, G: 0x00, B: 0xff, A: 0x77})
+		})
+	}
 }


### PR DESCRIPTION
Fixes #12536 (root-cause analysis in [this comment](https://github.com/gohugoio/hugo/issues/12536#issuecomment-5447487023)).

## What was wrong

Hex notation is not alpha-premultiplied, but `hexStringToColorGo` parsed it into a `color.RGBA` — which **is** premultiplied by definition. Every transparent color (e.g. `#00f7`) therefore became an invalid premultiplied color (component > alpha). Whether the corruption was visible depended on the destination image type the filter pipeline picks, which follows the source image type: a JPEG source draws onto `*image.NRGBA`, where the invalid color is clamped back to the intended value by accident; an opaque-PNG source (e.g. the intermediate written by a previous `.Resize "x200 png"`) decodes to an alpha-premultiplied `*image.RGBA`, the invalid pixels survive, and the PNG encoder un-premultiplies them into a different color. That is precisely the difference between the working and broken constructs in the issue.

## The change

- `hexStringToColorGo` returns the `color.NRGBA` the hex string denotes.
- `ColorGoToHexString` un-premultiplies via `color.NRGBAModel` for symmetry (opaque colors unchanged).
- `Color` normalizes to the same canonical non-premultiplied form whether it came from a hex string or from image pixels, so equal colors compare equal.
- `AddColorToPalette` compares color values instead of interface values, so an equal color is still found across color models.

## Verification

Built two binaries and ran a minimal site using the exact templates from the issue thread, sampling the padding pixel of the emitted PNGs:

| Construct | before | after |
|---|---|---|
| `images.Process "resize x200 png"` + `Padding` (one pass) | `rgba(0 0 255 / 119)` ✓ | `rgba(0 0 255 / 119)` ✓ (unchanged) |
| `.Resize "x200 png"` then `Filter` + `Padding` (chained) | `rgba(0 0 36 / 119)` ✗ | `rgba(0 0 255 / 119)` ✓ |

- New `TestPaddingTransparentColor` covers both destination paths through `ImageProcessor.Filter` with an encode/decode round-trip; with the fix reverted, exactly the RGBA-source case fails (the YCbCr case documents the previously-working path).
- `hexStringToColorGo` tests extended with transparent colors.
- `go test ./resources/... ./tpl/images/...` green, including the golden image tests (all golden colors are opaque, where NRGBA and RGBA bytes are identical).

## Note for review

The output bytes change for transparent filter colors while image cache keys do not, so an affected site needs its `resources/_gen` cache cleared to pick up the fix. If you'd rather force that globally I can bump `mainImageVersionNumber` in this PR — left out deliberately since it invalidates every cached image for everyone.

This also lets the `images.Padding` docs drop the "conversion to WEBP is required to support transparency" workaround note once released.

*Disclosure per the contribution guidelines: this PR was written with AI assistance (Claude Code); the analysis and both before/after builds were verified locally as described above.*