### PR TITLE
Fix: prevent render as <pre> code block

### DIFF
--- a/tpl/tplimpl/embedded/templates/_shortcodes/vimeo.html
+++ b/tpl/tplimpl/embedded/templates/_shortcodes/vimeo.html
@@ -43,7 +43,7 @@ title, then loading.
 		{{- $iframeStyle := "position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" }}
 
 		{{- with $id }}
-			{{- $src := printf "https://player.vimeo.com/video/%v?dnt=%v" . $dnt }}
+			{{- $src := printf "https://player.vimeo.com/video/%v?dnt=%v" . $dnt -}}
 			<div
 				{{- with $class }}
 					class="{{ . }}"


### PR DESCRIPTION
Shortcode is broken as code indentation leads to a render as codeblock.