### PR TITLE
resources/page: Don't let a title's "/" split an auto-derived slug

### DIFF
--- a/resources/page/permalinks.go
+++ b/resources/page/permalinks.go
@@ -293,9 +293,23 @@ func (l PermalinkExpander) pageToPermalinkDate(p Page, dateField string) (string
 	return p.Date().Format(dateField), nil
 }
 
-// pageToPermalinkTitle returns the URL-safe form of the title
+// segmentReplacer replaces path separators in a title before it's used to
+// build a single path segment (e.g. an automatically derived slug). Without
+// this, a title containing a "/" would silently introduce an extra, unintended
+// path segment in the resulting URL. See #3577.
+var segmentReplacer = strings.NewReplacer("/", "-", "\\", "-")
+
+// pageToPermalinkTitle returns the URL-safe form of the title.
 func (l PermalinkExpander) pageToPermalinkTitle(p Page, _ string) (string, error) {
-	return l.urlize(p.Title()), nil
+	title := p.Title()
+	if p.Kind() != kinds.KindTaxonomy && p.Kind() != kinds.KindTerm {
+		// Taxonomy and term pages are allowed to have '/' in their title
+		// (the term itself) to build multi-level taxonomy hierarchies.
+		// See #5571. All other kinds derive a single path segment from the
+		// title, so path separators must not be allowed through.
+		title = segmentReplacer.Replace(title)
+	}
+	return l.urlize(title), nil
 }
 
 // pageToPermalinkFilename returns the URL-safe form of the filename

--- a/resources/page/permalinks_test.go
+++ b/resources/page/permalinks_test.go
@@ -216,6 +216,52 @@ func TestPermalinkExpansionMultiSection(t *testing.T) {
 	c.Assert(expanded, qt.Equals, "/special:the-slug")
 }
 
+// https://github.com/gohugoio/hugo/issues/3577
+func TestPermalinkExpansionTitleSlash(t *testing.T) {
+	t.Parallel()
+
+	c := qt.New(t)
+
+	configs := PermalinksConfig{
+		{Target: PageMatcher{Kind: "page"}, Pattern: "/:slug/"},
+		{Target: PageMatcher{Kind: "term"}, Pattern: "/:slug/"},
+	}
+	expander, err := NewPermalinkExpander(urlize, configs)
+	c.Assert(err, qt.IsNil)
+
+	// A page with no explicit slug and a title containing a "/" must not
+	// silently introduce an extra, unintended path segment.
+	page := newTestPage()
+	page.kind = "page"
+	page.title = "Watch/listen to this"
+	page.slug = ""
+
+	expanded, err := expander.Expand(page)
+	c.Assert(err, qt.IsNil)
+	c.Assert(expanded, qt.Equals, "/watch-listen-to-this/")
+
+	// An explicit slug is left as-is; the user is in control of it.
+	pageWithSlug := newTestPage()
+	pageWithSlug.kind = "page"
+	pageWithSlug.slug = "explicit/slug"
+
+	expanded, err = expander.Expand(pageWithSlug)
+	c.Assert(err, qt.IsNil)
+	c.Assert(expanded, qt.Equals, "/explicit/slug/")
+
+	// Taxonomy term pages are allowed to preserve "/" in their title
+	// (the term itself) to build multi-level taxonomy hierarchies.
+	// See https://github.com/gohugoio/hugo/issues/5571.
+	term := newTestPage()
+	term.kind = "term"
+	term.title = "country/region/city"
+	term.slug = ""
+
+	expanded, err = expander.Expand(term)
+	c.Assert(err, qt.IsNil)
+	c.Assert(expanded, qt.Equals, "/country/region/city/")
+}
+
 func TestPermalinkExpansionConcurrent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

When a page has no explicit `slug` front matter value, the `:title` and
`:slug` permalink tokens fall back to a URL-safe form of the page title.
That fallback goes through `pageToPermalinkTitle`, which urlizes the title
with `PathSpec.URLize` (`MakePathSanitized`). That sanitizer intentionally
treats `/` as a valid path character — it's also used for e.g. taxonomy
term names, which are allowed to span multiple path segments (see #5571).

For a regular content page, section, etc., though, the auto-derived slug
is meant to be a single path segment — the `slug` front matter docs say it
"overrides the **last segment** of the URL path". A title containing a
literal `/`, e.g. `Watch/listen to this`, was passed straight through,
silently creating an extra, unintended nested path segment.

### Repro

```toml
[permalinks.page]
  blog = "/blog/:year/:slug/"
```

```md
---
title: "Watch/listen to this"
date: 2026-03-05
---
```

Before this fix, this built to `/blog/2026/watch/listen-to-this/`
(an extra `watch/` directory) instead of the intended single segment
`/blog/2026/watch-listen-to-this/`. The build succeeds silently, with no
warning — easy to miss, since it's not a build error, just an unintended
URL structure.

## Why this regressed

This is not a new problem — it was fixed once before via #4092 / #5282,
which used a stricter `helpers.PathSpec.MakeSegment` for auto-derived
titles, explicitly exempting only taxonomy pages (which need `/` to build
hierarchical terms). That taxonomy/non-taxonomy distinction was lost when
slash handling for taxonomy terms was restored for #5571 — the fix for
#5571 switched title handling back to the slash-preserving `URLize`
function for **all** page kinds, not just taxonomies, silently
reintroducing this bug for regular pages. This regression was called out
in a comment on #5571 by @max-arnold at the time but was never
separately tracked or fixed.

## The fix

Restore the taxonomy/term exemption, scoped narrowly:

* `pageToPermalinkTitle` now replaces `/` (and `\`) with `-` before
  urlizing the title, but **only** for page kinds other than `taxonomy`
  and `term`. Multi-level taxonomy hierarchies (the exact behavior #5571
  asked for) keep working unchanged — verified against the existing
  `TestTaxonomiesPathSeparation` test and a manual repro.
* Explicit `slug` front matter values are **not** touched by this change
  — `pageToPermalinkSlugElseTitle` only falls through to
  `pageToPermalinkTitle` when `p.Slug() == ""`. Users remain in full
  control of an explicitly-set slug, including any `/` in it.

## Testing

* Added `TestPermalinkExpansionTitleSlash` in
  `resources/page/permalinks_test.go`, covering: a page with a `/` in its
  auto-derived title/slug, an explicit slug containing `/` (unchanged),
  and a taxonomy term with `/` in its name (unchanged, multi-level
  hierarchy preserved).
* `go test ./...` passes (143 packages, 0 failures) on top of this change.
* `./check.sh ./resources/page/...` (gofmt + staticcheck + tests) passes.
* Manually verified against two throwaway sites built with this branch's
  `hugo` binary:
  * The repro above now builds to `/blog/2026/watch-listen-to-this/`.
  * A taxonomy site with `[permalinks.term]` using `:slug` and a term
    value of `country/region/city` still builds to
    `/regions/country/region/city/` (unchanged from before this fix).

Fixes #3577
See #5571
See #4090

## AI assistance disclosure

This PR was written primarily by Claude Code (research, reproduction,
root-cause analysis via `git log`/`git show` on the relevant history,
implementation, and tests), reviewed and submitted by me.