### PR TITLE
tpl/strings: Add strings.RemoveNonPrintableCharacters

### DIFF
--- a/tpl/strings/strings.go
+++ b/tpl/strings/strings.go
@@ -257,6 +257,34 @@ func (ns *Namespace) Replace(s, old, new any, limit ...any) (string, error) {
 	return strings.Replace(ss, so, sn, lim), nil
 }
 
+// RemoveNonPrintableCharacters removes non-printable characters from s.
+// Whitespace, including tabs and newlines, is replaced with a single space,
+// and runs of whitespace are collapsed. Other non-printable characters,
+// such as soft hyphens and zero-width spaces, are removed.
+func (ns *Namespace) RemoveNonPrintableCharacters(s any) (string, error) {
+	ss, err := cast.ToStringE(s)
+	if err != nil {
+		return "", err
+	}
+
+	var space bool
+	return strings.Map(func(r rune) rune {
+		switch {
+		case unicode.IsSpace(r):
+			if space {
+				return -1
+			}
+			space = true
+			return ' '
+		case unicode.IsPrint(r):
+			space = false
+			return r
+		default:
+			return -1
+		}
+	}, ss), nil
+}
+
 // ReplacePairs returns a copy of a string with multiple replacements performed
 // in a single pass. The last argument is the source string. Preceding arguments
 // are old/new string pairs, either as a slice or as individual arguments.

--- a/tpl/strings/strings_test.go
+++ b/tpl/strings/strings_test.go
@@ -967,3 +967,36 @@ func TestTrimSpace(t *testing.T) {
 		c.Assert(result, qt.Equals, test.expect)
 	}
 }
+
+func TestRemoveNonPrintableCharacters(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	for _, test := range []struct {
+		s      any
+		expect any
+	}{
+		{"\n\r test \n\r", " test "},
+		{"foo\tbar", "foo bar"},
+		{"foo\r\n\n\tbar", "foo bar"},
+		{"foo\u00a0\u2003bar", "foo bar"},
+		{"foo\u00adbar\u200bbaz\ufeff", "foobarbaz"},
+		{"foo \u00ad bar", "foo bar"},
+		{"caf\u0065\u0301 \U0001f44b\U0001f3fb", "caf\u0065\u0301 \U0001f44b\U0001f3fb"},
+		{template.HTML("\n\r test \n\r"), " test "},
+		{[]byte("\n\r test \n\r"), " test "},
+		// errors
+		{tstNoStringer{}, false},
+	} {
+
+		result, err := ns.RemoveNonPrintableCharacters(test.s)
+
+		if b, ok := test.expect.(bool); ok && !b {
+			c.Assert(err, qt.Not(qt.IsNil))
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(result, qt.Equals, test.expect)
+	}
+}


### PR DESCRIPTION
Whitespace, including tabs and newlines, is replaced with a single space and runs are collapsed. Other non-printable characters, e.g. soft hyphens and zero-width spaces, are removed.

Closes #11255

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
