### PR TITLE
hugofs: Drop symlinked mount roots

### DIFF
--- a/hugofs/nosymlinks_fs.go
+++ b/hugofs/nosymlinks_fs.go
@@ -46,6 +46,26 @@ func hasSymlinkParent(fs afero.Fs, base, name string) (bool, error) {
 	return false, nil
 }
 
+// isSymlinkOrHasSymlinkParent reports whether name is a symlink or has a symlinked parent below base.
+// Parents are only checked when base is set; absolute mount sources may legitimately
+// live below symlinked directories (e.g. /tmp on macOS).
+func isSymlinkOrHasSymlinkParent(fs afero.Fs, base, name string) (bool, error) {
+	fi, err := LstatIfPossible(fs, name)
+	if err != nil {
+		if herrors.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return true, nil
+	}
+	if base == "" {
+		return false, nil
+	}
+	return hasSymlinkParent(fs, filepath.Clean(base), name)
+}
+
 // NewDropSymlinksFs returns an afero.Fs wrapper that treats symlinks as non-existing files.
 func NewDropSymlinksFs(base afero.Fs) *DropSymlinksFs {
 	return &DropSymlinksFs{base}

--- a/hugofs/rootmapping_fs.go
+++ b/hugofs/rootmapping_fs.go
@@ -61,6 +61,16 @@ func NewRootMappingFs(fs afero.Fs, rms ...*RootMapping) (*RootMappingFs, error) 
 			panic(fmt.Sprintf("invalid root mapping; from/to: %s/%s", rm.From, rm.To))
 		}
 
+		// Don't allow a symlinked mount root (or any directory between it and
+		// the module root) to escape the module.
+		symlink, err := isSymlinkOrHasSymlinkParent(fs, rm.ToBase, rm.To)
+		if err != nil {
+			return nil, err
+		}
+		if symlink {
+			continue
+		}
+
 		fi, err := fs.Stat(rm.To)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/testscripts/commands/no_symlinks.txt
+++ b/testscripts/commands/no_symlinks.txt
@@ -4,6 +4,9 @@ ln ./rootfile.txt ./themes/mytheme/assets/modassetsymlink.txt
 ln ./rootfile.txt ./themes/mytheme/static/modstaticsymlink.txt
 ln ./README.md ./content/pagesymlink.md
 ln ./rootdir ./assets/myassets/symlinkdir
+ln ./rootdir ./projectmountroot
+ln ./rootdir ./themes/mytheme/thememountroot
+ln ./rootdir ./themes/mytheme/thememountparent
 
 hugo
 
@@ -24,6 +27,25 @@ stdout pageok
 disableKinds = ["taxonomy", "term", "rss"]
 [[module.imports]]
 path = 'mytheme'
+[[module.mounts]]
+source = 'assets'
+target = 'assets'
+[[module.mounts]]
+source = 'projectmountroot'
+target = 'assets/projectmountroot'
+-- themes/mytheme/hugo.toml --
+[[module.mounts]]
+source = 'assets'
+target = 'assets'
+[[module.mounts]]
+source = 'static'
+target = 'static'
+[[module.mounts]]
+source = 'thememountroot'
+target = 'assets/thememountroot'
+[[module.mounts]]
+source = 'thememountparent/subdir'
+target = 'assets/thememountparent'
 -- README.md --
 Read me.
 -- layouts/all.html --
@@ -32,6 +54,10 @@ Read me.
 {{ with resources.GetMatch "modassetsymlink.txt"}}FAIL {{ .Publish }}{{ else }}OK{{ end }}
 {{ with resources.GetMatch "myassets/symlinkdir/**"}}FAIL {{ .Publish }}{{ else }}OK{{ end }}
 {{ with resources.Get "myassets/symlinkdir/rootdirfile1.txt"}}FAIL {{ .Publish }}{{ else }}OK{{ end }}
+{{ with resources.Get "projectmountroot/rootdirfile1.txt"}}FAIL {{ .Publish }}{{ else }}OK{{ end }}
+{{ with resources.Get "thememountroot/rootdirfile1.txt"}}FAIL {{ .Publish }}{{ else }}OK{{ end }}
+{{ with resources.Get "thememountparent/rootdirfile3.txt"}}FAIL {{ .Publish }}{{ else }}OK{{ end }}
+{{ with resources.GetMatch "*mountroot/**"}}FAIL {{ .Publish }}{{ else }}OK{{ end }}
 Page: {{ .RelPermalink }}|{{ .Content }}|
 
 {{/* os template package. */}}


### PR DESCRIPTION
The symlink checks stopped at the mount root, so a mount root that was itself
a symlink (e.g. themes/mytheme/assets -> /somewhere/else) was followed. This
closes that gap in the themes/ confinement, which is the primary motivation.

For simplicity this applies to project mounts as well; one motivation behind
Hugo's mount setup was to remove the need for symlinks, and absolute mount
sources are still allowed there.

Thanks to @DONG2209 for finding and reporting this issue.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
