### PR TITLE
markup/highlight: Escape lineAnchors before passing it to Chroma

### DIFF
--- a/markup/goldmark/codeblocks/codeblocks_integration_test.go
+++ b/markup/goldmark/codeblocks/codeblocks_integration_test.go
@@ -472,3 +472,31 @@ echo "hello";
 		"&quot; onmouseover=&quot;alert(1)",
 	)
 }
+
+// The lineAnchors value from a code-fence attribute is written by Chroma
+// verbatim into id and href attributes, so it must be escaped before it gets there.
+func TestCodeblockLineAnchorsEscape(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+-- layouts/single.html --
+{{ .Content }}
+-- content/p1.md --
+---
+title: "p1"
+---
+
+§§§go {lineNos=true anchorLineNos=true lineAnchors="z\"><script>alert(1)</script>"}
+func main() {}
+§§§
+`
+
+	b := hugolib.Test(t, files)
+
+	b.AssertFileContent("public/p1/index.html",
+		"! <script>",
+		`id="z&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;-1"`,
+		`href="#z&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;-1"`,
+	)
+}

--- a/markup/highlight/config.go
+++ b/markup/highlight/config.go
@@ -16,6 +16,7 @@ package highlight
 
 import (
 	"fmt"
+	gohtml "html"
 	"strconv"
 	"strings"
 
@@ -95,7 +96,8 @@ func (cfg Config) toHTMLOptions() ([]html.Option, error) {
 	)
 
 	if cfg.LineAnchors != "" {
-		lineAnchors = cfg.LineAnchors + "-"
+		// Chroma writes this verbatim into id and href attributes.
+		lineAnchors = gohtml.EscapeString(cfg.LineAnchors) + "-"
 	}
 
 	switch v := cfg.LineNos.(type) {


### PR DESCRIPTION
Chroma writes the line anchor prefix verbatim into the id and href
attributes it generates, so a lineAnchors value from a code-fence
attribute could inject markup into the rendered page.

Thanks to @DONG2209 for reporting this issue.

Co-Authored-By: Nguyễn Quốc Đồng <126535119+DONG2209@users.noreply.github.com>
Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
