### PR TITLE
resources/images: Do not clamp filtered images to the source palette

### DIFF
--- a/resources/image.go
+++ b/resources/image.go
@@ -321,7 +321,7 @@ func (i *imageResource) Filter(filters ...any) (images.ImageResource, error) {
 		return nil, err
 	}
 
-	confMain.Action = "filter"
+	confMain.Action = images.ActionFilter
 	confMain.Key = hashing.HashString(gfilters)
 
 	return i.doWithImageConfig(confMain, func(src image.Image) (image.Image, error) {
@@ -438,7 +438,12 @@ func (i *imageResource) doWithImageConfig(conf images.ImageConfig, f func(src im
 			converted = tmp
 		}
 
-		if conf.TargetFormat == images.PNG {
+		// Preserve the source palette for the geometric actions (resize, crop,
+		// fit, fill), so an indexed PNG stays indexed. Filters (e.g.
+		// images.Overlay, images.Text) routinely introduce colors that do not
+		// exist in the source palette, and clamping the result back to that
+		// palette destroys the filtered output. See issue #12543.
+		if conf.TargetFormat == images.PNG && conf.Action != images.ActionFilter {
 			// Apply the colour palette from the source
 			if paletted, ok := src.(*image.Paletted); ok {
 				palette := paletted.Palette

--- a/resources/image_test.go
+++ b/resources/image_test.go
@@ -16,6 +16,8 @@ package resources_test
 import (
 	"context"
 	"fmt"
+	"image"
+	"image/color"
 	"io/fs"
 	"math/rand"
 	"os"
@@ -393,6 +395,45 @@ func TestImageResize8BitPNG(t *testing.T) {
 	c.Assert(resized.MediaType().Type, qt.Equals, "image/png")
 	c.Assert(resized.RelPermalink(), qt.Equals, "/a/gohugoio_hu_626cfc4db4222bfe.png")
 	c.Assert(resized.Width(), qt.Equals, 800)
+}
+
+// Issue 12543: applying a filter to an indexed PNG must not clamp the result
+// back to the source palette. An overlaid true color image was reduced to the
+// palette of the indexed background image.
+func TestImageFilterIndexedPNG(t *testing.T) {
+	c := qt.New(t)
+
+	spec, bg := fetchImage(c, "gohugoio8.png")
+	fg := fetchImageForSpec(spec, c, "fuzzy-cirlcle.png")
+
+	fgImage, err := fg.DecodeImage()
+	c.Assert(err, qt.IsNil)
+
+	filtered, err := bg.Filter((&images.Filters{}).Overlay(fg.(images.ImageSource), 0, 0))
+	c.Assert(err, qt.IsNil)
+	c.Assert(filtered.MediaType().Type, qt.Equals, "image/png")
+
+	composite, err := filtered.DecodeImage()
+	c.Assert(err, qt.IsNil)
+
+	// The composite must not be limited to the background's palette.
+	_, isPaletted := composite.(*image.Paletted)
+	c.Assert(isPaletted, qt.IsFalse)
+
+	// Every fully opaque foreground pixel must come through unchanged.
+	var checked int
+	bounds := fgImage.Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y += 21 {
+		for x := bounds.Min.X; x < bounds.Max.X; x += 21 {
+			if _, _, _, a := fgImage.At(x, y).RGBA(); a == 0xffff {
+				got := color.NRGBAModel.Convert(composite.At(x, y))
+				want := color.NRGBAModel.Convert(fgImage.At(x, y))
+				c.Assert(got, qt.DeepEquals, want)
+				checked++
+			}
+		}
+	}
+	c.Assert(checked > 0, qt.IsTrue)
 }
 
 func TestSVGImage(t *testing.T) {

--- a/resources/images/config.go
+++ b/resources/images/config.go
@@ -36,6 +36,7 @@ const (
 	ActionCrop   = "crop"
 	ActionFit    = "fit"
 	ActionFill   = "fill"
+	ActionFilter = "filter"
 )
 
 var Actions = map[string]bool{


### PR DESCRIPTION
Fixes #12543 (root-cause analysis in [this comment](https://github.com/gohugoio/hugo/issues/12543#issuecomment-5451689773)).

## What was wrong

When the source image decodes to `*image.Paletted` and the target format is PNG, `doWithImageConfig` draws the finished result back into the source's palette with Floyd–Steinberg dithering. For the geometric actions (resize, crop, fit, fill) that's desirable — an indexed PNG stays indexed. But the same block ran for `images.Filter`, where filters like `images.Overlay` and `images.Text` routinely introduce colors that don't exist in the source palette — so a true color image overlaid onto an indexed background was reduced to the background's 256 colors. GIF doesn't show the problem because the block only runs for PNG targets, which matches the issue report exactly.

## The change

- New `ActionFilter` constant (replaces the raw `"filter"` string at the one assignment site).
- The palette re-application is skipped when `conf.Action == images.ActionFilter`. Geometric actions are unchanged; GIF is unchanged.

## Verification

Two locally built binaries against a minimal site overlaying a true color image (`fuzzy-cirlcle.png`) onto an indexed background (`gohugoio8.png`):

| | composite output |
|---|---|
| before | `PNG 8-bit colormap` (clamped to the background's palette), 84KB |
| after | `PNG 8-bit/color RGB`, 180KB, every opaque foreground pixel byte-identical to the source |

- New `TestImageFilterIndexedPNG` uses only existing testdata: it asserts the composite is not paletted and that every sampled fully-opaque foreground pixel comes through unchanged. With the fix reverted, it fails on the paletted check.
- `TestImageResize8BitPNG` (indexed stays indexed on resize) passes unchanged, and `go test ./resources/ ./resources/images/` is green including the golden tests.

Same cache note as #15248: image cache keys don't change, so an affected site needs its `resources/_gen` cache cleared to pick up the fix.

*Disclosure per the contribution guidelines: this PR was written with AI assistance (Claude Code); the analysis and both before/after builds were verified locally as described above.*