### PR TITLE
hugofs: Let **/ match root-level files

### DIFF
--- a/hugofs/hglob/filename_filter.go
+++ b/hugofs/hglob/filename_filter.go
@@ -57,6 +57,26 @@ func normalizeFilenameGlobPattern(s string) string {
 	return s
 }
 
+func expandFilenameGlobPattern(s string) []string {
+	patterns := []string{normalizeFilenameGlobPattern(s)}
+	for i := 0; i < len(patterns); i++ {
+		p := patterns[i]
+		for j := 0; ; {
+			idx := strings.Index(p[j:], "/**/")
+			if idx == -1 {
+				break
+			}
+			idx += j
+			p2 := p[:idx+1] + p[idx+4:]
+			if !slices.Contains(patterns, p2) {
+				patterns = append(patterns, p2)
+			}
+			j = idx + 4
+		}
+	}
+	return patterns
+}
+
 func NewFilenameFilterV2(patterns []string) (*FilenameFilter, error) {
 	if len(patterns) == 0 {
 		return nil, nil
@@ -70,25 +90,26 @@ func NewFilenameFilterV2(patterns []string) (*FilenameFilter, error) {
 		} else {
 			t = globFilenameFilterEntryTypeInclusion
 		}
-		p = normalizeFilenameGlobPattern(p)
-		g, err := GetGlob(p)
-		if err != nil {
-			return nil, err
-		}
-		filter.entries = append(filter.entries, globFilenameFilterEntry{t: t, g: g})
-		if t == globFilenameFilterEntryTypeInclusion {
-			// For mounts that do directory walking (e.g. content) we
-			// must make sure that all directories up to this inclusion also
-			// gets included.
-			dir := path.Dir(p)
-			parts := strings.Split(dir, "/")
-			for i := range parts {
-				pattern := "/" + filepath.Join(parts[:i+1]...)
-				g, err := GetGlob(pattern)
-				if err != nil {
-					return nil, err
+		for _, p := range expandFilenameGlobPattern(p) {
+			g, err := GetGlob(p)
+			if err != nil {
+				return nil, err
+			}
+			filter.entries = append(filter.entries, globFilenameFilterEntry{t: t, g: g})
+			if t == globFilenameFilterEntryTypeInclusion {
+				// For mounts that do directory walking (e.g. content) we
+				// must make sure that all directories up to this inclusion also
+				// gets included.
+				dir := path.Dir(p)
+				parts := strings.Split(dir, "/")
+				for i := range parts {
+					pattern := "/" + filepath.Join(parts[:i+1]...)
+					g, err := GetGlob(pattern)
+					if err != nil {
+						return nil, err
+					}
+					filter.entries = append(filter.entries, globFilenameFilterEntry{t: globFilenameFilterEntryTypeInclusionDir, g: g})
 				}
-				filter.entries = append(filter.entries, globFilenameFilterEntry{t: globFilenameFilterEntryTypeInclusionDir, g: g})
 			}
 		}
 

--- a/hugofs/hglob/filename_filter_test.go
+++ b/hugofs/hglob/filename_filter_test.go
@@ -60,6 +60,12 @@ func TestFilenameFilter(t *testing.T) {
 	c.Assert(includeOnlyFilter.Match("ab.jpg", false), qt.Equals, true)
 	c.Assert(includeOnlyFilter.Match("ab.gif", false), qt.Equals, false)
 
+	includeIndexFilter, err := NewFilenameFilter([]string{"**/index.md"}, nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(includeIndexFilter.Match("index.md", false), qt.Equals, true)
+	c.Assert(includeIndexFilter.Match("a/index.md", false), qt.Equals, true)
+	c.Assert(includeIndexFilter.Match("index.html", false), qt.Equals, false)
+
 	excludeOnlyFilter, err := NewFilenameFilter(nil, []string{"**.json", "**.jpg"})
 	c.Assert(err, qt.IsNil)
 	c.Assert(excludeOnlyFilter.Match("ab.json", false), qt.Equals, false)

--- a/hugolib/mount_filters_test.go
+++ b/hugolib/mount_filters_test.go
@@ -94,3 +94,33 @@ Resource3: :END
 Resources: [/js/include.js]
 `)
 }
+
+// See issue 15320.
+func TestMountFilesFilterGlobStarRootIndex(t *testing.T) {
+	t.Parallel()
+
+	files := `
+-- hugo.toml --
+baseURL = "https://example.org/"
+disableKinds = ["taxonomy", "term", "rss", "sitemap"]
+[module]
+[[module.mounts]]
+source = "content"
+target = "content"
+[[module.mounts]]
+source = "bundle-src/guide"
+target = "content/guide"
+files = ["**/index.md"]
+-- bundle-src/guide/index.md --
+---
+title: "Guide"
+version: "2.1.2"
+---
+Leaf bundle body.
+-- layouts/page.html --
+THIS: kind={{ .Kind }} path={{ .Path }} version={{ .Params.version }}
+`
+	b := Test(t, files)
+
+	b.AssertFileContent("public/guide/index.html", "THIS: kind=page path=/guide version=2.1.2")
+}


### PR DESCRIPTION
## Summary

This fixes mounted content filters so `files = ["**/index.md"]` also matches an `index.md` at the mount root. That lets page bundles mounted from a directory root build the same way nested bundles already do.

Fixes #15320

## Testing

```sh
go test ./hugofs/hglob -run TestFilenameFilter -count=1
go test ./hugolib -run 'TestMountFilesFilterGlobStarRootIndex' -count=1
go test ./hugofs/hglob ./hugolib -count=1
```

I used AI assistance to help prepare this change.
