### PR TITLE
Add internalExternal.IgnoreTailwindCSSSecurityError config option

### DIFF
--- a/config/allconfig/allconfig.go
+++ b/config/allconfig/allconfig.go
@@ -74,6 +74,13 @@ type InternalConfig struct {
 	LiveReloadPort int
 }
 
+// InternalExternalConfig is read from the internalExternal config section in the project config file.
+// It's meant for internal use and is not documented. These settings can be changed at any time and may be removed without notice.
+type InternalExternalConfig struct {
+	// Used by the Hugo theme site's check command to allow us to build TailwindCSS sites with default security config without errors.
+	IgnoreTailwindCSSSecurityError bool
+}
+
 // All non-params config keys for language.
 var configLanguageKeys map[string]bool
 
@@ -102,6 +109,8 @@ func init() {
 type Config struct {
 	// For internal use only.
 	Internal InternalConfig `mapstructure:"-" json:"-"`
+	// For internal use only.
+	InternalExternal InternalExternalConfig `mapstructure:"-" json:"-"`
 	// For internal use only.
 	C               *ConfigCompiled `mapstructure:"-" json:"-"`
 	isLanguageClone bool

--- a/config/allconfig/alldecoders.go
+++ b/config/allconfig/alldecoders.go
@@ -494,6 +494,13 @@ var allDecoderSetups = map[string]decodeWeight{
 		},
 		internalOrDeprecated: true,
 	},
+	"internalexternal": {
+		key: "internalexternal",
+		decode: func(d decodeWeight, p decodeConfig) error {
+			return mapstructure.WeakDecode(p.p.GetStringMap(d.key), &p.c.InternalExternal)
+		},
+		internalOrDeprecated: true,
+	},
 }
 
 func init() {

--- a/config/allconfig/configlanguage.go
+++ b/config/allconfig/configlanguage.go
@@ -91,6 +91,10 @@ func (c ConfigLanguage) FastRenderMode() bool {
 	return c.config.Internal.FastRenderMode
 }
 
+func (c ConfigLanguage) IgnoreTailwindCSSSecurityError() bool {
+	return c.config.InternalExternal.IgnoreTailwindCSSSecurityError
+}
+
 func (c ConfigLanguage) IsMultilingual() bool {
 	return len(c.m.Languages) > 1
 }

--- a/config/configProvider.go
+++ b/config/configProvider.go
@@ -68,6 +68,7 @@ type AllProvider interface {
 	FastRenderMode() bool
 	PrintUnusedTemplates() bool
 	EnableMissingTranslationPlaceholders() bool
+	IgnoreTailwindCSSSecurityError() bool
 	TemplateMetrics() bool
 	TemplateMetricsHints() bool
 	PrintI18nWarnings() bool

--- a/resources/resource_transformers/cssjs/tailwindcss.go
+++ b/resources/resource_transformers/cssjs/tailwindcss.go
@@ -15,6 +15,7 @@ package cssjs
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"regexp"
 	"strings"
@@ -23,6 +24,7 @@ import (
 	"github.com/gohugoio/hugo/common/hexec"
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
+	"github.com/gohugoio/hugo/config/security"
 	"github.com/gohugoio/hugo/resources"
 	"github.com/gohugoio/hugo/resources/internal"
 	"github.com/gohugoio/hugo/resources/resource"
@@ -113,6 +115,17 @@ func (t *tailwindcssTransformation) Transform(ctx *resources.ResourceTransformat
 			// This may be on a CI server etc. Will fall back to pre-built assets.
 			return &herrors.FeatureNotAvailableError{Cause: err}
 		}
+
+		var accessDeniedErr *security.AccessDeniedError
+		if errors.As(err, &accessDeniedErr) {
+			if t.rs.Cfg.IgnoreTailwindCSSSecurityError() {
+				// This construct is here so the Hugo theme checker can build TailwindCSS sites with default security config without errors.
+				// Add some dummy CSS to the output so we can continue the build.
+				ctx.To.Write([]byte(".tailwindcss-security-error-ignored { display: none; }"))
+				return nil
+			}
+		}
+
 		return err
 	}
 

--- a/resources/resource_transformers/cssjs/tailwindcss_integration_test.go
+++ b/resources/resource_transformers/cssjs/tailwindcss_integration_test.go
@@ -99,7 +99,8 @@ CSS: {{ $css.Content | safeCSS }}|
 	b := hugolib.Test(t, files, hugolib.TestOptOsFs(), hugolib.TestOptWithNpmInstall(), hugolib.TestOptInfo())
 
 	// foo.css resolves in the import context before the assets filesystem.
-	b.AssertFileContent("public/index.html",
+	b.AssertFileContent(
+		"public/index.html",
 		".foo {\n    color: blue;\n  }",
 		".bar {\n    color: green;\n  }",
 	)
@@ -162,4 +163,51 @@ target = 'assets/css'
 	b.Assert(err, qt.IsNotNil)
 	b.Assert(err.Error(), qt.Contains, "Can't resolve 'colors/red.css'")
 	b.Assert(err.Error(), qt.Contains, "You may want to set the 'disableInlineImports' option to false")
+}
+
+// This tests an internal feature used in the Hugo themes sites building to allow us to build with
+// default security policy and still get a partial build even for themes using TailwindCSS.
+func TestTailwindCSSIgnoreSecError(t *testing.T) {
+	if !htesting.IsCI() {
+		t.Skip("Skip long running test when running locally")
+	}
+
+	files := `
+-- hugo.toml --
+[internalExternal]
+ignoreTailwindCSSSecurityError = true
+-- package.json --
+{
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bep/hugo-starter-tailwind-basic.git"
+  },
+  "devDependencies": {
+    "@tailwindcss/cli": "^4.0.1",
+    "tailwindcss": "^4.0.1"
+  },
+  "name": "hugo-starter-tailwind-basic",
+  "version": "0.1.0"
+}
+-- assets/css/styles.css --
+@import "tailwindcss";
+
+@theme {
+  --font-family-display: "Satoshi", "sans-serif";
+
+  --breakpoint-3xl: 1920px;
+
+  --color-neon-pink: oklch(71.7% 0.25 360);
+  --color-neon-lime: oklch(91.5% 0.258 129);
+  --color-neon-cyan: oklch(91.3% 0.139 195.8);
+}
+-- layouts/home.html --
+{{ $css := resources.Get "css/styles.css" | css.TailwindCSS }}
+CSS: {{ $css.Content | safeCSS }}|
+`
+
+	b := hugolib.Test(t, files, hugolib.TestOptOsFs(), hugolib.TestOptWithNpmInstall(), hugolib.TestOptInfo())
+
+	b.AssertFileContent("public/index.html", ".tailwindcss-security-error-ignored")
 }


### PR DESCRIPTION
This is marked internal, so it is not documented, but it is used in the Hugo themes sites building to allow us to build with default security policy and still get a partial build even for themes using TailwindCSS.
