### PR TITLE
create: Print new content path

### DIFF
--- a/create/content.go
+++ b/create/content.go
@@ -252,7 +252,7 @@ func (b *contentBuilder) buildFile() (string, error) {
 		return "", err
 	}
 
-	b.h.Log.Printf("Content %q created", contentPlaceholderAbsFilename)
+	b.h.Log.Printf("%s", contentPlaceholderAbsFilename)
 
 	return contentPlaceholderAbsFilename, nil
 }

--- a/create/content_test.go
+++ b/create/content_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bep/logg"
+	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/config"
 	"github.com/gohugoio/hugo/config/allconfig"
 	"github.com/gohugoio/hugo/config/testconfig"
@@ -35,6 +37,27 @@ import (
 	"github.com/gohugoio/hugo/helpers"
 	"github.com/spf13/afero"
 )
+
+func TestNewContentLog(t *testing.T) {
+	c := qt.New(t)
+
+	mm := afero.NewMemMapFs()
+	c.Assert(initFs(mm), qt.IsNil)
+	cfg, fs := newTestCfg(c, mm)
+	conf := testconfig.GetTestConfigs(fs.Source, cfg)
+
+	var logOutput strings.Builder
+	logger := loggers.New(loggers.Options{
+		Level:  logg.LevelInfo,
+		StdOut: &logOutput,
+		StdErr: &logOutput,
+	})
+	h, err := hugolib.NewHugoSites(deps.DepsCfg{Configs: conf, Fs: fs, TestLogger: logger})
+	c.Assert(err, qt.IsNil)
+	c.Assert(create.NewContent(h, "", "post/my-post.md", false), qt.IsNil)
+	c.Assert(logOutput.String(), qt.Contains, filepath.Join("content", "post", "my-post.md"))
+	c.Assert(logOutput.String(), qt.Not(qt.Contains), "Content")
+}
 
 // TODO(bep) clean this up. Export the test site builder in Hugolib or something.
 func TestNewContentFromFile(t *testing.T) {


### PR DESCRIPTION
Fixes #15233.

`hugo new` now prints the created content path without the surrounding label and quotes, so the output can be passed directly to another command, for example `vim -- $(hugo new foo/bar.md)`.

Added a regression test covering the log output.

AI assistance disclosure: This PR was prepared primarily with AI assistance; the change was manually reviewed and the focused Hugo checks passed.