### PR TITLE
langs: Add template filename to the LanguageName/LanguageCode deprecation messages

### DIFF
--- a/langs/language.go
+++ b/langs/language.go
@@ -15,6 +15,7 @@
 package langs
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -29,6 +30,7 @@ import (
 	"github.com/gohugoio/hugo/common/hugo"
 	"github.com/gohugoio/hugo/common/loggers"
 	"github.com/gohugoio/hugo/hugolib/sitesmatrix"
+	"github.com/gohugoio/hugo/tpl"
 )
 
 var _ sitesmatrix.DimensionInfo = (*Language)(nil)
@@ -136,8 +138,8 @@ func (l *Language) Params() hmaps.Params {
 }
 
 // Deprecated: Use Locale instead.
-func (l *Language) LanguageCode() string {
-	hugo.DeprecateWithLogger(".Language.LanguageCode", "Use .Language.Locale instead.", "v0.158.0", l.Logger())
+func (l *Language) LanguageCode(ctx context.Context) string {
+	hugo.DeprecateWithLogger(fmt.Sprintf(".Language.LanguageCode in %q", tpl.CurrentTemplateFilename(ctx)), "Use .Language.Locale instead.", "v0.158.0", l.Logger())
 	return l.Locale()
 }
 
@@ -165,8 +167,8 @@ func (l *Language) Direction() string {
 }
 
 // Deprecated: Use Label instead.
-func (l *Language) LanguageName() string {
-	hugo.DeprecateWithLogger(".Language.LanguageName", "Use .Language.Label instead.", "v0.158.0", l.Logger())
+func (l *Language) LanguageName(ctx context.Context) string {
+	hugo.DeprecateWithLogger(fmt.Sprintf(".Language.LanguageName in %q", tpl.CurrentTemplateFilename(ctx)), "Use .Language.Label instead.", "v0.158.0", l.Logger())
 	return l.Label()
 }
 

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gohugoio/hugo/common/collections"
 
 	"github.com/gohugoio/hugo/identity"
-	"github.com/gohugoio/hugo/langs"
 
 	htmltemplate "github.com/gohugoio/hugo/tpl/internal/go_templates/htmltemplate"
 	texttemplate "github.com/gohugoio/hugo/tpl/internal/go_templates/texttemplate"
@@ -78,6 +77,14 @@ var Context = struct {
 	IsInPartialCached:               contexthelpers.NewContextDispatcher[bool](contextKeyIsInPartialCached),
 }
 
+func CurrentTemplateFilename(ctx context.Context) string {
+	templ := Context.CurrentTemplate.Get(ctx)
+	if templ != nil {
+		return templ.Filename()
+	}
+	return ""
+}
+
 func init() {
 	Context.GetDependencyManagerInCurrentScope = func(ctx context.Context) identity.Manager {
 		idmsp := Context.DependencyManagerScopedProvider.Get(ctx)
@@ -99,7 +106,7 @@ type page interface {
 }
 
 type site interface {
-	Language() *langs.Language
+	ServerPort() int
 }
 
 const (


### PR DESCRIPTION

I had a hard time locating these in one of my own projects (it was in a module), and that's an indication that that's situation worth improving.

NOTE: I created this before I remembered that we have a more general purpose hugo --panicOnWarning flag for this. Opening PR as an information tidbit, I guess.

