### PR TITLE
tpl/partials: Slight performance improvement of the common partialCached case

### DIFF
--- a/tpl/partials/partials.go
+++ b/tpl/partials/partials.go
@@ -77,7 +77,8 @@ func New(deps *deps.Deps) *Namespace {
 		func(...any) bool {
 			cache.clear()
 			return false
-		})
+		},
+	)
 
 	return &Namespace{
 		deps:           deps,
@@ -180,11 +181,14 @@ func (ns *Namespace) doInclude(ctx context.Context, key string, templ *tplimpl.T
 // Note that ctx is provided by Hugo, not the end user.
 func (ns *Namespace) IncludeCached(ctx context.Context, name string, context any, variants ...any) (any, error) {
 	start := time.Now()
-	key := partialCacheKey{
-		Name:     name,
-		Variants: variants,
+	keyString := name
+	if len(variants) > 0 {
+		key := partialCacheKey{
+			Name:     name,
+			Variants: variants,
+		}
+		keyString = key.Key()
 	}
-	keyString := key.Key()
 
 	depsManagerIn := tpl.Context.GetDependencyManagerInCurrentScope(ctx)
 	ti, err := ns.lookup(name)

--- a/tpl/partials/partials_integration_test.go
+++ b/tpl/partials/partials_integration_test.go
@@ -15,7 +15,7 @@ package partials_test
 
 import (
 	"bytes"
-	"fmt"
+	"context"
 	"regexp"
 	"sort"
 	"strings"
@@ -26,6 +26,7 @@ import (
 	"github.com/gohugoio/hugo/htesting"
 	"github.com/gohugoio/hugo/htesting/hqt"
 	"github.com/gohugoio/hugo/hugolib"
+	"github.com/gohugoio/hugo/tpl/partials"
 )
 
 func TestInclude(t *testing.T) {
@@ -215,37 +216,35 @@ baseURL = 'http://example.com/'
 {{ partialCached "easy1.html" "bar" }}
 {{ partialCached "easy1.html" "baz" }}
 {{ partialCached "easy2.html" "baz" }}
--- layouts/_partials/easy1.html --
+-- layouts/_partials/abc.html --
 ABCD
--- layouts/_partials/easy2.html --
-ABCDE
--- layouts/_partials/heavy.html --
-{{ $result := slice }}
-{{ range site.RegularPages }}
-{{ $result = $result | append (dict "title" .Title "link" .RelPermalink "readingTime" .ReadingTime) }}
-{{ end }}
-{{ range $result }}
-* {{ .title }} {{ .link }} {{ .readingTime }}
-{{ end }}
+-- layouts/_partials/42.html --
+{{ return 42 }}
+
 
 
 `)
 
-	for i := 1; i < 100; i++ {
-		files.WriteString(fmt.Sprintf("\n-- content/p%d.md --\n---\ntitle: page\n---\n"+strings.Repeat("FOO ", i), i))
-	}
+	bb := hugolib.Test(b, files.String())
+	ns := bb.H.TemplateStore.GetTemplateFuncsNamespace("partials").(*partials.Namespace)
 
-	cfg := hugolib.IntegrationTestConfig{
-		T:           b,
-		TxtarString: files.String(),
-	}
+	b.Run("abc", func(b *testing.B) {
+		for b.Loop() {
+			_, _ = ns.IncludeCached(context.Background(), "abc.html", "foo")
+		}
+	})
 
-	for b.Loop() {
-		b.StopTimer()
-		bb := hugolib.NewIntegrationTestBuilder(cfg)
-		b.StartTimer()
-		bb.Build()
-	}
+	b.Run("variant", func(b *testing.B) {
+		for b.Loop() {
+			_, _ = ns.IncludeCached(context.Background(), "abc.html", "foo", "variant")
+		}
+	})
+
+	b.Run("return", func(b *testing.B) {
+		for b.Loop() {
+			_, _ = ns.IncludeCached(context.Background(), "42.html", "foo")
+		}
+	})
 }
 
 func TestIncludeTimeout(t *testing.T) {


### PR DESCRIPTION
```
                    │ stash.bench │  feat-perfpartialcachekey.bench   │
                         │   sec/op    │   sec/op     vs base              │
IncludeCached/abc-10       94.41n ± 0%   92.89n ± 0%  -1.62% (p=0.000 n=8)
IncludeCached/variant-10   321.5n ± 0%   323.3n ± 1%  +0.56% (p=0.003 n=8)
IncludeCached/return-10    94.63n ± 0%   93.18n ± 0%  -1.53% (p=0.007 n=8)
geomean                    142.1n        140.9n       -0.87%

                         │ stash.bench  │   feat-perfpartialcachekey.bench   │
                         │     B/op     │    B/op     vs base                │
IncludeCached/abc-10       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=8) ¹
IncludeCached/variant-10   168.0 ± 0%     168.0 ± 0%       ~ (p=1.000 n=8) ¹
IncludeCached/return-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=8) ¹
geomean                               ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                         │ stash.bench  │   feat-perfpartialcachekey.bench   │
                         │  allocs/op   │ allocs/op   vs base                │
IncludeCached/abc-10       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=8) ¹
IncludeCached/variant-10   8.000 ± 0%     8.000 ± 0%       ~ (p=1.000 n=8) ¹
IncludeCached/return-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=8) ¹
geomean                               ²               +0.00%
```
