### PR TITLE
js: Add es2025 as supported build target

### DIFF
--- a/internal/js/esbuild/options.go
+++ b/internal/js/esbuild/options.go
@@ -49,6 +49,7 @@ var (
 		"es2022": api.ES2022,
 		"es2023": api.ES2023,
 		"es2024": api.ES2024,
+		"es2025": api.ES2025,
 	}
 
 	engineName = map[string]api.EngineName{

--- a/internal/js/esbuild/options_test.go
+++ b/internal/js/esbuild/options_test.go
@@ -189,6 +189,8 @@ func TestToBuildOptionsTarget(t *testing.T) {
 		{"es2021", api.ES2021},
 		{"es2022", api.ES2022},
 		{"es2023", api.ES2023},
+		{"es2024", api.ES2024},
+		{"es2025", api.ES2025},
 		{"", api.ESNext},
 		{"esnext", api.ESNext},
 	} {


### PR DESCRIPTION
Fixes #15307
