### PR TITLE
hexec: Fail on symlinks that escape the Node.js permission paths

### DIFF
--- a/common/hexec/exec.go
+++ b/common/hexec/exec.go
@@ -99,11 +99,12 @@ func New(cfg security.Config, workingDir string, log loggers.Logger) *Exec {
 	}
 
 	return &Exec{
-		sc:              cfg,
-		workingDir:      workingDir,
-		infol:           log.InfoCommand("exec"),
-		baseEnviron:     baseEnviron,
-		nodeRunnerCache: hmaps.NewCache[string, func(arg ...any) (Runner, error)](),
+		sc:                cfg,
+		workingDir:        workingDir,
+		infol:             log.InfoCommand("exec"),
+		baseEnviron:       baseEnviron,
+		nodeRunnerCache:   hmaps.NewCache[string, func(arg ...any) (Runner, error)](),
+		nodeSymlinkChecks: hmaps.NewCache[string, bool](),
 	}
 }
 
@@ -126,6 +127,9 @@ type Exec struct {
 	nodeReadPaths []string
 
 	nodeRunnerCache *hmaps.Cache[string, func(arg ...any) (Runner, error)]
+
+	// Roots already scanned by checkNodeSymlinks, keyed by kind and path.
+	nodeSymlinkChecks *hmaps.Cache[string, bool]
 }
 
 // SetNodeReadPaths sets additional absolute paths to allow reading from
@@ -230,6 +234,15 @@ func (e *Exec) Npx(name string, arg ...any) (Runner, error) {
 
 // newNode runs a Node.js script via "node [--permission <flags>] <scriptPath> <args>".
 func (e *Exec) newNode(name, scriptPath string, arg ...any) (Runner, error) {
+	if e.sc.Node.Permissions.IsEnabled() {
+		if err := e.checkNodeSymlinks("allowRead", e.nodeReadRoots(scriptPath)); err != nil {
+			return nil, err
+		}
+		if err := e.checkNodeSymlinks("allowWrite", e.nodeWriteRoots()); err != nil {
+			return nil, err
+		}
+	}
+
 	var allArgs []any
 	for _, pa := range e.nodePermissionArgs(name, scriptPath) {
 		allArgs = append(allArgs, pa)
@@ -264,17 +277,10 @@ func (e *Exec) nodePermissionArgs(name, scriptPath string) []string {
 
 	args := []string{"--permission"}
 
-	for _, p := range e.resolveNodePermPaths(perms.AllowRead) {
+	for _, p := range e.nodeReadRoots(scriptPath) {
 		args = append(args, "--allow-fs-read="+p)
 	}
-	for _, p := range e.nodeReadPaths {
-		args = append(args, "--allow-fs-read="+p)
-	}
-	if p := nodeScriptReadPath(scriptPath); p != "" {
-		args = append(args, "--allow-fs-read="+p)
-	}
-
-	for _, p := range e.resolveNodePermPaths(perms.AllowWrite) {
+	for _, p := range e.nodeWriteRoots() {
 		args = append(args, "--allow-fs-write="+p)
 	}
 
@@ -301,6 +307,19 @@ func (e *Exec) nodePermissionArgs(name, scriptPath string) []string {
 	}
 
 	return args
+}
+
+func (e *Exec) nodeReadRoots(scriptPath string) []string {
+	roots := e.resolveNodePermPaths(e.sc.Node.Permissions.AllowRead)
+	roots = append(roots, e.nodeReadPaths...)
+	if p := nodeScriptReadPath(scriptPath); p != "" {
+		roots = append(roots, p)
+	}
+	return roots
+}
+
+func (e *Exec) nodeWriteRoots() []string {
+	return e.resolveNodePermPaths(e.sc.Node.Permissions.AllowWrite)
 }
 
 // resolveNodePermPaths resolves relative paths against the working directory.

--- a/common/hexec/exec_test.go
+++ b/common/hexec/exec_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/config/security"
 )
 
@@ -471,4 +472,67 @@ func mkdirAndWrite(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestCheckNodeSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks")
+	}
+	c := qt.New(t)
+
+	base := t.TempDir()
+	site := filepath.Join(base, "site")
+	outside := filepath.Join(base, "outside")
+	c.Assert(os.MkdirAll(filepath.Join(site, "assets", "css"), 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(site, "node_modules", ".bin"), 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(outside, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o644), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(site, "node_modules", "tool.js"), nil, 0o644), qt.IsNil)
+	c.Assert(os.Symlink(filepath.Join("..", "tool.js"), filepath.Join(site, "node_modules", ".bin", "tool")), qt.IsNil)
+	c.Assert(os.Symlink(filepath.Join(site, "doesnotexist"), filepath.Join(site, "dangling")), qt.IsNil)
+
+	newExec := func(allowRead ...string) *Exec {
+		sc := security.DefaultConfig
+		sc.Node.Permissions.AllowRead = allowRead
+		return New(sc, site, loggers.NewDefault())
+	}
+
+	c.Run("Relative and dangling symlinks inside", func(c *qt.C) {
+		e := newExec(".")
+		c.Assert(e.checkNodeSymlinks("allowRead", e.nodeReadRoots("")), qt.IsNil)
+	})
+
+	c.Assert(os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(site, "assets", "css", "slink.css")), qt.IsNil)
+
+	c.Run("Symlink outside", func(c *qt.C) {
+		e := newExec(".")
+		err := e.checkNodeSymlinks("allowRead", e.nodeReadRoots(""))
+		c.Assert(err, qt.ErrorMatches, `symlink ".*slink.css" resolves to ".*secret.txt" outside .*allowRead`)
+	})
+
+	c.Run("Target added to allowRead", func(c *qt.C) {
+		e := newExec(".", outside)
+		c.Assert(e.checkNodeSymlinks("allowRead", e.nodeReadRoots("")), qt.IsNil)
+	})
+
+	c.Run("Wildcard", func(c *qt.C) {
+		e := newExec("*")
+		c.Assert(e.checkNodeSymlinks("allowRead", e.nodeReadRoots("")), qt.IsNil)
+	})
+
+	c.Run("Empty write set", func(c *qt.C) {
+		e := newExec(".")
+		c.Assert(e.checkNodeSymlinks("allowWrite", e.nodeWriteRoots()), qt.IsNil)
+	})
+}
+
+func TestTopLevelDirs(t *testing.T) {
+	c := qt.New(t)
+	fs := func(ss ...string) []string {
+		for i, s := range ss {
+			ss[i] = filepath.FromSlash(s)
+		}
+		return ss
+	}
+	c.Assert(topLevelDirs(fs("/a/b", "/a", "/ab", "/a/c", "/a")), qt.DeepEquals, fs("/a", "/ab"))
 }

--- a/common/hexec/nodesymlinks.go
+++ b/common/hexec/nodesymlinks.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hexec
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// Node's permission model checks the lexical path only and follows symlinks
+// even when they point outside the allowed set (documented as a known
+// limitation). checkNodeSymlinks walks the allowed roots and fails on any
+// symlink whose target resolves outside them. Each root is walked once per
+// Exec; new symlinks created later are not seen.
+func (e *Exec) checkNodeSymlinks(kind string, roots []string) error {
+	if slices.Contains(roots, "*") {
+		return nil
+	}
+
+	var real []string
+	for _, r := range roots {
+		if p, err := filepath.EvalSymlinks(r); err == nil {
+			real = append(real, p)
+		}
+	}
+
+	for _, root := range topLevelDirs(real) {
+		if _, err := e.nodeSymlinkChecks.GetOrCreate(kind+"|"+root, func() (bool, error) {
+			return true, walkSymlinks(root, real, kind)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func walkSymlinks(root string, allowed []string, kind string) error {
+	return filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if p == root {
+				return nil
+			}
+			return err
+		}
+		if d.Type()&os.ModeSymlink == 0 {
+			return nil
+		}
+		target, err := filepath.EvalSymlinks(p)
+		if err != nil {
+			// Dangling; nothing to read through.
+			return nil
+		}
+		if !isBelowAny(target, allowed) {
+			return fmt.Errorf("symlink %q resolves to %q outside the paths Node.js is allowed to access; remove it or add its target to security.node.permissions.%s", p, target, kind)
+		}
+		return nil
+	})
+}
+
+// topLevelDirs drops dirs nested below another entry so they are not walked twice.
+func topLevelDirs(dirs []string) []string {
+	sorted := slices.Clone(dirs)
+	slices.Sort(sorted)
+	var top []string
+	for _, d := range sorted {
+		if len(top) > 0 && isBelow(d, top[len(top)-1]) {
+			continue
+		}
+		top = append(top, d)
+	}
+	return top
+}
+
+func isBelowAny(p string, dirs []string) bool {
+	return slices.ContainsFunc(dirs, func(d string) bool { return isBelow(p, d) })
+}
+
+func isBelow(p, dir string) bool {
+	return p == dir || strings.HasPrefix(p, strings.TrimSuffix(dir, string(filepath.Separator))+string(filepath.Separator))
+}

--- a/docs/content/en/configuration/security.md
+++ b/docs/content/en/configuration/security.md
@@ -59,6 +59,8 @@ This is the default security configuration:
 : {{< new-in 0.161.0 />}}
 : (`[]string`) A slice of file system paths that Node.js tools are allowed to read (`--allow-fs-read`). Paths are relative to the working directory; `"."` means the working directory itself. Use `"*"` to allow all paths.
 
+  Node.js follows symbolic links even when they point outside the allowed paths. Hugo therefore fails the build if any allowed path contains a symbolic link whose target resolves outside the allowed set. To permit such a link, add its target to the list. The check runs once per build; if you also grant write access to an allowed path, a Node.js tool can create links at build time that escape this check.
+
 `node.permissions.allowWorker`
 : {{< new-in 0.161.0 />}}
 : (`[]string`) A slice of Node.js tool names permitted to spawn worker threads (`--allow-worker`).

--- a/resources/resource_transformers/cssjs/postcss_integration_test.go
+++ b/resources/resource_transformers/cssjs/postcss_integration_test.go
@@ -456,3 +456,58 @@ export default { plugins: [postcssImport()] };
 		"RelPermalink: /css/styles.css|HasBody: true|",
 	)
 }
+
+// Node's permission model follows symlinks outside the allowed paths, so Hugo
+// rejects them before invoking Node.
+func TestTransformPostCSSSymlinkOutsideAllowRead(t *testing.T) {
+	if !htesting.IsCI() {
+		t.Skip("Skip long running test when running locally")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks")
+	}
+
+	c := qt.New(t)
+	tempDir, clean, err := htesting.CreateTempDir(hugofs.Os, "hugo-integration-test")
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(clean)
+
+	site := filepath.Join(tempDir, "site")
+	outside := filepath.Join(tempDir, "outside")
+	c.Assert(os.MkdirAll(filepath.Join(site, "assets", "css"), 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(outside, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o644), qt.IsNil)
+	c.Assert(os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(site, "assets", "css", "slink.css")), qt.IsNil)
+
+	files := `
+-- hugo.toml --
+disableKinds = ['taxonomy', 'term', 'page', 'section', 'rss', 'sitemap']
+[security.node.permissions]
+allowRead = ['.']
+-- assets/css/styles.css --
+body { color: red; }
+-- layouts/home.html --
+{{ $styles := resources.Get "css/styles.css" | css.PostCSS }}
+Styles: {{ $styles.Content | safeCSS }}|
+-- package.json --
+{
+	"devDependencies": {
+		"postcss": "8.5.6",
+		"postcss-cli": "11.0.0"
+	}
+}
+-- postcss.config.js --
+module.exports = { plugins: [] }
+`
+
+	withWorkingDir := hugolib.TestOptWithConfig(func(cfg *hugolib.IntegrationTestConfig) {
+		cfg.WorkingDir = site
+	})
+
+	b, err := hugolib.TestE(c, files, hugolib.TestOptOsFs(), hugolib.TestOptWithNpmInstall(), withWorkingDir)
+	b.Assert(err, qt.ErrorMatches, `.*symlink ".*slink.css" resolves to ".*secret.txt" outside .*allowRead.*`)
+
+	files = strings.ReplaceAll(files, "allowRead = ['.']", fmt.Sprintf("allowRead = ['.', %q]", outside))
+	b = hugolib.Test(c, files, hugolib.TestOptOsFs(), hugolib.TestOptWithNpmInstall(), withWorkingDir)
+	b.AssertFileContent("public/index.html", "Styles: body { color: red; }|")
+}


### PR DESCRIPTION
Node's permission model checks the lexical path only and follows symlinks even
when they point outside the allowed set. This is a documented limitation, so
a symlink committed to the project tree (e.g. assets/css/x.css -> /etc/passwd)
could be read by a PostCSS plugin and end up in the published site.

Before invoking a Node tool, walk the allow-read and allow-write roots once per
Exec and fail if any symlink resolves outside them. Relative links inside the
tree, such as node_modules/.bin, are still fine. Users with a legitimate link
can add its target to security.node.permissions.allowRead.

Thanks to @DONG2209 for finding and reporting this issue.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
