### PR TITLE
tpl/compare: Make eq compare numbers by value

### DIFF
--- a/tpl/compare/compare.go
+++ b/tpl/compare/compare.go
@@ -150,8 +150,48 @@ func (n *Namespace) Eq(first any, others ...any) bool {
 		if reflect.DeepEqual(normFirst, other) {
 			return true
 		}
+
+		// Numbers of different kinds normalize to different Go types, so
+		// reflect.DeepEqual reports 1 and 1.0 as unequal. Lt, Le, Gt and Ge
+		// compare such pairs numerically via compareGet, so eq did not agree
+		// with them: le and ge were both true while lt, eq and gt were all
+		// false. See #15322.
+		if numbersEqual(normFirst, other) {
+			return true
+		}
 	}
 
+	return false
+}
+
+// numbersEqual reports whether a and b are both numbers of equal value. Both
+// arguments must already be normalized to int64, uint64 or float64. Mixed
+// int/float comparisons go through float64, matching compareGet, so that eq
+// agrees with the ordering operators for every pair they both accept.
+func numbersEqual(a, b any) bool {
+	switch av := a.(type) {
+	case int64:
+		switch bv := b.(type) {
+		case uint64:
+			return av >= 0 && uint64(av) == bv
+		case float64:
+			return float64(av) == bv
+		}
+	case uint64:
+		switch bv := b.(type) {
+		case int64:
+			return bv >= 0 && av == uint64(bv)
+		case float64:
+			return float64(av) == bv
+		}
+	case float64:
+		switch bv := b.(type) {
+		case int64:
+			return av == float64(bv)
+		case uint64:
+			return av == float64(bv)
+		}
+	}
 	return false
 }
 

--- a/tpl/compare/compare_test.go
+++ b/tpl/compare/compare_test.go
@@ -307,6 +307,50 @@ func TestEqualExtend(t *testing.T) {
 	}
 }
 
+func TestEqualMixedNumberKinds(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	ns := New(time.UTC, false)
+
+	// eq compares numbers by value, as lt/le/gt/ge already do. Before #15322
+	// these normalized to different Go types and compared unequal, so le and ge
+	// were both true for 1 and 1.0 while lt, eq and gt were all false.
+	for _, test := range []struct {
+		first  any
+		other  any
+		expect bool
+	}{
+		{1, 1.0, true},
+		{1.0, 1, true},
+		{0, 0.0, true},
+		{-1, -1.0, true},
+		{int64(3), float64(3), true},
+		{uint(4), 4.0, true},
+		{1, 2.0, false},
+		{2.0, 1, false},
+	} {
+		c.Assert(ns.Eq(test.first, test.other), qt.Equals, test.expect,
+			qt.Commentf("eq(%#v, %#v)", test.first, test.other))
+		c.Assert(ns.Ne(test.first, test.other), qt.Equals, !test.expect,
+			qt.Commentf("ne(%#v, %#v)", test.first, test.other))
+
+		// The six operators must agree: exactly one of lt/eq/gt holds,
+		// le means lt or eq, and ge means gt or eq.
+		lt, eq := ns.Lt(test.first, test.other), ns.Eq(test.first, test.other)
+		gt := ns.Gt(test.first, test.other)
+		c.Assert(ns.Le(test.first, test.other), qt.Equals, lt || eq,
+			qt.Commentf("le disagrees for %#v, %#v", test.first, test.other))
+		c.Assert(ns.Ge(test.first, test.other), qt.Equals, gt || eq,
+			qt.Commentf("ge disagrees for %#v, %#v", test.first, test.other))
+	}
+
+	// A number and a numeric string remain unequal. Comparing across those
+	// kinds is a separate question from comparing two numbers.
+	c.Assert(ns.Eq(1, "1"), qt.Equals, false)
+	c.Assert(ns.Eq("1", 1), qt.Equals, false)
+}
+
 func TestNotEqualExtend(t *testing.T) {
 	t.Parallel()
 	c := qt.New(t)


### PR DESCRIPTION
Closes #15322.

Per your note that making `eq` compare numerically would generate the least noise.

`Eq` normalizes ints to `int64` and floats to `float64`, then compares with `reflect.DeepEqual`, which reports them unequal. `Lt`, `Le`, `Gt` and `Ge` go through `compareGet`, which converts both to `float64`. So for `1` and `1.0`, `le` and `ge` were both true while `lt`, `eq` and `gt` were all false: the value was neither less than, greater than, nor equal to itself.

This adds a `numbersEqual` fallback that runs only when `DeepEqual` says no and both sides are numeric.

I did not reuse `compareGet`, though it would have been shorter. It also compares arrays, slices, maps and channels **by length**, so routing `eq` through it would make `eq` of two same-length slices return true.

Also unchanged: a number and a numeric string. `eq 1 "1"` is still false. Worth flagging that it has the same shape as the reported bug (`eq=false lt=false gt=false le=true ge=true`), but equating a number with a numeric string is a much larger semantic change than making two numbers compare by value, so I left it alone. Happy to open a separate issue for it if you want it tracked.

The new test pins the six operators against each other for mixed numeric kinds, so they cannot drift apart again without a failure.

`go test ./tpl/... ./hugolib/...` passes.

This PR was written with AI assistance (Claude Code).
