### PR TITLE
markup/pandoc: Use non-deprecated math method option

### DIFF
--- a/docs/content/en/content-management/formats.md
+++ b/docs/content/en/content-management/formats.md
@@ -83,7 +83,7 @@ Create your content in the [Pandoc][] format preceded by front matter. Hugo rend
 Hugo passes these CLI flags when calling the Pandoc executable:
 
 ```sh
---mathjax
+--math-method=mathjax
 ```
 
 ### reStructuredText

--- a/markup/pandoc/convert.go
+++ b/markup/pandoc/convert.go
@@ -62,7 +62,7 @@ func (c *pandocConverter) getPandocContent(src []byte, ctx converter.DocumentCon
 	if binaryName == "" {
 		return nil, fmt.Errorf("pandoc not found in $PATH, cannot render %q", ctx.DocumentName)
 	}
-	args := []string{"--mathjax", "--citeproc"}
+	args := []string{"--math-method=mathjax", "--citeproc"}
 	return internal.ExternallyRenderContent(c.cfg, ctx, src, binaryName, args)
 }
 


### PR DESCRIPTION
Fixes #15271

Replace Pandoc's deprecated `--mathjax` flag with `--math-method=mathjax` and update the Pandoc format documentation. This removes the deprecation warning on current Pandoc releases while preserving MathJax output.

Tests: `go test ./markup/pandoc -count=1`

AI assistance: this PR was prepared with substantial assistance from Codex; the changes and test results were manually reviewed.