### PR TITLE
tpl/collections: Fix union of slices with different numeric element types

### DIFF
--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -657,7 +657,12 @@ func (ns *Namespace) Union(l1, l2 any) (any, error) {
 			if l1v.Type() != l2v.Type() &&
 				l1v.Type().Elem().Kind() != reflect.Interface &&
 				l2v.Type().Elem().Kind() != reflect.Interface {
-				return ins.r.Interface(), nil
+				// Numeric element types unify through the conversion below,
+				// mirroring how intersect matches numbers across types.
+				if !hreflect.IsNumber(l1v.Type().Elem().Kind()) ||
+					!hreflect.IsNumber(l2v.Type().Elem().Kind()) {
+					return ins.r.Interface(), nil
+				}
 			}
 
 			var (
@@ -698,7 +703,8 @@ func (ns *Namespace) Union(l1, l2 any) (any, error) {
 				case hreflect.IsNumber(kind):
 					var err error
 					l2vv, err = convertNumber(l2vv, typ)
-					if err == nil {
+					// The empty l1 prototype comes from l2 and may not match l1's element type.
+					if err == nil && l2vv.Type().AssignableTo(l1v.Type().Elem()) {
 						ins.appendIfNotSeen(l2vv)
 					}
 				case kind == reflect.Interface, kind == reflect.Struct, kind == reflect.Pointer:

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -667,6 +667,13 @@ func TestUnion(t *testing.T) {
 		{[]string{"1", "2"}, []int{3}, []string{}, false},
 		{[]int{1, 2}, []string{"1", "2"}, []int{}, false},
 
+		// numeric []A ∪ []B unify. See issue 15323.
+		{[]int{1}, []float64{1.0}, []int{1}, false},
+		{[]int{1, 2}, []float64{2.0, 3.0}, []int{1, 2, 3}, false},
+		{[]float64{1.0}, []int{1, 2}, []float64{1.0, 2.0}, false},
+		// the empty l1 prototype comes from l2, so appends must stay assignable to l1's element type.
+		{[]int{}, []float64{1.0}, []int{}, false},
+
 		// []T ∪ []T
 		{[]string{"a", "b", "c", "c"}, []string{"a", "b", "b"}, []string{"a", "b", "c"}, false},
 		{[]string{"a", "b"}, []string{"a", "b", "c"}, []string{"a", "b", "c"}, false},


### PR DESCRIPTION
## Summary
union returns an empty slice with no error whenever the two arguments have different slice types and neither has an interface element type, so `union (slice 1) (slice 1.0)` gives `[]` while `intersect` with the same inputs gives `[2]`

the early return for different element types drops everything even when both element types are numeric, and the code right below already converts numbers across types with convertNumber, intersect also matches numbers across types, so the two siblings disagree on the same input

this narrows the early return to non numeric mismatches only, numeric lists now unify through the existing conversion path, values that cant convert lossless are skipped, string mismatches keep the old empty result so the tested behavior from the `[]A ∪ []B` cases is unchanged

### Steps to reproduce

`layouts/index.html`:

```go-html-template
{{ printf "%T" (slice 1) }}
{{ printf "%T" (slice 1.0) }}
union int,int    -> {{ union (slice 1) (slice 2) }}
union int,float  -> {{ union (slice 1) (slice 1.0) }}
union int,string -> {{ union (slice 1) (slice "a") }}
union lists      -> {{ union (slice 1 2) (slice 2.0 3.0) }}
intersect lists  -> {{ intersect (slice 1 2) (slice 2.0 3.0) }}
```

before, on master at ae07063:

```
union int,int    -> [1 2]
union int,float  -> []
union int,string -> []
union lists      -> []
intersect lists  -> [2]
```

after this change:

```
union int,int    -> [1 2]
union int,float  -> [1]
union int,string -> []
union lists      -> [1 2 3]
intersect lists  -> [2]
```

tests added to TestUnion pin the numeric unify cases, the full tpl/collections suite passes, see issue 15323

## Assistance Disclosure
AI used: yes, for drafting test coverage and description formatting
