### PR TITLE
tpl/strings: Fix replaceRE with zero-width assertions

### DIFF
--- a/tpl/strings/regexp.go
+++ b/tpl/strings/regexp.go
@@ -104,12 +104,17 @@ func (ns *Namespace) ReplaceRE(pattern, repl, s any, n ...any) (_ string, err er
 		return "", err
 	}
 
-	return re.ReplaceAllStringFunc(ss, func(str string) string {
-		if nn == 0 {
-			return str
-		}
+	// Expand against the original string. ReplaceAllStringFunc hands the
+	// callback the match on its own, so a pattern with a zero-width assertion
+	// such as \b would not match again inside it.
+	var b []byte
+	last := 0
 
-		nn -= 1
-		return re.ReplaceAllString(str, sr)
-	}), nil
+	for _, m := range re.FindAllStringSubmatchIndex(ss, nn) {
+		b = append(b, ss[last:m[0]]...)
+		b = re.ExpandString(b, sr, ss, m)
+		last = m[1]
+	}
+
+	return string(b) + ss[last:], nil
 }

--- a/tpl/strings/regexp_test.go
+++ b/tpl/strings/regexp_test.go
@@ -99,6 +99,11 @@ func TestReplaceRE(t *testing.T) {
 		{"^https?://([^/]+).*", "$2", "http://gohugo.io/docs", nil, ""},
 		{"(ab)", "AB", "aabbaab", nil, "aABbaAB"},
 		{"(ab)", "AB", "aabbaab", []any{1}, "aABbaab"},
+		// A zero-width assertion needs the surrounding text to match.
+		{`\Bcd`, "-", "abcdef", nil, "ab-ef"},
+		{`\b`, "|", "foo bar", nil, "|foo| |bar|"},
+		{`\Bb`, "X", "foobar bar bab", nil, "fooXar bar baX"},
+		{`\Bb`, "X", "foobar bar bab", []any{1}, "fooXar bar bab"},
 		// errors
 		{"(ab", "AB", "aabb", nil, false}, // invalid re
 		{tstNoStringer{}, "$2", "http://gohugo.io/docs", nil, false},


### PR DESCRIPTION
`replaceRE` returns its input unchanged, with no error, whenever the pattern contains a zero-width assertion such as `\b` or `\B`.

```
pattern  input          stdlib regexp    replaceRE
"\\Bcd"  "abcdef"       "ab-ef"          "abcdef"
"\\Bb"   "foobar bar"   "fooXar bar"     "foobar bar"
"\\B\\d" "a1234"        "a####"          "a1234"
"\\b"    "foo bar"      "|foo| |bar|"    "foo bar"
```

`ReplaceRE` calls `re.ReplaceAllStringFunc` and re-runs the same regexp inside the callback (`tpl/strings/regexp.go:104`). The callback receives the match on its own, stripped of its surroundings, so the context the assertion needs is gone: `\Bcd` matches inside `abcdef`, but against the isolated `cd` the `\B` sits at start-of-text, which is a word boundary, so the inner `ReplaceAllString` finds nothing and returns `cd` verbatim.

`findRE`, twenty lines up in the same file, passes the optional limit straight to the standard library (`re.FindAllString(conv, lim)`, `tpl/strings/regexp.go:42`) and is unaffected — `findRE "\\Bcd" "abcdef"` correctly returns `[cd]` on master. That asymmetry is what this patch removes.

The `ReplaceAllStringFunc` wrapper exists only to implement the optional limit argument. The fix takes the limit through `FindAllStringSubmatchIndex(ss, nn)`, which accepts it natively, and expands against the original string.

A template author writing something like `{{ $s | replaceRE "\\B-\\B" "" }}` currently gets their string back untouched and no error, so the wrong text is published.

## Testing

Cases added to the existing `TestReplaceRE` table, including one with a limit so the limit path is asserted too.

- The new rows fail on master and pass with the patch.
- Differential over 14 patterns x 14 inputs x 6 replacements: unlimited results match `regexp.ReplaceAllString` exactly (0 mismatches), and across 7 limit values the results are identical to the previous implementation for every context-free pattern (0 behaviour changes), so the limit semantics are unchanged.
- I verified that differential can actually detect a regression: breaking the limit, or dropping the trailing remainder, both make it fail; a no-op edit leaves it passing.
- `go test ./tpl/...` passes, including `tplimpl`, which executes the `replaceRE` doc examples.
- `./check.sh ./tpl/strings/...`: gofmt OK. staticcheck reports the same 13 pre-existing "requires newer Go version go1.27" compile errors on master and on this branch in my environment, so it is not exercised by this change.
- `go build ./...` and `GOOS=windows go build ./tpl/...` clean.

Side effect: the regexp is no longer re-executed once per match.

## AI Assistance Notice

This PR was written primarily by Claude Code. I have reviewed the change, and the measurements and command output quoted above are verbatim from running them against master.
