### PR TITLE
related: Speed up index creation

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -174,14 +174,10 @@ func (ps *pageState) Param(key any) (any, error) {
 }
 
 // RelatedKeywords implements the related.Document interface needed for fast page searches.
-func (ps *pageState) RelatedKeywords(cfg related.IndexConfig) ([]related.Keyword, error) {
+func (ps *pageState) RelatedKeywords(cfg related.IndexConfig) ([]string, error) {
 	v, found, err := page.NamedPageMetaValue(ps, cfg.Name)
-	if err != nil {
+	if err != nil || !found {
 		return nil, err
-	}
-
-	if !found {
-		return nil, nil
 	}
 
 	return cfg.ToKeywords(v)

--- a/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
+++ b/hugolib/pagesfromdata/pagesfromgotmpl_integration_test.go
@@ -369,11 +369,11 @@ func TestPagesFromGoRelatedKeywords(t *testing.T) {
 	}
 	k, err := p1.RelatedKeywords(icfg)
 	b.Assert(err, qt.IsNil)
-	b.Assert(k, qt.DeepEquals, icfg.StringsToKeywords("foo", "Bar"))
+	b.Assert(k, qt.DeepEquals, []string{"foo", "Bar"})
 	icfg.Name = "title"
 	k, err = p1.RelatedKeywords(icfg)
 	b.Assert(err, qt.IsNil)
-	b.Assert(k, qt.DeepEquals, icfg.StringsToKeywords("p1:p1"))
+	b.Assert(k, qt.DeepEquals, []string{"p1:p1"})
 }
 
 func TestPagesFromGoTmplLanguagePerFile(t *testing.T) {

--- a/related/inverted_index.go
+++ b/related/inverted_index.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
+	"iter"
 	"maps"
 	"math"
 	"sort"
@@ -49,8 +50,7 @@ var validTypes = map[string]bool{
 }
 
 var (
-	_        Keyword = (*StringKeyword)(nil)
-	zeroDate         = time.Time{}
+	zeroDate = time.Time{}
 
 	// DefaultConfig is the default related config.
 	DefaultConfig = Config{
@@ -138,8 +138,9 @@ type IndexConfig struct {
 
 // Document is the interface an indexable document in Hugo must fulfill.
 type Document interface {
-	// RelatedKeywords returns a list of keywords for the given index config.
-	RelatedKeywords(cfg IndexConfig) ([]Keyword, error)
+	// RelatedKeywords returns the keywords for the given index config.
+	// The returned slice may share backing with the document's data and must not be mutated.
+	RelatedKeywords(cfg IndexConfig) ([]string, error)
 
 	// When this document was or will be published.
 	PublishDate() time.Time
@@ -161,7 +162,7 @@ type FragmentProvider interface {
 // lists, for every possible search term, the documents that contain that term.
 type InvertedIndex struct {
 	cfg   Config
-	index map[string]map[Keyword][]Document
+	index map[string]map[string][]Document
 	// Counts the number of documents added to each index.
 	indexDocCount map[string]int
 
@@ -185,9 +186,9 @@ func (idx *InvertedIndex) getIndexCfg(name string) (IndexConfig, bool) {
 // NewInvertedIndex creates a new InvertedIndex.
 // Documents to index must be added in Add.
 func NewInvertedIndex(cfg Config) *InvertedIndex {
-	idx := &InvertedIndex{index: make(map[string]map[Keyword][]Document), indexDocCount: make(map[string]int), cfg: cfg}
+	idx := &InvertedIndex{index: make(map[string]map[string][]Document), indexDocCount: make(map[string]int), cfg: cfg}
 	for _, conf := range cfg.Indices {
-		idx.index[conf.Name] = make(map[Keyword][]Document)
+		idx.index[conf.Name] = make(map[string][]Document)
 		if conf.Weight < idx.minWeight {
 			// By default, the weight scale starts at 0, but we allow
 			// negative weights.
@@ -216,7 +217,7 @@ func (idx *InvertedIndex) Add(ctx context.Context, docs ...Document) error {
 
 		for _, doc := range docs {
 			var added bool
-			var words []Keyword
+			var words []string
 			words, err = doc.RelatedKeywords(config)
 			if err != nil {
 				continue
@@ -230,14 +231,14 @@ func (idx *InvertedIndex) Add(ctx context.Context, docs ...Document) error {
 			if config.Type == TypeFragments {
 				if fp, ok := doc.(FragmentProvider); ok {
 					frags := fp.Fragments(ctx)
-					seenKW := make(map[Keyword]bool)
+					seenKW := make(map[string]bool)
 					for _, fragment := range frags.Identifiers {
 						added = true
 						if config.Tokenize {
 							if h, found := frags.HeadingsMap[fragment]; found {
-								for _, word := range splitWords(h.Title) {
+								for word := range splitWordsSeq(h.Title) {
 									if !config.shouldSkipToken(word) {
-										kw := config.stringToKeyword(word)
+										kw := config.normalizeKeyword(word)
 										if !seenKW[kw] {
 											seenKW[kw] = true
 											setm[kw] = append(setm[kw], doc)
@@ -247,7 +248,7 @@ func (idx *InvertedIndex) Add(ctx context.Context, docs ...Document) error {
 								continue
 							}
 						}
-						setm[FragmentKeyword(fragment)] = append(setm[FragmentKeyword(fragment)], doc)
+						setm[fragment] = append(setm[fragment], doc)
 					}
 				}
 			}
@@ -295,10 +296,10 @@ func (idx *InvertedIndex) Finalize(ctx context.Context) error {
 // search for related content.
 type queryElement struct {
 	Index    string
-	Keywords []Keyword
+	Keywords []string
 }
 
-func newQueryElement(index string, keywords ...Keyword) queryElement {
+func newQueryElement(index string, keywords ...string) queryElement {
 	return queryElement{Index: index, Keywords: keywords}
 }
 
@@ -337,7 +338,7 @@ func (r ranks) Len() int      { return len(r) }
 func (r ranks) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
 func (r ranks) Less(i, j int) bool {
 	if r[i].Weight == r[j].Weight {
-		if r[i].Doc.PublishDate() == r[j].Doc.PublishDate() {
+		if r[i].Doc.PublishDate().Equal(r[j].Doc.PublishDate()) {
 			return r[i].Doc.Name() < r[j].Doc.Name()
 		}
 		return r[i].Doc.PublishDate().After(r[j].Doc.PublishDate())
@@ -388,7 +389,7 @@ func (idx *InvertedIndex) Search(ctx context.Context, opts SearchOpts) ([]Docume
 	}
 
 	for _, cfg := range configs {
-		var keywords []Keyword
+		var keywords []string
 		if opts.Document != nil {
 			k, err := opts.Document.RelatedKeywords(cfg)
 			if err != nil {
@@ -397,19 +398,17 @@ func (idx *InvertedIndex) Search(ctx context.Context, opts SearchOpts) ([]Docume
 			keywords = append(keywords, k...)
 		}
 		if cfg.Type == TypeFragments {
-			for _, fragment := range opts.Fragments {
-				keywords = append(keywords, FragmentKeyword(fragment))
-			}
+			keywords = append(keywords, opts.Fragments...)
 			if opts.Document != nil {
 				if fp, ok := opts.Document.(FragmentProvider); ok {
 					frags := fp.Fragments(ctx)
-					seenKW := make(map[Keyword]bool)
+					seenKW := make(map[string]bool)
 					for _, fragment := range frags.Identifiers {
 						if cfg.Tokenize {
 							if h, found := frags.HeadingsMap[fragment]; found {
-								for _, word := range splitWords(h.Title) {
+								for word := range splitWordsSeq(h.Title) {
 									if !cfg.shouldSkipToken(word) {
-										kw := cfg.stringToKeyword(word)
+										kw := cfg.normalizeKeyword(word)
 										if !seenKW[kw] {
 											seenKW[kw] = true
 											keywords = append(keywords, kw)
@@ -419,7 +418,7 @@ func (idx *InvertedIndex) Search(ctx context.Context, opts SearchOpts) ([]Docume
 								continue
 							}
 						}
-						keywords = append(keywords, FragmentKeyword(fragment))
+						keywords = append(keywords, fragment)
 					}
 				}
 			}
@@ -428,7 +427,7 @@ func (idx *InvertedIndex) Search(ctx context.Context, opts SearchOpts) ([]Docume
 		queryElements = append(queryElements, newQueryElement(cfg.Name, keywords...))
 	}
 	for _, slice := range opts.NamedSlices {
-		var keywords []Keyword
+		var keywords []string
 		key := slice.KeyString()
 		if key == "" {
 			return nil, fmt.Errorf("index %q not valid", slice.Key)
@@ -454,51 +453,52 @@ func (idx *InvertedIndex) Search(ctx context.Context, opts SearchOpts) ([]Docume
 	return idx.search(ctx, queryElements...)
 }
 
-func (cfg IndexConfig) stringToKeyword(s string) Keyword {
+func (cfg IndexConfig) normalizeKeyword(s string) string {
 	if cfg.ToLower {
-		s = strings.ToLower(s)
+		return strings.ToLower(s)
 	}
-	if cfg.Type == TypeFragments {
-		return FragmentKeyword(s)
-	}
-	return StringKeyword(s)
+	return s
 }
 
 func (cfg IndexConfig) shouldSkipToken(word string) bool {
 	return cfg.MinTokenLength > 0 && utf8.RuneCountInString(word) < cfg.MinTokenLength
 }
 
-// ToKeywords returns a Keyword slice of the given input.
-func (cfg IndexConfig) ToKeywords(v any) ([]Keyword, error) {
-	var keywords []Keyword
+// appendTokens appends the normalized tokens in s to keywords.
+func (cfg IndexConfig) appendTokens(keywords []string, s string) []string {
+	for word := range splitWordsSeq(s) {
+		if !cfg.shouldSkipToken(word) {
+			keywords = append(keywords, cfg.normalizeKeyword(word))
+		}
+	}
+	return keywords
+}
 
+// ToKeywords returns the keywords for the given input.
+// The returned slice may share backing with the input and must not be mutated.
+func (cfg IndexConfig) ToKeywords(v any) ([]string, error) {
 	switch vv := v.(type) {
 	case string:
 		if cfg.Tokenize {
-			for _, word := range splitWords(vv) {
-				if !cfg.shouldSkipToken(word) {
-					keywords = append(keywords, cfg.stringToKeyword(word))
-				}
-			}
-		} else {
-			keywords = append(keywords, cfg.stringToKeyword(vv))
+			return cfg.appendTokens(make([]string, 0, 4), vv), nil
 		}
+		return []string{cfg.normalizeKeyword(vv)}, nil
 	case []string:
-		if !cfg.Tokenize {
-			kw := make([]Keyword, len(vv))
-			for i, s := range vv {
-				kw[i] = cfg.stringToKeyword(s)
-			}
-			keywords = append(keywords, kw...)
-		} else {
+		if cfg.Tokenize {
+			keywords := make([]string, 0, len(vv)*2)
 			for _, s := range vv {
-				for _, word := range splitWords(s) {
-					if !cfg.shouldSkipToken(word) {
-						keywords = append(keywords, cfg.stringToKeyword(word))
-					}
-				}
+				keywords = cfg.appendTokens(keywords, s)
 			}
+			return keywords, nil
 		}
+		if !cfg.ToLower {
+			return vv, nil
+		}
+		keywords := make([]string, len(vv))
+		for i, s := range vv {
+			keywords[i] = strings.ToLower(s)
+		}
+		return keywords, nil
 	case []any:
 		return cfg.ToKeywords(cast.ToStringSlice(vv))
 	case time.Time:
@@ -506,14 +506,12 @@ func (cfg IndexConfig) ToKeywords(v any) ([]Keyword, error) {
 		if cfg.Pattern != "" {
 			layout = cfg.Pattern
 		}
-		keywords = append(keywords, StringKeyword(vv.Format(layout)))
+		return []string{vv.Format(layout)}, nil
 	case nil:
-		return keywords, nil
+		return nil, nil
 	default:
-		return keywords, fmt.Errorf("indexing currently not supported for index %q and type %T", cfg.Name, vv)
+		return nil, fmt.Errorf("indexing currently not supported for index %q and type %T", cfg.Name, vv)
 	}
-
-	return keywords, nil
 }
 
 func (idx *InvertedIndex) search(ctx context.Context, query ...queryElement) ([]Document, error) {
@@ -566,12 +564,10 @@ func (idx *InvertedIndex) searchDate(ctx context.Context, self Document, upperDa
 					}
 
 					if config.Type == TypeFragments && config.ApplyFilter {
-						if fkw, ok := kw.(FragmentKeyword); ok {
-							if config.Tokenize {
-								ff.words = append(ff.words, string(fkw))
-							} else {
-								ff.ids = append(ff.ids, string(fkw))
-							}
+						if config.Tokenize {
+							ff.words = append(ff.words, kw)
+						} else {
+							ff.ids = append(ff.ids, kw)
 						}
 					}
 					r, found := matchm[doc]
@@ -618,7 +614,7 @@ func (idx *InvertedIndex) searchDate(ctx context.Context, self Document, upperDa
 						return true
 					}
 					if len(ff.words) > 0 {
-						for _, word := range splitWords(h.Title) {
+						for word := range splitWordsSeq(h.Title) {
 							if ff.toLower {
 								word = strings.ToLower(word)
 							}
@@ -688,57 +684,19 @@ func DecodeConfig(m hmaps.Params) (Config, error) {
 	return c, nil
 }
 
-// StringKeyword is a string search keyword.
-type StringKeyword string
-
-func (s StringKeyword) String() string {
-	return string(s)
-}
-
-// FragmentKeyword represents a document fragment.
-type FragmentKeyword string
-
-func (f FragmentKeyword) String() string {
-	return string(f)
-}
-
-// Keyword is the interface a keyword in the search index must implement.
-type Keyword interface {
-	String() string
-}
-
-// splitWords splits s into normalized words, stripping HTML entities and
-// leading/trailing punctuation from each word.
-func splitWords(title string) []string {
-	// Fast path: no whitespace or HTML entities means at most one token.
-	if strings.IndexFunc(title, unicode.IsSpace) == -1 && strings.IndexByte(title, '&') == -1 {
-		title = strings.TrimFunc(html.UnescapeString(title), func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsDigit(r) })
-		if title == "" {
-			return nil
-		}
-		return []string{title}
-	}
-	raw := strings.Fields(html.UnescapeString(title))
-	words := raw[:0]
-	for _, w := range raw {
-		w = strings.TrimFunc(w, func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsDigit(r) })
-		if w != "" {
-			words = append(words, w)
+// splitWordsSeq iterates the normalized words in title, stripping HTML
+// entities and leading/trailing punctuation from each word.
+func splitWordsSeq(title string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for w := range strings.FieldsSeq(html.UnescapeString(title)) {
+			w = strings.TrimFunc(w, isNotWordRune)
+			if w != "" && !yield(w) {
+				return
+			}
 		}
 	}
-	if len(words) == 0 {
-		return nil
-	}
-	return words
 }
 
-// StringsToKeywords converts the given slice of strings to a slice of Keyword.
-func (cfg IndexConfig) StringsToKeywords(s ...string) []Keyword {
-	kw := make([]Keyword, len(s))
-
-	for i := range s {
-		kw[i] = cfg.stringToKeyword(s[i])
-	}
-
-	return kw
+func isNotWordRune(r rune) bool {
+	return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 }

--- a/related/inverted_index_test.go
+++ b/related/inverted_index_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -26,7 +27,7 @@ import (
 )
 
 type testDoc struct {
-	keywords map[string][]Keyword
+	keywords map[string][]string
 	date     time.Time
 	name     string
 }
@@ -37,7 +38,7 @@ func (d *testDoc) String() string {
 	for k, v := range d.keywords {
 		s.WriteString(k + ":\t\t")
 		for _, vv := range v {
-			s.WriteString("  " + vv.String())
+			s.WriteString("  " + vv)
 		}
 		s.WriteString("\n")
 	}
@@ -54,7 +55,7 @@ func newTestDoc(name string, keywords ...string) *testDoc {
 }
 
 func newTestDocWithDate(name string, date time.Time, keywords ...string) *testDoc {
-	km := make(map[string][]Keyword)
+	km := make(map[string][]string)
 
 	kw := &testDoc{keywords: km, date: date}
 
@@ -66,11 +67,7 @@ func (d *testDoc) addKeywords(name string, keywords ...string) *testDoc {
 	keywordm := createTestKeywords(name, keywords...)
 
 	for k, v := range keywordm {
-		keywords := make([]Keyword, len(v))
-		for i := range v {
-			keywords[i] = StringKeyword(v[i])
-		}
-		d.keywords[k] = keywords
+		d.keywords[k] = v
 	}
 	return d
 }
@@ -81,8 +78,8 @@ func createTestKeywords(name string, keywords ...string) map[string][]string {
 	}
 }
 
-func (d *testDoc) RelatedKeywords(cfg IndexConfig) ([]Keyword, error) {
-	return d.keywords[cfg.Name], nil
+func (d *testDoc) RelatedKeywords(cfg IndexConfig) ([]string, error) {
+	return cfg.ToKeywords(d.keywords[cfg.Name])
 }
 
 func (d *testDoc) PublishDate() time.Time {
@@ -102,7 +99,7 @@ func TestCardinalityThreshold(t *testing.T) {
 
 	idx := NewInvertedIndex(config)
 	hasKeyword := func(index, keyword string) bool {
-		_, found := idx.index[index][StringKeyword(keyword)]
+		_, found := idx.index[index][keyword]
 		return found
 	}
 
@@ -160,8 +157,7 @@ func TestSearch(t *testing.T) {
 
 	t.Run("search-tags", func(t *testing.T) {
 		c := qt.New(t)
-		var cfg IndexConfig
-		m, err := idx.search(context.Background(), newQueryElement("tags", cfg.StringsToKeywords("a", "b", "d", "z")...))
+		m, err := idx.search(context.Background(), newQueryElement("tags", "a", "b", "d", "z"))
 		c.Assert(err, qt.IsNil)
 		c.Assert(len(m), qt.Equals, 2)
 		c.Assert(m[0], qt.Equals, docs[0])
@@ -170,10 +166,9 @@ func TestSearch(t *testing.T) {
 
 	t.Run("search-tags-and-keywords", func(t *testing.T) {
 		c := qt.New(t)
-		var cfg IndexConfig
 		m, err := idx.search(context.Background(),
-			newQueryElement("tags", cfg.StringsToKeywords("a", "b", "z")...),
-			newQueryElement("keywords", cfg.StringsToKeywords("a", "b")...))
+			newQueryElement("tags", "a", "b", "z"),
+			newQueryElement("keywords", "a", "b"))
 		c.Assert(err, qt.IsNil)
 		c.Assert(len(m), qt.Equals, 3)
 		c.Assert(m[0], qt.Equals, docs[3])
@@ -245,11 +240,7 @@ func TestToKeywordsToLower(t *testing.T) {
 	keywords, err := config.ToKeywords(slice)
 	c.Assert(err, qt.IsNil)
 	c.Assert(slice, qt.DeepEquals, []string{"A", "B", "C"})
-	c.Assert(keywords, qt.DeepEquals, []Keyword{
-		StringKeyword("a"),
-		StringKeyword("b"),
-		StringKeyword("c"),
-	})
+	c.Assert(keywords, qt.DeepEquals, []string{"a", "b", "c"})
 }
 
 func TestDecodeConfig(t *testing.T) {
@@ -302,11 +293,7 @@ func TestToKeywordsAnySlice(t *testing.T) {
 	slice := []any{"A", 32, "C"}
 	keywords, err := config.ToKeywords(slice)
 	c.Assert(err, qt.IsNil)
-	c.Assert(keywords, qt.DeepEquals, []Keyword{
-		StringKeyword("A"),
-		StringKeyword("32"),
-		StringKeyword("C"),
-	})
+	c.Assert(keywords, qt.DeepEquals, []string{"A", "32", "C"})
 }
 
 func TestSplitWords(t *testing.T) {
@@ -337,11 +324,12 @@ func TestSplitWords(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		c.Assert(splitWords(tt.in), qt.DeepEquals, tt.want, qt.Commentf("input: %q", tt.in))
+		c.Assert(slices.Collect(splitWordsSeq(tt.in)), qt.DeepEquals, tt.want, qt.Commentf("input: %q", tt.in))
 	}
 }
 
 func BenchmarkRelatedNewIndex(b *testing.B) {
+	rnd := rand.New(rand.NewSource(32))
 	pages := make([]*testDoc, 100)
 	numkeywords := 30
 	allKeywords := make([]string, numkeywords)
@@ -350,7 +338,7 @@ func BenchmarkRelatedNewIndex(b *testing.B) {
 	}
 
 	for i := range pages {
-		start := rand.Intn(len(allKeywords))
+		start := rnd.Intn(len(allKeywords))
 		end := start + 3
 		if end >= len(allKeywords) {
 			end = start + 1
@@ -358,7 +346,7 @@ func BenchmarkRelatedNewIndex(b *testing.B) {
 
 		kw := newTestDoc("tags", allKeywords[start:end]...)
 		if i%5 == 0 {
-			start := rand.Intn(len(allKeywords))
+			start := rnd.Intn(len(allKeywords))
 			end := start + 3
 			if end >= len(allKeywords) {
 				end = start + 1
@@ -399,10 +387,10 @@ func BenchmarkRelatedNewIndex(b *testing.B) {
 }
 
 func BenchmarkRelatedMatchesIn(b *testing.B) {
-	var icfg IndexConfig
-	q1 := newQueryElement("tags", icfg.StringsToKeywords("keyword2", "keyword5", "keyword32", "asdf")...)
-	q2 := newQueryElement("keywords", icfg.StringsToKeywords("keyword3", "keyword4")...)
+	q1 := newQueryElement("tags", "keyword2", "keyword5", "keyword32", "asdf")
+	q2 := newQueryElement("keywords", "keyword3", "keyword4")
 
+	rnd := rand.New(rand.NewSource(32))
 	docs := make([]*testDoc, 1000)
 	numkeywords := 20
 	allKeywords := make([]string, numkeywords)
@@ -421,7 +409,7 @@ func BenchmarkRelatedMatchesIn(b *testing.B) {
 	idx := NewInvertedIndex(cfg)
 
 	for i := range docs {
-		start := rand.Intn(len(allKeywords))
+		start := rnd.Intn(len(allKeywords))
 		end := start + 3
 		if end >= len(allKeywords) {
 			end = start + 1
@@ -441,6 +429,49 @@ func BenchmarkRelatedMatchesIn(b *testing.B) {
 			idx.search(ctx, q2)
 		} else {
 			idx.search(ctx, q1)
+		}
+	}
+}
+
+func BenchmarkRelatedTokenizeCreateIndex(b *testing.B) {
+	rnd := rand.New(rand.NewSource(32))
+	keywordsCfg := IndexConfig{Name: "keywords", Weight: 100, Tokenize: true}
+
+	docs := make([]*testDoc, 100)
+	numGroups := 5
+	numKeywords := 3
+	allKeywords := make([]string, numGroups)
+	for i := range numGroups {
+		for j := range numKeywords {
+			allKeywords[i] += fmt.Sprintf("keyword%d ", i*numKeywords+j+1)
+		}
+	}
+
+	for i := range docs {
+		start := rnd.Intn(len(allKeywords))
+		end := start + 3
+		if end >= len(allKeywords) {
+			end = start + 1
+		}
+
+		kws := slices.Clone(allKeywords[start:end])
+		kws = append(kws, "keyword3")
+		docs[i] = newTestDoc("keywords", kws...)
+	}
+
+	for b.Loop() {
+		cfg := Config{
+			Threshold: 10,
+			Indices:   IndicesConfig{keywordsCfg},
+		}
+
+		idx := NewInvertedIndex(cfg)
+
+		for j := range docs {
+			idx.Add(context.Background(), docs[j])
+		}
+		if err := idx.Finalize(context.Background()); err != nil {
+			b.Fatal(err)
 		}
 	}
 }

--- a/resources/page/page.go
+++ b/resources/page/page.go
@@ -449,7 +449,7 @@ type RefProvider interface {
 type RelatedKeywordsProvider interface {
 	// Make it indexable as a related.Document
 	// RelatedKeywords is meant for internal usage only.
-	RelatedKeywords(cfg related.IndexConfig) ([]related.Keyword, error)
+	RelatedKeywords(cfg related.IndexConfig) ([]string, error)
 }
 
 // ShortcodeInfoProvider provides info about the shortcodes in a Page.

--- a/resources/page/page_nop.go
+++ b/resources/page/page_nop.go
@@ -423,7 +423,7 @@ func (p *nopPage) Store() *hstore.Scratch {
 	return nil
 }
 
-func (p *nopPage) RelatedKeywords(cfg related.IndexConfig) ([]related.Keyword, error) {
+func (p *nopPage) RelatedKeywords(cfg related.IndexConfig) ([]string, error) {
 	return nil, nil
 }
 

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -507,7 +507,7 @@ func (p *testPage) Store() *hstore.Scratch {
 	panic("testpage: not implemented")
 }
 
-func (p *testPage) RelatedKeywords(cfg related.IndexConfig) ([]related.Keyword, error) {
+func (p *testPage) RelatedKeywords(cfg related.IndexConfig) ([]string, error) {
 	v, err := p.Param(cfg.Name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```
                              │ relatedperfcmp.bench │       feat-relatedperf.bench       │
                              │        sec/op        │   sec/op     vs base               │
RelatedNewIndex/singles-10               37.85µ ± 3%   23.83µ ± 0%  -37.05% (p=0.000 n=8)
RelatedNewIndex/all-10                   34.47µ ± 1%   21.86µ ± 0%  -36.59% (p=0.000 n=8)
RelatedMatchesIn-10                      42.38µ ± 1%   41.56µ ± 1%   -1.95% (p=0.000 n=8)
RelatedTokenizeCreateIndex-10            72.00µ ± 0%   46.49µ ± 0%  -35.43% (p=0.000 n=8)
RelatedSite-10                           14.24m ± 5%   14.66m ± 5%        ~ (p=0.161 n=8)
geomean                                  141.5µ        108.1µ       -23.60%

                              │ relatedperfcmp.bench │       feat-relatedperf.bench        │
                              │         B/op         │     B/op      vs base               │
RelatedNewIndex/singles-10              39.78Ki ± 0%   24.33Ki ± 0%  -38.85% (p=0.000 n=8)
RelatedNewIndex/all-10                  41.53Ki ± 0%   26.08Ki ± 0%  -37.21% (p=0.000 n=8)
RelatedMatchesIn-10                     12.11Ki ± 0%   12.11Ki ± 0%        ~ (p=0.324 n=8)
RelatedTokenizeCreateIndex-10           75.70Ki ± 0%   50.01Ki ± 0%  -33.94% (p=0.000 n=8)
RelatedSite-10                          37.95Mi ± 0%   37.85Mi ± 0%   -0.26% (p=0.000 n=8)
geomean                                 142.5Ki        108.3Ki       -24.03%

                              │ relatedperfcmp.bench │        feat-relatedperf.bench        │
                              │      allocs/op       │  allocs/op   vs base                 │
RelatedNewIndex/singles-10                886.0 ± 0%    325.0 ± 0%  -63.32% (p=0.000 n=8)
RelatedNewIndex/all-10                    887.0 ± 0%    326.0 ± 0%  -63.25% (p=0.000 n=8)
RelatedMatchesIn-10                       7.000 ± 0%    7.000 ± 0%        ~ (p=1.000 n=8) ¹
RelatedTokenizeCreateIndex-10            1448.0 ± 0%    342.0 ± 0%  -76.38% (p=0.000 n=8)
RelatedSite-10                           166.2k ± 0%   159.5k ± 0%   -4.04% (p=0.000 n=8)
geomean                                  1.058k         526.5       -50.22%
¹ all samples are equal
```
