### PR TITLE
common/hreflect: Fix the off-by-one in the float to int overflow guards

### DIFF
--- a/common/hreflect/convert.go
+++ b/common/hreflect/convert.go
@@ -145,7 +145,7 @@ func convertToUintIfPossible(val reflect.Value, typ reflect.Type) (reflect.Value
 	}
 	if IsFloat(val.Kind()) {
 		f := val.Float()
-		if f < 0 || f > float64(math.MaxUint64) {
+		if f < 0 || f >= float64(math.MaxUint64) {
 			return reflect.Value{}, false
 		}
 		if f != math.Trunc(f) {
@@ -205,7 +205,7 @@ func convertToIntIfPossible(val reflect.Value, typ reflect.Type) (reflect.Value,
 	}
 	if IsFloat(val.Kind()) {
 		f := val.Float()
-		if f < float64(math.MinInt64) || f > float64(math.MaxInt64) {
+		if f < float64(math.MinInt64) || f >= float64(math.MaxInt64) {
 			return reflect.Value{}, false
 		}
 		if f != math.Trunc(f) {

--- a/common/hreflect/convert_test.go
+++ b/common/hreflect/convert_test.go
@@ -110,6 +110,29 @@ func TestConvertIfPossible(t *testing.T) {
 			ok:    false, // overflow
 		},
 		{
+			// float64(math.MaxInt64) rounds up to 2^63, which is out of range.
+			name:  "float64(math.MaxInt64) to int64",
+			value: float64(math.MaxInt64),
+			typ:   int64(0),
+			ok:    false, // overflow
+		},
+		{
+			// The largest float64 that is a valid int64.
+			name:     "float64(9223372036854774784) to int64",
+			value:    float64(9223372036854774784),
+			typ:      int64(0),
+			ok:       true,
+			expected: int64(9223372036854774784),
+		},
+		{
+			// float64(math.MinInt64) is exact, so this is in range.
+			name:     "float64(math.MinInt64) to int64",
+			value:    float64(math.MinInt64),
+			typ:      int64(0),
+			ok:       true,
+			expected: int64(math.MinInt64),
+		},
+		{
 			name:     "float64(32767) to int16",
 			value:    float64(32767),
 			typ:      int16(0),
@@ -210,6 +233,21 @@ func TestConvertIfPossible(t *testing.T) {
 			typ:      uint64(0),
 			ok:       true,
 			expected: uint64(3),
+		},
+		{
+			// float64(math.MaxUint64) rounds up to 2^64, which is out of range.
+			name:  "float64(math.MaxUint64) to uint64",
+			value: float64(math.MaxUint64),
+			typ:   uint64(0),
+			ok:    false, // overflow
+		},
+		{
+			// The largest float64 that is a valid uint64.
+			name:     "float64(18446744073709549568) to uint64",
+			value:    float64(18446744073709549568),
+			typ:      uint64(0),
+			ok:       true,
+			expected: uint64(18446744073709549568),
 		},
 		// From uint to float.
 		{


### PR DESCRIPTION
`convertToIntIfPossible` rejects an out-of-range float64 with `f > float64(math.MaxInt64)` (`common/hreflect/convert.go:208`). `float64(math.MaxInt64)` rounds up to exactly 2^63, which int64 cannot hold, so `f == 2^63` passes the guard, `math.Trunc` leaves it unchanged, and `typ.OverflowInt(int64(f))` is handed an already-wrapped value and also passes.

`convertToUintIfPossible` has the same problem at `:148` against `float64(math.MaxUint64)`, which rounds up to 2^64.

Measured on `master`:

```
float64 input              to type    ok?      result
2^63 (float64(MaxInt64))   int64      true     -9223372036854775808
largest float64 < 2^63     int64      true     9223372036854774784
-2^63 (float64(MinInt64))  int64      true     -9223372036854775808
2^64 (float64(MaxUint64))  uint64     true     9223372036854775808
```

So a positive value comes back as the most negative int64, and 2^64 comes back as exactly half of what was asked for — from a function whose doc comment at `:95` says *"This conversion is lossless."*

### Why this is reachable

`ConvertIfPossible` exists so template calls can pass data-file numbers to Go methods with concrete integer parameters (`:96` cites #14079). `validateType` calls it at `tpl/internal/go_templates/texttemplate/hugo_template.go:553`, and a large integer in a JSON or YAML data file decodes to float64.

Executing a template that passes such a value to a method taking an `int`, on `master`:

```
{{ (.Limit .Big) }}   error: slice bounds out of range [:-9223372036854775808]
```

The negative value reaches the method and it panics on the slice bound. With this change the same input reports the ordinary type error instead:

```
{{ (.Limit .Big) }}   error: wrong type for value; expected int; got float64
```

which is already what one float step above 2^63 does today.

### The change

`>` becomes `>=` on the two upper bounds. Nothing else moves.

The lower bound is deliberately left alone: unlike the upper one, `float64(math.MinInt64)` is exactly -2^63 and *is* representable, so it stays in range. A test row pins that so the two bounds do not get made symmetric later.

The uint branch of the same function already gets this right by comparing exactly — `val.Uint() > uint64(math.MaxInt64)` at `:198` — rather than in float64.

### Testing

Rows added to the existing `TestConvertIfPossible` table: the two rejected boundaries, the largest float64 that is a valid int64 and uint64, and `float64(math.MinInt64)` as accepted.

- The new rejection rows fail on `master`; the accepted rows pass on both trees.
- Mutation-checked, all four caught: reverting either upper bound to `>`, over-rejecting the exact negative bound, and over-rejecting the largest valid int64.
- `go test ./common/... ./tpl/...` passes, as do `./hugolib/...`, `./resources/...` and `./markup/...` including `TestYAMLAddDateIssue14079`.
- `go build ./...` and `GOOS=windows go build ./common/...` clean; `gofmt` via `./check.sh` clean; `go vet ./common/... ./tpl/...` clean.

## AI Assistance Notice

This PR was written primarily by Claude Code. I have reviewed the change and can explain it; the tables above are verbatim from running the conversion and the template engine against `master`.
