### PR TITLE
security: Add security.http.proxyFromEnvironment config option

### DIFF
--- a/config/security/securityConfig.go
+++ b/config/security/securityConfig.go
@@ -133,6 +133,10 @@ type HTTP struct {
 
 	// Media types where the Content-Type in the response is used instead of resolving from the file content.
 	MediaTypes Whitelist `json:"mediaTypes"`
+
+	// ProxyFromEnvironment specifies whether to use HTTP/HTTPS proxy settings
+	// from the environment (e.g. HTTP_PROXY, HTTPS_PROXY).
+	ProxyFromEnvironment bool `json:"proxyFromEnvironment"`
 }
 
 // Node holds Node.js security settings.

--- a/config/security/securityConfig_test.go
+++ b/config/security/securityConfig_test.go
@@ -135,7 +135,7 @@ func TestToTOML(t *testing.T) {
 	got := DefaultConfig.ToTOML()
 
 	c.Assert(got, qt.Equals,
-		"[security]\n  allowContent = ['! ^text/html$', '! ^text/org$']\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^(dart-)?sass$', '^go$', '^git$', '^node$', '^postcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\\w+|(XDG_CONFIG_)?HOME|USERPROFILE|SSH_AUTH_SOCK|DISPLAY|LANG|SYSTEMDRIVE|PROGRAMDATA)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_', '^CI$']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    urls = ['(?i)^https?://[a-z0-9]', '! (?i)^https?://\\d+\\.', '! (?i)localhost', '! (?i)^https?://[^/?#]*@']\n\n  [security.node]\n    [security.node.permissions]\n      allowAddons = ['tailwindcss']\n      allowChildProcess = ['tailwindcss']\n      allowRead = ['.']\n      allowWorker = ['tailwindcss']\n      allowWrite = []\n      disable = false",
+		"[security]\n  allowContent = ['! ^text/html$', '! ^text/org$']\n  enableInlineShortcodes = false\n\n  [security.exec]\n    allow = ['^(dart-)?sass$', '^go$', '^git$', '^node$', '^postcss$']\n    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\\w+|(XDG_CONFIG_)?HOME|USERPROFILE|SSH_AUTH_SOCK|DISPLAY|LANG|SYSTEMDRIVE|PROGRAMDATA)$']\n\n  [security.funcs]\n    getenv = ['^HUGO_', '^CI$']\n\n  [security.http]\n    methods = ['(?i)GET|POST']\n    proxyFromEnvironment = false\n    urls = ['(?i)^https?://[a-z0-9]', '! (?i)^https?://\\d+\\.', '! (?i)localhost', '! (?i)^https?://[^/?#]*@']\n\n  [security.node]\n    [security.node.permissions]\n      allowAddons = ['tailwindcss']\n      allowChildProcess = ['tailwindcss']\n      allowRead = ['.']\n      allowWorker = ['tailwindcss']\n      allowWrite = []\n      disable = false",
 	)
 }
 
@@ -156,6 +156,7 @@ func TestDecodeConfigDefault(t *testing.T) {
 	c.Assert(pc.HTTP.Methods.Accept("get"), qt.IsTrue)
 	c.Assert(pc.HTTP.Methods.Accept("DELETE"), qt.IsFalse)
 	c.Assert(pc.HTTP.MediaTypes.Accept("application/msword"), qt.IsFalse)
+	c.Assert(pc.HTTP.ProxyFromEnvironment, qt.IsFalse)
 
 	c.Assert(pc.Exec.OsEnv.Accept("PATH"), qt.IsTrue)
 	c.Assert(pc.Exec.OsEnv.Accept("GOROOT"), qt.IsTrue)
@@ -478,4 +479,19 @@ allowWrite = ["*"]
 		c.Assert(pc.Node.Permissions.IsEnabled(), qt.IsTrue)
 		c.Assert(pc.Node.Permissions.AllowRead, qt.DeepEquals, []string{"*"})
 	})
+}
+
+// See issue 15302.
+func TestDecodeConfigProxyFromEnvironment(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	cfg, err := config.FromConfigString(`
+[security.http]
+proxyFromEnvironment = true
+`, "toml")
+	c.Assert(err, qt.IsNil)
+	pc, err := DecodeConfig(cfg)
+	c.Assert(err, qt.IsNil)
+	c.Assert(pc.HTTP.ProxyFromEnvironment, qt.IsTrue)
 }

--- a/docs/content/en/configuration/security.md
+++ b/docs/content/en/configuration/security.md
@@ -34,6 +34,9 @@ This is the default security configuration:
 `http.mediaTypes`
 : (`[]string`) Applicable to the `resources.GetRemote` function, a slice of [regular expressions](g) matching the `Content-Type` in HTTP responses that Hugo trusts, bypassing file content analysis for media type detection.
 
+`http.proxyFromEnvironment`
+: (`bool`) Whether to use HTTP(S) proxy settings from the environment (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`). Default is `false`.
+
 `http.urls`
 : (`[]string`) A slice of [regular expressions](g) matching the URLs that the `resources.GetRemote` function is allowed to access.
 

--- a/hugolib/securitypolicies_test.go
+++ b/hugolib/securitypolicies_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"sync/atomic"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -375,4 +376,47 @@ mediaTypes=["application/json"]
 `, ts.URL)
 		Test(c, files)
 	})
+}
+
+// See issue 15302.
+func TestProxyFromEnvironment(t *testing.T) {
+	c := qt.New(t)
+
+	var proxyHit atomic.Bool
+	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyHit.Store(true)
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("from-proxy"))
+	}))
+	t.Cleanup(proxySrv.Close)
+
+	t.Setenv("HTTP_PROXY", proxySrv.URL)
+
+	// Case 1: Default config (proxyFromEnvironment = false).
+	filesDefault := `
+-- hugo.toml --
+baseURL = "https://example.org"
+[security.http]
+urls = ['.*']
+-- layouts/home.html --
+{{ $res := resources.GetRemote "http://example.com/test.txt" }}
+`
+	proxyHit.Store(false)
+	TestE(c, filesDefault)
+	c.Assert(proxyHit.Load(), qt.IsFalse)
+
+	// Case 2: Explicit proxyFromEnvironment = true.
+	filesProxied := `
+-- hugo.toml --
+baseURL = "https://example.org"
+[security.http]
+urls = ['.*']
+proxyFromEnvironment = true
+-- layouts/home.html --
+{{ $res := resources.GetRemote "http://example.com/test.txt" }}{{ $res.Content }}
+`
+	proxyHit.Store(false)
+	b := Test(c, filesProxied)
+	c.Assert(proxyHit.Load(), qt.IsTrue)
+	b.AssertFileContent("public/index.html", "from-proxy")
 }

--- a/resources/resource_factories/create/create.go
+++ b/resources/resource_factories/create/create.go
@@ -156,6 +156,9 @@ func New(rs *resources.Spec) *Client {
 // reach internal endpoints. See CheckAllowedHTTPAddress.
 func newSecureBaseTransport(sec security.Config) http.RoundTripper {
 	base := http.DefaultTransport.(*http.Transport).Clone()
+	if !sec.HTTP.ProxyFromEnvironment {
+		base.Proxy = nil
+	}
 	d := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,

--- a/resources/resource_factories/create/remote_test.go
+++ b/resources/resource_factories/create/remote_test.go
@@ -14,8 +14,10 @@
 package create
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -172,4 +174,65 @@ urls = ['.*']
 	resp, err := newSecureBaseTransport(sec).RoundTrip(req)
 	c.Assert(err, qt.IsNil)
 	resp.Body.Close()
+}
+
+// See issue 15302.
+func TestSecureBaseTransportProxyFromEnvironment(t *testing.T) {
+	c := qt.New(t)
+
+	var proxyHit atomic.Bool
+	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("proxied"))
+	}))
+	t.Cleanup(proxySrv.Close)
+
+	targetSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("target"))
+	}))
+	t.Cleanup(targetSrv.Close)
+
+	t.Setenv("HTTP_PROXY", proxySrv.URL)
+
+	// Default ProxyFromEnvironment (false): Proxy is nil, target server is reached directly even if HTTP_PROXY is set.
+	secDefault, err := security.DecodeConfig(config.FromTOMLConfigString(`
+[security.http]
+urls = ['.*']
+`))
+	c.Assert(err, qt.IsNil)
+	trDefault := newSecureBaseTransport(secDefault).(*http.Transport)
+	c.Assert(trDefault.Proxy, qt.IsNil)
+
+	reqDirect, err := http.NewRequest("GET", targetSrv.URL, nil)
+	c.Assert(err, qt.IsNil)
+	proxyHit.Store(false)
+	resp, err := trDefault.RoundTrip(reqDirect)
+	c.Assert(err, qt.IsNil)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	c.Assert(string(body), qt.Equals, "target")
+	c.Assert(proxyHit.Load(), qt.IsFalse)
+
+	// Explicit proxyFromEnvironment = true: Proxy is configured and HTTP_PROXY is used.
+	secProxy, err := security.DecodeConfig(config.FromTOMLConfigString(`
+[security.http]
+urls = ['.*']
+proxyFromEnvironment = true
+`))
+	c.Assert(err, qt.IsNil)
+	trProxy := newSecureBaseTransport(secProxy).(*http.Transport)
+	c.Assert(trProxy.Proxy, qt.IsNotNil)
+
+	// Go's ProxyFromEnvironment ignores proxy for loopback targets, so use non-loopback URL for proxy test.
+	reqProxied, err := http.NewRequest("GET", "http://example.com/test", nil)
+	c.Assert(err, qt.IsNil)
+	proxyHit.Store(false)
+	resp, err = trProxy.RoundTrip(reqProxied)
+	c.Assert(err, qt.IsNil)
+	body, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	c.Assert(string(body), qt.Equals, "proxied")
+	c.Assert(proxyHit.Load(), qt.IsTrue)
 }


### PR DESCRIPTION
Add a bool config option `security.http.proxyFromEnvironment`, defaulting to `false`, to disable inheriting `HTTP_PROXY`/`HTTPS_PROXY` from the environment on remote fetches unless explicitly enabled.

Closes #15302