### PR TITLE
deps: Upgrade github.com/gobwas/glob v0.2.3 => v1.0.0

### DIFF
--- a/common/hmaps/maps.go
+++ b/common/hmaps/maps.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/types"
 
 	"github.com/gobwas/glob"
@@ -145,7 +146,7 @@ func MergeShallow(dst, src map[string]any) {
 }
 
 type keyRename struct {
-	pattern glob.Glob
+	pattern hstrings.Matcher
 	newKey  string
 }
 

--- a/common/hstrings/strings.go
+++ b/common/hstrings/strings.go
@@ -61,7 +61,8 @@ var reCache = *maphelpers.NewConcurrentMap[string, *regexp.Regexp]()
 // If the pattern is not found in the cache, the pattern is compiled and added to
 // the cache.
 func GetOrCompileRegexp(pattern string) (re *regexp.Regexp, err error) {
-	return reCache.GetOrCreate(pattern,
+	return reCache.GetOrCreate(
+		pattern,
 		func() (*regexp.Regexp, error) {
 			return regexp.Compile(pattern)
 		},
@@ -176,4 +177,9 @@ func UniqueStringsSorted(s []string) []string {
 	}
 
 	return s[:i+1]
+}
+
+// Matcher is an interface for matching strings.
+type Matcher interface {
+	Match(s string) bool
 }

--- a/common/predicate/predicate.go
+++ b/common/predicate/predicate.go
@@ -17,7 +17,7 @@ import (
 	"iter"
 	"strings"
 
-	"github.com/gobwas/glob"
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/hugofs/hglob"
 )
 
@@ -184,7 +184,7 @@ func cutRangeOp(s string) (op int, rest string) {
 
 // NewStringPredicateFromGlobs creates a string predicate from the given glob patterns.
 // A glob pattern starting with "!" is a negation pattern which will be ANDed with the rest.
-func NewStringPredicateFromGlobs(patterns []string, getGlob func(pattern string) (glob.Glob, error)) (P[string], error) {
+func NewStringPredicateFromGlobs(patterns []string, getGlob func(pattern string) (hstrings.Matcher, error)) (P[string], error) {
 	var p PR[string]
 	for _, pattern := range patterns {
 		pattern = strings.TrimSpace(pattern)
@@ -219,7 +219,7 @@ func NewStringPredicateFromGlobs(patterns []string, getGlob func(pattern string)
 // NewIndexStringPredicateFromGlobsAndRanges creates an IndexString predicate from the given glob patterns and range patterns.
 // A glob pattern starting with "!" is a negation pattern which will be ANDed with the rest.
 // A range pattern is one of "> value", ">= value", "< value" or "<= value".
-func NewIndexStringPredicateFromGlobsAndRanges(patterns []string, getIndex func(s string) int, getGlob func(pattern string) (glob.Glob, error)) (P[IndexString], error) {
+func NewIndexStringPredicateFromGlobsAndRanges(patterns []string, getIndex func(s string) int, getGlob func(pattern string) (hstrings.Matcher, error)) (P[IndexString], error) {
 	var p PR[IndexString]
 	for _, pattern := range patterns {
 		pattern = strings.TrimSpace(pattern)

--- a/common/predicate/predicate_test.go
+++ b/common/predicate/predicate_test.go
@@ -18,6 +18,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/gobwas/glob"
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/predicate"
 )
 
@@ -127,7 +128,7 @@ var intP4 = func(i int) predicate.Match {
 func TestNewStringPredicateFromGlobs(t *testing.T) {
 	c := qt.New(t)
 
-	getGlob := func(pattern string) (glob.Glob, error) {
+	getGlob := func(pattern string) (hstrings.Matcher, error) {
 		return glob.Compile(pattern)
 	}
 
@@ -160,7 +161,7 @@ func TestNewIndexStringPredicateFromGlobsAndRanges(t *testing.T) {
 		}
 		return -1
 	}
-	getGlob := func(pattern string) (glob.Glob, error) {
+	getGlob := func(pattern string) (hstrings.Matcher, error) {
 		return glob.Compile(pattern)
 	}
 

--- a/config/allconfig/load.go
+++ b/config/allconfig/load.go
@@ -22,10 +22,10 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/gobwas/glob"
 	"github.com/gohugoio/hugo/common/herrors"
 	"github.com/gohugoio/hugo/common/hexec"
 	"github.com/gohugoio/hugo/common/hmaps"
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/common/paths"
@@ -451,7 +451,7 @@ func (l *configLoader) loadModules(configs *Configs, ignoreModuleDoesNotExist bo
 
 	cfg := configs.LoadingInfo.Cfg
 
-	var ignoreVendor glob.Glob
+	var ignoreVendor hstrings.Matcher
 	if s := conf.IgnoreVendorPaths; s != "" {
 		ignoreVendor, _ = hglob.GetGlob(hglob.NormalizePath(s))
 	}

--- a/config/commonConfig.go
+++ b/config/commonConfig.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/bep/logg"
 	"github.com/gobwas/glob"
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/common/types"
 
@@ -154,14 +155,14 @@ func (s BuildConfig) MatchCacheBuster(logger loggers.Logger, p string) (func(str
 		}
 	}
 	if len(matchers) > 0 {
-		return (func(cacheKey string) bool {
+		return func(cacheKey string) bool {
 			for _, m := range matchers {
 				if m(cacheKey) {
 					return true
 				}
 			}
 			return false
-		}), nil
+		}, nil
 	}
 	return nil, nil
 }
@@ -227,14 +228,14 @@ type Server struct {
 	Headers   []Headers
 	Redirects []Redirect
 
-	compiledHeaders   []glob.Glob
+	compiledHeaders   []hstrings.Matcher
 	compiledRedirects []redirect
 }
 
 type redirect struct {
-	from    glob.Glob
+	from    hstrings.Matcher
 	fromRe  *regexp.Regexp
-	headers map[string]glob.Glob
+	headers map[string]hstrings.Matcher
 }
 
 func (r redirect) matchHeader(header http.Header) bool {
@@ -262,7 +263,7 @@ func (s *Server) CompileConfig(logger loggers.Logger) error {
 			return fmt.Errorf("redirects must have either From or FromRe set")
 		}
 		rd := redirect{
-			headers: make(map[string]glob.Glob),
+			headers: make(map[string]hstrings.Matcher),
 		}
 		if r.From != "" {
 			g, err := glob.Compile(r.From)

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -34,7 +34,7 @@ import (
 	"sync"
 
 	"github.com/dustin/go-humanize"
-	"github.com/gobwas/glob"
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/common/para"
 	"github.com/gohugoio/hugo/config"
@@ -132,7 +132,7 @@ func (d *Deployer) Deploy(ctx context.Context) error {
 	}
 
 	// Load local files from the source directory.
-	var include, exclude glob.Glob
+	var include, exclude hstrings.Matcher
 	var mappath func(string) string
 	if d.target != nil {
 		include, exclude = d.target.IncludeGlob, d.target.ExcludeGlob
@@ -487,7 +487,7 @@ func knownHiddenDirectory(name string) bool {
 
 // walkLocal walks the source directory and returns a flat list of files,
 // using localFile.SlashPath as the map keys.
-func (d *Deployer) walkLocal(fs afero.Fs, matchers []*deployconfig.Matcher, include, exclude glob.Glob, mediaTypes media.Types, mappath func(string) string) (map[string]*localFile, error) {
+func (d *Deployer) walkLocal(fs afero.Fs, matchers []*deployconfig.Matcher, include, exclude hstrings.Matcher, mediaTypes media.Types, mappath func(string) string) (map[string]*localFile, error) {
 	retval := make(map[string]*localFile)
 	var mu sync.Mutex
 
@@ -575,7 +575,7 @@ func stripIndexHTML(slashpath string) string {
 }
 
 // walkRemote walks the target bucket and returns a flat list.
-func (d *Deployer) walkRemote(ctx context.Context, bucket *blob.Bucket, include, exclude glob.Glob) (map[string]*blob.ListObject, error) {
+func (d *Deployer) walkRemote(ctx context.Context, bucket *blob.Bucket, include, exclude hstrings.Matcher) (map[string]*blob.ListObject, error) {
 	retval := map[string]*blob.ListObject{}
 	iter := bucket.List(nil)
 	for {

--- a/deploy/deployconfig/deployConfig.go
+++ b/deploy/deployconfig/deployConfig.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/gobwas/glob"
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/config"
 	hglob "github.com/gohugoio/hugo/hugofs/hglob"
 	"github.com/mitchellh/mapstructure"
@@ -67,8 +67,8 @@ type Target struct {
 	Exclude string
 
 	// Parsed versions of Include/Exclude.
-	IncludeGlob glob.Glob `json:"-"`
-	ExcludeGlob glob.Glob `json:"-"`
+	IncludeGlob hstrings.Matcher `json:"-"`
+	ExcludeGlob hstrings.Matcher `json:"-"`
 
 	// If true, any local path matching <dir>/index.html will be mapped to the
 	// remote path <dir>/. This does not affect the top-level index.html file,

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/getkin/kin-openapi v0.146.0
 	github.com/gobuffalo/flect v1.0.3
-	github.com/gobwas/glob v0.2.3
+	github.com/gobwas/glob v1.0.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/gohugoio/gift v0.2.0
 	github.com/gohugoio/go-i18n/v2 v2.1.3-0.20251018145728-cfcc22d823c6

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,8 @@ github.com/gobuffalo/flect v1.0.3 h1:xeWBM2nui+qnVvNM4S3foBhCAL2XgPU+a7FdpelbTq4
 github.com/gobuffalo/flect v1.0.3/go.mod h1:A5msMlrHtLqh9umBSnvabjsMrCcCpAyzglnDvkbYKHs=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/gobwas/glob v1.0.0 h1:p+FKbLEIsK1yZ39/OINwFvqNb5oyPY4H8xcy6uYu8dg=
+github.com/gobwas/glob v1.0.0/go.mod h1:oWCdo522i2P1n/hMXGNWs7yoV4wy/ciZuUIbvKj5rkc=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gohugoio/gift v0.2.0 h1:vA31pP0rTVmBxBrhpY3WEt+4zM4g+1sDqYeemwsYeqc=

--- a/hugofs/hglob/filename_filter.go
+++ b/hugofs/hglob/filename_filter.go
@@ -19,7 +19,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/gobwas/glob"
+	"github.com/gohugoio/hugo/common/hstrings"
 )
 
 type FilenameFilter struct {
@@ -44,7 +44,7 @@ const (
 const NegationPrefix = "! "
 
 type globFilenameFilterEntry struct {
-	g glob.Glob
+	g hstrings.Matcher
 	t globFilenameFilterEntryType
 }
 

--- a/hugofs/hglob/glob.go
+++ b/hugofs/hglob/glob.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gobwas/glob"
 	"github.com/gobwas/glob/syntax"
 	"github.com/gohugoio/hugo/common/hmaps"
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/identity"
 )
 
@@ -38,7 +39,7 @@ var (
 )
 
 type globErr struct {
-	glob glob.Glob
+	glob hstrings.Matcher
 	err  error
 }
 
@@ -50,8 +51,8 @@ type pathGlobCache struct {
 	cache *hmaps.Cache[string, globErr]
 }
 
-// GetGlobDot returns a glob.Glob that matches the given pattern, using '.' as the path separator.
-func GetGlobDot(pattern string) (glob.Glob, error) {
+// GetGlobDot returns a hstrings.Matcher that matches the given pattern, using '.' as the path separator.
+func GetGlobDot(pattern string) (hstrings.Matcher, error) {
 	v, err := dotGlobCache.GetOrCreate(pattern, func() (globErr, error) {
 		g, err := glob.Compile(pattern, '.')
 		return globErr{
@@ -66,7 +67,7 @@ func GetGlobDot(pattern string) (glob.Glob, error) {
 	return v.glob, v.err
 }
 
-func (gc *pathGlobCache) GetGlob(pattern string) (glob.Glob, error) {
+func (gc *pathGlobCache) GetGlob(pattern string) (hstrings.Matcher, error) {
 	v, err := gc.cache.GetOrCreate(pattern, func() (globErr, error) {
 		pattern = filepath.ToSlash(pattern)
 		g, err := glob.Compile(strings.ToLower(pattern), '/')
@@ -86,11 +87,11 @@ func (gc *pathGlobCache) GetGlob(pattern string) (glob.Glob, error) {
 }
 
 // Or creates a new Glob from the given globs.
-func Or(globs ...glob.Glob) glob.Glob {
+func Or(globs ...hstrings.Matcher) hstrings.Matcher {
 	return globSlice{globs: globs}
 }
 
-// MatchesFunc is a convenience type to create a glob.Glob from a function.
+// MatchesFunc is a convenience type to create a hstrings.Matcher from a function.
 type MatchesFunc func(s string) bool
 
 func (m MatchesFunc) Match(s string) bool {
@@ -98,7 +99,7 @@ func (m MatchesFunc) Match(s string) bool {
 }
 
 type globSlice struct {
-	globs []glob.Glob
+	globs []hstrings.Matcher
 }
 
 func (g globSlice) Match(s string) bool {
@@ -115,7 +116,7 @@ type globDecorator struct {
 	// which we need to normalize.
 	isWindows bool
 
-	g glob.Glob
+	g hstrings.Matcher
 }
 
 func (g globDecorator) Match(s string) bool {
@@ -126,7 +127,7 @@ func (g globDecorator) Match(s string) bool {
 	return g.g.Match(s)
 }
 
-func GetGlob(pattern string) (glob.Glob, error) {
+func GetGlob(pattern string) (hstrings.Matcher, error) {
 	return defaultGlobCache.GetGlob(pattern)
 }
 
@@ -171,7 +172,7 @@ func FilterGlobParts(a []string) []string {
 // HasGlobChar returns whether s contains any glob wildcards.
 func HasGlobChar(s string) bool {
 	for i := range len(s) {
-		if syntax.Special(s[i]) {
+		if syntax.IsSpecial(s[i]) {
 			return true
 		}
 	}

--- a/hugolib/segments/segments.go
+++ b/hugolib/segments/segments.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gobwas/glob"
 	"github.com/gohugoio/hugo/common/hmaps"
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/common/predicate"
@@ -153,7 +153,8 @@ func (s *segmentsBuilder) buildOne(f []SegmentMatcherFields) (predicate.PR[Segme
 
 	for _, fields := range f {
 		if len(fields.Kind) > 0 {
-			if err := addToSection(fields,
+			if err := addToSection(
+				fields,
 				func(fields SegmentMatcherFields) []string { return fields.Kind },
 				func(fields SegmentQuery) string { return fields.Kind },
 			); err != nil {
@@ -161,7 +162,8 @@ func (s *segmentsBuilder) buildOne(f []SegmentMatcherFields) (predicate.PR[Segme
 			}
 		}
 		if len(fields.Path) > 0 {
-			if err := addToSection(fields,
+			if err := addToSection(
+				fields,
 				func(fields SegmentMatcherFields) []string { return fields.Path },
 				func(fields SegmentQuery) string { return fields.Path },
 			); err != nil {
@@ -185,7 +187,8 @@ func (s *segmentsBuilder) buildOne(f []SegmentMatcherFields) (predicate.PR[Segme
 			)
 		}
 		if len(fields.Output) > 0 {
-			if err := addToSection(fields,
+			if err := addToSection(
+				fields,
 				func(fields SegmentMatcherFields) []string { return fields.Output },
 				func(fields SegmentQuery) string { return fields.Output },
 			); err != nil {
@@ -275,7 +278,7 @@ type SegmentMatcherFields struct {
 	Sites  sitesmatrix.Sites // Note that we only use Sites.Matrix for now.
 }
 
-func getGlob(s string) (glob.Glob, error) {
+func getGlob(s string) (hstrings.Matcher, error) {
 	if s == "" {
 		return nil, nil
 	}

--- a/modules/client.go
+++ b/modules/client.go
@@ -33,13 +33,12 @@ import (
 	"github.com/gohugoio/hugo/common/hashing"
 	"github.com/gohugoio/hugo/common/herrors"
 	"github.com/gohugoio/hugo/common/hexec"
+	"github.com/gohugoio/hugo/common/hstrings"
 	"github.com/gohugoio/hugo/common/hugio"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/config"
 
 	hglob "github.com/gohugoio/hugo/hugofs/hglob"
-
-	"github.com/gobwas/glob"
 
 	"github.com/gohugoio/hugo/hugofs"
 
@@ -88,7 +87,7 @@ func NewClient(cfg ClientConfig) *Client {
 		logger = loggers.NewDefault()
 	}
 
-	var noVendor glob.Glob
+	var noVendor hstrings.Matcher
 	if cfg.ModuleConfig.NoVendor != "" {
 		noVendor, _ = hglob.GetGlob(hglob.NormalizePath(cfg.ModuleConfig.NoVendor))
 	}
@@ -109,7 +108,7 @@ type Client struct {
 	fs     afero.Fs
 	logger loggers.Logger
 
-	noVendor glob.Glob
+	noVendor hstrings.Matcher
 
 	ccfg ClientConfig
 
@@ -405,7 +404,7 @@ func (c *Client) Clean(pattern string) error {
 		return err
 	}
 
-	var g glob.Glob
+	var g hstrings.Matcher
 
 	if pattern != "" {
 		var err error
@@ -903,7 +902,7 @@ type ClientConfig struct {
 
 	// Ignore any _vendor directory for module paths matching the given pattern.
 	// This can be nil.
-	IgnoreVendor glob.Glob
+	IgnoreVendor hstrings.Matcher
 
 	// Ignore any module not found errors.
 	IgnoreModuleDoesNotExist bool

--- a/resources/page/page_matcher.go
+++ b/resources/page/page_matcher.go
@@ -20,7 +20,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/gobwas/glob"
 	"github.com/gohugoio/hugo/common/hashing"
 	"github.com/gohugoio/hugo/common/hmaps"
 	"github.com/gohugoio/hugo/common/hstrings"
@@ -59,9 +58,9 @@ type PageMatcher struct {
 	// Compiled values.
 	// The site vectors to apply this to.
 	SitesMatrixCompiled sitesmatrix.VectorProvider `mapstructure:"-"`
-	kindGlob            glob.Glob
-	pathGlob            glob.Glob
-	environmentGlob     glob.Glob
+	kindGlob            hstrings.Matcher
+	pathGlob            hstrings.Matcher
+	environmentGlob     hstrings.Matcher
 }
 
 // Equal compares the configured fields; compiled state is ignored.


### PR DESCRIPTION
Note that there may be some subtle and potentially breaking changes here (no tests broke, which is a good sign, I guess). I would say that looking at some examples, `v1.0.0` is the more correct and sensible one. `v0.2.3` had some odd matches, e.g. `a/**/b` matched `a/b`. In v1.0.0 it requires at least one directory between them, so `a/b` no longer matches while `a/x/b` still does. With this example, the v1 behaviour is obviously more useful (and also more correct as I understand it). One can still get the old behaviour with something like `a/{**/,}/b`.

/cc @jmooring 

See https://github.com/gobwas/glob#syntax
See https://github.com/gobwas/glob/pull/73

Close #15273
