### PR TITLE
Two CVE fixes

### DIFF
--- a/config/security/securityConfig.go
+++ b/config/security/securityConfig.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/netip"
 	"net/url"
 	"reflect"
@@ -208,6 +209,47 @@ func (c Config) CheckAllowedHTTPURL(u string) error {
 	// the policy treats every encoding of the same address alike.
 	if canon, ok := canonicalIPv4URL(u); ok && !c.HTTP.URLs.Accept(canon) {
 		return deny(u)
+	}
+	return nil
+}
+
+// CheckAllowedHTTPAddress reports whether a dial-time destination address may
+// be connected to. address is the resolved "host:port" passed to a net.Dialer
+// control hook, i.e. the actual address the HTTP client is about to connect to.
+//
+// The security.http.urls allowlist only inspects the URL text and never sees
+// the resolved address, so a hostname that resolves to a loopback, private or
+// link-local (including the cloud metadata endpoint) address would otherwise
+// satisfy the policy and let resources.GetRemote reach an internal endpoint.
+// We deny any non–global-unicast or private address here to close that gap.
+func (c Config) CheckAllowedHTTPAddress(network, address string) error {
+	// Only enforced under the default hardened allowlist. If the user has
+	// customized security.http.urls they have opted into whatever hosts they
+	// listed, including internal ones (e.g. a local dev server), so we do not
+	// second-guess the resolved address.
+	if !slices.Equal(c.HTTP.URLs.patternsStrings, DefaultConfig.HTTP.URLs.patternsStrings) {
+		return nil
+	}
+	deny := func(name string) error {
+		return &AccessDeniedError{
+			name:     name,
+			path:     "security.http.urls",
+			policies: c.ToTOML(),
+		}
+	}
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	ip, err := netip.ParseAddr(host)
+	if err != nil {
+		// The dial hook always hands us a resolved IP literal; anything else
+		// is unexpected, so fail closed.
+		return deny(address)
+	}
+	ip = ip.Unmap()
+	if !ip.IsGlobalUnicast() || ip.IsPrivate() {
+		return deny(host)
 	}
 	return nil
 }

--- a/config/security/securityConfig_test.go
+++ b/config/security/securityConfig_test.go
@@ -247,6 +247,39 @@ urls = ['.*', '! ^https?://evil\.example\.com']
 	})
 }
 
+// A resolved destination address must be validated so a hostname that resolves
+// to an internal address cannot reach an internal endpoint via GetRemote.
+// See CVE-2026-10582.
+func TestCheckAllowedHTTPAddress(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	pc := DefaultConfig
+
+	for _, addr := range []string{
+		"93.184.216.34:80",
+		"[2001:db8::1]:443",
+	} {
+		c.Assert(pc.CheckAllowedHTTPAddress("tcp", addr), qt.IsNil, qt.Commentf(addr))
+	}
+
+	for _, addr := range []string{
+		"127.0.0.1:80",
+		"[::1]:80",
+		"10.0.0.1:8080",
+		"172.16.0.1:80",
+		"192.168.1.1:80",
+		"169.254.169.254:80", // Cloud metadata.
+		"[fe80::1]:80",
+		"[fc00::1]:80",
+		"0.0.0.0:80",
+		"[::ffff:127.0.0.1]:80", // IPv4-mapped loopback.
+	} {
+		err := pc.CheckAllowedHTTPAddress("tcp", addr)
+		c.Assert(err, qt.IsNotNil, qt.Commentf(addr))
+		c.Assert(err, qt.ErrorMatches, `(?s).*is not whitelisted in policy "security\.http\.urls".*`, qt.Commentf(addr))
+	}
+}
+
 func TestCheckAllowedHTTPURLAtInPathIssue14825(t *testing.T) {
 	t.Parallel()
 	c := qt.New(t)

--- a/markup/goldmark/codeblocks/codeblocks_integration_test.go
+++ b/markup/goldmark/codeblocks/codeblocks_integration_test.go
@@ -437,3 +437,38 @@ Some code.
 
 	b.AssertFileContent("public/p1/index.html", "! <script>")
 }
+
+// A quote inside a code-fence attribute value must not break out of the
+// attribute and inject a further attribute (e.g. an event handler).
+// See CVE-2026-10618.
+func TestCodeblockAttributeValueEscape(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+-- layouts/single.html --
+{{ .Content }}
+-- content/p1.md --
+---
+title: "p1"
+---
+
+§§§bash { title="x\" onmouseover=\"alert(1)" }
+echo "hello";
+§§§
+
+§§§bash { class="x\" onmouseover=\"alert(2)" }
+echo "hello";
+§§§
+`
+
+	b := hugolib.Test(t, files)
+
+	// The quote must be escaped so it cannot close the attribute and start a
+	// new one; the literal onmouseover="alert breakout must not appear.
+	b.AssertFileContent("public/p1/index.html",
+		`! onmouseover="alert`,
+		"&#34; onmouseover=&#34;alert(2)",
+		"&quot; onmouseover=&quot;alert(1)",
+	)
+}

--- a/markup/highlight/highlight.go
+++ b/markup/highlight/highlight.go
@@ -316,7 +316,7 @@ func writeDivStart(w hugio.FlexiWriter, attrs []attributes.Attribute, wrapperCla
 	if attrs != nil {
 		for _, attr := range attrs {
 			if attr.Name == "class" {
-				w.WriteString(" " + attr.ValueString())
+				w.WriteString(" " + gohtml.EscapeString(attr.ValueString()))
 				break
 			}
 		}

--- a/markup/internal/attributes/attributes.go
+++ b/markup/internal/attributes/attributes.go
@@ -187,12 +187,7 @@ func RenderASTAttributes(w hugio.FlexiWriter, attributes ...ast.Attribute) {
 		_, _ = w.Write(attr.Name)
 		_, _ = w.WriteString(`="`)
 
-		switch v := attr.Value.(type) {
-		case []byte:
-			_, _ = w.Write(util.EscapeHTML(v))
-		default:
-			w.WriteString(cast.ToString(v))
-		}
+		writeAttributeValue(w, attr.Value)
 
 		_ = w.WriteByte('"')
 	}
@@ -211,13 +206,22 @@ func RenderAttributes(w hugio.FlexiWriter, skipClass bool, attributes ...Attribu
 		_, _ = w.WriteString(attr.Name)
 		_, _ = w.WriteString(`="`)
 
-		switch v := attr.Value.(type) {
-		case []byte:
-			_, _ = w.Write(util.EscapeHTML(v))
-		default:
-			w.WriteString(cast.ToString(v))
-		}
+		writeAttributeValue(w, attr.Value)
 
 		_ = w.WriteByte('"')
+	}
+}
+
+// writeAttributeValue writes v HTML-escaped as a double-quoted HTML attribute
+// value. Note that New converts string values from a []byte to a string, so
+// the string case is the common one and must be escaped too.
+func writeAttributeValue(w hugio.FlexiWriter, v any) {
+	switch vv := v.(type) {
+	case []byte:
+		_, _ = w.Write(util.EscapeHTML(vv))
+	case string:
+		_, _ = w.Write(util.EscapeHTML([]byte(vv)))
+	default:
+		_, _ = w.Write(util.EscapeHTML([]byte(cast.ToString(vv))))
 	}
 }

--- a/resources/resource_factories/create/create.go
+++ b/resources/resource_factories/create/create.go
@@ -17,11 +17,13 @@ package create
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/bep/helpers/contexthelpers"
@@ -40,6 +42,7 @@ import (
 
 	"github.com/gohugoio/hugo/common/hugio"
 	"github.com/gohugoio/hugo/common/tasks"
+	"github.com/gohugoio/hugo/config/security"
 	"github.com/gohugoio/hugo/resources"
 	"github.com/gohugoio/hugo/resources/resource"
 )
@@ -139,11 +142,29 @@ func New(rs *resources.Spec) *Client {
 				Transport: &transport{
 					Cfg:    rs.Cfg,
 					Logger: rs.Logger,
+					base:   newSecureBaseTransport(rs.ExecHelper.Sec()),
 				},
 			},
 		},
 		cacheGetResource: fileCache,
 	}
+}
+
+// newSecureBaseTransport clones the default transport and installs a dial-time
+// hook that validates the resolved destination address against the security
+// policy, so a hostname resolving to an internal address cannot be used to
+// reach internal endpoints. See CheckAllowedHTTPAddress.
+func newSecureBaseTransport(sec security.Config) http.RoundTripper {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	d := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control: func(network, address string, _ syscall.RawConn) error {
+			return sec.CheckAllowedHTTPAddress(network, address)
+		},
+	}
+	base.DialContext = d.DialContext
+	return base
 }
 
 // Copy copies r to the new targetPath.

--- a/resources/resource_factories/create/remote.go
+++ b/resources/resource_factories/create/remote.go
@@ -464,6 +464,10 @@ var _ http.RoundTripper = (*transport)(nil)
 type transport struct {
 	Cfg    config.AllProvider
 	Logger loggers.Logger
+
+	// base does the actual round trip. It carries a dial-time hook that
+	// validates the resolved destination address (see New).
+	base http.RoundTripper
 }
 
 func (t *transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
@@ -482,7 +486,7 @@ func (t *transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 
 	for {
 		resp, retry, err = func() (*http.Response, bool, error) {
-			resp2, err := http.DefaultTransport.RoundTrip(req)
+			resp2, err := t.base.RoundTrip(req)
 			if err != nil {
 				return resp2, false, err
 			}

--- a/resources/resource_factories/create/remote_test.go
+++ b/resources/resource_factories/create/remote_test.go
@@ -14,9 +14,14 @@
 package create
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/gohugoio/hugo/config"
+	"github.com/gohugoio/hugo/config/security"
 )
 
 func TestDecodeRemoteOptions(t *testing.T) {
@@ -133,4 +138,38 @@ func TestRemoteResourceKeys(t *testing.T) {
 	check("foo", map[string]any{"key": "12345", "bar": "baz"}, "14335752410685132726", "5783339285578751849")
 	check("asdf", map[string]any{"key": "1234", "bar": "asdf"}, "15578353952571222948", "15615023578599429261")
 	check("asdf", map[string]any{"key": "12345", "bar": "asdf"}, "14335752410685132726", "15615023578599429261")
+}
+
+// The transport used for remote fetches must refuse to connect to an internal
+// (here loopback) address under the default security policy, even though the
+// URL text check happens elsewhere. See CVE-2026-10582.
+func TestSecureBaseTransportBlocksInternalAddress(t *testing.T) {
+	t.Parallel()
+
+	c := qt.New(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("secret"))
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequest("GET", srv.URL, nil)
+	c.Assert(err, qt.IsNil)
+
+	// Default policy: the loopback address the httptest server listens on is
+	// refused at dial time.
+	_, err = newSecureBaseTransport(security.DefaultConfig).RoundTrip(req)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(security.IsAccessDenied(err), qt.IsTrue)
+
+	// Customized policy: the user has opted into their own hosts, so the dial
+	// check stands down and the fetch succeeds.
+	sec, err := security.DecodeConfig(config.FromTOMLConfigString(`
+[security.http]
+urls = ['.*']
+`))
+	c.Assert(err, qt.IsNil)
+	resp, err := newSecureBaseTransport(sec).RoundTrip(req)
+	c.Assert(err, qt.IsNil)
+	resp.Body.Close()
 }


### PR DESCRIPTION
- **markup: Escape code-fence attribute values in the default renderer**
- **resources: Validate the resolved address on remote fetches**
