### PR TITLE
config/security: Deny text/org content by default

### DIFF
--- a/config/security/securityConfig.go
+++ b/config/security/securityConfig.go
@@ -79,9 +79,11 @@ var DefaultConfig = Config{
 	},
 	// Content under /content is treated as untrusted. text/html bodies are
 	// emitted verbatim and are an XSS sink, so they are denied by default.
+	// The same goes for text/org, whose export blocks and inline snippets
+	// pass raw HTML through unescaped.
 	// Everything else is allowed because Whitelist treats a deny-only list as
 	// "allow anything not denied".
-	AllowContent: MustNewWhitelist("! ^text/html$"),
+	AllowContent: MustNewWhitelist("! ^text/html$", "! ^text/org$"),
 }
 
 // Config is the top level security config.

--- a/config/security/securityConfig_test.go
+++ b/config/security/securityConfig_test.go
@@ -135,7 +135,7 @@ func TestToTOML(t *testing.T) {
 	got := DefaultConfig.ToTOML()
 
 	c.Assert(got, qt.Equals,
-		"[security]\n  allowContent = ['! ^text/html$']\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^(dart-)?sass$', '^go$', '^git$', '^node$', '^postcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\\w+|(XDG_CONFIG_)?HOME|USERPROFILE|SSH_AUTH_SOCK|DISPLAY|LANG|SYSTEMDRIVE|PROGRAMDATA)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_', '^CI$']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['(?i)^https?://[a-z0-9]', '! ^https?://\\d+\\.', '! (?i)localhost', '! (?i)^https?://[^/?#]*@']\n\n  [security.node]\n    [security.node.permissions]\n      allowAddons = ['tailwindcss']\n      allowChildProcess = ['tailwindcss']\n      allowRead = ['.']\n      allowWorker = ['tailwindcss']\n      allowWrite = []\n      disable = false",
+		"[security]\n  allowContent = ['! ^text/html$', '! ^text/org$']\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^(dart-)?sass$', '^go$', '^git$', '^node$', '^postcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\\w+|(XDG_CONFIG_)?HOME|USERPROFILE|SSH_AUTH_SOCK|DISPLAY|LANG|SYSTEMDRIVE|PROGRAMDATA)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_', '^CI$']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['(?i)^https?://[a-z0-9]', '! ^https?://\\d+\\.', '! (?i)localhost', '! (?i)^https?://[^/?#]*@']\n\n  [security.node]\n    [security.node.permissions]\n      allowAddons = ['tailwindcss']\n      allowChildProcess = ['tailwindcss']\n      allowRead = ['.']\n      allowWorker = ['tailwindcss']\n      allowWrite = []\n      disable = false",
 	)
 }
 
@@ -379,6 +379,15 @@ func TestCheckAllowedContent(t *testing.T) {
 		c.Assert(err, qt.ErrorMatches, `(?s).*"text/html" is not whitelisted in policy "security\.allowContent".*`)
 	})
 
+	c.Run("text/org denied by default", func(c *qt.C) {
+		c.Parallel()
+		pc, err := DecodeConfig(config.New())
+		c.Assert(err, qt.IsNil)
+		err = pc.CheckAllowedContent("text/org")
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err, qt.ErrorMatches, `(?s).*"text/org" is not whitelisted in policy "security\.allowContent".*`)
+	})
+
 	c.Run("Other content types allowed by default", func(c *qt.C) {
 		c.Parallel()
 		pc, err := DecodeConfig(config.New())
@@ -386,7 +395,6 @@ func TestCheckAllowedContent(t *testing.T) {
 		for _, mt := range []string{
 			"text/markdown",
 			"text/asciidoc",
-			"text/x-org",
 			"text/rst",
 			"text/pandoc",
 		} {

--- a/create/content_test.go
+++ b/create/content_test.go
@@ -334,6 +334,8 @@ func newTestCfg(c *qt.C, mm afero.Fs) (config.Provider, *hugofs.Fs) {
 	cfg := `
 
 theme = "mytheme"
+[security]
+allowContent = ['.*']
 [languages]
 [languages.en]
 weight = 1

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1456,6 +1456,8 @@ func TestPageManualSummary(t *testing.T) {
 	files := `
 -- hugo.toml --
 baseURL = "http://example.com/"
+[security]
+allowContent = ['.*']
 -- content/page-md-shortcode.md --
 ---
 title: "Hugo"
@@ -2022,6 +2024,8 @@ func TestHomePageIsLeafBundle(t *testing.T) {
 -- hugo.toml --
 defaultContentLanguage = 'de'
 defaultContentLanguageInSubdir = true
+[security]
+allowContent = ['.*']
 [languages.de]
 weight = 1
 [languages.en]

--- a/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
+++ b/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
@@ -162,6 +162,7 @@ func TestPagesFromGoTmplAsciiDocAndSimilar(t *testing.T) {
 disableKinds = ["taxonomy", "term", "rss", "sitemap"]
 baseURL = "https://example.com"
 [security]
+allowContent = ['.*']
 [security.exec]
 allow = [%s]
 -- layouts/single.html --

--- a/hugolib/securitypolicies_test.go
+++ b/hugolib/securitypolicies_test.go
@@ -98,6 +98,58 @@ allowContent = ['.*']
 		b.AssertFileContent("public/p1/index.html", "<p>hello</p>")
 	})
 
+	c.Run("Org content, denied by default", func(c *qt.C) {
+		c.Parallel()
+		files := `
+-- hugo.toml --
+baseURL = "https://example.org"
+-- content/page.org --
+---
+title: "Untrusted"
+---
+@@html:<script>alert(1)</script>@@
+-- layouts/single.html --
+{{ .Content }}
+`
+		_, err := TestE(c, files)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err, qt.ErrorMatches, `(?s).*"text/org" is not whitelisted in policy "security\.allowContent".*`)
+	})
+
+	c.Run("Org content, allowed via override", func(c *qt.C) {
+		c.Parallel()
+		files := `
+-- hugo.toml --
+baseURL = "https://example.org"
+[security]
+allowContent = ['.*']
+-- content/page.org --
+---
+title: "Trusted"
+---
+hello
+-- layouts/single.html --
+{{ .Content }}
+`
+		b := Test(c, files)
+		b.AssertFileContent("public/page/index.html", "hello")
+	})
+
+	c.Run("Org content from content adapter, denied by default", func(c *qt.C) {
+		c.Parallel()
+		files := `
+-- hugo.toml --
+baseURL = "https://example.org"
+-- content/_content.gotmpl --
+{{ .AddPage (dict "path" "p1" "title" "Untrusted" "content" (dict "value" "@@html:<script>alert(1)</script>@@" "mediaType" "text/org")) }}
+-- layouts/single.html --
+{{ .Content }}
+`
+		_, err := TestE(c, files)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err, qt.ErrorMatches, `(?s).*"text/org" is not whitelisted in policy "security\.allowContent".*`)
+	})
+
 	c.Run("os.GetEnv, denied", func(c *qt.C) {
 		c.Parallel()
 		files := `


### PR DESCRIPTION
Org export blocks and @@html:...@@ snippets pass raw HTML through
unescaped, making text/org the same XSS sink as text/html, which is
already denied. Sites with Org content can opt back in via
security.allowContent.

Thanks to @philipdissert for finding and reporting this issue.

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>
