### PR TITLE
config/security: Add http.proxyFromEnvironment and document the resolved address check

### DIFF
--- a/config/security/securityConfig.go
+++ b/config/security/securityConfig.go
@@ -128,6 +128,12 @@ type HTTP struct {
 	// URLs to allow in remote HTTP (resources.Get, getJSON, getCSV).
 	URLs Whitelist `json:"urls"`
 
+	// Whether to honor the HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment
+	// variables for remote HTTP. Off by default, as a proxy hides the
+	// resolved destination address from the security policy.
+	// <docsmeta>{ "newIn": "0.166.0" }</docsmeta>
+	ProxyFromEnvironment bool `json:"proxyFromEnvironment"`
+
 	// HTTP methods to allow.
 	Methods Whitelist `json:"methods"`
 

--- a/config/security/securityConfig_test.go
+++ b/config/security/securityConfig_test.go
@@ -135,7 +135,7 @@ func TestToTOML(t *testing.T) {
 	got := DefaultConfig.ToTOML()
 
 	c.Assert(got, qt.Equals,
-		"[security]\n  allowContent = ['! ^text/html$', '! ^text/org$']\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^(dart-)?sass$', '^go$', '^git$', '^node$', '^postcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\\w+|(XDG_CONFIG_)?HOME|USERPROFILE|SSH_AUTH_SOCK|DISPLAY|LANG|SYSTEMDRIVE|PROGRAMDATA)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_', '^CI$']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['(?i)^https?://[a-z0-9]', '! (?i)^https?://\\d+\\.', '! (?i)localhost', '! (?i)^https?://[^/?#]*@']\n\n  [security.node]\n    [security.node.permissions]\n      allowAddons = ['tailwindcss']\n      allowChildProcess = ['tailwindcss']\n      allowRead = ['.']\n      allowWorker = ['tailwindcss']\n      allowWrite = []\n      disable = false",
+		"[security]\n  allowContent = ['! ^text/html$', '! ^text/org$']\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^(dart-)?sass$', '^go$', '^git$', '^node$', '^postcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\\w+|(XDG_CONFIG_)?HOME|USERPROFILE|SSH_AUTH_SOCK|DISPLAY|LANG|SYSTEMDRIVE|PROGRAMDATA)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_', '^CI$']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    proxyFromEnvironment = false\n    urls = ['(?i)^https?://[a-z0-9]', '! (?i)^https?://\\d+\\.', '! (?i)localhost', '! (?i)^https?://[^/?#]*@']\n\n  [security.node]\n    [security.node.permissions]\n      allowAddons = ['tailwindcss']\n      allowChildProcess = ['tailwindcss']\n      allowRead = ['.']\n      allowWorker = ['tailwindcss']\n      allowWrite = []\n      disable = false",
 	)
 }
 
@@ -156,6 +156,7 @@ func TestDecodeConfigDefault(t *testing.T) {
 	c.Assert(pc.HTTP.Methods.Accept("get"), qt.IsTrue)
 	c.Assert(pc.HTTP.Methods.Accept("DELETE"), qt.IsFalse)
 	c.Assert(pc.HTTP.MediaTypes.Accept("application/msword"), qt.IsFalse)
+	c.Assert(pc.HTTP.ProxyFromEnvironment, qt.IsFalse)
 
 	c.Assert(pc.Exec.OsEnv.Accept("PATH"), qt.IsTrue)
 	c.Assert(pc.Exec.OsEnv.Accept("GOROOT"), qt.IsTrue)

--- a/docs/content/en/configuration/security.md
+++ b/docs/content/en/configuration/security.md
@@ -34,8 +34,14 @@ This is the default security configuration:
 `http.mediaTypes`
 : (`[]string`) Applicable to the `resources.GetRemote` function, a slice of [regular expressions](g) matching the `Content-Type` in HTTP responses that Hugo trusts, bypassing file content analysis for media type detection.
 
+`http.proxyFromEnvironment`
+: {{< new-in 0.166.0 />}}
+: (`bool`) Whether the `resources.GetRemote` function honors the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. Default is `false`. When a proxy is used, Hugo connects to the proxy rather than the destination, so the resolved address validation described under `http.urls` does not apply.
+
 `http.urls`
 : (`[]string`) A slice of [regular expressions](g) matching the URLs that the `resources.GetRemote` function is allowed to access.
+
+  The default allowlist denies URLs with an IP address or `localhost` as the host name. In addition, with the default allowlist, Hugo validates the resolved address when connecting and rejects connections to loopback, private, link-local, and other non-public addresses, e.g. a host name that resolves to a cloud metadata endpoint. This validation is disabled if you override `http.urls`, as the override may intentionally allow access to hosts on your local network, such as a development server.
 
 `node.permissions.disable`
 : {{< new-in 0.161.0 />}}

--- a/docs/data/docs.yaml
+++ b/docs/data/docs.yaml
@@ -2240,6 +2240,7 @@ config:
       mediaTypes: null
       methods:
       - (?i)GET|POST
+      proxyFromEnvironment: false
       urls:
       - (?i)^https?://[a-z0-9]
       - '! (?i)^https?://\d+\.'

--- a/resources/resource_factories/create/create.go
+++ b/resources/resource_factories/create/create.go
@@ -16,15 +16,19 @@
 package create
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/net/http/httpproxy"
 
 	"github.com/bep/helpers/contexthelpers"
 
@@ -65,6 +69,7 @@ type contextKey uint8
 
 const (
 	contextKeyResourceID contextKey = iota
+	contextKeyProxyURL
 )
 
 // New creates a new Client with the given specification.
@@ -154,17 +159,80 @@ func New(rs *resources.Spec) *Client {
 // hook that validates the resolved destination address against the security
 // policy, so a hostname resolving to an internal address cannot be used to
 // reach internal endpoints. See CheckAllowedHTTPAddress.
+//
+// Proxies are only used when security.http.proxyFromEnvironment is enabled.
+// A proxied connection is dialed to the proxy, not the destination, so the
+// address check is skipped for that dial; the user has opted into trusting
+// the proxy with the destination. The proxy decision is carried per request
+// in its context, so a direct dial is always validated, even to the proxy's
+// own address.
 func newSecureBaseTransport(sec security.Config) http.RoundTripper {
 	base := http.DefaultTransport.(*http.Transport).Clone()
-	d := &net.Dialer{
+	secureDialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 		Control: func(network, address string, _ syscall.RawConn) error {
 			return sec.CheckAllowedHTTPAddress(network, address)
 		},
 	}
-	base.DialContext = d.DialContext
-	return base
+	base.Proxy = nil
+	base.DialContext = secureDialer.DialContext
+
+	if !sec.HTTP.ProxyFromEnvironment {
+		return base
+	}
+
+	proxyFromCtx := func(ctx context.Context) *url.URL {
+		u, _ := ctx.Value(contextKeyProxyURL).(*url.URL)
+		return u
+	}
+	base.Proxy = func(req *http.Request) (*url.URL, error) {
+		return proxyFromCtx(req.Context()), nil
+	}
+	proxyDialer := &net.Dialer{Timeout: secureDialer.Timeout, KeepAlive: secureDialer.KeepAlive}
+	base.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if u := proxyFromCtx(ctx); u != nil && canonicalAddr(u) == addr {
+			return proxyDialer.DialContext(ctx, network, addr)
+		}
+		return secureDialer.DialContext(ctx, network, addr)
+	}
+	return &proxyTransport{base: base, proxyFunc: httpproxy.FromEnvironment().ProxyFunc()}
+}
+
+// proxyTransport resolves the proxy for each request up front and stores it
+// in the request context, where both the Proxy and DialContext hooks of base
+// can see it.
+type proxyTransport struct {
+	base      *http.Transport
+	proxyFunc func(*url.URL) (*url.URL, error)
+}
+
+func (t *proxyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	u, err := t.proxyFunc(req.URL)
+	if err != nil {
+		return nil, err
+	}
+	if u != nil {
+		req = req.WithContext(context.WithValue(req.Context(), contextKeyProxyURL, u))
+	}
+	return t.base.RoundTrip(req)
+}
+
+// canonicalAddr mirrors net/http's canonicalAddr: the host:port the transport
+// dials for u, with the port defaulted from the scheme.
+func canonicalAddr(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		switch u.Scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		case "socks5", "socks5h":
+			port = "1080"
+		}
+	}
+	return net.JoinHostPort(u.Hostname(), port)
 }
 
 // Copy copies r to the new targetPath.

--- a/resources/resource_factories/create/remote_test.go
+++ b/resources/resource_factories/create/remote_test.go
@@ -14,8 +14,10 @@
 package create
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -172,4 +174,79 @@ urls = ['.*']
 	resp, err := newSecureBaseTransport(sec).RoundTrip(req)
 	c.Assert(err, qt.IsNil)
 	resp.Body.Close()
+}
+
+// Proxies from the environment are ignored unless
+// security.http.proxyFromEnvironment is enabled. When enabled, the dial-time
+// address check does not apply to the proxy itself. See issue 15302.
+func TestSecureBaseTransportProxyFromEnvironment(t *testing.T) {
+	c := qt.New(t)
+
+	var proxyHits, targetHits atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyHits.Add(1)
+		w.Write([]byte("via proxy"))
+	}))
+	t.Cleanup(proxy.Close)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetHits.Add(1)
+		w.Write([]byte("direct"))
+	}))
+	t.Cleanup(target.Close)
+
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+
+	decode := func(toml string) security.Config {
+		sec, err := security.DecodeConfig(config.FromTOMLConfigString(toml))
+		c.Assert(err, qt.IsNil)
+		return sec
+	}
+	fetch := func(sec security.Config, u string) (string, error) {
+		req, err := http.NewRequest("GET", u, nil)
+		c.Assert(err, qt.IsNil)
+		resp, err := newSecureBaseTransport(sec).RoundTrip(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		c.Assert(err, qt.IsNil)
+		return string(b), nil
+	}
+
+	// Default: proxy ignored, fetched directly.
+	body, err := fetch(decode(`
+[security.http]
+urls = ['.*']
+`), target.URL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(body, qt.Equals, "direct")
+	c.Assert(proxyHits.Load(), qt.Equals, int32(0))
+	c.Assert(targetHits.Load(), qt.Equals, int32(1))
+
+	// Enabled: the loopback proxy is dialed even under the default hardened
+	// policy, and the destination is never dialed directly.
+	body, err = fetch(decode(`
+[security.http]
+proxyFromEnvironment = true
+`), "http://example.com/")
+	c.Assert(err, qt.IsNil)
+	c.Assert(body, qt.Equals, "via proxy")
+	c.Assert(proxyHits.Load(), qt.Equals, int32(1))
+	c.Assert(targetHits.Load(), qt.Equals, int32(1))
+
+	// Enabled, but loopback destinations are never proxied: the address
+	// check still applies to the direct dial, also when the destination is
+	// the proxy's own address.
+	for _, u := range []string{target.URL, proxy.URL} {
+		_, err = fetch(decode(`
+[security.http]
+proxyFromEnvironment = true
+`), u)
+		c.Assert(security.IsAccessDenied(err), qt.IsTrue, qt.Commentf(u))
+	}
+	c.Assert(proxyHits.Load(), qt.Equals, int32(1))
+	c.Assert(targetHits.Load(), qt.Equals, int32(1))
 }


### PR DESCRIPTION
Proxies from HTTP_PROXY/HTTPS_PROXY hide the resolved destination address
from the dial-time validation added in d6e6f9e50, so ignore them unless the
new security.http.proxyFromEnvironment (default false) is enabled. When
enabled, the address check is skipped only for the proxy addresses handed
out by the proxy func; direct dials (e.g. NO_PROXY) are still validated.

Also document that the resolved address validation only applies under the
default security.http.urls allowlist.

Thanks to @Reload3d for reporting these issues.

Closes #15301
Closes #15302

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
