### PR TITLE
resources/page: Preserve alternate output suffixes for explicit URLs

### DIFF
--- a/hugolib/page__paths.go
+++ b/hugolib/page__paths.go
@@ -48,6 +48,7 @@ func newPagePaths(ps *pageState) (pagePaths, error) {
 		}
 	}
 
+	targetPathDescriptor.PrimaryMediaType = outputFormats[0].MediaType.Type
 	pageOutputFormats := make(page.OutputFormats, len(outputFormats))
 	targets := make(map[string]targetPathsHolder)
 

--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -14,8 +14,55 @@
 package hugolib
 
 import (
+	"strings"
 	"testing"
 )
+
+// See issue 10393.
+func TestRSSWithExplicitSectionURL(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = 'https://example.org/'
+disableKinds = ['home', 'sitemap', 'taxonomy', 'term']
+CONFIG
+[outputs]
+section = ['HTML', 'RSS', 'JSON']
+-- content/posts/_index.md --
++++
+title = 'Posts'
+url = 'FRONTMATTER_URL'
++++
+-- layouts/list.html --
+HTML: {{ .Title }}
+{{ range .OutputFormats }}{{ .Name }}: {{ .RelPermalink }}|{{ end }}
+-- layouts/list.rss.xml --
+<rss>{{ .Title }}</rss>
+-- layouts/list.json.json --
+{"title": "{{ .Title }}"}
+`
+	for _, test := range []struct {
+		name   string
+		config string
+		url    string
+		prefix string
+		suffix string
+	}{
+		{"html", "", "/posts/custom.html", "", ".html"},
+		{"custom suffix", "", "/posts/custom.php", "", ".php"},
+		{"language prefix with ugly URLs", "uglyURLs = true\ndefaultContentLanguageInSubdir = true", "posts/custom.php", "en/", ".php"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			b := Test(t, strings.NewReplacer("CONFIG", test.config, "FRONTMATTER_URL", test.url).Replace(files))
+			base := test.prefix + "posts/custom"
+			b.AssertFileContent("public/"+base+test.suffix,
+				"HTML: Posts", "html: /"+base+test.suffix+"|", "rss: /"+base+".xml|", "json: /"+base+".json|")
+			b.AssertFileContent("public/"+base+".xml", "<rss>Posts</rss>")
+			b.AssertFileContent("public/"+base+".json", `{"title": "Posts"}`)
+		})
+	}
+}
 
 // Before Hugo 0.49 we set the pseudo page kind RSS on the page when output to RSS.
 // This had some unintended side effects, esp. when the only output format for that page

--- a/resources/page/page_paths.go
+++ b/resources/page/page_paths.go
@@ -42,6 +42,9 @@ type TargetPathDescriptor struct {
 	Type output.Format
 	Kind string
 
+	// The media type of the page's first output format.
+	PrimaryMediaType string
+
 	Path    *paths.Path
 	Section *paths.Path
 
@@ -136,6 +139,12 @@ func CreateTargetPaths(d TargetPathDescriptor) (tp TargetPaths) {
 	if d.Type.Root && !d.ForcePrefix {
 		d.PrefixFilePath = ""
 		d.PrefixLink = ""
+	}
+
+	if d.Kind != kinds.KindHome && d.PrimaryMediaType != "" && d.PrimaryMediaType != d.Type.MediaType.Type {
+		if ext := paths.Ext(d.URL); ext != "" {
+			d.URL = strings.TrimSuffix(d.URL, ext) + d.Type.MediaType.FirstSuffix.FullSuffix
+		}
 	}
 
 	pb := getPagePathBuilder(d)

--- a/resources/page/page_paths_test.go
+++ b/resources/page/page_paths_test.go
@@ -14,7 +14,13 @@
 package page
 
 import (
+	"path/filepath"
 	"testing"
+
+	"github.com/gohugoio/hugo/common/paths"
+	"github.com/gohugoio/hugo/hugofs/files"
+	"github.com/gohugoio/hugo/output"
+	"github.com/gohugoio/hugo/resources/kinds"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -28,6 +34,53 @@ func TestPagePathsBuilder(t *testing.T) {
 	b.Add("foo", "bar")
 
 	c.Assert(b.Path(0), qt.Equals, "/foo/bar")
+}
+
+// See issue 10393.
+func TestTargetPathsExplicitURLWithOutputFormats(t *testing.T) {
+	t.Parallel()
+
+	pp := &paths.PathParser{IsContentExt: func(ext string) bool { return ext == "md" }}
+	p := pp.Parse(files.ComponentFolderContent, "/posts/_index.md")
+	json := output.JSONFormat
+	json.Name = "custom"
+	json.Path = "api"
+	json.BaseName = "data"
+
+	for _, test := range []struct {
+		name             string
+		format           output.Format
+		primaryMediaType string
+		url              string
+		ugly             bool
+		want             string
+	}{
+		{"html", output.HTMLFormat, output.HTMLFormat.MediaType.Type, "/posts/test.html", false, "/posts/test.html"},
+		{"rss", output.RSSFormat, output.HTMLFormat.MediaType.Type, "/posts/test.html", false, "/posts/test.xml"},
+		{"rss ugly", output.RSSFormat, output.HTMLFormat.MediaType.Type, "/posts/test.html", true, "/posts/test.xml"},
+		{"html arbitrary suffix", output.HTMLFormat, output.HTMLFormat.MediaType.Type, "/posts/test.php", false, "/posts/test.php"},
+		{"rss arbitrary suffix", output.RSSFormat, output.HTMLFormat.MediaType.Type, "/posts/test.php", false, "/posts/test.xml"},
+		{"custom alternate", json, output.HTMLFormat.MediaType.Type, "/posts/test.php", false, "/api/posts/test.json"},
+		{"same media type", output.AMPFormat, output.HTMLFormat.MediaType.Type, "/posts/test.php", false, "/amp/posts/test.php"},
+		{"rss primary", output.RSSFormat, output.RSSFormat.MediaType.Type, "/posts/test.feed", false, "/posts/test.feed"},
+		{"custom primary", json, json.MediaType.Type, "/posts/test.data", false, "/api/posts/test.data"},
+		{"no primary media type", output.RSSFormat, "", "/posts/test.feed", false, "/posts/test.feed"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			tp := CreateTargetPaths(TargetPathDescriptor{
+				Type:             test.format,
+				PrimaryMediaType: test.primaryMediaType,
+				Kind:             kinds.KindSection,
+				Path:             p,
+				Section:          p,
+				URL:              test.url,
+				UglyURLs:         test.ugly,
+			})
+			c.Assert(filepath.ToSlash(tp.TargetFilename), qt.Equals, test.want)
+			c.Assert(tp.Link, qt.Equals, test.want)
+		})
+	}
 }
 
 func BenchmarkPagePathsBuilderPath(b *testing.B) {


### PR DESCRIPTION
An explicit section URL such as `/posts/custom.html` makes HTML and RSS target the same file, allowing RSS to overwrite the rendered HTML.

Use each alternate media type's suffix while preserving the first output's explicit filename. This also retains arbitrary primary suffixes such as `.php`, same-media outputs such as AMP, and existing output-format and language path prefixes.

Fixes #10393.

Validation on Windows with Go 1.27.0 and Ubuntu with Go 1.27.1:

- Reproduced the overwritten HTML content before the fix.
- Passed ten target-path cases and three integration cases checking HTML/RSS/JSON content and links, including a relative URL with a language prefix and `uglyURLs`.
- Passed existing paginator, JSON pagination and multilingual alias tests.
- Passed `go test -failfast ./resources/page ./hugolib` on Windows.
- Repository-wide gofmt and staticcheck (0.8.1) passed on both platforms.
- The unmodified `./check.sh` test step fails on both platforms in `TestCommands/mod`: module collection taking over 500 ms prints progress to stderr, while the test expects empty stderr. The same assertion failed with all four changed files replaced by byte-verified base-commit blobs through Go overlay. All remaining default Go tests passed on Ubuntu with only this exact subtest excluded: `go test -failfast -skip '^TestCommands$/^mod$' ./...`. Git Bash also lacks `bc` for the script's timing.

The integration reproduction is adapted from jmooring's issue example; the commit credits Joe Mooring. OpenAI Codex was used for investigation, implementation, tests, code review and this description.
